### PR TITLE
ci:Skip macOS app build in Ghostty zig step

### DIFF
--- a/crates/con-ghostty/build.rs
+++ b/crates/con-ghostty/build.rs
@@ -14,7 +14,12 @@ fn main() {
 
     // Build libghostty via zig build
     let status = Command::new("zig")
-        .args(["build", "-Dapp-runtime=none", "-Dxcframework-target=native"])
+        .args([
+            "build",
+            "-Dapp-runtime=none",
+            "-Dxcframework-target=native",
+            "-Demit-macos-app=false",
+        ])
         .current_dir(&ghostty_dir)
         .status()
         .expect("failed to run zig build — is zig installed?");


### PR DESCRIPTION
Add -Demit-macos-app=false to the zig build invocation. We only need libghostty-fat.a (produced by the xcframework step), not the full Ghostty macOS app. The xcodebuild target was failing on CI (macos-15 / Xcode 16.4) due to DockTilePlugin Swift compilation errors that are irrelevant to our use case.