### PR TITLE
ci: Fix release upload 404 by uploading files sequentially

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -130,9 +130,15 @@ jobs:
             gh release create "$tag" --title "$tag" --generate-notes "${prerelease_flag[@]}"
           fi
 
-          find release-artifacts -type f \
+          # Upload files one at a time to avoid GitHub API race conditions.
+          # xargs can invoke multiple gh processes that compete for the same
+          # upload endpoint, causing spurious 404s.
+          while IFS= read -r -d '' file; do
+            echo "Uploading: $file"
+            gh release upload "$tag" "$file" --clobber
+          done < <(find release-artifacts -type f \
             \( -name '*.zip' -o -name '*.dmg' -o -name 'SHA256SUMS.txt' \) \
-            -print0 | xargs -0 gh release upload "$tag" --clobber
+            -print0)
 
   update-appcast:
     name: Update Sparkle appcast


### PR DESCRIPTION
xargs can invoke multiple gh release upload processes that race on the GitHub upload API, causing spurious 404 errors. Upload one file at a time instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of the macOS release process by updating artifact upload handling during publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->