### PR TITLE
ci(release): disable Defender real-time scan on Windows build

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -62,6 +62,23 @@ jobs:
         with:
           workspaces: C:\src\repo
 
+      - name: Disable Windows Defender real-time scanning
+        # Zig 0.15.2 builds on windows-latest intermittently fail with
+        # `FileNotFound` when spawning a just-compiled build-tool exe
+        # (e.g. `uucode_build_tables.exe`). Root cause: Defender's
+        # real-time protection briefly locks fresh PE files before the
+        # MpEngine scan completes, racing zig's exec. Runners are
+        # Administrator so we can turn real-time off for the session
+        # plus exclude the build dirs.
+        shell: pwsh
+        run: |
+          Set-MpPreference -DisableRealtimeMonitoring $true
+          Add-MpPreference -ExclusionPath $env:CON_CHECKOUT_DIR
+          Add-MpPreference -ExclusionPath $env:TEMP
+          Add-MpPreference -ExclusionPath "$env:USERPROFILE\.local"
+          Add-MpPreference -ExclusionPath "$env:USERPROFILE\AppData\Local\zig"
+          Get-MpPreference | Select-Object -Property DisableRealtimeMonitoring, ExclusionPath
+
       - name: Install Zig 0.15.2
         shell: pwsh
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ See `docs/impl/windows-port.md` for the porting plan and the path to
 a working terminal on Windows.
 
 ```bash
-# Windows (from a Developer Command Prompt for VS 2022; needs Zig 0.13+ on PATH
+# Windows (from a Developer Command Prompt for VS 2022; needs Zig 0.15.2+ on PATH
 # for libghostty-vt; the binary ships as `con-app.exe` because `CON` is a
 # reserved DOS device name):
 cargo wbuild -p con --release          # produces target\release\con-app.exe

--- a/HACKING.md
+++ b/HACKING.md
@@ -36,8 +36,8 @@ For the full breakdown, see `docs/impl/agent-harness.md`.
 
 - Rust (stable, edition 2024)
 - `cmake`
-- **macOS**: Zig 0.13+ (for `libghostty`)
-- **Windows**: Zig 0.13+ (for `libghostty-vt`), Visual Studio 2022 Build Tools with the Windows 10/11 SDK. Run the build from a _Developer Command Prompt for VS 2022_ so `rc.exe` is on `PATH`.
+- **macOS**: Zig 0.15.2+ (ghostty's `build.zig.zon` pins `minimum_zig_version = "0.15.2"`)
+- **Windows**: Zig 0.15.2+ (same reason), Visual Studio 2022 Build Tools with the Windows 10/11 SDK. Run the build from a _Developer Command Prompt for VS 2022_ so `rc.exe` is on `PATH`. If Windows Defender is on, either add an exclusion for the repo dir or disable real-time scanning — zig's sub-build exes get briefly locked by MpEngine and spawn with `FileNotFound`.
 
 ## Build
 


### PR DESCRIPTION
## Summary

The `v0.1.0-beta.25` Windows release failed during `zig build -Demit-lib-vt=true`:

\`\`\`
error: failed to spawn and capture stdio from
  ...\ghostty-src\.zig-cache\o\c34a18740b7b71032a4fb6c6be44c637\uucode_build_tables.exe:
  FileNotFound
\`\`\`

Root cause: Zig 0.15.2 sub-builds on \`windows-latest\` race against Windows Defender. Zig compiles an intermediate build-tool exe (here, \`uucode_build_tables.exe\`), then immediately tries to \`spawnAndCapture\` it. MpEngine's real-time scanner grabs the fresh PE file for inspection and zig's spawn fails with \`FileNotFound\`. Reproducible across multiple Zig 0.15.x projects on GHA; the user's local build works because their machine has Defender exclusions.

## Fix

Disable real-time monitoring for the runner session and add \`ExclusionPath\` entries for the checkout, temp, and zig-cache dirs before the \"Install Zig\" step. GHA runners are Administrator so \`Set-MpPreference\` succeeds.

Also corrects a stale \"Zig 0.13+\" claim in HACKING.md / CLAUDE.md — ghostty's \`build.zig.zon\` pins \`minimum_zig_version = \"0.15.2\"\`.

## Test plan
- [ ] Merge and cut a fresh tag (\`v0.1.0-beta.26\` — \`-beta.25\` is burned, its release has no Windows ZIP)
- [ ] Observe \`release-windows.yml\` build step succeed past the \`uucode_build_tables\` spawn
- [ ] Verify the \`con-windows-x86_64.zip\` artifact attaches to the GitHub release
- [ ] Verify the Sparkle appcast signs and the \`beta-windows-x86_64.xml\` publishes to gh-pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)