### PR TITLE
optimization: settings, markdown table rendering, cjk rendering

### DIFF
--- a/crates/con/src/chat_markdown.rs
+++ b/crates/con/src/chat_markdown.rs
@@ -664,24 +664,31 @@ fn render_table_block(
 
     let header = &rows[0];
     let body_rows = rows.iter().skip(1).enumerate().map(|(row_idx, row)| {
-        div()
+        let row_content = div()
             .w_full()
             .flex()
-            .bg(if row_idx % 2 == 0 {
-                style.table_cell_background
-            } else {
-                style.table_cell_background.opacity(0.96)
-            })
+            .bg(style.table_cell_background)
             .children(row.iter().enumerate().map(|(column_idx, cell)| {
                 render_table_cell(cell, column_idx, aligns, false, style)
-            }))
-            .into_any_element()
+            }));
+
+        if row_idx == 0 {
+            row_content.into_any_element()
+        } else {
+            div()
+                .w_full()
+                .flex()
+                .flex_col()
+                .child(div().h(px(1.0)).bg(style.table_border))
+                .child(row_content)
+                .into_any_element()
+        }
     });
 
     div()
         .w_full()
         .overflow_hidden()
-        .rounded(px(11.0))
+        .rounded(px(10.0))
         .bg(style.table_border)
         .p(px(1.0))
         .child(
@@ -689,8 +696,7 @@ fn render_table_block(
                 .w_full()
                 .flex()
                 .flex_col()
-                .gap(px(1.0))
-                .bg(style.table_border)
+                .bg(style.table_cell_background)
                 .child(
                     div()
                         .w_full()
@@ -700,6 +706,7 @@ fn render_table_block(
                             render_table_cell(cell, column_idx, aligns, true, style)
                         })),
                 )
+                .child(div().h(px(1.0)).bg(style.table_border))
                 .children(body_rows),
         )
         .into_any_element()
@@ -730,10 +737,10 @@ fn render_table_cell(
 
     let cell = div()
         .flex_1()
-        .min_w(px(84.0))
+        .min_w(px(68.0))
         .min_w_0()
-        .px(px(11.0))
-        .py(px(if is_header { 8.0 } else { 9.0 }))
+        .px(px(12.0))
+        .py(px(if is_header { 8.0 } else { 8.5 }))
         .child(match align {
             MarkdownTableAlign::Center => div().w_full().text_center().child(content),
             MarkdownTableAlign::Right => div().w_full().text_right().child(content),
@@ -1182,19 +1189,21 @@ fn render_inline_text_segment(content: &str, text_style: &TextStyle) -> AnyEleme
 
 fn render_inline_code_chip(
     value: &str,
-    _text_style: &TextStyle,
+    text_style: &TextStyle,
     style: &ChatMarkdownStyle<'_>,
 ) -> AnyElement {
-    let font_size = style.code_font_size - px(0.5);
-    let line_height = style.code_line_height - px(3.0);
+    let surrounding_font_size = text_style_font_size(text_style);
+    let surrounding_line_height = text_style_line_height(text_style, surrounding_font_size);
+    let font_size = style.code_font_size.min(surrounding_font_size - px(0.25));
+    let line_height = font_size + px(1.0);
+    let chip_height = (surrounding_line_height - px(2.0)).max(font_size + px(8.0));
     div()
         .flex()
         .flex_none()
         .items_center()
+        .h(chip_height)
         .mx(px(1.0))
-        .my(px(0.5))
         .px(px(6.0))
-        .py(px(2.0))
         .rounded(px(6.0))
         .bg(style.inline_code_background)
         .font_family(style.theme.mono_font_family.clone())

--- a/crates/con/src/chat_markdown.rs
+++ b/crates/con/src/chat_markdown.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use gpui::{
     AbsoluteLength, AnyElement, DefiniteLength, FontStyle, FontWeight, Hsla, IntoElement,
     ParentElement, SharedString, Styled, StyledText, TextStyle, TextRun, UnderlineStyle,
-    WhiteSpace, div, px,
+    WhiteSpace, div, px, relative,
 };
 use gpui_component::clipboard::Clipboard;
 use gpui_component::highlighter::SyntaxHighlighter;
@@ -663,13 +663,14 @@ fn render_table_block(
     }
 
     let header = &rows[0];
+    let column_count = header.len().max(1);
     let body_rows = rows.iter().skip(1).enumerate().map(|(row_idx, row)| {
         let row_content = div()
             .w_full()
             .flex()
             .bg(style.table_cell_background)
             .children(row.iter().enumerate().map(|(column_idx, cell)| {
-                render_table_cell(cell, column_idx, aligns, false, style)
+                render_table_cell(cell, column_idx, column_count, aligns, false, style)
             }));
 
         if row_idx == 0 {
@@ -703,7 +704,7 @@ fn render_table_block(
                         .flex()
                         .bg(style.table_header_background)
                         .children(header.iter().enumerate().map(|(column_idx, cell)| {
-                            render_table_cell(cell, column_idx, aligns, true, style)
+                            render_table_cell(cell, column_idx, column_count, aligns, true, style)
                         })),
                 )
                 .child(div().h(px(1.0)).bg(style.table_border))
@@ -715,6 +716,7 @@ fn render_table_block(
 fn render_table_cell(
     cell: &[MarkdownInline],
     column_idx: usize,
+    column_count: usize,
     aligns: &[MarkdownTableAlign],
     is_header: bool,
     style: &ChatMarkdownStyle<'_>,
@@ -736,7 +738,9 @@ fn render_table_cell(
     let content = render_inline_content(cell, &base_style, style);
 
     let cell = div()
-        .flex_1()
+        .flex_grow()
+        .flex_shrink()
+        .flex_basis(relative(1.0 / column_count as f32))
         .min_w(px(68.0))
         .min_w_0()
         .px(px(12.0))

--- a/crates/con/src/chat_markdown.rs
+++ b/crates/con/src/chat_markdown.rs
@@ -737,10 +737,8 @@ fn render_table_cell(
 
     let content = render_inline_content(cell, &base_style, style);
 
-    let cell = div()
-        .flex_grow()
-        .flex_shrink()
-        .flex_basis(relative(1.0 / column_count as f32))
+    let content_cell = div()
+        .flex_1()
         .min_w(px(68.0))
         .min_w_0()
         .px(px(12.0))
@@ -751,15 +749,29 @@ fn render_table_cell(
             MarkdownTableAlign::Left | MarkdownTableAlign::None => div().w_full().child(content),
         });
 
+    let basis = relative(1.0 / column_count as f32);
+
     if column_idx > 0 {
         div()
             .flex()
+            .flex_grow()
+            .flex_shrink()
+            .flex_basis(basis)
+            .min_w(px(68.0))
+            .min_w_0()
             .bg(style.table_border)
             .child(div().w(px(1.0)).self_stretch())
-            .child(cell)
+            .child(content_cell)
             .into_any_element()
     } else {
-        cell.into_any_element()
+        div()
+            .flex_grow()
+            .flex_shrink()
+            .flex_basis(basis)
+            .min_w(px(68.0))
+            .min_w_0()
+            .child(content_cell)
+            .into_any_element()
     }
 }
 

--- a/crates/con/src/settings_panel.rs
+++ b/crates/con/src/settings_panel.rs
@@ -1908,23 +1908,7 @@ impl SettingsPanel {
             );
         }
 
-        container.child(
-            card(theme, card_opacity).child(
-                div()
-                    .flex()
-                    .items_center()
-                    .justify_between()
-                    .px(px(16.0))
-                    .h(px(44.0))
-                    .child(div().text_sm().child("Terminal History"))
-                    .child(
-                        div()
-                            .text_size(px(11.0))
-                            .text_color(theme.muted_foreground)
-                            .child("Managed by Ghostty"),
-                    ),
-            ),
-        )
+        container
         // Skills paths
         .child(
             div()

--- a/crates/con/src/settings_panel.rs
+++ b/crates/con/src/settings_panel.rs
@@ -2745,7 +2745,7 @@ impl SettingsPanel {
                                 .line_height(px(16.0))
                                 .text_color(theme.muted_foreground)
                                 .child(
-                                    "Choose the provider and model Con should use by default. Connection details live under Providers.",
+                                    "Default provider and model.",
                                 ),
                         ),
                 )
@@ -2848,7 +2848,7 @@ impl SettingsPanel {
 
         section_content(
             "AI",
-            "Choose how Con should use AI globally. Provider credentials and endpoint details live in Providers.",
+            "Model selection and AI harness configuration.",
             theme,
         )
         .child(ai_layout)

--- a/crates/con/src/settings_panel.rs
+++ b/crates/con/src/settings_panel.rs
@@ -1765,63 +1765,130 @@ impl SettingsPanel {
                             .child(
                                 div()
                                     .flex()
-                                    .items_center()
-                                    .justify_between()
                                     .px(px(16.0))
-                                    .h(px(44.0))
-                                    .child(div().text_sm().child("Channel"))
+                                    .py(px(14.0))
+                                    .flex_col()
+                                    .gap(px(12.0))
                                     .child(
                                         div()
-                                            .text_size(px(11.0))
-                                            .text_color(theme.muted_foreground)
-                                            .child(channel.display_name()),
+                                            .flex()
+                                            .items_start()
+                                            .justify_between()
+                                            .gap(px(16.0))
+                                            .child(
+                                                div()
+                                                    .flex()
+                                                    .flex_col()
+                                                    .gap(px(8.0))
+                                                    .child(
+                                                        div()
+                                                            .text_size(px(10.0))
+                                                            .font_weight(FontWeight::MEDIUM)
+                                                            .text_color(
+                                                                theme
+                                                                    .muted_foreground
+                                                                    .opacity(0.5),
+                                                            )
+                                                            .child("Channel"),
+                                                    )
+                                                    .child(
+                                                        div()
+                                                            .text_size(px(13.0))
+                                                            .line_height(px(18.0))
+                                                            .font_weight(FontWeight::MEDIUM)
+                                                            .child(channel.display_name()),
+                                                    ),
+                                            )
+                                            .child(
+                                                div()
+                                                    .flex()
+                                                    .flex_col()
+                                                    .items_end()
+                                                    .gap(px(8.0))
+                                                    .child(
+                                                        div()
+                                                            .text_size(px(10.0))
+                                                            .font_weight(FontWeight::MEDIUM)
+                                                            .text_color(
+                                                                theme
+                                                                    .muted_foreground
+                                                                    .opacity(0.5),
+                                                            )
+                                                            .child("Version"),
+                                                    )
+                                                    .child(
+                                                        div()
+                                                            .text_size(px(12.0))
+                                                            .line_height(px(18.0))
+                                                            .font_family(
+                                                                theme.mono_font_family.clone(),
+                                                            )
+                                                            .text_color(
+                                                                theme
+                                                                    .muted_foreground
+                                                                    .opacity(0.82),
+                                                            )
+                                                            .child(format!(
+                                                                "{} ({})",
+                                                                crate::app_display_version(),
+                                                                crate::app_build_number()
+                                                            )),
+                                                    ),
+                                            ),
                                     ),
                             )
-                            .child(row_separator(&theme))
+                            .child(
+                                div()
+                                    .mx(px(16.0))
+                                    .h(px(1.0))
+                                    .bg(theme.muted.opacity(0.10)),
+                            )
                             .child(
                                 div()
                                     .flex()
-                                    .items_center()
+                                    .items_end()
                                     .justify_between()
+                                    .gap(px(16.0))
                                     .px(px(16.0))
-                                    .h(px(44.0))
-                                    .child(div().text_sm().child("Version"))
-                                    .child(
-                                        div()
-                                            .text_size(px(11.0))
-                                            .font_family(theme.mono_font_family.clone())
-                                            .text_color(theme.muted_foreground)
-                                            .child(format!(
-                                                "{} ({})",
-                                                crate::app_display_version(),
-                                                crate::app_build_number()
-                                            )),
-                                    ),
-                            )
-                            .child(row_separator(&theme))
-                            .child(
-                                div()
-                                    .flex()
-                                    .items_center()
-                                    .justify_between()
-                                    .px(px(16.0))
-                                    .h(px(44.0))
+                                    .pb(px(14.0))
                                     .child(
                                         div()
                                             .flex()
                                             .flex_col()
-                                            .gap(px(2.0))
-                                            .child(div().text_sm().child("Status"))
+                                            .gap(px(3.0))
+                                            .max_w(px(420.0))
                                             .child(
                                                 div()
                                                     .text_size(px(10.0))
-                                                    .text_color(theme.muted_foreground.opacity(0.6))
+                                                    .font_weight(FontWeight::MEDIUM)
+                                                    .text_color(
+                                                        theme
+                                                            .muted_foreground
+                                                            .opacity(0.5),
+                                                    )
+                                                    .child("Status"),
+                                            )
+                                            .child(
+                                                div()
+                                                    .text_size(px(12.5))
+                                                    .line_height(px(17.0))
+                                                    .font_weight(FontWeight::MEDIUM)
+                                                    .text_color(
+                                                        theme
+                                                            .foreground
+                                                            .opacity(0.88),
+                                                    )
                                                     .child(updater_status.summary()),
                                             )
                                             .child(
                                                 div()
-                                                    .text_size(px(10.0))
-                                                    .text_color(theme.muted_foreground.opacity(0.5))
+                                                    .text_size(px(10.5))
+                                                    .line_height(px(15.0))
+                                                    .text_color(
+                                                        theme
+                                                            .muted_foreground
+                                                            .opacity(0.62),
+                                                    )
                                                     .child(updater_status.detail()),
                                             ),
                                     )

--- a/crates/con/src/settings_panel.rs
+++ b/crates/con/src/settings_panel.rs
@@ -1916,7 +1916,7 @@ impl SettingsPanel {
                     .justify_between()
                     .px(px(16.0))
                     .h(px(44.0))
-                    .child(div().text_sm().child("Scrollback"))
+                    .child(div().text_sm().child("Terminal History"))
                     .child(
                         div()
                             .text_size(px(11.0))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only layout tweaks; primary risk is minor visual regressions in markdown tables/inline code sizing or the Updates settings card on macOS.
> 
> **Overview**
> Improves chat markdown rendering by reworking table layout: cells now use equal-width `flex_basis` based on header column count, consistent backgrounds, and explicit 1px separators between header/body rows and body rows.
> 
> Adjusts inline code “chip” sizing to derive font size/height from the surrounding `TextStyle`, aiming for better baseline/line-height behavior (notably for CJK and mixed typography).
> 
> Redesigns the Settings `Updates` card to a stacked layout that shows *Channel* and *Version* together, replaces row separators with a thin divider line, and tightens spacing/alignment around the status and “Check for Updates” action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d2119f4401b3ace8031c51b31c964090565d2df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->