### PR TITLE
ci(release): retry cargo wbuild on Zig/uucode spawn flake

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -62,22 +62,18 @@ jobs:
         with:
           workspaces: C:\src\repo
 
-      - name: Disable Windows Defender real-time scanning
-        # Zig 0.15.2 builds on windows-latest intermittently fail with
-        # `FileNotFound` when spawning a just-compiled build-tool exe
-        # (e.g. `uucode_build_tables.exe`). Root cause: Defender's
-        # real-time protection briefly locks fresh PE files before the
-        # MpEngine scan completes, racing zig's exec. Runners are
-        # Administrator so we can turn real-time off for the session
-        # plus exclude the build dirs.
+      - name: Defense-in-depth — exclude build dirs from Defender
+        # Probably not the dominant failure mode (see retry logic in the
+        # build step) but Defender real-time scanning can still briefly
+        # lock a just-written PE file. Admin-exclude the hot paths so
+        # MpEngine at least doesn't contribute to the race.
         shell: pwsh
         run: |
-          Set-MpPreference -DisableRealtimeMonitoring $true
-          Add-MpPreference -ExclusionPath $env:CON_CHECKOUT_DIR
-          Add-MpPreference -ExclusionPath $env:TEMP
-          Add-MpPreference -ExclusionPath "$env:USERPROFILE\.local"
-          Add-MpPreference -ExclusionPath "$env:USERPROFILE\AppData\Local\zig"
-          Get-MpPreference | Select-Object -Property DisableRealtimeMonitoring, ExclusionPath
+          Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
+          Add-MpPreference -ExclusionPath $env:CON_CHECKOUT_DIR -ErrorAction SilentlyContinue
+          Add-MpPreference -ExclusionPath $env:TEMP -ErrorAction SilentlyContinue
+          Add-MpPreference -ExclusionPath "$env:USERPROFILE\.local" -ErrorAction SilentlyContinue
+          Add-MpPreference -ExclusionPath "$env:USERPROFILE\AppData\Local\zig" -ErrorAction SilentlyContinue
 
       - name: Install Zig 0.15.2
         shell: pwsh
@@ -99,7 +95,27 @@ jobs:
         # `cargo build --no-default-features --features con/bin-con-app`
         # — required because CON is a reserved DOS name and plain
         # `con.exe` cannot be created.
-        run: cargo wbuild -p con --release
+        #
+        # Retry rationale: Zig 0.15.2 building libghostty-vt on
+        # windows-latest intermittently fails with `FileNotFound` when
+        # spawning a just-compiled build-tool exe (seen repeatedly with
+        # `uucode_build_tables.exe`). The exe is on disk moments later —
+        # it's a transient visibility race between `WriteFile` /
+        # `CreateProcess` on freshly-linked PE files. Zig's .zig-cache
+        # persists across invocations inside OUT_DIR, so a second run
+        # skips the steps that already succeeded and typically completes.
+        # We retry up to twice (3 total attempts) before giving up.
+        run: |
+          $maxAttempts = 3
+          for ($i = 1; $i -le $maxAttempts; $i++) {
+            Write-Host "=== cargo wbuild attempt $i/$maxAttempts ==="
+            cargo wbuild -p con --release
+            if ($LASTEXITCODE -eq 0) { exit 0 }
+            Write-Warning "Build failed on attempt $i (exit $LASTEXITCODE) — retrying..."
+            Start-Sleep -Seconds 5
+          }
+          Write-Error "cargo wbuild failed after $maxAttempts attempts"
+          exit 1
 
       - name: Package ZIP
         id: package


### PR DESCRIPTION
## Summary

PR #42 disabled Windows Defender real-time scanning, but the \`v0.1.0-beta.26\` release run **failed with the identical error** — so Defender isn't (or isn't the only) culprit:

\`\`\`
error: failed to spawn and capture stdio from
  ...uucode_build_tables.exe: FileNotFound
Build Summary: 6/17 steps succeeded; 1 failed
\`\`\`

The exe **is** on disk seconds later (verifiable by retrying the build). The real issue is a transient visibility race in Zig 0.15.x on Windows between \`WriteFile\` on a freshly-linked PE file and the subsequent \`CreateProcess\`. Upstream Zig has known issues filed around this pattern; it's a genuine platform flake, not a consumer bug.

## Fix

Retry \`cargo wbuild\` up to 3 times. Zig's \`.zig-cache\` lives inside cargo's \`OUT_DIR\` and persists across cargo invocations, so the retry replays only the steps that didn't finish — typically completes on attempt 2.

The Defender hardening from #42 is kept as defense-in-depth but softened with \`-ErrorAction SilentlyContinue\`, since it's not load-bearing.

## Test plan

- [ ] Merge
- [ ] Cut \`v0.1.0-beta.27\` (\`-beta.25\` and \`-beta.26\` both burned without a Windows ZIP)
- [ ] Observe \`release-windows.yml\` build step: expect one retry on \`uucode_build_tables\` before green
- [ ] Verify \`con-0.1.0-beta.27-windows-x86_64.zip\` attaches to the GitHub release
- [ ] Verify \`beta-windows-x86_64.xml\` publishes to gh-pages

## If this still doesn't fix it

Escalation paths in decreasing preference:
1. Bump Zig to master / 0.15.3 if released
2. Pass \`ZIG_GLOBAL_CACHE_DIR=C:\\z\` to force a short cache path (would also tell us if it's a path-length regression)
3. Serialize the zig build with \`-j1\` via a env var in \`build.rs\`
4. Upstream a retry in zig's \`std.ChildProcess.spawn\` when we get \`STATUS_OBJECT_NAME_NOT_FOUND\` on a file we just wrote

🤖 Generated with [Claude Code](https://claude.com/claude-code)