### PR TITLE
fix: Guard Sparkle init with ObjC @try/@catch trampoline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,6 +1074,7 @@ name = "con"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cc",
  "chrono",
  "cocoa 0.26.0",
  "con-agent",

--- a/crates/con/Cargo.toml
+++ b/crates/con/Cargo.toml
@@ -42,6 +42,9 @@ cocoa = "=0.26.0"
 objc = "0.2"
 raw-window-handle = "0.6"
 
+[build-dependencies]
+cc = "1"
+
 [package.metadata.bundle]
 icon = ["resources/app-icon@2x.png", "resources/app-icon.png"]
 identifier = "co.nowledge.con"

--- a/crates/con/build.rs
+++ b/crates/con/build.rs
@@ -1,0 +1,12 @@
+fn main() {
+    #[cfg(target_os = "macos")]
+    {
+        cc::Build::new()
+            .file("src/objc/sparkle_trampoline.m")
+            .flag("-fobjc-arc")
+            .flag("-fmodules")
+            .compile("sparkle_trampoline");
+
+        println!("cargo:rerun-if-changed=src/objc/sparkle_trampoline.m");
+    }
+}

--- a/crates/con/src/objc/sparkle_trampoline.m
+++ b/crates/con/src/objc/sparkle_trampoline.m
@@ -1,0 +1,91 @@
+// ObjC exception trampoline for Sparkle initialization.
+//
+// Rust's catch_unwind cannot catch ObjC exceptions (__rust_foreign_exception).
+// This file provides @try/@catch wrappers so the Rust side never sees an
+// uncatchable exception from Sparkle.
+//
+// Sparkle classes are loaded dynamically at runtime, so we use the ObjC
+// runtime API (objc_msgSend) rather than compiled method calls.
+
+#import <Foundation/Foundation.h>
+#import <objc/message.h>
+#import <objc/runtime.h>
+
+/// Initialize SPUStandardUpdaterController with @try/@catch.
+///
+/// Returns the initialized controller, or NULL if an ObjC exception was thrown.
+/// Uses initForStartingUpdater:NO so the caller controls when checking begins.
+void *con_sparkle_init_controller(void) {
+    @try {
+        Class cls = NSClassFromString(@"SPUStandardUpdaterController");
+        if (!cls) return NULL;
+
+        id alloc = [cls alloc];
+        if (!alloc) return NULL;
+
+        // initForStartingUpdater:(BOOL)startingUpdater
+        //   updaterDelegate:(id)updaterDelegate
+        //   userDriverDelegate:(id)userDriverDelegate
+        SEL initSel = NSSelectorFromString(
+            @"initForStartingUpdater:updaterDelegate:userDriverDelegate:");
+
+        // Use objc_msgSend typed cast for the 3-arg init
+        typedef id (*InitIMP)(id, SEL, BOOL, id, id);
+        InitIMP initFunc = (InitIMP)objc_msgSend;
+        id controller = initFunc(alloc, initSel, NO, nil, nil);
+
+        if (!controller) return NULL;
+        return (__bridge_retained void *)controller;
+    } @catch (NSException *exception) {
+        NSLog(@"[con-updater] ObjC exception during Sparkle init: %@ — %@",
+              exception.name, exception.reason);
+        return NULL;
+    }
+}
+
+/// Call -[SPUUpdater startUpdater:] with @try/@catch.
+///
+/// Returns 1 on success, 0 on failure or exception.
+int con_sparkle_start_updater(void *controller) {
+    @try {
+        id ctrl = (__bridge id)controller;
+
+        // Get the SPUUpdater from the controller
+        SEL updaterSel = NSSelectorFromString(@"updater");
+        id updater = ((id (*)(id, SEL))objc_msgSend)(ctrl, updaterSel);
+        if (!updater) return 0;
+
+        // -[SPUUpdater startUpdater:] returns BOOL, takes NSError**
+        SEL startSel = NSSelectorFromString(@"startUpdater:");
+        NSError *error = nil;
+        typedef BOOL (*StartIMP)(id, SEL, NSError **);
+        StartIMP startFunc = (StartIMP)objc_msgSend;
+        BOOL ok = startFunc(updater, startSel, &error);
+        if (!ok) {
+            NSLog(@"[con-updater] startUpdater failed: %@", error);
+            return 0;
+        }
+        return 1;
+    } @catch (NSException *exception) {
+        NSLog(@"[con-updater] ObjC exception in startUpdater: %@ — %@",
+              exception.name, exception.reason);
+        return 0;
+    }
+}
+
+/// Call -[SPUUpdater checkForUpdates] with @try/@catch.
+void con_sparkle_check_for_updates(void *controller) {
+    @try {
+        id ctrl = (__bridge id)controller;
+
+        SEL updaterSel = NSSelectorFromString(@"updater");
+        id updater = ((id (*)(id, SEL))objc_msgSend)(ctrl, updaterSel);
+        if (!updater) return;
+
+        SEL checkSel = NSSelectorFromString(@"checkForUpdates");
+        ((void (*)(id, SEL))objc_msgSend)(updater, checkSel);
+    } @catch (NSException *exception) {
+        NSLog(@"[con-updater] ObjC exception in checkForUpdates: %@ — %@",
+              exception.name, exception.reason);
+    }
+}

--- a/crates/con/src/updater.rs
+++ b/crates/con/src/updater.rs
@@ -5,13 +5,22 @@
 //! absent (e.g. `cargo run` dev builds), the updater silently
 //! disables itself.
 //!
-//! Sparkle reads `SUFeedURL` and `SUPublicEDKey` from Info.plist,
-//! which are injected by the release build scripts when
-//! `CON_SPARKLE_FEED_URL` and `CON_SPARKLE_PUBLIC_ED_KEY` are set.
+//! All Sparkle ObjC calls go through a C trampoline
+//! (`sparkle_trampoline.m`) that wraps them in `@try/@catch`.
+//! Rust's `catch_unwind` cannot catch ObjC exceptions — without the
+//! trampoline, any ObjC exception during Sparkle init would
+//! propagate as `__rust_foreign_exception` → SIGABRT.
 
 use cocoa::base::{BOOL, YES, id, nil};
 use objc::{class, msg_send, sel, sel_impl};
 use std::sync::OnceLock;
+
+// FFI to the ObjC trampoline compiled by build.rs
+unsafe extern "C" {
+    fn con_sparkle_init_controller() -> *mut std::ffi::c_void;
+    fn con_sparkle_start_updater(controller: *mut std::ffi::c_void) -> i32;
+    fn con_sparkle_check_for_updates(controller: *mut std::ffi::c_void);
+}
 
 /// Opaque handle to the Sparkle updater controller.
 ///
@@ -24,14 +33,10 @@ static CONTROLLER: OnceLock<usize> = OnceLock::new();
 /// Call once during app launch, after the main window is open.
 /// Returns `true` if Sparkle was loaded and started successfully.
 ///
-/// This function catches both Rust panics and ObjC exceptions so that
-/// a broken or missing Sparkle framework can never crash the app.
+/// Sparkle init and start are wrapped in ObjC `@try/@catch` so that
+/// any exception from the framework is logged and swallowed rather
+/// than crashing the app.
 pub fn init() -> bool {
-    // catch_unwind handles Rust panics (e.g. from assert!/expect!).
-    // ObjC exceptions are a separate mechanism — we guard against those
-    // by checking every return value for nil and avoiding calls that
-    // could throw (Sparkle's public API is exception-free when inputs
-    // are valid, and we validate all inputs before passing them).
     match std::panic::catch_unwind(init_inner) {
         Ok(result) => result,
         Err(_) => {
@@ -53,14 +58,13 @@ fn init_inner() -> bool {
     }
 
     unsafe {
-        // Locate Sparkle.framework inside the app bundle
+        // Verify we're running inside an app bundle with Sparkle
         let main_bundle: id = msg_send![class!(NSBundle), mainBundle];
         if main_bundle == nil {
             log::warn!("updater: no main bundle — likely running outside .app");
             return false;
         }
 
-        // Build path: <bundle>/Contents/Frameworks/Sparkle.framework
         let frameworks_path: id = msg_send![main_bundle, privateFrameworksPath];
         if frameworks_path == nil {
             log::warn!("updater: no Frameworks path");
@@ -73,7 +77,6 @@ fn init_inner() -> bool {
         let sparkle_path: id =
             msg_send![frameworks_path, stringByAppendingPathComponent: sparkle_subpath];
 
-        // Load the framework bundle
         let sparkle_bundle: id = msg_send![class!(NSBundle), bundleWithPath: sparkle_path];
         if sparkle_bundle == nil {
             log::info!("updater: Sparkle.framework not found — auto-update disabled");
@@ -85,7 +88,7 @@ fn init_inner() -> bool {
             return false;
         }
 
-        // Verify SUFeedURL is set (otherwise Sparkle will crash)
+        // Verify SUFeedURL is set (otherwise Sparkle will throw)
         let info_dict: id = msg_send![main_bundle, infoDictionary];
         let feed_key: id = msg_send![
             class!(NSString),
@@ -97,38 +100,22 @@ fn init_inner() -> bool {
             return false;
         }
 
-        // Create SPUStandardUpdaterController.
-        // `initForStartingUpdater:updaterDelegate:userDriverDelegate:`
-        //   startingUpdater: YES — start checking immediately
-        //   updaterDelegate: nil — use Sparkle defaults
-        //   userDriverDelegate: nil — use Sparkle's standard UI
-        let controller_class = objc::runtime::Class::get("SPUStandardUpdaterController");
-        let controller_class = match controller_class {
-            Some(c) => c,
-            None => {
-                log::warn!("updater: SPUStandardUpdaterController class not found");
-                return false;
-            }
-        };
-
-        let alloc: id = msg_send![controller_class, alloc];
-        if alloc == nil {
-            log::warn!("updater: SPUStandardUpdaterController alloc failed");
-            return false;
-        }
-        let controller: id = msg_send![alloc,
-            initForStartingUpdater: YES
-            updaterDelegate: nil
-            userDriverDelegate: nil
-        ];
-        if controller == nil {
-            log::warn!("updater: failed to create SPUStandardUpdaterController");
+        // Create SPUStandardUpdaterController via the ObjC trampoline.
+        // The trampoline uses initForStartingUpdater:NO and wraps in @try/@catch.
+        let controller = con_sparkle_init_controller();
+        if controller.is_null() {
+            log::warn!("updater: SPUStandardUpdaterController init failed or threw — auto-update disabled");
             return false;
         }
 
-        // alloc+init returns a +1 retained object.  We store the raw
-        // pointer as usize in a static and never release — the controller
-        // lives for the entire process lifetime.
+        // Start the updater (begins automatic checking).
+        // Also wrapped in @try/@catch.
+        let started = con_sparkle_start_updater(controller);
+        if started == 0 {
+            log::warn!("updater: startUpdater failed — auto-update disabled");
+            return false;
+        }
+
         let _ = CONTROLLER.set(controller as usize);
 
         log::info!(
@@ -142,7 +129,7 @@ fn init_inner() -> bool {
 /// Trigger a manual update check (e.g. from Settings → "Check for Updates").
 pub fn check_for_updates() {
     let controller = match CONTROLLER.get() {
-        Some(&ptr) => ptr as id,
+        Some(&ptr) => ptr as *mut std::ffi::c_void,
         None => {
             log::info!("updater: not initialized — cannot check for updates");
             return;
@@ -150,12 +137,7 @@ pub fn check_for_updates() {
     };
 
     unsafe {
-        let updater: id = msg_send![controller, updater];
-        if updater == nil {
-            log::warn!("updater: controller returned nil updater");
-            return;
-        }
-        let _: () = msg_send![updater, checkForUpdates];
+        con_sparkle_check_for_updates(controller);
     }
 }
 

--- a/postmortem/2026-04-14-sparkle-release-pipeline.md
+++ b/postmortem/2026-04-14-sparkle-release-pipeline.md
@@ -32,10 +32,19 @@ Framework symlinks are a macOS requirement: `Sparkle.framework/Sparkle` must be 
 
 **Fix:** DMG is the primary distribution format; zip is for CI/automation only. Additionally hardened the updater init to never crash.
 
-### FFI panic propagation
-The Sparkle init code ran inside GPUI's `did_finish_launching` callback. A panic in this context crosses the ObjC/Rust FFI boundary, turning into `panic_cannot_unwind` → `SIGABRT`.
+### FFI panic propagation / ObjC exception crash
+The Sparkle init code ran inside GPUI's `did_finish_launching` callback. Two failure modes:
+1. A Rust panic crosses the ObjC/Rust FFI boundary → `panic_cannot_unwind` → SIGABRT.
+2. An ObjC exception (e.g. from `SPUStandardUpdaterController` init) propagates as `__rust_foreign_exception` — `catch_unwind` does **not** catch these.
 
-**Fix:** Wrapped `updater::init()` in `catch_unwind`. Also added nil checks on every ObjC return value (alloc, updater property).
+The initial fix (`catch_unwind` + nil checks) only addressed (1). The app still crashed in CI build 9 from an ObjC exception.
+
+**Final fix:** Created an ObjC trampoline (`sparkle_trampoline.m`) compiled via `cc` in `build.rs`. All Sparkle calls now go through `@try/@catch` wrappers:
+- `con_sparkle_init_controller()` — alloc+init with `initForStartingUpdater:NO`
+- `con_sparkle_start_updater()` — deferred start via `startUpdater:`
+- `con_sparkle_check_for_updates()` — manual check
+
+Changed from `initForStartingUpdater:YES` to `NO` + explicit `startUpdater:` to separate initialization from network activity, giving the app time to finish launching before Sparkle begins polling.
 
 ## Additional issues found during review
 
@@ -48,6 +57,6 @@ The Sparkle init code ran inside GPUI's `did_finish_launching` callback. A panic
 
 1. **Never trust xcodebuild in library builds.** When building a C library from a project that also has a macOS app, explicitly opt out of the app target. Zig's `-Demit-macos-app=false` was the right lever.
 2. **DMG is the only reliable macOS distribution format.** Zip files lose framework symlinks. Serve DMG to users; zip is for programmatic consumption only.
-3. **ObjC FFI must be nil-checked at every level.** `catch_unwind` doesn't catch ObjC exceptions — the only defense is defensive nil checking on every `msg_send!` return.
+3. **ObjC exceptions require ObjC `@try/@catch` — `catch_unwind` is not enough.** Rust's `catch_unwind` only catches Rust panics. ObjC exceptions propagate as `__rust_foreign_exception` and terminate the process. The only defense is a compiled ObjC trampoline with `@try/@catch`.
 4. **First-release CI always has latent failures** — each job should be individually testable. The publish and update-appcast jobs should have been tested with a dry-run tag before the real release.
 5. **Sparkle's deprecated flags still appear in examples.** Always check `--help` on the actual downloaded binary, not old blog posts.


### PR DESCRIPTION
catch_unwind cannot catch ObjC exceptions — they propagate as __rust_foreign_exception and SIGABRT the process. Replace direct msg_send! Sparkle calls with a compiled ObjC trampoline that wraps alloc/init, startUpdater, and checkForUpdates in @try/@catch.

Also switch from initForStartingUpdater:YES to NO + explicit startUpdater: to separate init from network activity during launch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced macOS update system stability by implementing improved exception handling for Sparkle framework operations, preventing application crashes during update initialization, startup, and checking.

* **Chores**
  * Added macOS-specific build infrastructure for compiling native update system components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->