### PR TITLE
windows: in-place auto-update + appcast full-tag version

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -411,12 +411,20 @@ jobs:
           # Re-use the same appcast generator the macOS pipeline uses.
           # Windows has no OS minimum so we feed a harmless sentinel;
           # the Windows client ignores the field.
+          # ITEM_SHORT_VERSION is the string the Windows client compares
+          # against its baked `CON_RELEASE_VERSION`. It must be the full
+          # tag-derived version (0.1.0-beta.31), not the stripped
+          # marketing version (0.1.0) - otherwise the client, which now
+          # runs a SemVer-aware `is_newer`, correctly reads GA `0.1.0`
+          # as newer than prerelease `0.1.0-beta.31` and spuriously
+          # reports "update available" on the very build it was just
+          # cut from.
           APPCAST_FILE="$appcast_file" \
           APPCAST_TITLE="con" \
           APPCAST_LINK="https://con-releases.nowledge.co" \
-          ITEM_TITLE="Version ${marketing}" \
+          ITEM_TITLE="Version ${version}" \
           ITEM_VERSION="$build_number" \
-          ITEM_SHORT_VERSION="$marketing" \
+          ITEM_SHORT_VERSION="$version" \
           ITEM_URL="$download_url" \
           ITEM_LENGTH="$length" \
           ITEM_SIGNATURE="$signature" \

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -2213,13 +2213,20 @@ impl SettingsPanel {
                                                 if let Some(url) =
                                                     update_download_url(&latest_state)
                                                 {
+                                                    let label = match &latest_state {
+                                                        crate::updater::CheckState::UpdateAvailable { version, .. } =>
+                                                            format!("Download v{version}"),
+                                                        _ => "Download release".to_string(),
+                                                    };
                                                     col = col.child(
-                                                        gpui_component::link::Link::new(
-                                                            "update-download-link",
-                                                        )
-                                                        .href(url.clone())
-                                                        .text_size(px(11.0))
-                                                        .child(url),
+                                                        div().pt(px(4.0)).child(
+                                                            gpui_component::link::Link::new(
+                                                                "update-download-link",
+                                                            )
+                                                            .href(url)
+                                                            .text_size(px(11.0))
+                                                            .child(label),
+                                                        ),
                                                     );
                                                 }
                                                 col
@@ -4328,7 +4335,7 @@ fn update_summary_and_detail(
         ),
         CheckState::UpdateAvailable { version, .. } => (
             format!("Update available: {version}"),
-            "Download the new release from the link below.".to_string(),
+            "A newer build has been published.".to_string(),
         ),
         CheckState::UpToDate => (
             "Up to date".to_string(),

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -2232,16 +2232,42 @@ impl SettingsPanel {
                                                 col
                                             }),
                                     )
-                                    .child(
-                                        Button::new("check-updates")
-                                            .small()
-                                            .ghost()
-                                            .disabled(!updater_status.can_check_manually())
-                                            .label("Check for Updates")
-                                            .on_click(cx.listener(|_this, _, _window, _cx| {
-                                                crate::updater::check_for_updates();
-                                            })),
-                                    ),
+                                    .child({
+                                        let actions = div().flex().items_center().gap(px(6.0));
+
+                                        #[cfg(target_os = "windows")]
+                                        let actions = if matches!(
+                                            &latest_state,
+                                            crate::updater::CheckState::UpdateAvailable { .. }
+                                        ) {
+                                            actions.child(
+                                                Button::new("apply-update")
+                                                    .small()
+                                                    .primary()
+                                                    .label("Update now")
+                                                    .on_click(cx.listener(
+                                                        |_this, _, _window, _cx| {
+                                                            crate::updater::apply_update_in_place();
+                                                        },
+                                                    )),
+                                            )
+                                        } else {
+                                            actions
+                                        };
+
+                                        actions.child(
+                                            Button::new("check-updates")
+                                                .small()
+                                                .ghost()
+                                                .disabled(!updater_status.can_check_manually())
+                                                .label("Check for Updates")
+                                                .on_click(cx.listener(
+                                                    |_this, _, _window, _cx| {
+                                                        crate::updater::check_for_updates();
+                                                    },
+                                                )),
+                                        )
+                                    }),
                             ),
                     ),
             );

--- a/crates/con-app/src/updater.rs
+++ b/crates/con-app/src/updater.rs
@@ -352,6 +352,54 @@ pub fn check_for_updates() {
 #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
 pub fn check_for_updates() {}
 
+/// Re-run `install.ps1` in a new console and exit this process so the
+/// installer can replace `con-app.exe`. Windows only.
+///
+/// The script already does the full lifecycle — stop running instance,
+/// download, verify SHA256, unpack, update PATH, relaunch — so we spawn
+/// it and get out of the way. `CREATE_NEW_CONSOLE` gives the user
+/// visible progress; without it a GUI-subsystem binary has no console
+/// to inherit and the script would run silently.
+#[cfg(target_os = "windows")]
+pub fn apply_update_in_place() {
+    use std::os::windows::process::CommandExt;
+
+    const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
+    const INSTALL_URL: &str = "https://con-releases.nowledge.co/install.ps1";
+
+    let command = format!("irm {INSTALL_URL} | iex");
+    match std::process::Command::new("powershell.exe")
+        .args([
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            &command,
+        ])
+        .creation_flags(CREATE_NEW_CONSOLE)
+        .spawn()
+    {
+        Ok(_) => {
+            // Give the installer a beat to grab the ZIP before we drop
+            // our exe locks. `install.ps1` also does `Stop-Process -Name
+            // con-app` as a belt-and-braces step, but exiting cleanly
+            // lets pending writes (config, sessions) flush normally.
+            std::thread::sleep(std::time::Duration::from_millis(400));
+            std::process::exit(0);
+        }
+        Err(e) => {
+            log::error!("updater: failed to spawn install.ps1: {e}");
+            set_latest(CheckState::Error(format!(
+                "could not launch installer: {e}"
+            )));
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+#[allow(dead_code)]
+pub fn apply_update_in_place() {}
+
 pub fn status() -> UpdaterStatus {
     *STATUS.get_or_init(|| {
         #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

Two fixes bundled together since they both touch the Updates card in Settings on Windows.

### 1. In-place auto-update from Settings

Settings → Updates now shows a primary **Update now** button when a newer build is advertised. Clicking it re-runs the canonical `install.ps1` pipeline:

```
powershell.exe -NoProfile -ExecutionPolicy Bypass -Command 'irm https://con-releases.nowledge.co/install.ps1 | iex'
```

spawned with `CREATE_NEW_CONSOLE` so the GUI-subsystem binary's child gets a visible console. The app then exits so the installer can overwrite `con-app.exe`. `install.ps1` already owns the full lifecycle — stop running instance, download, verify SHA256, unpack, update PATH, relaunch — so the Rust side just starts it and gets out of the way.

The existing **Download v\<version\>** link stays as a fallback for users who want the ZIP.

### 2. Appcast advertises full tag-derived version (`-beta.N` included)

The Windows appcast was publishing `<sparkle:shortVersionString>0.1.0</sparkle:shortVersionString>` (marketing version, stripped of the prerelease suffix). Our SemVer-aware `is_newer` correctly ruled GA `0.1.0` > prerelease `0.1.0-beta.31`, so Settings → Updates reported "Update available: 0.1.0" on the very build it was cut from.

`release-windows.yml` now feeds `ITEM_SHORT_VERSION="$version"` (full tag) instead of `"$marketing"` (stripped). Detail copy swaps from "Download the new release from the link below." to "A newer build has been published." and the raw-URL child becomes a short "Download v\<version\>" label.

## Test plan

- [x] `cargo check -p con` passes on macOS (stub + cfg-gated Windows-only code).
- [ ] After tagging `v0.1.0-beta.32`:
  - [ ] `curl https://con-releases.nowledge.co/appcast/beta-windows-x86_64.xml` shows `<sparkle:shortVersionString>0.1.0-beta.32</sparkle:shortVersionString>`.
  - [ ] Fresh install of beta.32: Settings → Updates reads "Up to date".
  - [ ] Existing beta.31 install: Settings → Updates shows "Update now" + "Download v0.1.0-beta.32".
  - [ ] Clicking "Update now" opens a PowerShell console, runs install.ps1 to completion, relaunches con-app.exe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)