### PR TITLE
ci(release): short Zig cache dir to dodge MAX_PATH on spawn

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -20,21 +20,26 @@ permissions:
 jobs:
   build:
     name: Build windows-x86_64
-    # `windows-latest` currently aliases to `windows-2025` (Server 2025),
-    # on which Zig 0.15.2 building libghostty-vt fails deterministically
-    # with `FileNotFound` when spawning `uucode_build_tables.exe`. The
-    # retry loop below confirmed it's not a visibility race — all three
-    # attempts hit the same cached exe hash and fail identically. Pin
-    # to `windows-2022` (Server 2022) which upstream ghostty also
-    # avoids via Namespace.so custom runners; we want the oldest still-
-    # supported GHA image until we understand the root cause.
     runs-on: windows-2022
 
-    # Same CON-reserved-name workaround as ci-portable.yml — git.exe
-    # refuses to operate inside any directory named CON. We clone into
-    # C:\src\repo and cd there for every subsequent step.
+    # Two workarounds converge here:
+    #
+    # 1. CON_CHECKOUT_DIR sidesteps the CON reserved-name trap: runner
+    #    2.333.1+ rejects any workspace path whose components match a
+    #    DOS device name. Cloning to C:\src\repo keeps us out of that
+    #    namespace — same workaround ci-portable.yml uses.
+    #
+    # 2. ZIG_GLOBAL_CACHE_DIR shortens the uucode package cache path so
+    #    Zig's build system can spawn uucode_build_tables.exe. The
+    #    default cache lives at %LOCALAPPDATA%\zig (~60 chars deep),
+    #    and Zig invokes the exe via a relative path walking back up
+    #    to the project's .zig-cache — combined length lands just over
+    #    MAX_PATH (260) and CreateProcessW returns FILE_NOT_FOUND. A
+    #    short cache root (C:\zc) keeps the composed path comfortably
+    #    under the legacy limit.
     env:
       CON_CHECKOUT_DIR: C:\src\repo
+      ZIG_GLOBAL_CACHE_DIR: C:\zc
 
     defaults:
       run:
@@ -70,18 +75,23 @@ jobs:
         with:
           workspaces: C:\src\repo
 
+      - name: Prepare short-path Zig cache
+        working-directory: C:\
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path $env:ZIG_GLOBAL_CACHE_DIR | Out-Null
+
       - name: Defense-in-depth — exclude build dirs from Defender
-        # Probably not the dominant failure mode (see retry logic in the
-        # build step) but Defender real-time scanning can still briefly
-        # lock a just-written PE file. Admin-exclude the hot paths so
-        # MpEngine at least doesn't contribute to the race.
+        # Defender real-time scanning can briefly lock a just-written
+        # PE file. Not the dominant failure mode (path-length was) but
+        # cheap to rule out.
         shell: pwsh
         run: |
           Set-MpPreference -DisableRealtimeMonitoring $true -ErrorAction SilentlyContinue
           Add-MpPreference -ExclusionPath $env:CON_CHECKOUT_DIR -ErrorAction SilentlyContinue
           Add-MpPreference -ExclusionPath $env:TEMP -ErrorAction SilentlyContinue
           Add-MpPreference -ExclusionPath "$env:USERPROFILE\.local" -ErrorAction SilentlyContinue
-          Add-MpPreference -ExclusionPath "$env:USERPROFILE\AppData\Local\zig" -ErrorAction SilentlyContinue
+          Add-MpPreference -ExclusionPath $env:ZIG_GLOBAL_CACHE_DIR -ErrorAction SilentlyContinue
 
       - name: Install Zig 0.15.2
         shell: pwsh
@@ -104,23 +114,8 @@ jobs:
         # `cargo build --no-default-features --features con/bin-con-app`
         # — required because CON is a reserved DOS name and plain
         # `con.exe` cannot be created.
-        #
-        # Retry loop kept as cheap insurance against true visibility
-        # races. On windows-2022 we have not yet reproduced the
-        # deterministic `uucode_build_tables.exe: FileNotFound` seen on
-        # windows-latest; if it returns, the diagnostic step below will
-        # capture the real Windows spawn error for follow-up.
         run: |
-          $maxAttempts = 3
-          for ($i = 1; $i -le $maxAttempts; $i++) {
-            Write-Host "=== cargo wbuild attempt $i/$maxAttempts ==="
-            cargo wbuild -p con --release
-            if ($LASTEXITCODE -eq 0) { exit 0 }
-            Write-Warning "Build failed on attempt $i (exit $LASTEXITCODE) — retrying..."
-            Start-Sleep -Seconds 5
-          }
-          Write-Error "cargo wbuild failed after $maxAttempts attempts"
-          exit 1
+          cargo wbuild -p con --release
 
       - name: Diagnose build failure
         if: failure() && steps.build.conclusion == 'failure'

--- a/postmortem/2026-04-21-windows-ci-max-path.md
+++ b/postmortem/2026-04-21-windows-ci-max-path.md
@@ -1,0 +1,70 @@
+# Windows CI release — uucode_build_tables.exe `FileNotFound`
+
+## What happened
+
+The `Release Windows` workflow failed on every free GHA runner (both
+`windows-latest`/Server 2025 and `windows-2022`) while building the
+`con-ghostty` crate. Zig surfaced the error as:
+
+```
+error: failed to spawn and capture stdio from
+  .\..\..\..\..\..\..\..\src\repo\target\release\build\
+  con-ghostty-<hash>\out\ghostty-src\.zig-cache\o\<hash>\
+  uucode_build_tables.exe: FileNotFound
+```
+
+Three separate attempts in a retry loop all failed with the same
+error on the same cached exe hash, ruling out a visibility race.
+
+## Root cause
+
+`CreateProcessW` on Windows still honors the legacy `MAX_PATH` (260
+char) limit unless the process is opted into long paths via both the
+system registry **and** a manifest. Zig's build-host `build.exe` isn't
+manifested for long paths in 0.15.2, so spawn calls whose composed
+(CWD + relative path) crosses 260 bytes get rejected and surfaced as
+`FileNotFound`.
+
+In this pipeline the spawn was:
+
+- CWD (set by uucode's `build.zig` via `run.setCwd(b.path(""))`):
+  `C:\Users\runneradmin\AppData\Local\zig\p\uucode-0.2.0-<49-char-hash>`
+  ≈ **96 chars**
+- Relative exe path:
+  `.\..\..\..\..\..\..\..\src\repo\target\release\build\con-ghostty-<16hex>\out\ghostty-src\.zig-cache\o\<32hex>\uucode_build_tables.exe`
+  ≈ **167 chars**
+- Composed length: **~264 chars** — just over the limit.
+
+A diagnostic step re-ran the same exe by absolute path via `cmd /c`
+and got a clean stack trace (it panicked later on a hardcoded
+relative `ucd/UnicodeData.txt`), confirming the exe itself is fine
+and the problem was purely in the spawn step path resolution.
+
+The local Windows dev machine doesn't reproduce because its username
+is shorter (`C:\Users\WeyGu\...` vs `C:\Users\runneradmin\...`),
+putting composed spawn paths under 260.
+
+## Fix applied
+
+Set `ZIG_GLOBAL_CACHE_DIR=C:\zc` at the job level. That drops the CWD
+from ~96 chars to ~55, bringing composed spawn paths comfortably
+below `MAX_PATH`.
+
+Also removed the retry loop (not a race, no reason to retry) and
+relaxed the `windows-2022` runner comment (the pin isn't load-bearing
+against this failure; it was pinned while we were chasing a Zig 0.15
+vs Defender on Server 2025 theory that turned out wrong).
+
+## What we learned
+
+- "failed to spawn … FileNotFound" from zig on Windows is almost
+  always `CreateProcessW` returning `ERROR_PATH_NOT_FOUND` /
+  `ERROR_FILE_NOT_FOUND`, which can be triggered by path length even
+  when the file exists and is executable.
+- The on-failure diagnostic step (re-spawning the missing exe via
+  `cmd /c` by absolute path, and dumping Defender/VS/OS state) was
+  what made the root cause obvious — keep that pattern around for
+  future Windows build regressions.
+- Keep the Zig global cache short on CI. `%LOCALAPPDATA%` is too deep
+  once you factor in the `p\<package>-<hash>\` layer plus any relative
+  walks zig synthesizes from inside a dependency's build graph.


### PR DESCRIPTION
## Summary

Root-cause fix for the Windows release pipeline. PRs #42/#43/#44 chased three wrong theories (Defender, spawn race, Server 2025); the on-failure diagnostic in #44 finally unmasked the real one.

**What was happening:** `CreateProcessW` on Windows still honors the legacy 260-char `MAX_PATH` for relative spawn paths unless the caller is long-path-aware (Zig 0.15.2's `build.exe` isn't). uucode's `build.zig` does `run.setCwd(b.path(""))`, pinning CWD to the uucode package cache at `%LOCALAPPDATA%\zig\p\uucode-0.2.0-<49-char-hash>` ≈ 96 chars. Zig then synthesizes a relative path (`.\..\..\..\..\..\..\..\src\repo\target\release\build\con-ghostty-<hash>\out\ghostty-src\.zig-cache\o\<hash>\uucode_build_tables.exe` ≈ 167 chars) to invoke the exe. Composed length lands at ~264 — just over — and Windows returns `ERROR_FILE_NOT_FOUND`, which Zig surfaces as the confusingly named `error.FileNotFound`. The diagnostic step in #44 re-ran the exe by absolute path via `cmd /c` and got a clean internal stack trace, proving the exe itself was fine.

**Why local didn't repro:** `C:\Users\WeyGu\…` is shorter than `C:\Users\runneradmin\…` on GHA hosted runners. Wey also keeps his local ghostty checkout under `C:\` to avoid the same class of issue.

## Changes

- `.github/workflows/release-windows.yml`
  - Add `ZIG_GLOBAL_CACHE_DIR: C:\zc` to job `env` — drops CWD to ~55 chars, composed path comfortably <220.
  - Add `Prepare short-path Zig cache` step that mkdirs `C:\zc`.
  - Update Defender exclusion to match the new path.
  - Drop the 3-attempt retry loop from #43 (error was deterministic, never was a race).
  - Keep the on-failure diagnostic step from #44 — the pattern that solved this, worth keeping around for future Windows-spawn regressions.
  - Simplify the leading comment block (no longer need to gloss over the old Server-2025 theory).

- `postmortem/2026-04-21-windows-ci-max-path.md` — full write-up.

## Test plan

- [ ] Cut a fresh tag (either retag `v0.1.0-beta.29` or move to `v0.1.0-beta.30`)
- [ ] Windows release job gets past `Build release binary` without the `FileNotFound` error
- [ ] ZIP artifact + `SHA256SUMS-windows.txt` published to the release
- [ ] macOS release workflow completes alongside (wasn't failing on its own; got cancelled last time because Windows blew up)
- [ ] Sparkle appcast for Windows updates on gh-pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Windows CI build configuration with improved cache directory handling and removed retry logic for more efficient builds.

* **Documentation**
  * Added postmortem documentation for a resolved Windows CI build issue related to path length constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->