### PR TITLE
feat: ui font size & fix performance issue markdown code block rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ con is still pre-release, so entries may group larger areas of work while the pr
 
 ### Added
 
+**Interface**
+- A modeless `About con` window now shows the app icon, release version, build number, release channel, and repository URL.
+- Appearance settings now include a configurable UI font size, separate from terminal font size.
+- `cmd-n` now opens a real new window instead of reusing the current workspace.
+- The bottom command bar now has a pane-scope picker that can target the focused pane, all panes, or an explicit subset of panes.
+- The command bar now supports global command-history suggestions, local path completion for local panes, and an AI suggestion fallback that can be enabled independently.
+
 **Terminal — Ghostty Backend**
 - GPU-accelerated terminal rendering on macOS via Ghostty's Metal engine. Text rendering, scrollback, and compositing all run on the GPU for consistently smooth performance, even with high-throughput output.
 - Full VT compliance out of the box — Kitty keyboard protocol, hyperlinks, sixel graphics, and OSC 133 shell integration are handled natively by Ghostty. No configuration needed.
@@ -24,9 +31,13 @@ con is still pre-release, so entries may group larger areas of work while the pr
 
 ### Improved
 
+**Release and Packaging**
+- The macOS app bundle, updater, and release pipeline are now documented and exercised as real product surfaces. Local updater testing now runs from a bundled beta app instead of `cargo run`, and version metadata is visible in both Settings and the About window.
+- Workspace dependencies no longer rely on local `3pp/` checkouts at build time. GPUI, gpui-component, Rig, and Ghostty now resolve from upstream git sources or scripted fetches instead of local path dependencies.
+
 **AI Agent**
 - The agent system prompt has been restructured for sharper tool usage. Questions are answered with minimal side effects; tasks are executed carefully with verification. Each tool now has explicit guidelines so the agent picks the right one the first time.
-- con now depends directly on upstream Rig main for agent runtime behavior. The temporary fork used to carry the streaming multi-turn tool-call history fix has been removed now that the fix is merged upstream.
+- `con` currently pins `rig-core` to a maintained fork revision while provider work settles upstream. The build no longer depends on a local source checkout for Rig.
 - Busy/idle detection works on Ghostty panes — the agent waits for a running command to finish before sending another.
 - Pane-aware context is stricter and more honest. con no longer guesses SSH hosts, tmux sessions, or agent CLIs from pane titles or status-line patterns. When the foreground runtime is not proven, it stays `unknown`.
 - Visible shell execution now depends on real Ghostty command boundaries instead of stale cwd or title clues. After any unconfirmed input, con stops trusting shell metadata until shell integration proves a fresh prompt again.
@@ -111,6 +122,7 @@ con is still pre-release, so entries may group larger areas of work while the pr
 
 **Terminal**
 - New Ghostty panes now inherit the requested working directory and font size at creation time, which keeps restored tabs and newly opened panes aligned with the workspace state.
+- Split-pane creation and new-tab activation are now off the synchronous session-save path, which reduces visible latency during interactive workspace changes.
 - Split requests now flow through Ghostty's native split action path before con creates the new surface, so pane insertion follows Ghostty split direction semantics instead of treating every split as a purely external GPUI command.
 - Font size changes now apply to existing Ghostty panes immediately, so terminal text updates in place when you save Settings.
 - Terminal theme changes now apply to live Ghostty panes immediately instead of only updating the surrounding con interface.
@@ -138,6 +150,8 @@ con is still pre-release, so entries may group larger areas of work while the pr
 - Fixed empty agent responses appearing as stuck/hanging when providers don't emit text items during streaming
 - Fixed a Unicode logging crash where long tool-result previews could be truncated at an invalid UTF-8 byte boundary
 - Fixed tmux native control helper quoting so tmux list/capture/exec commands no longer leak into the target shell as broken `quote>` input when a quoted tmux target is present
+- Fixed a visible-panel performance regression where assistant messages were reparsed as markdown on every render.
+- Fixed a second visible-panel performance regression where fenced code blocks rebuilt syntax-highlight runs on every render.
 
 **Terminal**
 - Full terminal emulation with 256-color and truecolor support
@@ -149,6 +163,7 @@ con is still pre-release, so entries may group larger areas of work while the pr
 - Fixed a Ghostty theme sync regression where the Settings panel could update con's chrome but leave the terminal on an old palette after a later runtime config update
 - Fixed a shutdown crash in the workspace mouse/resize path when the active tab index outlived the tab list during window teardown
 - Fixed another shutdown-time panic where late workspace renders or actions could still assume an active pane after the last tab was already gone
+- Fixed last-window close teardown for embedded Ghostty surfaces. Closing the final tab or window now shuts down Ghostty surfaces explicitly before window removal instead of relying on late destructor cleanup.
 - Tab management — Cmd+T to open, Cmd+W to close, Cmd+1–9 to switch, Cmd+Shift+[/] to cycle
 - Session restore — your tabs, layout, and panel state are preserved when you relaunch
 - Full compatibility with terminal applications like vim, htop, and tmux (alternate screen, application cursor keys, DEC private modes, Kitty keyboard protocol)
@@ -169,6 +184,7 @@ con is still pre-release, so entries may group larger areas of work while the pr
 
 **Interface**
 - Smart input bar that auto-detects intent — shell commands go to the terminal, questions go to the agent, /skills invoke workflows
+- The single-tab state now uses a compact titlebar instead of a full tab strip, which recovers terminal space without hiding core window controls.
 - Agent panel (Cmd+L) with structured tool call cards, inline approval dialogs, code block rendering, and a resizable width you can drag to adjust
 - The agent panel now keeps live activity visible near the top while a run is in progress, shows a labeled Stop action in the header, and lets you expand long tool results instead of forcing every step into the same short preview.
 - Settings panel (Cmd+,) to configure your provider, model, and preferences

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -224,7 +224,7 @@ See `docs/study/terminal-control-plane.md`.
 | **AutoAgents** | Multi-agent focused, heavier weight. Good for orchestration but overkill for terminal agent. |
 | **Raw HTTP** | Maximum control but months of provider-specific work. |
 
-**Rig v0.34 gives us:**
+**Rig gives us:**
 
 - `CompletionClient::agent()` builder — preamble + tools + model config in one chain
 - `Tool` trait — type-safe tool definitions with `Args` (Deserialize), `Output` (Serialize), `Error`
@@ -454,8 +454,8 @@ cargo test --workspace         # test everything
 
 ### Build Pipeline
 
-1. Cargo resolves workspace deps from crates.io (gpui, rig-core 0.34)
-2. GPUI-CE compiles Metal shaders at runtime (`runtime_shaders` feature — no Xcode.app needed for dev)
+1. Cargo resolves workspace deps from upstream git sources and crates.io as declared in the workspace manifest
+2. GPUI compiles Metal shaders at runtime (`runtime_shaders` feature — no Xcode.app needed for dev)
 3. `cargo build` produces the `con` binary with all crates linked
 
 ---
@@ -519,11 +519,11 @@ new-tab = "cmd+t"
 
 ### 2. GPUI IME: Production-Ready
 
-GPUI-CE implements the full `InputHandler` trait (modeled after `NSTextInputClient`):
+GPUI implements the full `InputHandler` trait (modeled after `NSTextInputClient`):
 
 - `marked_text_range()` / `replace_and_mark_text_in_range()` for IME composition
 - `bounds_for_range()` for candidate window positioning
-- GPUI-CE has broader platform support, but con currently ships the macOS AppKit path.
+- GPUI has broader platform support, but con currently ships the macOS AppKit path.
 - CJK input works. No blocker.
 
 ### 3. GPU Fallback: Not Needed
@@ -563,7 +563,7 @@ con (Rust)  ─── Unix socket (JSON-RPC) ───  plugin process (Node/Pyt
 
 ### 5. Licensing: MIT
 
-- **GPUI-CE**: Apache 2.0 (compatible with MIT, allows sublicensing)
+- **GPUI**: Apache 2.0 (compatible with MIT, allows sublicensing)
 - **Ghostty libghostty**: MIT
 - **Rig**: MIT
 - **con**: MIT (already in LICENSE)

--- a/README.md
+++ b/README.md
@@ -5,14 +5,11 @@
 <p align="center"><strong>The terminal emulator with AI harness, nothing more</strong></p>
 
 <p align="center">
-  Open source. Fast. Terminal-first.
+  Open source. GPU-accelerated. Terminal-first.
 </p>
 <p align="center">
   Built for SSH, tmux, and agent-native workflows.
 </p>
-
-
-
 
 <p align="center">
   <a href="https://opensource.org/licenses/MIT">
@@ -25,19 +22,21 @@
 
 ## Why con?
 
-If you're an old-school terminal user and only want enough AI harness when needed, nothing more or less, `con` is for you.
+`con` is for people who want a serious terminal first and AI help only when it earns its place.
 
-Think of it like a beloved old beast with modern Bluetooth done right, or a truck lover who still wants an electric future.
+It keeps the PTY real, the shell visible, and the agent accountable.
+
+If you're an old-school terminal user and only want enough AI harness when needed, nothing more or less, `con` is for you.
 
 ## What it does
 
-- a terminal emulator
-- built-in AI harness aware of panes within a tab
-- works well with `ssh`, `tmux`, and agent CLIs running directly in the terminal
+- native macOS terminal windows, tabs, and split panes
+- a built-in AI harness that can read context, ask before acting, and work directly in the terminal you can already see
+- terminal-native workflows for `ssh`, `tmux`, and coding-agent CLIs
 
 ## Status
 
-`con` is in active pre-release development.
+`con` is in active beta development.
 
 Best-supported target today: **macOS**.
 
@@ -56,15 +55,16 @@ Best-supported target today: **macOS**.
 
 ## Download
 
-Grab the latest binary from [Releases](https://github.com/nowledge-co/con/releases).
+Download the latest beta from [Releases](https://github.com/nowledge-co/con/releases).
 
-If you want to build from source or hack on `con`, see `HACKING.md`.
+If you want to build from source or work on `con`, see `HACKING.md`.
 
 ## Docs
 
 - `DESIGN.md` vision and architecture
 - `HACKING.md` build and contributor quickstart
 - `docs/screenshots.md` UI gallery
+- `CHANGELOG.md` release notes and product changes
 
 ## License
 
@@ -72,18 +72,14 @@ If you want to build from source or hack on `con`, see `HACKING.md`.
 
 ## Credits ♥️
 
-`con` stands on the work of several upstream projects we rely on directly and respect deeply:
+`con` depends on upstream projects we rely on directly and respect deeply:
 
 - [Ghostty](https://github.com/ghostty-org/ghostty) for the terminal runtime and rendering foundation that powers our embedded terminal surfaces.
 - [GPUI](https://github.com/zed-industries/zed/tree/main/crates/gpui) from the Zed team for the native GPU UI framework we build the shell on.
 - [gpui-component](https://github.com/longbridge/gpui-component) from the Longbridge team for the component library that accelerates much of the UI layer.
-- [Rig](https://github.com/0xPlaygrounds/rig) for the Rust AI agent framework behind Con's agent harness, along with the provider work we maintain in our own fork(before our upstream first work merged).
+- [Rig](https://github.com/0xPlaygrounds/rig) for the Rust agent framework behind `con`'s AI harness, including provider work we currently pin through a maintained fork revision while upstream changes settle.
 - [Phosphor Icons](https://phosphoricons.com/) for the icon system used across the app.
 - [Flexoki](https://stephango.com/flexoki) for the default visual theme direction.
 - [Iosevka](https://typeof.net/Iosevka/) and [Ioskeley Mono](https://github.com/jewlexx/ioskeley) for the mono type foundation used in terminal chrome and code-heavy UI.
 
-If you build or use `con`, you are also benefiting from the care and engineering work of those communities.
-
-
-
-`con` was initially inspired of [warp.dev](http://warp.dev/), but is doing less than warp, if you need more, you proababbly should go for warp instead.
+`con` was initially inspired by [warp.dev](http://warp.dev/), but is doing less than warp, if you need more, you should go for warp instead.

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -3,6 +3,9 @@ use con_agent::AgentConfig;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+pub const MIN_UI_FONT_SIZE: f32 = 12.0;
+pub const MAX_UI_FONT_SIZE: f32 = 24.0;
+
 fn default_font_family() -> String {
     "Ioskeley Mono".into()
 }
@@ -19,7 +22,7 @@ fn default_ui_font_family() -> String {
     ".SystemUIFont".into()
 }
 fn default_ui_font_size() -> f32 {
-    16.0
+    16.0f32.clamp(MIN_UI_FONT_SIZE, MAX_UI_FONT_SIZE)
 }
 fn default_terminal_opacity() -> f32 {
     0.80

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -18,6 +18,9 @@ fn default_cursor_style() -> String {
 fn default_ui_font_family() -> String {
     ".SystemUIFont".into()
 }
+fn default_ui_font_size() -> f32 {
+    16.0
+}
 fn default_terminal_opacity() -> f32 {
     0.80
 }
@@ -60,6 +63,7 @@ pub struct AppearanceConfig {
     pub terminal_opacity: f32,
     pub ui_opacity: f32,
     pub ui_font_family: String,
+    pub ui_font_size: f32,
     pub background_image: Option<String>,
     pub background_image_opacity: f32,
     pub background_image_position: String,
@@ -73,6 +77,7 @@ impl Default for AppearanceConfig {
             terminal_opacity: default_terminal_opacity(),
             ui_opacity: default_ui_opacity(),
             ui_font_family: default_ui_font_family(),
+            ui_font_size: default_ui_font_size(),
             background_image: None,
             background_image_opacity: default_background_image_opacity(),
             background_image_position: default_background_image_position(),

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -1349,11 +1349,13 @@ mod tests {
         let mut patch = GhosttyConfigPatch {
             colors: Some(original_colors.clone()),
             font_size: Some(14.0),
+            ..Default::default()
         };
 
         patch.merge(&GhosttyConfigPatch {
             colors: None,
             font_size: Some(16.0),
+            ..Default::default()
         });
 
         assert_eq!(
@@ -1373,11 +1375,13 @@ mod tests {
         let mut patch = GhosttyConfigPatch {
             colors: Some(sample_colors(10)),
             font_size: Some(14.0),
+            ..Default::default()
         };
 
         patch.merge(&GhosttyConfigPatch {
             colors: Some(replacement_colors.clone()),
             font_size: None,
+            ..Default::default()
         });
 
         assert_eq!(

--- a/crates/con/src/agent_panel.rs
+++ b/crates/con/src/agent_panel.rs
@@ -11,15 +11,14 @@ use gpui_component::{ActiveTheme, Icon, IndexPath, Sizable as _};
 
 /// Max lines to show for tool result previews in collapsed steps
 const TOOL_RESULT_PREVIEW_LINES: usize = 6;
-/// Max characters to show in expanded thinking section
-const THINKING_DISPLAY_LEN: usize = 2000;
-
 use con_agent::{ConversationSummary, ProviderKind, ToolApprovalDecision, conversation::AgentStep};
 use con_core::harness::HarnessEvent;
 
 use chrono::Utc;
 
-use crate::chat_markdown::{ChatMarkdownTone, render_chat_markdown};
+use crate::chat_markdown::{
+    ChatMarkdownTone, ParsedChatMarkdown, render_parsed_chat_markdown,
+};
 use crate::input_bar::SkillEntry;
 use crate::motion::{MotionValue, vertical_reveal_offset};
 use crate::settings_panel::provider_label;
@@ -186,7 +185,7 @@ impl PanelState {
     pub fn restore_last_assistant_trace(&mut self, thinking: Option<&str>, steps: &[AgentStep]) {
         if let Some(last) = self.messages.last_mut() {
             if last.role == "assistant" {
-                last.thinking = thinking.map(ToOwned::to_owned);
+                last.set_thinking(thinking.map(ToOwned::to_owned));
                 last.steps = restored_steps_from_agent_steps(steps);
                 last.thinking_collapsed = true;
                 if !last.steps.is_empty() {
@@ -250,13 +249,12 @@ impl PanelState {
         self.status = AgentStatus::Thinking;
         if !self.streaming {
             let mut msg = PanelMessage::assistant();
-            msg.thinking = Some(String::new());
+            msg.set_thinking(Some(String::new()));
             self.messages.push(msg);
             self.streaming = true;
         }
         if let Some(last) = self.messages.last_mut() {
-            let thinking = last.thinking.get_or_insert_with(String::new);
-            thinking.push_str(text);
+            last.append_thinking(text);
         }
     }
 
@@ -267,7 +265,7 @@ impl PanelState {
             self.streaming = true;
         }
         if let Some(last) = self.messages.last_mut() {
-            last.content.push_str(token);
+            last.append_content(token);
         }
     }
 
@@ -284,7 +282,7 @@ impl PanelState {
             // in that case, keep whatever was accumulated during streaming.
             if !final_content.is_empty() {
                 if let Some(last) = self.messages.last_mut() {
-                    last.content = final_content.to_string();
+                    last.replace_content(final_content);
                 }
             }
             // Attach metadata to the last assistant message
@@ -486,8 +484,10 @@ impl SelectItem for ProviderSelectItem {
 struct PanelMessage {
     role: String,
     content: String,
+    content_markdown: Option<ParsedChatMarkdown>,
     /// Extended thinking/reasoning text from the model (collapsible)
     thinking: Option<String>,
+    thinking_markdown: Option<ParsedChatMarkdown>,
     thinking_collapsed: bool,
     steps: Vec<StepEntry>,
     steps_collapsed: bool,
@@ -524,7 +524,9 @@ impl PanelMessage {
         Self {
             role: role.to_string(),
             content: content.to_string(),
+            content_markdown: (!content.is_empty()).then(|| ParsedChatMarkdown::parse(content)),
             thinking: None,
+            thinking_markdown: None,
             thinking_collapsed: true,
             steps: Vec::new(),
             steps_collapsed: false,
@@ -535,6 +537,51 @@ impl PanelMessage {
 
     fn assistant() -> Self {
         Self::new("assistant", "")
+    }
+
+    fn append_content(&mut self, token: &str) {
+        self.content.push_str(token);
+        self.content_markdown = None;
+    }
+
+    fn replace_content(&mut self, content: &str) {
+        self.content = content.to_string();
+        self.content_markdown = (!content.is_empty()).then(|| ParsedChatMarkdown::parse(content));
+    }
+
+    fn set_thinking(&mut self, thinking: Option<String>) {
+        self.thinking_markdown = thinking
+            .as_deref()
+            .filter(|text| !text.is_empty())
+            .map(ParsedChatMarkdown::parse);
+        self.thinking = thinking;
+    }
+
+    fn append_thinking(&mut self, text: &str) {
+        let thinking = self.thinking.get_or_insert_with(String::new);
+        thinking.push_str(text);
+        self.thinking_markdown = None;
+    }
+
+    fn content_markdown(&mut self) -> Option<&ParsedChatMarkdown> {
+        if self.content.is_empty() {
+            return None;
+        }
+        if self.content_markdown.is_none() {
+            self.content_markdown = Some(ParsedChatMarkdown::parse(&self.content));
+        }
+        self.content_markdown.as_ref()
+    }
+
+    fn thinking_markdown(&mut self) -> Option<&ParsedChatMarkdown> {
+        let thinking = self.thinking.as_deref()?;
+        if thinking.is_empty() {
+            return None;
+        }
+        if self.thinking_markdown.is_none() {
+            self.thinking_markdown = Some(ParsedChatMarkdown::parse(thinking));
+        }
+        self.thinking_markdown.as_ref()
     }
 }
 
@@ -2350,7 +2397,7 @@ impl Render for AgentPanel {
             .pb(px(64.0))
             .gap(px(16.0));
 
-        for (msg_idx, msg) in self.state.messages.iter().enumerate() {
+        for (msg_idx, msg) in self.state.messages.iter_mut().enumerate() {
             let is_user = msg.role == "user";
             let is_system = msg.role == "system";
 
@@ -2635,58 +2682,48 @@ impl Render for AgentPanel {
 
                         // Expanded content
                         if !thinking_collapsed {
-                            let display_text: SharedString = if thinking.len()
-                                > THINKING_DISPLAY_LEN
-                            {
-                                format!(
-                                    "{}…",
-                                    &thinking[..thinking.floor_char_boundary(THINKING_DISPLAY_LEN)]
-                                )
-                                .into()
-                            } else {
-                                thinking.clone().into()
-                            };
-                            msg_el = msg_el.child(
-                                div()
-                                    .ml(px(23.0))
-                                    .mr(px(4.0))
-                                    .mt(px(1.0))
-                                    .mb(px(2.0))
-                                    .px(px(10.0))
-                                    .py(px(7.0))
-                                    .rounded(px(8.0))
-                                    .bg(theme.muted.opacity(0.04))
-                                    .max_h(px(200.0))
-                                    .overflow_y_hidden()
-                                    .text_size(px(12.0))
-                                    .line_height(px(18.0))
-                                    .text_color(theme.muted_foreground.opacity(0.54))
-                                    .child(render_chat_markdown(
-                                        &display_text,
-                                        ChatMarkdownTone::Thinking,
-                                        theme,
-                                    )),
-                            );
+                            let mut thinking_el = div()
+                                .ml(px(23.0))
+                                .mr(px(4.0))
+                                .mt(px(1.0))
+                                .mb(px(2.0))
+                                .px(px(10.0))
+                                .py(px(7.0))
+                                .rounded(px(8.0))
+                                .bg(theme.muted.opacity(0.04))
+                                .max_h(px(200.0))
+                                .overflow_y_hidden()
+                                .text_size(px(12.0))
+                                .line_height(px(18.0))
+                                .text_color(theme.muted_foreground.opacity(0.54));
+                            if let Some(markdown) = msg.thinking_markdown() {
+                                thinking_el = thinking_el.child(render_parsed_chat_markdown(
+                                    markdown,
+                                    ChatMarkdownTone::Thinking,
+                                    theme,
+                                ));
+                            }
+                            msg_el = msg_el.child(thinking_el);
                         }
                     }
                 }
 
                 // Message content — render as markdown
                 if !msg.content.is_empty() {
-                    let content: SharedString = msg.content.clone().into();
-                    msg_el = msg_el.child(
-                        div()
-                            .ml(px(19.0))
-                            .pr(px(4.0))
-                            .text_size(px(14.0))
-                            .line_height(px(23.0))
-                            .text_color(theme.foreground.opacity(0.88))
-                            .child(render_chat_markdown(
-                                &content,
-                                ChatMarkdownTone::Message,
-                                theme,
-                            )),
-                    );
+                    let mut content_el = div()
+                        .ml(px(19.0))
+                        .pr(px(4.0))
+                        .text_size(px(14.0))
+                        .line_height(px(23.0))
+                        .text_color(theme.foreground.opacity(0.88));
+                    if let Some(markdown) = msg.content_markdown() {
+                        content_el = content_el.child(render_parsed_chat_markdown(
+                            markdown,
+                            ChatMarkdownTone::Message,
+                            theme,
+                        ));
+                    }
+                    msg_el = msg_el.child(content_el);
 
                     // Copy button — slightly tighter
                     let content_for_clip = assistant_content_for_copy;

--- a/crates/con/src/chat_markdown.rs
+++ b/crates/con/src/chat_markdown.rs
@@ -18,7 +18,7 @@ pub enum ChatMarkdownTone {
     Thinking,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 enum MarkdownBlock {
     Paragraph(Vec<MarkdownInline>),
     Heading {
@@ -42,6 +42,63 @@ enum MarkdownBlock {
     },
     Rule,
 }
+
+impl PartialEq for MarkdownBlock {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Paragraph(a), Self::Paragraph(b)) => a == b,
+            (
+                Self::Heading {
+                    level: level_a,
+                    inlines: inlines_a,
+                },
+                Self::Heading {
+                    level: level_b,
+                    inlines: inlines_b,
+                },
+            ) => level_a == level_b && inlines_a == inlines_b,
+            (
+                Self::CodeBlock {
+                    language: language_a,
+                    code: code_a,
+                    ..
+                },
+                Self::CodeBlock {
+                    language: language_b,
+                    code: code_b,
+                    ..
+                },
+            ) => language_a == language_b && code_a == code_b,
+            (Self::BlockQuote(a), Self::BlockQuote(b)) => a == b,
+            (
+                Self::List {
+                    ordered: ordered_a,
+                    start: start_a,
+                    items: items_a,
+                },
+                Self::List {
+                    ordered: ordered_b,
+                    start: start_b,
+                    items: items_b,
+                },
+            ) => ordered_a == ordered_b && start_a == start_b && items_a == items_b,
+            (
+                Self::Table {
+                    aligns: aligns_a,
+                    rows: rows_a,
+                },
+                Self::Table {
+                    aligns: aligns_b,
+                    rows: rows_b,
+                },
+            ) => aligns_a == aligns_b && rows_a == rows_b,
+            (Self::Rule, Self::Rule) => true,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for MarkdownBlock {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MarkdownTableAlign {

--- a/crates/con/src/chat_markdown.rs
+++ b/crates/con/src/chat_markdown.rs
@@ -207,9 +207,26 @@ impl<'a> ChatMarkdownStyle<'a> {
     }
 }
 
-pub fn render_chat_markdown(source: &str, tone: ChatMarkdownTone, theme: &Theme) -> AnyElement {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedChatMarkdown {
+    blocks: Vec<MarkdownBlock>,
+}
+
+impl ParsedChatMarkdown {
+    pub fn parse(source: &str) -> Self {
+        Self {
+            blocks: parse_markdown(source),
+        }
+    }
+}
+
+pub fn render_parsed_chat_markdown(
+    document: &ParsedChatMarkdown,
+    tone: ChatMarkdownTone,
+    theme: &Theme,
+) -> AnyElement {
     let style = ChatMarkdownStyle::new(theme, tone);
-    let blocks = parse_markdown(source);
+    let blocks = &document.blocks;
 
     if blocks.is_empty() {
         return div().into_any_element();
@@ -221,12 +238,7 @@ pub fn render_chat_markdown(source: &str, tone: ChatMarkdownTone, theme: &Theme)
         .flex_col()
         .gap(style.block_gap)
         .max_w(style.content_width)
-        .children(
-            blocks
-                .iter()
-                .enumerate()
-                .map(|(idx, block)| render_block(block, idx, &style)),
-        )
+        .children(blocks.iter().enumerate().map(|(idx, block)| render_block(block, idx, &style)))
         .into_any_element()
 }
 

--- a/crates/con/src/chat_markdown.rs
+++ b/crates/con/src/chat_markdown.rs
@@ -1,7 +1,10 @@
+use std::cell::RefCell;
+use std::sync::Arc;
+
 use gpui::{
     AbsoluteLength, AnyElement, DefiniteLength, FontStyle, FontWeight, Hsla, IntoElement,
-    ParentElement, SharedString, Styled, StyledText, TextStyle, UnderlineStyle, WhiteSpace, div,
-    px,
+    ParentElement, SharedString, Styled, StyledText, TextStyle, TextRun, UnderlineStyle,
+    WhiteSpace, div, px,
 };
 use gpui_component::clipboard::Clipboard;
 use gpui_component::highlighter::SyntaxHighlighter;
@@ -25,6 +28,7 @@ enum MarkdownBlock {
     CodeBlock {
         language: Option<String>,
         code: String,
+        highlight_cache: RefCell<Option<CachedCodeHighlightRuns>>,
     },
     BlockQuote(Vec<MarkdownBlock>),
     List {
@@ -60,6 +64,19 @@ enum MarkdownInline {
     },
     SoftBreak,
     LineBreak,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CodeHighlightCacheKey {
+    highlight_theme_ptr: usize,
+    mono_font_family: SharedString,
+    mono_font_size_bits: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CachedCodeHighlightRuns {
+    key: CodeHighlightCacheKey,
+    runs: Option<Vec<Vec<TextRun>>>,
 }
 
 struct ChatMarkdownStyle<'a> {
@@ -264,6 +281,7 @@ fn parse_block_node(node: &mdast::Node) -> Option<MarkdownBlock> {
         mdast::Node::Code(raw) => Some(MarkdownBlock::CodeBlock {
             language: raw.lang.clone().filter(|lang| !lang.trim().is_empty()),
             code: raw.value.clone(),
+            highlight_cache: RefCell::new(None),
         }),
         mdast::Node::Blockquote(val) => Some(MarkdownBlock::BlockQuote(
             val.children.iter().filter_map(parse_block_node).collect(),
@@ -319,14 +337,17 @@ fn parse_block_node(node: &mdast::Node) -> Option<MarkdownBlock> {
         mdast::Node::Yaml(val) => Some(MarkdownBlock::CodeBlock {
             language: Some("yml".to_string()),
             code: val.value.clone(),
+            highlight_cache: RefCell::new(None),
         }),
         mdast::Node::Toml(val) => Some(MarkdownBlock::CodeBlock {
             language: Some("toml".to_string()),
             code: val.value.clone(),
+            highlight_cache: RefCell::new(None),
         }),
         mdast::Node::Math(val) => Some(MarkdownBlock::CodeBlock {
             language: None,
             code: val.value.clone(),
+            highlight_cache: RefCell::new(None),
         }),
         mdast::Node::FootnoteDefinition(def) => Some(MarkdownBlock::Paragraph(
             std::iter::once(MarkdownInline::Text(format!("[{}]: ", def.identifier)))
@@ -473,9 +494,11 @@ fn render_block(block: &MarkdownBlock, index: usize, style: &ChatMarkdownStyle<'
                 style,
             ))
             .into_any_element(),
-        MarkdownBlock::CodeBlock { language, code } => {
-            render_code_block(index, language, code, style)
-        }
+        MarkdownBlock::CodeBlock {
+            language,
+            code,
+            highlight_cache,
+        } => render_code_block(index, language, code, highlight_cache, style),
         MarkdownBlock::BlockQuote(blocks) => div()
             .w_full()
             .px(px(10.0))
@@ -676,6 +699,7 @@ fn render_code_block(
     _index: usize,
     language: &Option<String>,
     code: &str,
+    highlight_cache: &RefCell<Option<CachedCodeHighlightRuns>>,
     style: &ChatMarkdownStyle<'_>,
 ) -> AnyElement {
     let mono_style = style.code_text_style();
@@ -734,7 +758,7 @@ fn render_code_block(
         );
 
     let mut code_column = div().flex().flex_col().gap(px(0.0)).w_full();
-    let syntax_runs = highlighted_code_runs(code, language, style);
+    let syntax_runs = cached_highlighted_code_runs(code, language, highlight_cache, style);
 
     for (line_idx, line) in lines.iter().enumerate() {
         let display_line = if line.is_empty() { "\u{200B}" } else { line };
@@ -779,6 +803,38 @@ fn render_code_block(
             ),
         )
         .into_any_element()
+}
+
+fn cached_highlighted_code_runs(
+    code: &str,
+    language: &Option<String>,
+    cache: &RefCell<Option<CachedCodeHighlightRuns>>,
+    style: &ChatMarkdownStyle<'_>,
+) -> Option<Vec<Vec<TextRun>>> {
+    let key = CodeHighlightCacheKey {
+        highlight_theme_ptr: Arc::as_ptr(&style.theme.highlight_theme) as usize,
+        mono_font_family: style.theme.mono_font_family.clone(),
+        mono_font_size_bits: {
+            let size: f32 = style.code_font_size.into();
+            size.to_bits()
+        },
+    };
+
+    {
+        let cached = cache.borrow();
+        if let Some(cached) = cached.as_ref()
+            && cached.key == key
+        {
+            return cached.runs.clone();
+        }
+    }
+
+    let runs = highlighted_code_runs(code, language, style);
+    *cache.borrow_mut() = Some(CachedCodeHighlightRuns {
+        key,
+        runs: runs.clone(),
+    });
+    runs
 }
 
 fn highlighted_code_runs(

--- a/crates/con/src/main.rs
+++ b/crates/con/src/main.rs
@@ -381,6 +381,7 @@ fn main() {
             &config.terminal.theme,
             &config.terminal.font_family,
             &config.appearance.ui_font_family,
+            config.appearance.ui_font_size,
         );
 
         // Register ghostty terminal key bindings (Tab interception, etc.)

--- a/crates/con/src/settings_panel.rs
+++ b/crates/con/src/settings_panel.rs
@@ -105,6 +105,7 @@ pub struct SettingsPanel {
     terminal_font_select: Entity<SelectState<SearchableVec<String>>>,
     ui_font_select: Entity<SelectState<SearchableVec<String>>>,
     font_size_input: Entity<InputState>,
+    ui_font_size_input: Entity<InputState>,
     terminal_opacity_slider: Entity<SliderState>,
     ui_opacity_slider: Entity<SliderState>,
     background_image_input: Entity<InputState>,
@@ -167,6 +168,10 @@ struct EndpointPreset {
 }
 
 impl SettingsPanel {
+    fn clamp_ui_font_size(value: f32) -> f32 {
+        value.clamp(12.0, 24.0)
+    }
+
     fn clamp_terminal_opacity(value: f32) -> f32 {
         value.clamp(0.25, 1.0)
     }
@@ -792,6 +797,16 @@ impl SettingsPanel {
             s.set_value(&config.terminal.font_size.to_string(), window, cx);
             s
         });
+        let ui_font_size_input = cx.new(|cx| {
+            let mut s = InputState::new(window, cx);
+            s.set_placeholder("16.0", window, cx);
+            s.set_value(
+                &Self::clamp_ui_font_size(config.appearance.ui_font_size).to_string(),
+                window,
+                cx,
+            );
+            s
+        });
         let terminal_opacity_slider = cx.new(|_| {
             SliderState::new()
                 .min(0.25)
@@ -1043,6 +1058,7 @@ impl SettingsPanel {
             terminal_font_select,
             ui_font_select,
             font_size_input,
+            ui_font_size_input,
             terminal_opacity_slider,
             ui_opacity_slider,
             background_image_input,
@@ -1125,6 +1141,13 @@ impl SettingsPanel {
             });
             self.font_size_input.update(cx, |s, cx| {
                 s.set_value(&self.config.terminal.font_size.to_string(), window, cx)
+            });
+            self.ui_font_size_input.update(cx, |s, cx| {
+                s.set_value(
+                    &Self::clamp_ui_font_size(self.config.appearance.ui_font_size).to_string(),
+                    window,
+                    cx,
+                )
             });
             self.terminal_opacity_slider.update(cx, |slider, cx| {
                 slider.set_value(
@@ -1446,6 +1469,7 @@ impl SettingsPanel {
             .cloned()
             .unwrap_or_default();
         let font_size_text = self.font_size_input.read(cx).value().to_string();
+        let ui_font_size_text = self.ui_font_size_input.read(cx).value().to_string();
 
         // Save current provider's per-provider fields into the map
         let pc = self.read_provider_inputs(cx);
@@ -1469,6 +1493,11 @@ impl SettingsPanel {
             },
         };
         self.config.terminal.font_size = font_size_text.parse().unwrap_or(14.0);
+        self.config.appearance.ui_font_size = Self::clamp_ui_font_size(
+            ui_font_size_text
+                .parse()
+                .unwrap_or(self.config.appearance.ui_font_size),
+        );
         self.config.appearance.terminal_opacity =
             Self::clamp_terminal_opacity(self.terminal_opacity_slider.read(cx).value().end());
         self.config.appearance.ui_opacity =
@@ -2035,6 +2064,7 @@ impl SettingsPanel {
         let terminal_font_select = self.terminal_font_select.clone();
         let ui_font_select = self.ui_font_select.clone();
         let font_size_input = self.font_size_input.clone();
+        let ui_font_size_input = self.ui_font_size_input.clone();
         let terminal_opacity_slider = self.terminal_opacity_slider.clone();
         let ui_opacity_slider = self.ui_opacity_slider.clone();
         let background_image_input = self.background_image_input.clone();
@@ -2249,6 +2279,8 @@ impl SettingsPanel {
                             "Search fonts…",
                             theme,
                         ))
+                        .child(row_separator(theme))
+                        .child(row_field("UI Size", &ui_font_size_input))
                         .child(row_separator(theme))
                         .child(row_field("Terminal Size", &font_size_input)),
                 ),

--- a/crates/con/src/settings_panel.rs
+++ b/crates/con/src/settings_panel.rs
@@ -3,7 +3,10 @@ use con_agent::{
     SuggestionModelConfig, authorize_oauth_provider,
 };
 use con_agent::provider::AgentPurpose;
-use con_core::Config;
+use con_core::{
+    Config,
+    config::{MAX_UI_FONT_SIZE, MIN_UI_FONT_SIZE},
+};
 use futures::{FutureExt, StreamExt};
 use gpui::*;
 
@@ -169,7 +172,7 @@ struct EndpointPreset {
 
 impl SettingsPanel {
     fn clamp_ui_font_size(value: f32) -> f32 {
-        value.clamp(12.0, 24.0)
+        value.clamp(MIN_UI_FONT_SIZE, MAX_UI_FONT_SIZE)
     }
 
     fn clamp_terminal_opacity(value: f32) -> f32 {
@@ -1469,7 +1472,7 @@ impl SettingsPanel {
             .cloned()
             .unwrap_or_default();
         let font_size_text = self.font_size_input.read(cx).value().to_string();
-        let ui_font_size_text = self.ui_font_size_input.read(cx).value().to_string();
+        let ui_font_size_text = self.ui_font_size_input.read(cx).value().trim().to_string();
 
         // Save current provider's per-provider fields into the map
         let pc = self.read_provider_inputs(cx);
@@ -1493,11 +1496,20 @@ impl SettingsPanel {
             },
         };
         self.config.terminal.font_size = font_size_text.parse().unwrap_or(14.0);
-        self.config.appearance.ui_font_size = Self::clamp_ui_font_size(
-            ui_font_size_text
-                .parse()
-                .unwrap_or(self.config.appearance.ui_font_size),
-        );
+        let parsed_ui_font_size = if ui_font_size_text.is_empty() {
+            Some(self.config.appearance.ui_font_size)
+        } else {
+            ui_font_size_text.parse::<f32>().ok()
+        };
+        let Some(parsed_ui_font_size) = parsed_ui_font_size else {
+            self.save_error = Some(format!(
+                "UI Size must be a number between {:.1} and {:.1}.",
+                MIN_UI_FONT_SIZE, MAX_UI_FONT_SIZE
+            ));
+            cx.notify();
+            return;
+        };
+        self.config.appearance.ui_font_size = Self::clamp_ui_font_size(parsed_ui_font_size);
         self.config.appearance.terminal_opacity =
             Self::clamp_terminal_opacity(self.terminal_opacity_slider.read(cx).value().end());
         self.config.appearance.ui_opacity =

--- a/crates/con/src/terminal_pane.rs
+++ b/crates/con/src/terminal_pane.rs
@@ -1,7 +1,7 @@
 //! TerminalPane — Ghostty-backed terminal pane wrapper.
 
 use con_agent::context::{PaneObservationFrame, PaneObservationSupport, derive_screen_hints};
-use con_ghostty::{GhosttySplitDirection, TerminalColors};
+use con_ghostty::TerminalColors;
 use con_terminal::TerminalTheme;
 use gpui::*;
 
@@ -103,12 +103,6 @@ impl TerminalPane {
             if let Err(err) = terminal.clear_screen_and_scrollback() {
                 log::error!("Failed to clear Ghostty scrollback: {}", err);
             }
-        }
-    }
-
-    pub fn request_split(&self, direction: GhosttySplitDirection, cx: &App) {
-        if let Some(terminal) = self.entity.read(cx).terminal() {
-            terminal.request_split(direction);
         }
     }
 

--- a/crates/con/src/theme.rs
+++ b/crates/con/src/theme.rs
@@ -1,3 +1,4 @@
+use con_core::config::{MAX_UI_FONT_SIZE, MIN_UI_FONT_SIZE};
 use con_terminal::{Color, TerminalTheme};
 use gpui::App;
 use gpui_component::highlighter::LanguageRegistry;
@@ -243,8 +244,11 @@ fn apply_font_overrides(
 ) {
     Theme::global_mut(cx).mono_font_family = terminal_font_family.to_string().into();
     Theme::global_mut(cx).font_family = ui_font_family.to_string().into();
-    Theme::global_mut(cx).font_size = gpui::px(ui_font_size.clamp(12.0, 24.0));
-    Theme::global_mut(cx).mono_font_size = gpui::px((ui_font_size - 3.0).clamp(11.0, 21.0));
+    let clamped_ui_font_size = ui_font_size.clamp(MIN_UI_FONT_SIZE, MAX_UI_FONT_SIZE);
+    Theme::global_mut(cx).font_size = gpui::px(clamped_ui_font_size);
+    Theme::global_mut(cx).mono_font_size = gpui::px(
+        (clamped_ui_font_size - 3.0).clamp(MIN_UI_FONT_SIZE - 1.0, MAX_UI_FONT_SIZE - 3.0),
+    );
 }
 
 /// Apply con's scrollbar overrides after any Theme::change call.

--- a/crates/con/src/theme.rs
+++ b/crates/con/src/theme.rs
@@ -158,6 +158,7 @@ pub fn init_theme(
     terminal_theme: &str,
     terminal_font_family: &str,
     ui_font_family: &str,
+    ui_font_size: f32,
 ) {
     register_command_prompt_language();
     cx.text_system()
@@ -194,7 +195,7 @@ pub fn init_theme(
         ThemeMode::Dark
     };
     Theme::change(mode, None, cx);
-    apply_font_overrides(terminal_font_family, ui_font_family, cx);
+    apply_font_overrides(terminal_font_family, ui_font_family, ui_font_size, cx);
     apply_scrollbar_overrides(cx);
 }
 
@@ -219,6 +220,7 @@ pub fn sync_gpui_theme(
     terminal_theme: &TerminalTheme,
     terminal_font_family: &str,
     ui_font_family: &str,
+    ui_font_size: f32,
     window: &mut gpui::Window,
     cx: &mut gpui::App,
 ) {
@@ -229,13 +231,20 @@ pub fn sync_gpui_theme(
         ThemeMode::Dark
     };
     Theme::change(mode, Some(window), cx);
-    apply_font_overrides(terminal_font_family, ui_font_family, cx);
+    apply_font_overrides(terminal_font_family, ui_font_family, ui_font_size, cx);
     apply_scrollbar_overrides(cx);
 }
 
-fn apply_font_overrides(terminal_font_family: &str, ui_font_family: &str, cx: &mut App) {
+fn apply_font_overrides(
+    terminal_font_family: &str,
+    ui_font_family: &str,
+    ui_font_size: f32,
+    cx: &mut App,
+) {
     Theme::global_mut(cx).mono_font_family = terminal_font_family.to_string().into();
     Theme::global_mut(cx).font_family = ui_font_family.to_string().into();
+    Theme::global_mut(cx).font_size = gpui::px(ui_font_size.clamp(12.0, 24.0));
+    Theme::global_mut(cx).mono_font_size = gpui::px((ui_font_size - 3.0).clamp(11.0, 21.0));
 }
 
 /// Apply con's scrollbar overrides after any Theme::change call.

--- a/crates/con/src/workspace.rs
+++ b/crates/con/src/workspace.rs
@@ -91,6 +91,7 @@ pub struct ConWorkspace {
     active_tab: usize,
     terminal_font_family: String,
     ui_font_family: String,
+    ui_font_size: f32,
     font_size: f32,
     terminal_opacity: f32,
     ui_opacity: f32,
@@ -269,6 +270,7 @@ impl ConWorkspace {
         let sidebar = cx.new(|cx| SessionSidebar::new(cx));
         let terminal_font_family = config.terminal.font_family.clone();
         let ui_font_family = config.appearance.ui_font_family.clone();
+        let ui_font_size = config.appearance.ui_font_size;
         let font_size = config.terminal.font_size;
         let terminal_opacity = Self::effective_terminal_opacity(config.appearance.terminal_opacity);
         let ui_opacity = Self::clamp_ui_opacity(config.appearance.ui_opacity);
@@ -571,6 +573,7 @@ impl ConWorkspace {
             active_tab,
             terminal_font_family,
             ui_font_family,
+            ui_font_size,
             font_size,
             terminal_opacity,
             ui_opacity,
@@ -2301,6 +2304,7 @@ impl ConWorkspace {
         let appearance_config = settings.read(cx).appearance_config().clone();
         self.terminal_font_family = term_config.font_family.clone();
         self.ui_font_family = appearance_config.ui_font_family.clone();
+        self.ui_font_size = appearance_config.ui_font_size;
         self.font_size = term_config.font_size;
         self.terminal_opacity =
             Self::effective_terminal_opacity(appearance_config.terminal_opacity);
@@ -2397,6 +2401,7 @@ impl ConWorkspace {
             &theme,
             &self.terminal_font_family,
             &self.ui_font_family,
+            self.ui_font_size,
             window,
             cx,
         );

--- a/crates/con/src/workspace.rs
+++ b/crates/con/src/workspace.rs
@@ -5198,14 +5198,6 @@ impl Render for ConWorkspace {
         let agent_panel_progress = self.agent_panel_motion.value(window);
         let input_bar_progress = self.input_bar_motion.value(window);
         let tab_strip_progress = self.tab_strip_motion.value(window);
-        let shell_chrome_animating = self.agent_panel_motion.is_animating()
-            || self.input_bar_motion.is_animating()
-            || self.tab_strip_motion.is_animating();
-        if shell_chrome_animating {
-            for terminal in self.tabs[self.active_tab].pane_tree.all_terminals() {
-                terminal.notify(cx);
-            }
-        }
         let layout_matte_active = self.layout_matte_active();
         if layout_matte_active {
             window.request_animation_frame();

--- a/crates/con/src/workspace.rs
+++ b/crates/con/src/workspace.rs
@@ -150,6 +150,8 @@ pub struct ConWorkspace {
     workspace_handle: WeakEntity<ConWorkspace>,
     /// Ensures native window-close cleanup only runs once.
     window_close_prepared: bool,
+    /// Ordered, coalescing session persistence worker.
+    session_save_tx: crossbeam_channel::Sender<SessionSaveRequest>,
 }
 
 #[derive(Clone)]
@@ -182,6 +184,52 @@ struct PendingControlAgentRequest {
     prompt: String,
     auto_approve_tools: bool,
     response_tx: tokio::sync::oneshot::Sender<ControlResult>,
+}
+
+enum SessionSaveRequest {
+    Save(Session),
+    Flush(Session, crossbeam_channel::Sender<()>),
+}
+
+fn spawn_session_save_worker() -> crossbeam_channel::Sender<SessionSaveRequest> {
+    let (tx, rx) = crossbeam_channel::unbounded();
+    std::thread::Builder::new()
+        .name("con-session-save".into())
+        .spawn(move || {
+            loop {
+                let request = match rx.recv() {
+                    Ok(request) => request,
+                    Err(_) => break,
+                };
+
+                let (mut latest_session, mut flush_waiters) = match request {
+                    SessionSaveRequest::Save(session) => (Some(session), Vec::new()),
+                    SessionSaveRequest::Flush(session, waiter) => (Some(session), vec![waiter]),
+                };
+
+                while let Ok(request) = rx.try_recv() {
+                    match request {
+                        SessionSaveRequest::Save(session) => latest_session = Some(session),
+                        SessionSaveRequest::Flush(session, waiter) => {
+                            latest_session = Some(session);
+                            flush_waiters.push(waiter);
+                        }
+                    }
+                }
+
+                if let Some(session) = latest_session
+                    && let Err(err) = session.save()
+                {
+                    log::warn!("Failed to save session: {}", err);
+                }
+
+                for waiter in flush_waiters {
+                    let _ = waiter.send(());
+                }
+            }
+        })
+        .expect("failed to spawn session save worker");
+    tx
 }
 
 // ── Theme conversion ──────────────────────────────────────────
@@ -305,6 +353,7 @@ impl ConWorkspace {
         });
         harness.prewarm_input_classification();
         let shell_suggestion_engine = harness.suggestion_engine(180);
+        let session_save_tx = spawn_session_save_worker();
         let (control_request_tx, control_request_rx) = crossbeam_channel::unbounded();
         let (shell_suggestion_tx, shell_suggestion_rx) = crossbeam_channel::unbounded();
         let control_socket = match con_core::spawn_control_socket_server(
@@ -615,6 +664,7 @@ impl ConWorkspace {
             window_handle: window.window_handle(),
             workspace_handle: cx.weak_entity(),
             window_close_prepared: false,
+            session_save_tx,
         }
     }
 
@@ -1841,7 +1891,7 @@ impl ConWorkspace {
         state
     }
 
-    fn save_session(&self, cx: &App) {
+    fn snapshot_session(&self, cx: &App) -> Session {
         let tabs: Vec<con_core::session::TabState> = self
             .tabs
             .iter()
@@ -1886,7 +1936,7 @@ impl ConWorkspace {
             })
             .collect();
 
-        let session = Session {
+        Session {
             tabs,
             active_tab: self.active_tab,
             agent_panel_open: self.agent_panel_open,
@@ -1901,14 +1951,36 @@ impl ConWorkspace {
                 })
                 .collect(),
             conversation_id: None, // deprecated — per-tab now
-        };
-        cx.background_executor()
-            .spawn(async move {
-                if let Err(e) = session.save() {
-                    log::warn!("Failed to save session: {}", e);
-                }
-            })
-            .detach();
+        }
+    }
+
+    fn save_session(&self, cx: &App) {
+        let session = self.snapshot_session(cx);
+        if let Err(err) = self.session_save_tx.send(SessionSaveRequest::Save(session)) {
+            log::warn!("Failed to queue session save: {}", err);
+        }
+    }
+
+    fn flush_session_save(&self, cx: &App) {
+        let session = self.snapshot_session(cx);
+        let (done_tx, done_rx) = crossbeam_channel::bounded(1);
+        if let Err(err) = self
+            .session_save_tx
+            .send(SessionSaveRequest::Flush(session.clone(), done_tx))
+        {
+            log::warn!("Failed to flush session save queue: {}", err);
+            if let Err(save_err) = session.save() {
+                log::warn!("Failed to save session directly during flush: {}", save_err);
+            }
+            return;
+        }
+
+        if let Err(err) = done_rx.recv_timeout(Duration::from_secs(2)) {
+            log::warn!("Timed out waiting for session save flush: {}", err);
+            if let Err(save_err) = session.save() {
+                log::warn!("Failed to save session directly after flush timeout: {}", save_err);
+            }
+        }
     }
 
     fn restore_shell_history(
@@ -3965,7 +4037,7 @@ impl ConWorkspace {
 
     fn quit(&mut self, _: &Quit, _window: &mut Window, cx: &mut Context<Self>) {
         self.cancel_all_sessions();
-        self.save_session(cx);
+        self.flush_session_save(cx);
         // Tear down ghostty surfaces before app exit to avoid Metal/NSView crashes.
         // Hide views and unfocus first, then clear the tabs vector so GhosttyTerminal
         // Drop runs (calling ghostty_surface_free) before cx.quit() exits the process.
@@ -4215,6 +4287,7 @@ impl ConWorkspace {
         self.window_close_prepared = true;
 
         self.cancel_all_sessions();
+        self.flush_session_save(cx);
 
         for request in std::mem::take(&mut self.pending_window_control_requests) {
             match request {
@@ -4761,6 +4834,13 @@ impl ConWorkspace {
             direction,
             placement,
             terminal.clone(),
+        );
+        self.record_runtime_event_for_terminal(
+            self.active_tab,
+            &terminal,
+            con_agent::context::PaneRuntimeEvent::PaneCreated {
+                startup_command: None,
+            },
         );
         terminal.ensure_surface(window, cx);
         terminal.notify(cx);

--- a/crates/con/src/workspace.rs
+++ b/crates/con/src/workspace.rs
@@ -1902,9 +1902,13 @@ impl ConWorkspace {
                 .collect(),
             conversation_id: None, // deprecated — per-tab now
         };
-        if let Err(e) = session.save() {
-            log::warn!("Failed to save session: {}", e);
-        }
+        cx.background_executor()
+            .spawn(async move {
+                if let Err(e) = session.save() {
+                    log::warn!("Failed to save session: {}", e);
+                }
+            })
+            .detach();
     }
 
     fn restore_shell_history(
@@ -4774,18 +4778,24 @@ impl ConWorkspace {
     }
 
     fn split_right(&mut self, _: &SplitRight, window: &mut Window, cx: &mut Context<Self>) {
-        let _ = window;
         if self.has_active_tab() {
-            self.active_terminal()
-                .request_split(con_ghostty::GhosttySplitDirection::Right, cx);
+            self.split_pane(
+                SplitDirection::Horizontal,
+                SplitPlacement::After,
+                window,
+                cx,
+            );
         }
     }
 
     fn split_down(&mut self, _: &SplitDown, window: &mut Window, cx: &mut Context<Self>) {
-        let _ = window;
         if self.has_active_tab() {
-            self.active_terminal()
-                .request_split(con_ghostty::GhosttySplitDirection::Down, cx);
+            self.split_pane(
+                SplitDirection::Vertical,
+                SplitPlacement::After,
+                window,
+                cx,
+            );
         }
     }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This folder collects research notes, implementation notes, and design handoff do
 ## Start Here
 
 - `../README.md` — project overview
+- `../CHANGELOG.md` — release notes and product changes
 - `../DESIGN.md` — vision and architecture
 - `../HACKING.md` — contributor quickstart
 
@@ -18,6 +19,7 @@ This folder collects research notes, implementation notes, and design handoff do
 ## Implementation
 
 - `impl/agent-harness.md` — AI harness architecture
+- `impl/macos-release.md` — packaging, signing, notarization, and updater flow
 - `impl/terminal-agent-benchmark.md` — benchmark architecture and evaluation policy
 - `impl/terminal-rendering.md` — rendering pipeline
 - `impl/socket-api.md` — automation and control API

--- a/docs/design/con-design-language.md
+++ b/docs/design/con-design-language.md
@@ -62,20 +62,9 @@ The goal is not to imitate any one reference. The goal is to produce a design la
 
 ## Dual Theme Philosophy
 
-con is light-first (Flexoki Light default) but must excel in both themes. Following Apple's design language.
+con is light-first (Flexoki Light default) but must excel in both themes.
 
-### Dark Mode (Primary) - Apple Style
-
-- **Base**: `#0a0a0b` (near-black, not gray)
-- **Surfaces**: White at 2-8% opacity (`bg-white/[0.02]` to `bg-white/[0.08]`)
-- **Text primary**: White at 100%
-- **Text secondary**: White at 60%
-- **Text muted**: White at 30-40%
-- **Borders**: White at 4-6% opacity (nearly invisible)
-- **Interactive hover**: White at 4-6% opacity lift
-- **Accent**: Blue `#3b82f6` for agent/AI, Amber for warnings
-
-### Light Mode - Apple Style
+### Light Mode (Default) - Apple Style
 
 - **Base**: Pure white `#ffffff`
 - **Surfaces**: Black at 2-6% opacity (`bg-black/[0.02]` to `bg-black/[0.06]`)
@@ -84,7 +73,18 @@ con is light-first (Flexoki Light default) but must excel in both themes. Follow
 - **Text muted**: Black at 25-40%
 - **Borders**: Black at 4-6% opacity (nearly invisible)
 - **Interactive hover**: Black at 3-6% opacity lift
-- **Accent**: Blue `#2563eb` for agent/AI, Amber for warnings
+- **Accent**: Blue `#2563eb` for agent/AI, amber for warnings
+
+### Dark Mode - Apple Style
+
+- **Base**: `#0a0a0b` (near-black, not gray)
+- **Surfaces**: White at 2-8% opacity (`bg-white/[0.02]` to `bg-white/[0.08]`)
+- **Text primary**: White at 100%
+- **Text secondary**: White at 60%
+- **Text muted**: White at 30-40%
+- **Borders**: White at 4-6% opacity (nearly invisible)
+- **Interactive hover**: White at 4-6% opacity lift
+- **Accent**: Blue `#3b82f6` for agent/AI, amber for warnings
 
 ### Key Rules
 
@@ -93,7 +93,7 @@ con is light-first (Flexoki Light default) but must excel in both themes. Follow
 - **Opacity-based system** - All neutrals derived from white/black with opacity
 - **Single accent color** - Blue for AI/agent, used sparingly
 
-### Light Mode (v0.6 Nowledge-inspired)
+### Light Mode Details (Nowledge-inspired)
 
 Following the Nowledge Graph Design System's **borderless, colorless** philosophy:
 

--- a/docs/design/con-ui-visual-spec.md
+++ b/docs/design/con-ui-visual-spec.md
@@ -58,21 +58,20 @@ From strong terminal-native UX patterns, con should inherit:
 - keyboard-forward usability
 - clearer session and task orientation
 
-What makes con distinct is that all of these qualities must be adapted to a **dark-first, terminal-native** environment.
+What makes con distinct is that all of these qualities must be adapted to a **terminal-native** environment without losing polish in either theme.
 
 ---
 
 ## Theme Strategy
 
-### Dark-first by default
+### Light-first by default
 
-The design system should be built from dark mode outward.
-Dark mode is the primary design language, optimized for long terminal sessions.
+Flexoki Light is the default shipping theme, so the design system must hold up in light mode first.
 
-### Light mode as premium alternative
+### Dark mode as equal partner
 
-Light mode must feel equally polished, not an afterthought.
-Reference: Nowledge production UI demonstrates the quality bar.
+Dark mode must feel equally polished, not like a downgraded variant.
+The product should feel native and intentional in either theme.
 
 ### Surface philosophy
 

--- a/docs/design/con-ux-product-spec.md
+++ b/docs/design/con-ux-product-spec.md
@@ -122,7 +122,7 @@ The best version of con should combine:
 - strong discoverability and compositional command UX
 - the **restraint, spacing, and typography discipline** seen in the Nowledge Labs reference UI
 
-The result should be dark-first (with an equally polished light mode), quieter, and more terminal-native than either reference.
+The result should be light-first by default (with an equally polished dark mode), quieter, and more terminal-native than either reference.
 
 ### Nowledge UI Patterns to Adopt
 

--- a/docs/impl/build-system.md
+++ b/docs/impl/build-system.md
@@ -43,12 +43,20 @@ members = [
 
 | Dependency | Purpose |
 |------------|---------|
-| `gpui` | native GPU UI framework |
-| `gpui-component` | reusable UI controls |
-| `rig-core` | multi-provider agent runtime |
+| `gpui` | native GPU UI framework (upstream Zed git source) |
+| `gpui-component` | reusable UI controls (upstream Longbridge git source) |
+| `rig-core` | multi-provider agent runtime (pinned fork revision) |
 | `tokio` | async runtime for agent work |
 | `crossbeam-channel` | UI and harness event routing |
 | `reqwest` | live model list fetch from models.dev |
+
+## Dependency sourcing
+
+`con` does not build against live sources in `3pp/`.
+
+- `3pp/` is read-only reference material only.
+- Cargo dependencies resolve from crates.io or explicit git sources in the workspace manifest.
+- Ghostty source is fetched by `con-ghostty/build.rs` when needed, unless an override source directory is provided for local development.
 
 ## Platform boundary
 

--- a/docs/impl/macos-release.md
+++ b/docs/impl/macos-release.md
@@ -179,6 +179,13 @@ so Sparkle should see any real published beta release as newer. `cargo run`
 cannot test updates because it is not running inside a bundled app and does not
 embed `Sparkle.framework`.
 
+After the update installs, verify the result from either of these product surfaces:
+
+- `con` → `About con`
+- Settings → Updates
+
+Both should show the updated marketing version, build number, and release channel.
+
 ## CI Output
 
 The workflow currently builds native artifacts on:
@@ -234,6 +241,16 @@ The Rust FFI bridge (`crates/con/src/updater.rs`) uses `objc` crate to:
 2. Verify `SUFeedURL` is set in Info.plist
 3. Create `SPUStandardUpdaterController` (starts automatic checking)
 4. Expose `check_for_updates()` for the manual “Check for Updates” menu action
+
+### Manual Smoke Checklist
+
+Before shipping a beta or stable build, verify these flows from the bundled app:
+
+1. Open the app from Finder and confirm the terminal renders normally.
+2. Open `About con` and confirm the app icon, version, build, and channel are visible.
+3. Open Settings → Updates and confirm the same version/build information is shown there.
+4. Run `Check for Updates…` against the intended channel and confirm Sparkle presents the expected UI.
+5. After installation, reopen `About con` and confirm the build number changed.
 
 ### Release Channel Runtime
 

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -1,6 +1,6 @@
 # Screenshots
 
-The README shows one representative view. This page keeps the full gallery.
+The README shows one representative view. This page keeps the full gallery in one place.
 
 ## Gallery
 
@@ -20,3 +20,6 @@ The README shows one representative view. This page keeps the full gallery.
 
 <img alt="con screenshot 4" src="https://github.com/user-attachments/assets/21e295c9-34eb-465c-90b8-5ba3163182e5" />
 
+### Main Window
+
+<img alt="con screenshot 5" src="https://github.com/user-attachments/assets/81dcf6e4-6074-497e-98b8-00c884442cc2" />

--- a/docs/study/gpui.md
+++ b/docs/study/gpui.md
@@ -1,8 +1,8 @@
-# Study: GPUI (Community Edition)
+# Study: GPUI
 
 ## Overview
 
-GPUI-CE is the community fork of Zed's GPU-accelerated UI framework. Apache 2.0 licensed.
+con currently builds against the upstream GPUI crates from the Zed repository, not a local GPUI-CE checkout. The framework remains Apache 2.0 licensed.
 
 ## Key Properties
 
@@ -10,7 +10,7 @@ GPUI-CE is the community fork of Zed's GPU-accelerated UI framework. Apache 2.0 
 - **Text**: Core Text (macOS), cosmic-text (Linux), DirectWrite (Windows)
 - **Layout**: taffy (flexbox/CSS Grid)
 - **IME**: Full InputHandler trait — macOS AppKit, Linux X11 xim, Windows WM_IME
-- **Version**: 0.3.3 (crate: gpui-ce, lib name: gpui)
+- **Source**: upstream `zed-industries/zed` git dependency (crate name: `gpui`)
 
 ## Programming Model
 
@@ -40,24 +40,13 @@ fn paint_terminal(grid: &Grid, cx: &mut PaintContext) {
 
 GPUI's text shaping handles ligatures, emoji, CJK — same quality as Zed's editor.
 
-## Scaffolding
+## Reference Sources
 
-`3pp/create-gpui-app` provides templates:
-- `default/` — single binary app
-- `workspace/` — multi-crate workspace
+Read these upstream or read-only reference sources when you need framework details:
 
-We'll use the workspace pattern but customize for our crate structure.
-
-## Key Files in 3pp
-
-- `3pp/gpui-ce/src/gpui.rs` — main exports
-- `3pp/gpui-ce/examples/learn/` — layout, styling, text, animation examples
-- `3pp/create-gpui-app/templates/` — project scaffolding templates
-- `3pp/awesome-gpui/README.md` — community apps including `termy` (terminal emulator)
+- upstream `gpui` crates under the Zed repository checkout
+- `3pp/` reference material in this repo, when present, as read-only study material only
 
 ## Dependency
 
-In our Cargo.toml:
-```toml
-gpui = { path = "3pp/gpui-ce", package = "gpui-ce" }
-```
+In our workspace manifest, GPUI resolves from the upstream Zed git source rather than a local path dependency.

--- a/docs/study/rig.md
+++ b/docs/study/rig.md
@@ -3,7 +3,7 @@
 ## Overview
 
 [Rig](https://rig.rs/) is the most mature Rust-native AI agent framework. MIT licensed.
-Using `rig-core` v0.34 from crates.io (upgraded from v0.32; API stable, feature renamed `reqwest-rustls` → `rustls`).
+The current workspace pins `rig-core` to a maintained git revision in `wey-gu/rig` rather than a crates.io release. The architecture notes here still apply, but the exact provider surface is tied to that pinned revision.
 
 ## Core Architecture
 

--- a/postmortem/2026-04-14-agent-panel-markdown-reparse-lag.md
+++ b/postmortem/2026-04-14-agent-panel-markdown-reparse-lag.md
@@ -1,0 +1,24 @@
+## What happened
+
+Con felt noticeably less responsive when the agent panel was visible and contained rendered messages. The slowdown was easy to feel during pane splits, new-tab creation, and other workspace actions, but disappeared when the agent panel was hidden or visible with no messages.
+
+## Root cause
+
+The hot path was in the agent panel render loop, not Ghostty.
+
+Assistant message bodies and thinking blocks were rendered through `chat_markdown.rs`, and that renderer reparsed markdown into mdast on every render. Because the agent panel stays visible while the workspace changes, those reparses happened repeatedly for the same static messages.
+
+That meant message-heavy panels turned ordinary workspace renders into repeated markdown parsing work.
+
+## Fix applied
+
+- Added `ParsedChatMarkdown` in `chat_markdown.rs` so parsed markdown can be retained and reused.
+- Cached parsed message content and parsed thinking blocks on `PanelMessage` in `agent_panel.rs`.
+- Invalidated the cache only when streamed content or thinking text actually changed.
+- Switched the render loop to reuse the parsed representation instead of reparsing source strings every frame.
+
+## What we learned
+
+- Performance regressions in Con often present as “terminal lag” even when the terminal runtime is not the bottleneck.
+- For visible side panels, repeated parse/format work must be treated as render-path work and cached at the model layer.
+- Ghostty and GPUI are only part of the frame budget; expensive panel rendering can dominate interaction feel even when terminal rendering itself is healthy.

--- a/postmortem/2026-04-14-session-save-race.md
+++ b/postmortem/2026-04-14-session-save-race.md
@@ -1,0 +1,27 @@
+## What happened
+
+Workspace session saves were moved off the interactive path to improve split and tab responsiveness.
+
+That removed synchronous disk I/O from the UI path, but the first implementation spawned detached background writes with no ordering guarantees.
+
+## Root cause
+
+Each `save_session()` call created an independent background task that wrote the full session snapshot to disk.
+
+That meant:
+
+- multiple saves could finish out of order
+- an older snapshot could overwrite a newer one
+- shutdown could exit before the latest queued save finished
+
+## Fix applied
+
+- Replaced detached per-save tasks with a single ordered session-save worker.
+- The worker coalesces rapid save requests and writes only the latest snapshot.
+- Quit and window-close paths now flush the final snapshot before teardown.
+
+## What we learned
+
+- Moving blocking work off the UI path is necessary, but detached writes are not a correctness strategy.
+- Persistence paths need both responsiveness and ordering guarantees.
+- Session save queues should be designed explicitly, not assembled from ad hoc background tasks.

--- a/postmortem/2026-04-14-split-pane-latency.md
+++ b/postmortem/2026-04-14-split-pane-latency.md
@@ -1,0 +1,25 @@
+## What happened
+
+Pane splits in Con began to feel materially slower than Ghostty, especially in two-pane mode. The visible symptom was that invoking a split could take close to a second before the new pane felt present and responsive.
+
+## Root cause
+
+Two design mistakes were compounding on the interactive split path:
+
+1. App-level split shortcuts were routed through `ghostty_surface_split`, then back into Con through Ghostty's pending-event loop. That added an unnecessary round-trip for a UI action Con already knows how to perform locally.
+2. `save_session()` was synchronous and wrote the full session JSON to disk directly on the UI path after a split.
+
+Neither issue was catastrophic alone, but together they made pane creation feel much heavier than it needed to.
+
+## Fix applied
+
+- App-level `SplitRight` / `SplitDown` now call Con's local `split_pane(...)` path directly.
+- Session persistence is now written on the background executor instead of blocking the interactive path.
+
+Ghostty-originated split requests are still supported through the existing event bridge, but Con no longer uses that bridge for its own top-level split shortcuts.
+
+## What we learned
+
+- UI actions should not round-trip through terminal action bridges when the workspace already owns the layout model.
+- Persisting session state synchronously on interactive paths is the wrong tradeoff, even when the data format is small.
+- Responsiveness regressions often come from several "reasonable" steps layered together rather than one dramatic mistake.


### PR DESCRIPTION
impl: #15 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable UI font size (12.0–24.0) in appearance settings.

* **Performance Improvements**
  * Reduced UI lag in the agent panel during intensive operations.
  * Improved pane splitting responsiveness.
  * Accelerated session persistence to prevent blocking interactions.

* **Documentation**
  * Added incident postmortems documenting recent performance optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core UI render paths (agent panel markdown caching) and changes session persistence/split behavior to be async, which could introduce subtle UI state or rendering regressions but is not security-sensitive.
> 
> **Overview**
> Adds a configurable **UI font size** setting (separate from terminal font size) and threads it through theme initialization/sync so GPUI text scales consistently.
> 
> Fixes agent panel performance regressions by caching parsed markdown and code-block highlight runs (avoiding reparse/re-highlight every render) and updating streaming message/thinking updates to invalidate caches only when content changes.
> 
> Improves interactive responsiveness by moving `save_session()` disk writes to the background executor and routing split shortcuts through Con’s local `split_pane(...)` path instead of round-tripping via Ghostty split requests; also removes the now-unused `TerminalPane::request_split` helper.
> 
> Updates docs/changelog with release/packaging notes and adds two postmortems documenting the markdown-render and split-latency incidents/fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0cdb5d4eaaa5e1e8ea745a3a950879577631178. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->