### PR TITLE
chore: rename in-tree URLs from /con to /con-terminal

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -375,17 +375,17 @@ jobs:
 
             on_arm do
               sha256 "${arm64_sha}"
-              url "https://github.com/nowledge-co/con/releases/download/v#{version}/${dmg_prefix}-#{version}-macos-arm64.dmg"
+              url "https://github.com/nowledge-co/con-terminal/releases/download/v#{version}/${dmg_prefix}-#{version}-macos-arm64.dmg"
             end
 
             on_intel do
               sha256 "${x86_64_sha}"
-              url "https://github.com/nowledge-co/con/releases/download/v#{version}/${dmg_prefix}-#{version}-macos-x86_64.dmg"
+              url "https://github.com/nowledge-co/con-terminal/releases/download/v#{version}/${dmg_prefix}-#{version}-macos-x86_64.dmg"
             end
 
             name "${app_name}"
             desc "GPU-accelerated terminal emulator with built-in AI agent"
-            homepage "https://github.com/nowledge-co/con"
+            homepage "https://github.com/nowledge-co/con-terminal"
 
             livecheck do
               url :url

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-blue?style=flat"></a>
-  <a href="https://github.com/nowledge-co/con/releases/latest"><img alt="Latest GitHub release" src="https://img.shields.io/github/v/release/nowledge-co/con?sort=semver&logo=github&style=flat"></a>
+  <a href="https://github.com/nowledge-co/con-terminal/releases/latest"><img alt="Latest GitHub release" src="https://img.shields.io/github/v/release/nowledge-co/con-terminal?sort=semver&logo=github&style=flat"></a>
   <a href="https://developer.apple.com/macos/"><img alt="Native on macOS (Metal)" src="https://img.shields.io/badge/native-Metal-3D3D3D?logo=apple&logoColor=white&style=flat"></a>
-  <a href="https://github.com/nowledge-co/con/issues/34"><img alt="Windows beta (tracker)" src="https://img.shields.io/badge/Windows-beta-0078D4?logo=windows&logoColor=white&style=flat"></a>
-  <a href="https://github.com/nowledge-co/con/issues/18"><img alt="Linux support planned (tracker)" src="https://img.shields.io/badge/Linux-planned-1D4ED8?logo=linux&logoColor=white&style=flat"></a>
+  <a href="https://github.com/nowledge-co/con-terminal/issues/34"><img alt="Windows beta (tracker)" src="https://img.shields.io/badge/Windows-beta-0078D4?logo=windows&logoColor=white&style=flat"></a>
+  <a href="https://github.com/nowledge-co/con-terminal/issues/18"><img alt="Linux support planned (tracker)" src="https://img.shields.io/badge/Linux-planned-1D4ED8?logo=linux&logoColor=white&style=flat"></a>
   <a href="https://www.rust-lang.org/"><img alt="Rust" src="https://img.shields.io/badge/Rust-CE422B?logo=rust&logoColor=white&style=flat"></a>
 </p>
 
@@ -39,8 +39,8 @@ If you're an old-school terminal user and only want enough AI harness when neede
 `con` is in active beta development.
 
 - **macOS** — fully supported. Metal-backed libghostty terminal, Sparkle auto-update, signed DMG.
-- **Windows** — first beta ships as of `v0.1.0-beta.25`. D3D11/DirectWrite renderer over ConPTY + libghostty-vt. Unsigned ZIP (expect a SmartScreen prompt on first launch); notify-only update checker surfaces newer releases in Settings → Updates. Tracker: [#34](https://github.com/nowledge-co/con/issues/34).
-- **Linux** — planned. Tracker: [#18](https://github.com/nowledge-co/con/issues/18).
+- **Windows** — first beta ships as of `v0.1.0-beta.25`. D3D11/DirectWrite renderer over ConPTY + libghostty-vt. Unsigned ZIP (expect a SmartScreen prompt on first launch); notify-only update checker surfaces newer releases in Settings → Updates. Tracker: [#34](https://github.com/nowledge-co/con-terminal/issues/34).
+- **Linux** — planned. Tracker: [#18](https://github.com/nowledge-co/con-terminal/issues/18).
 
 ## Screenshot
 
@@ -70,11 +70,11 @@ brew install --cask nowledge-co/tap/con-beta
 curl -fsSL https://con-releases.nowledge.co/install.sh | sh
 ```
 
-Or download the DMG directly from [Releases](https://github.com/nowledge-co/con/releases).
+Or download the DMG directly from [Releases](https://github.com/nowledge-co/con-terminal/releases).
 
 **Windows**
 
-Download `con-windows-x86_64.zip` from the latest [Release](https://github.com/nowledge-co/con/releases), unpack anywhere, and run `con-app.exe`. The ZIP is unsigned today, so Windows SmartScreen will prompt on first launch — click _More info → Run anyway_. Con ships as `con-app.exe` (not `con.exe`) because `CON` is a reserved DOS device name.
+Download `con-windows-x86_64.zip` from the latest [Release](https://github.com/nowledge-co/con-terminal/releases), unpack anywhere, and run `con-app.exe`. The ZIP is unsigned today, so Windows SmartScreen will prompt on first launch — click _More info → Run anyway_. Con ships as `con-app.exe` (not `con.exe`) because `CON` is a reserved DOS device name.
 
 To build from source, see `HACKING.md`.
 

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -418,7 +418,7 @@ struct AboutView {
 impl Render for AboutView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
-        let repo_url = "https://github.com/nowledge-co/con";
+        let repo_url = "https://github.com/nowledge-co/con-terminal";
         let detail_surface = theme.secondary_active.opacity(0.34);
         let quiet_text = theme.foreground.opacity(0.64);
         let muted_text = theme.foreground.opacity(0.48);

--- a/docs/impl/windows-port.md
+++ b/docs/impl/windows-port.md
@@ -24,8 +24,8 @@ On Windows (from a Developer Command Prompt for VS 2022):
 
 ```powershell
 rustup default stable
-git clone https://github.com/nowledge-co/con.git
-cd con
+git clone https://github.com/nowledge-co/con-terminal.git
+cd con-terminal
 cargo wbuild -p con --release          # → target\release\con-app.exe
 cargo wtest  -p con-core -p con-cli -p con-agent -p con-terminal
 ```
@@ -346,8 +346,8 @@ is independent upstream work.
 ### What you can do *today* on Windows after Phase 3b
 
 ```powershell
-git clone https://github.com/nowledge-co/con.git
-cd con
+git clone https://github.com/nowledge-co/con-terminal.git
+cd con-terminal
 cargo wbuild -p con --release
 target\release\con-app.exe
 ```

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,7 +3,7 @@
 # Usage: curl -fsSL https://con-releases.nowledge.co/install.sh | sh
 set -eu
 
-REPO="nowledge-co/con"
+REPO="nowledge-co/con-terminal"
 INSTALL_DIR="/Applications"
 
 # ── Colors ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Rewrites all hardcoded `github.com/nowledge-co/con` references to `/con-terminal` so that the tree matches the repo name once we rename away from the reserved DOS device name `con`.
- Covers: README badges + release links, `scripts/install.sh` REPO var, the in-app *Report Issue* URL (`crates/con-app/src/main.rs`), the Homebrew cask URL template inside `release-macos.yml`, and both `docs/impl/windows-port.md` clone examples (clone target also becomes `con-terminal`, which is itself needed because Windows rejects a dir literally named `con`).
- Postmortem `2026-04-16-prepare-windows-port.md` is deliberately left unchanged — historical record; GitHub's rename redirect keeps the old clone command working.
- `nowledge-co/homebrew-tap` is a separate repo and is *not* renamed; only the URL template that the macOS release workflow writes into `Casks/*.rb` moves. The cask name (`con-beta` / `con`) stays.
- Anything in workflows using `${{ github.repository }}` auto-resolves to the new name, so `release-windows.yml` needs no edits.

## Why this fixes Windows CI

GHA runner `2.333.1`'s `Prepare workflow directory` phase fails on `D:\a\con\con` with `Could not find a part of the path '\\.\con'` — .NET's newer path normalization turns the `con` component into the DOS device namespace. That phase runs *before* any YAML step, so our `C:\src\repo` workaround never gets a chance. Renaming the repo is the one durable fix that removes the class of bug (not just this instance).

## Merge order (important)

Merge this PR **after**:
1. You rename the repo on github.com: `con` → `con-terminal`.
2. You create an empty placeholder repo `nowledge-co/con` (README pointing at the new name), so no one can squat the old slot and break GitHub's permanent 301 redirects.

If we merge before the rename, there's a gap where in-tree URLs point at `/con-terminal` but the repo still lives at `/con`, and any install-script run or release tag caught in that window breaks. Rename-first means old URLs redirect and new URLs already exist — no broken window.

## Test plan

- [ ] After rename + placeholder + merge: a tagged release builds on Windows (no more `\\.\con` failure at workflow-dir prep).
- [ ] Tagged release on macOS regenerates `Casks/con-beta.rb` with the new URL; `brew install --cask nowledge-co/tap/con-beta` still installs.
- [ ] `curl -fsSL https://con-releases.nowledge.co/install.sh | sh` pulls the right release ZIP.
- [ ] In-app *About* → *Report issue* opens the new repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)