### PR TITLE
fix(windows): GUI subsystem in release — no stray console window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ __pycache__/
 dist
 .env
 .sparkle
+.claude

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -1,3 +1,12 @@
+// Release builds on Windows use the GUI subsystem so double-clicking
+// the exe (or launching it from Explorer / a shortcut) doesn't spawn a
+// stray console window alongside the GPUI window. Debug builds keep
+// the console subsystem so `cargo wrun` in a terminal still prints
+// env_logger output and panic traces inline.
+#![cfg_attr(
+    all(target_os = "windows", not(debug_assertions)),
+    windows_subsystem = "windows"
+)]
 // Suppress warnings from objc 0.2's `sel_impl!` and `class!` macros
 // checking `cfg(feature = "cargo-clippy")`.
 #![allow(unexpected_cfgs)]


### PR DESCRIPTION
## Summary

The Windows release build shipped with the default console subsystem, so launching `con-app.exe` from Explorer / a shortcut / any non-console context spawned an extra PowerShell host alongside the GPUI window. An embedded terminal emulator being framed by an outer terminal is exactly the wrong impression, and it's the first thing you see on install.

Fix: add a gated inner attribute on the crate root so release builds on Windows use the `windows` subsystem. Debug stays on `console` so `cargo wrun` in a terminal still shows `env_logger` output and panic backtraces inline.

```rust
#![cfg_attr(
    all(target_os = "windows", not(debug_assertions)),
    windows_subsystem = "windows"
)]
```

## Tradeoff (follow-up, not in this PR)

Launching the release exe from an interactive `cmd`/`pwsh` no longer inherits a console, so `env_logger` output won't stream to the parent shell. That's the price of no stray window. If we want to restore that later, the idiom is `AttachConsole(ATTACH_PARENT_PROCESS)` early in `main()` plus a stdio re-bind — we can add that when someone actually wants it. Panics still persist to `%TEMP%\con-panic.log` via the existing panic hook, so a crashed release build remains diagnosable.

## Test plan

- [x] `cargo check -p con` clean on macOS (the cfg_attr is target-gated, so this just proves the attribute parses).
- [ ] After merge, the next tagged release produces a `con-app.exe` that opens cleanly from Explorer with no console alongside.
- [ ] Debug build (`cargo wrun -p con`) still streams env_logger output to the host terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)