### PR TITLE
windows: wire terminal theme + transparency into D3D11 renderer

### DIFF
--- a/crates/con-app/Cargo.toml
+++ b/crates/con-app/Cargo.toml
@@ -70,7 +70,8 @@ windows = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_System_Diagnostics_Debug",  # AddVectoredExceptionHandler
     "Win32_System_Kernel",             # EXCEPTION_POINTERS definition
-    "Win32_Graphics_Dwm",              # DwmSetWindowAttribute — Mica backdrop
+    "Win32_Graphics_Dwm",              # DwmSetWindowAttribute — Mica/Acrylic backdrop
+    "Win32_UI_Controls",               # MARGINS — DwmExtendFrameIntoClientArea
 ] }
 # Used only by the Windows `GhosttyView` to wrap D3D11-readback BGRA into
 # a GPUI `RenderImage` (GPUI's `RenderImage::new` takes a

--- a/crates/con-app/Cargo.toml
+++ b/crates/con-app/Cargo.toml
@@ -71,7 +71,6 @@ windows = { version = "0.61", features = [
     "Win32_System_Diagnostics_Debug",  # AddVectoredExceptionHandler
     "Win32_System_Kernel",             # EXCEPTION_POINTERS definition
     "Win32_Graphics_Dwm",              # DwmSetWindowAttribute — Mica/Acrylic backdrop
-    "Win32_UI_Controls",               # MARGINS — DwmExtendFrameIntoClientArea
 ] }
 # Used only by the Windows `GhosttyView` to wrap D3D11-readback BGRA into
 # a GPUI `RenderImage` (GPUI's `RenderImage::new` takes a

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -172,10 +172,9 @@ fn set_windows_backdrop(window: &mut Window, blur: bool) -> Option<()> {
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
     use windows::Win32::Foundation::HWND;
     use windows::Win32::Graphics::Dwm::{
-        DwmExtendFrameIntoClientArea, DwmSetWindowAttribute, DWMSBT_MAINWINDOW,
-        DWMSBT_TRANSIENTWINDOW, DWMWA_SYSTEMBACKDROP_TYPE,
+        DwmSetWindowAttribute, DWMSBT_MAINWINDOW, DWMSBT_TRANSIENTWINDOW,
+        DWMWA_SYSTEMBACKDROP_TYPE,
     };
-    use windows::Win32::UI::Controls::MARGINS;
 
     let handle = HasWindowHandle::window_handle(window).ok()?;
     let hwnd = match handle.as_raw() {
@@ -183,27 +182,16 @@ fn set_windows_backdrop(window: &mut Window, blur: bool) -> Option<()> {
         _ => return None,
     };
 
-    // DWMWA_SYSTEMBACKDROP_TYPE only paints in regions where the DWM
-    // frame has been extended. Without this call the backdrop shows
-    // only on the narrow non-client strip (titlebar), which looks like
-    // "transparent window, no blur" because the client area falls
-    // through to whatever is behind. MARGINS { -1, -1, -1, -1 } is
-    // the documented "extend the sheet of glass over the whole window"
-    // value from the Mica / Acrylic sample code.
-    let margins = MARGINS {
-        cxLeftWidth: -1,
-        cxRightWidth: -1,
-        cyTopHeight: -1,
-        cyBottomHeight: -1,
-    };
-    // SAFETY: hwnd is live; margins is a 16-byte POD we pass by &.
-    if let Err(err) = unsafe { DwmExtendFrameIntoClientArea(hwnd, &margins) } {
-        log::info!(
-            "Windows: DwmExtendFrameIntoClientArea failed ({err:?}); \
-             backdrop will paint only non-client area"
-        );
-    }
-
+    // NB: we deliberately do NOT call DwmExtendFrameIntoClientArea
+    // here. That call is the documented path for legacy GDI / WPF
+    // windows and it works well on a Win32-composed window, but GPUI's
+    // top-level window is composited through DirectComposition. Mixing
+    // the two made the whole window render opaque (see
+    // Screenshot 2026-04-22 at 13.14.09). Acrylic/Mica with a DComp
+    // client requires a `DCompositionCreateBackdropBrush` visual in
+    // GPUI's tree; until that lands upstream, we keep the attribute
+    // set so the non-client strip reflects the user's choice and the
+    // terminal stays transparent.
     let (backdrop, label) = if blur {
         (DWMSBT_TRANSIENTWINDOW.0, "Acrylic")
     } else {

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -139,7 +139,13 @@ fn supports_transparent_main_window() -> bool {
     true
 }
 
-/// Enable Windows 11 Mica backdrop on the top-level window via DWM.
+/// Enable a Windows 11 DWM backdrop on the top-level window.
+///
+/// `blur=true` selects `DWMSBT_TRANSIENTWINDOW` (Acrylic, real Gaussian
+/// blur of what's behind the window). `blur=false` selects
+/// `DWMSBT_MAINWINDOW` (Mica, a static desktop-image-tinted fill — no
+/// blur, much cheaper). Both render only when the GPUI Root above is
+/// transparent.
 ///
 /// Returns `true` when the DWM attribute was accepted — we use that
 /// signal to keep the GPUI Root transparent so the backdrop shows
@@ -149,22 +155,38 @@ fn supports_transparent_main_window() -> bool {
 /// compositor shows the desktop through the window, which is what the
 /// user observed when a modal hid the pane HWND).
 #[cfg(target_os = "windows")]
-fn apply_windows_backdrop(window: &mut Window) -> bool {
+fn apply_windows_backdrop(window: &mut Window, blur: bool) -> bool {
+    set_windows_backdrop(window, blur).is_some()
+}
+
+/// Live re-apply of the DWM backdrop type. Called from the workspace
+/// theme-update path so toggling "background blur" in settings switches
+/// between Acrylic and Mica without restarting the window.
+#[cfg(target_os = "windows")]
+pub fn set_windows_backdrop_blur(window: &mut Window, blur: bool) {
+    let _ = set_windows_backdrop(window, blur);
+}
+
+#[cfg(target_os = "windows")]
+fn set_windows_backdrop(window: &mut Window, blur: bool) -> Option<()> {
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
     use windows::Win32::Foundation::HWND;
     use windows::Win32::Graphics::Dwm::{
-        DwmSetWindowAttribute, DWMSBT_MAINWINDOW, DWMWA_SYSTEMBACKDROP_TYPE,
+        DwmSetWindowAttribute, DWMSBT_MAINWINDOW, DWMSBT_TRANSIENTWINDOW,
+        DWMWA_SYSTEMBACKDROP_TYPE,
     };
 
-    let Ok(handle) = HasWindowHandle::window_handle(window) else {
-        return false;
-    };
+    let handle = HasWindowHandle::window_handle(window).ok()?;
     let hwnd = match handle.as_raw() {
         RawWindowHandle::Win32(h) => HWND(h.hwnd.get() as *mut std::ffi::c_void),
-        _ => return false,
+        _ => return None,
     };
 
-    let backdrop: i32 = DWMSBT_MAINWINDOW.0;
+    let (backdrop, label) = if blur {
+        (DWMSBT_TRANSIENTWINDOW.0, "Acrylic")
+    } else {
+        (DWMSBT_MAINWINDOW.0, "Mica")
+    };
     // SAFETY: hwnd is a live top-level window (we just received it
     // from GPUI's window-handle surface); DWMWA_SYSTEMBACKDROP_TYPE
     // takes a 4-byte integer by pointer.
@@ -178,15 +200,15 @@ fn apply_windows_backdrop(window: &mut Window) -> bool {
     };
     match hr {
         Ok(()) => {
-            log::info!("Windows: enabled DWM Mica backdrop on main window");
-            true
+            log::info!("Windows: applied DWM {label} backdrop on main window");
+            Some(())
         }
         Err(err) => {
             log::info!(
-                "Windows: Mica backdrop unavailable ({err:?}); \
+                "Windows: {label} backdrop unavailable ({err:?}); \
                  falling back to opaque theme fill"
             );
-            false
+            None
         }
     }
 }
@@ -223,7 +245,7 @@ fn open_con_window(config: con_core::Config, session: Session, exit_on_error: bo
             let view = cx
                 .new(|cx| ConWorkspace::from_session(config.clone(), restored_session, window, cx));
             #[cfg(target_os = "windows")]
-            let mica_applied = apply_windows_backdrop(window);
+            let mica_applied = apply_windows_backdrop(window, config.appearance.terminal_blur);
             #[cfg(not(target_os = "windows"))]
             let mica_applied = false;
             cx.new(|cx| {

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -172,15 +172,37 @@ fn set_windows_backdrop(window: &mut Window, blur: bool) -> Option<()> {
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
     use windows::Win32::Foundation::HWND;
     use windows::Win32::Graphics::Dwm::{
-        DwmSetWindowAttribute, DWMSBT_MAINWINDOW, DWMSBT_TRANSIENTWINDOW,
-        DWMWA_SYSTEMBACKDROP_TYPE,
+        DwmExtendFrameIntoClientArea, DwmSetWindowAttribute, DWMSBT_MAINWINDOW,
+        DWMSBT_TRANSIENTWINDOW, DWMWA_SYSTEMBACKDROP_TYPE,
     };
+    use windows::Win32::UI::Controls::MARGINS;
 
     let handle = HasWindowHandle::window_handle(window).ok()?;
     let hwnd = match handle.as_raw() {
         RawWindowHandle::Win32(h) => HWND(h.hwnd.get() as *mut std::ffi::c_void),
         _ => return None,
     };
+
+    // DWMWA_SYSTEMBACKDROP_TYPE only paints in regions where the DWM
+    // frame has been extended. Without this call the backdrop shows
+    // only on the narrow non-client strip (titlebar), which looks like
+    // "transparent window, no blur" because the client area falls
+    // through to whatever is behind. MARGINS { -1, -1, -1, -1 } is
+    // the documented "extend the sheet of glass over the whole window"
+    // value from the Mica / Acrylic sample code.
+    let margins = MARGINS {
+        cxLeftWidth: -1,
+        cxRightWidth: -1,
+        cyTopHeight: -1,
+        cyBottomHeight: -1,
+    };
+    // SAFETY: hwnd is live; margins is a 16-byte POD we pass by &.
+    if let Err(err) = unsafe { DwmExtendFrameIntoClientArea(hwnd, &margins) } {
+        log::info!(
+            "Windows: DwmExtendFrameIntoClientArea failed ({err:?}); \
+             backdrop will paint only non-client area"
+        );
+    }
 
     let (backdrop, label) = if blur {
         (DWMSBT_TRANSIENTWINDOW.0, "Acrylic")

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -192,30 +192,35 @@ fn set_windows_backdrop(window: &mut Window, blur: bool) -> Option<()> {
     // GPUI's tree; until that lands upstream, we keep the attribute
     // set so the non-client strip reflects the user's choice and the
     // terminal stays transparent.
-    let (backdrop, label) = if blur {
-        (DWMSBT_TRANSIENTWINDOW.0, "Acrylic")
-    } else {
-        (DWMSBT_MAINWINDOW.0, "Mica")
-    };
     // SAFETY: hwnd is a live top-level window (we just received it
     // from GPUI's window-handle surface); DWMWA_SYSTEMBACKDROP_TYPE
     // takes a 4-byte integer by pointer.
-    let hr = unsafe {
-        DwmSetWindowAttribute(
-            hwnd,
-            DWMWA_SYSTEMBACKDROP_TYPE,
-            &backdrop as *const i32 as *const std::ffi::c_void,
-            std::mem::size_of::<i32>() as u32,
-        )
-    };
-    match hr {
-        Ok(()) => {
-            log::info!("Windows: applied DWM {label} backdrop on main window");
-            Some(())
+    let try_apply = |value: i32, label: &'static str| -> windows::core::Result<()> {
+        unsafe {
+            DwmSetWindowAttribute(
+                hwnd,
+                DWMWA_SYSTEMBACKDROP_TYPE,
+                &value as *const i32 as *const std::ffi::c_void,
+                std::mem::size_of::<i32>() as u32,
+            )
         }
+        .map(|()| log::info!("Windows: applied DWM {label} backdrop on main window"))
+    };
+
+    if blur {
+        // Try Acrylic first; if the OS rejects it (older Win11 builds,
+        // disabled effects), fall back to Mica so the window stays
+        // transparent instead of going opaque.
+        if try_apply(DWMSBT_TRANSIENTWINDOW.0, "Acrylic").is_ok() {
+            return Some(());
+        }
+        log::info!("Windows: Acrylic backdrop unavailable; trying Mica fallback");
+    }
+    match try_apply(DWMSBT_MAINWINDOW.0, "Mica") {
+        Ok(()) => Some(()),
         Err(err) => {
             log::info!(
-                "Windows: {label} backdrop unavailable ({err:?}); \
+                "Windows: Mica backdrop unavailable ({err:?}); \
                  falling back to opaque theme fill"
             );
             None

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -360,6 +360,15 @@ impl GhosttyView {
                     false
                 }
             }
+            Ok(RenderOutcome::Pending) => {
+                // The renderer submitted a new draw into its staging
+                // ring but had nothing prior to drain non-blocking. The
+                // slot will be ready by the next prepaint — return
+                // `true` so the caller `cx.notify()`s and we come back
+                // to drain it. Cached image stays untouched so the
+                // user sees the previous frame in the meantime (~16ms).
+                true
+            }
             Err(err) => {
                 log::warn!("RenderSession::render_frame failed: {err:#}");
                 false

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -3182,6 +3182,8 @@ impl ConWorkspace {
                 terminal.sync_window_background_blur(cx);
             }
         }
+        #[cfg(target_os = "windows")]
+        crate::set_windows_backdrop_blur(window, self.terminal_blur);
         // Sync GPUI UI theme colors with terminal theme
         crate::theme::sync_gpui_theme(
             &theme,

--- a/crates/con-ghostty/build.rs
+++ b/crates/con-ghostty/build.rs
@@ -57,7 +57,6 @@ fn main() {
 fn build_macos() {
     let ghostty_dir = resolve_ghostty_source();
     let optimize = ghostty_optimize();
-    println!("cargo:warning=libghostty: -Doptimize={optimize}");
 
     let status = Command::new("zig")
         .args([
@@ -248,7 +247,6 @@ fn build_windows() {
     };
 
     let optimize = ghostty_optimize();
-    println!("cargo:warning=libghostty-vt: -Doptimize={optimize}");
 
     let mut cmd = Command::new(&zig_bin);
     cmd.current_dir(&ghostty_dir);

--- a/crates/con-ghostty/build.rs
+++ b/crates/con-ghostty/build.rs
@@ -57,6 +57,7 @@ fn main() {
 fn build_macos() {
     let ghostty_dir = resolve_ghostty_source();
     let optimize = ghostty_optimize();
+    println!("cargo:warning=libghostty: -Doptimize={optimize}");
 
     let status = Command::new("zig")
         .args([
@@ -218,7 +219,13 @@ fn build_windows() {
     // `CON_GHOSTTY_VT_EMIT_OPTION=1` (force the option-based path).
     let invocation = pick_vt_invocation(&zig_bin, &ghostty_dir);
 
-    // `-Doptimize=ReleaseFast` for terminal-class throughput.
+    // `-Doptimize=ReleaseFast` for terminal-class throughput. Default
+    // matches macOS so debug Rust builds still get a release-grade VT
+    // parser — past macOS lag (resize/reflow stalls of seconds) was
+    // traced to building libghostty *without* an explicit optimize
+    // flag, which left it at zig's `-ODebug`. Same risk applies on
+    // Windows, so default it on regardless of cargo profile and let
+    // `CON_GHOSTTY_OPTIMIZE=Debug` opt back in for VT-debugging.
     //
     // `-Dsimd`: Ghostty vendors `simdutf` (a C++ SIMD UTF-8 library)
     // when SIMD is on. Zig's `-Demit-lib-vt=true` produces
@@ -240,13 +247,16 @@ fn build_windows() {
         "-Dsimd=false"
     };
 
+    let optimize = ghostty_optimize();
+    println!("cargo:warning=libghostty-vt: -Doptimize={optimize}");
+
     let mut cmd = Command::new(&zig_bin);
     cmd.current_dir(&ghostty_dir);
     cmd.arg("build");
     for arg in &invocation {
         cmd.arg(arg);
     }
-    cmd.args(["-Doptimize=ReleaseFast", simd_flag]);
+    cmd.args([&format!("-Doptimize={optimize}"), simd_flag]);
 
     let status = cmd
         .status()

--- a/crates/con-ghostty/src/windows/backend.rs
+++ b/crates/con-ghostty/src/windows/backend.rs
@@ -10,11 +10,19 @@ use std::time::Duration;
 use parking_lot::Mutex;
 
 use super::host_view::RenderSession;
-use super::render::RendererConfig;
+use super::render::{RendererConfig, ThemeColors};
 use crate::stub::{
     CommandFinishedSignal, CommandRecord, GhosttyConfigPatch, GhosttySplitDirection,
     GhosttySurfaceEvent, MouseButton, SurfaceSize, TerminalColors,
 };
+
+fn theme_from_colors(colors: &TerminalColors) -> ThemeColors {
+    ThemeColors::from_ansi16(colors.foreground, colors.background, colors.palette)
+}
+
+fn clamp_opacity(v: f32) -> f32 {
+    v.clamp(0.0, 1.0)
+}
 
 /// One per GPUI window. Holds shared, app-wide terminal config.
 pub struct WindowsGhosttyApp {
@@ -24,10 +32,10 @@ pub struct WindowsGhosttyApp {
 impl WindowsGhosttyApp {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        _colors: Option<&TerminalColors>,
+        colors: Option<&TerminalColors>,
         font_family: Option<&str>,
         font_size: Option<f32>,
-        _background_opacity: Option<f32>,
+        background_opacity: Option<f32>,
         _background_blur: Option<bool>,
         _cursor_style: Option<&str>,
         _background_image: Option<&str>,
@@ -42,6 +50,19 @@ impl WindowsGhosttyApp {
         }
         if let Some(size) = font_size {
             config.font_size_px = size;
+        }
+        if let Some(colors) = colors {
+            let theme = theme_from_colors(colors);
+            config.clear_color = [
+                colors.background[0] as f32 / 255.0,
+                colors.background[1] as f32 / 255.0,
+                colors.background[2] as f32 / 255.0,
+                1.0,
+            ];
+            config.theme = Some(theme);
+        }
+        if let Some(op) = background_opacity {
+            config.background_opacity = clamp_opacity(op);
         }
         Ok(Self {
             config: Mutex::new(config),
@@ -62,10 +83,10 @@ impl WindowsGhosttyApp {
     #[allow(clippy::too_many_arguments)]
     pub fn update_appearance(
         &self,
-        _colors: &TerminalColors,
+        colors: &TerminalColors,
         font_family: &str,
         font_size: f32,
-        _background_opacity: f32,
+        background_opacity: f32,
         _background_blur: bool,
         _cursor_style: &str,
         _background_image: Option<&str>,
@@ -74,9 +95,18 @@ impl WindowsGhosttyApp {
         _background_image_fit: Option<&str>,
         _background_image_repeat: bool,
     ) -> Result<(), String> {
+        let theme = theme_from_colors(colors);
         let mut config = self.config.lock();
         config.font_family = font_family.to_string();
         config.font_size_px = font_size;
+        config.clear_color = [
+            colors.background[0] as f32 / 255.0,
+            colors.background[1] as f32 / 255.0,
+            colors.background[2] as f32 / 255.0,
+            1.0,
+        ];
+        config.theme = Some(theme);
+        config.background_opacity = clamp_opacity(background_opacity);
         Ok(())
     }
 
@@ -157,10 +187,10 @@ impl WindowsGhosttyTerminal {
     #[allow(clippy::too_many_arguments)]
     pub fn update_appearance(
         &self,
-        _colors: &TerminalColors,
+        colors: &TerminalColors,
         _font_family: &str,
         _font_size: f32,
-        _background_opacity: f32,
+        background_opacity: f32,
         _background_blur: bool,
         _cursor_style: &str,
         _background_image: Option<&str>,
@@ -169,6 +199,10 @@ impl WindowsGhosttyTerminal {
         _background_image_fit: Option<&str>,
         _background_image_repeat: bool,
     ) -> Result<(), String> {
+        if let Some(session) = self.inner.lock().as_ref() {
+            let theme = theme_from_colors(colors);
+            session.set_appearance(Some(&theme), clamp_opacity(background_opacity));
+        }
         Ok(())
     }
 

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -174,8 +174,10 @@ impl RenderSession {
     /// requested level. Bumping the VT generation forces the next
     /// prepaint to repaint with the new colors / opacity.
     pub fn set_appearance(&self, theme: Option<&ThemeColors>, background_opacity: f32) {
+        let clamped_opacity = background_opacity.clamp(0.0, 1.0);
         let mut config = self.config.lock();
-        config.background_opacity = background_opacity;
+        let opacity_changed = (config.background_opacity - clamped_opacity).abs() > f32::EPSILON;
+        config.background_opacity = clamped_opacity;
         if let Some(theme) = theme {
             // Margins (pixels outside the cell grid) paint from
             // `clear_color`, so a theme switch that only rewrites the
@@ -189,9 +191,20 @@ impl RenderSession {
                 1.0,
             ];
             config.theme = Some(theme.clone());
+            // `set_theme` bumps the VT generation itself, so the next
+            // prepaint re-runs draw_cells with the new palette + new
+            // clear_color + any new opacity.
             self.vt.set_theme(theme);
         } else {
             config.theme = None;
+            // An opacity-only change doesn't touch the VT screen, so
+            // the renderer's `needs_draw` gate (keyed on
+            // snapshot.generation ⨁ selection) would otherwise serve
+            // a stale cached frame until the next VT byte arrives.
+            // Force a generation bump so the change is visible now.
+            if opacity_changed {
+                self.vt.bump_generation();
+            }
         }
     }
 

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -23,7 +23,7 @@ use anyhow::{Context, Result};
 use parking_lot::Mutex;
 
 use super::conpty::{ConPty, PtySize};
-use super::render::{RenderOutcome, Renderer, RendererConfig, Selection};
+use super::render::{RenderOutcome, Renderer, RendererConfig, Selection, ThemeColors};
 use super::vt::{ScreenSnapshot, VtScreen};
 
 use super::render::CellMetrics;
@@ -99,7 +99,10 @@ impl RenderSession {
         let (cols, rows) = renderer.grid_for_dimensions(&renderer_config);
         log::info!("RenderSession: grid {cols}x{rows}");
 
-        let vt = Arc::new(VtScreen::new(cols, rows).context("VtScreen::new failed")?);
+        let vt = Arc::new(
+            VtScreen::new(cols, rows, renderer_config.theme.as_ref())
+                .context("VtScreen::new failed")?,
+        );
 
         let vt_for_pty = vt.clone();
         let wake_for_pty: Arc<dyn Fn() + Send + Sync> = Arc::new(wake);
@@ -158,6 +161,27 @@ impl RenderSession {
             "RenderSession::resize -> {width_px}x{height_px} grid={cols}x{rows} cell={cell_w}x{cell_h}"
         );
         Ok(())
+    }
+
+    /// Live update of the user-visible theme + window opacity.
+    ///
+    /// `theme` (when present) replaces libghostty's default fg/bg/palette
+    /// so SGR colors resolve to the user's palette without restarting
+    /// the pane. `background_opacity` is stored on the renderer config
+    /// and read on every frame — the renderer rewrites the sentinel
+    /// alpha=0 default-bg cells to `opacity*255` and pre-multiplies the
+    /// clear color, so the cell grid composites over Mica / DComp at the
+    /// requested level. Bumping the VT generation forces the next
+    /// prepaint to repaint with the new colors / opacity.
+    pub fn set_appearance(&self, theme: Option<&ThemeColors>, background_opacity: f32) {
+        let mut config = self.config.lock();
+        config.background_opacity = background_opacity;
+        if let Some(theme) = theme {
+            config.theme = Some(theme.clone());
+            self.vt.set_theme(theme);
+        } else {
+            config.theme = None;
+        }
     }
 
     /// Notify of a DPI change. Rebuilds the glyph atlas at the new

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -177,6 +177,17 @@ impl RenderSession {
         let mut config = self.config.lock();
         config.background_opacity = background_opacity;
         if let Some(theme) = theme {
+            // Margins (pixels outside the cell grid) paint from
+            // `clear_color`, so a theme switch that only rewrites the
+            // palette would leave the border showing the previous
+            // theme's background. Mirror what `WindowsGhosttyApp::
+            // update_appearance` does at session construction.
+            config.clear_color = [
+                theme.bg[0] as f32 / 255.0,
+                theme.bg[1] as f32 / 255.0,
+                theme.bg[2] as f32 / 255.0,
+                1.0,
+            ];
             config.theme = Some(theme.clone());
             self.vt.set_theme(theme);
         } else {

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -583,12 +583,21 @@ impl Renderer {
         // last — on top of any wide PUA glyph that might otherwise
         // overdraw the cursor cell.
         if let Some(src) = cursor_source {
+            // Force both alphas to 0xFF on the swapped cursor instance.
+            // `src.bg` may carry the opacity sentinel (see `apply_opacity`
+            // above — default-bg cells get alpha = opacity_byte so Mica
+            // shows through). Without this mask the cursor block itself
+            // would stay solid (it uses `src.fg`, which is always 0xFF)
+            // but the cursor's text glyph — which now draws with
+            // `fg = src.bg` — would render semi-transparent against
+            // the solid block. Cursor is meant to be a solid highlight,
+            // so both channels are pinned to opaque.
             instances.push(Instance {
                 cell_pos: src.cell_pos,
                 atlas_pos: src.atlas_pos,
                 atlas_size: src.atlas_size,
-                fg: src.bg,
-                bg: src.fg,
+                fg: (src.bg & 0xFFFFFF00) | 0xFF,
+                bg: (src.fg & 0xFFFFFF00) | 0xFF,
                 attrs: src.attrs & !0x10,
             });
         }

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -53,6 +53,7 @@ use atlas::{GlyphCache, GlyphKey};
 use pipeline::{Globals, Instance, Pipeline, instance_for_cell};
 
 pub use atlas::CellMetrics;
+pub use super::vt::ThemeColors;
 
 const ATLAS_SIZE_PX: u32 = 2048;
 /// Initial instance-buffer capacity. 16 384 covers a 200×80 grid
@@ -66,7 +67,18 @@ pub struct RendererConfig {
     pub font_size_px: f32,
     pub initial_width: u32,
     pub initial_height: u32,
+    /// RGB clear-target color. Alpha is taken from `background_opacity`
+    /// at render time so opacity changes don't have to thread back into
+    /// here.
     pub clear_color: [f32; 4],
+    /// 0.0 (fully see-through) … 1.0 (opaque). Multiplied into the
+    /// clear-color alpha and the per-cell default-bg alpha so that
+    /// unstyled cells composite over Mica / DComp visuals beneath.
+    /// Cells with explicit SGR backgrounds stay solid.
+    pub background_opacity: f32,
+    /// Theme handed to libghostty so SGR colors resolve to the user's
+    /// palette. `None` keeps libghostty's built-in defaults.
+    pub theme: Option<ThemeColors>,
 }
 
 impl Default for RendererConfig {
@@ -77,6 +89,8 @@ impl Default for RendererConfig {
             initial_width: 800,
             initial_height: 600,
             clear_color: [0.06, 0.06, 0.07, 1.0],
+            background_opacity: 1.0,
+            theme: None,
         }
     }
 }
@@ -316,16 +330,28 @@ impl Renderer {
             MinDepth: 0.0,
             MaxDepth: 1.0,
         };
+        // Multiply alpha by background_opacity so transparent cells
+        // composite with the backdrop (Mica / DComp). Pre-multiply RGB
+        // so the BGRA readback handed to GPUI behaves correctly under
+        // GPUI's premultiplied-alpha blend (otherwise translucent
+        // pixels look washed out / haloed against the visual beneath).
+        let opacity = config.background_opacity.clamp(0.0, 1.0);
+        let clear = [
+            config.clear_color[0] * opacity,
+            config.clear_color[1] * opacity,
+            config.clear_color[2] * opacity,
+            config.clear_color[3] * opacity,
+        ];
         unsafe {
             self.context.RSSetViewports(Some(&[vp]));
             self.context
                 .OMSetRenderTargets(Some(&[Some(self.rtv.clone())]), None);
             self.context
-                .ClearRenderTargetView(&self.rtv, &config.clear_color);
+                .ClearRenderTargetView(&self.rtv, &clear);
         }
 
         if !snapshot.cells.is_empty() {
-            self.draw_cells(snapshot)?;
+            self.draw_cells(snapshot, config)?;
         }
 
         let bytes = self.readback_rt()?;
@@ -336,11 +362,24 @@ impl Renderer {
         }))
     }
 
-    fn draw_cells(&self, snapshot: &ScreenSnapshot) -> Result<()> {
+    fn draw_cells(&self, snapshot: &ScreenSnapshot, config: &RendererConfig) -> Result<()> {
         let selection = *self
             .selection
             .lock()
             .expect("selection mutex poisoned in draw_cells()");
+        // Sentinel alpha=0 in cell.bg means "default theme background"
+        // (set by the VT layer); rewrite it to the configured opacity
+        // so the shader composes the cell over Mica with the right
+        // see-through level. Cells with explicit SGR backgrounds carry
+        // alpha=0xFF and aren't touched.
+        let opacity_byte: u8 = (config.background_opacity.clamp(0.0, 1.0) * 255.0).round() as u8;
+        let apply_opacity = |bg: u32| -> u32 {
+            if (bg & 0xFF) == 0 {
+                (bg & 0xFFFFFF00) | opacity_byte as u32
+            } else {
+                bg
+            }
+        };
 
         let mut atlas = self
             .atlas
@@ -372,7 +411,7 @@ impl Renderer {
                     atlas_pos: [0, 0],
                     atlas_size: [0, 0],
                     fg: cell.fg,
-                    bg: cell.bg,
+                    bg: apply_opacity(cell.bg),
                     attrs: effective_attrs as u32,
                 });
                 continue;
@@ -403,7 +442,7 @@ impl Renderer {
                                 atlas_pos: [0, 0],
                                 atlas_size: [0, 0],
                                 fg: cell.fg,
-                                bg: cell.bg,
+                                bg: apply_opacity(cell.bg),
                                 attrs: effective_attrs as u32,
                             });
                             continue;
@@ -417,7 +456,7 @@ impl Renderer {
                 row,
                 glyph,
                 cell.fg,
-                cell.bg,
+                apply_opacity(cell.bg),
                 effective_attrs,
             ));
         }

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -465,6 +465,16 @@ impl Renderer {
         // so the shader composes the cell over Mica with the right
         // see-through level. Cells with explicit SGR backgrounds carry
         // alpha=0xFF and aren't touched.
+        //
+        // Invariant: any non-sentinel bg value MUST carry alpha=0xFF.
+        // Producers in `vt.rs::read_cell` enforce this — explicit RGB
+        // and palette colors hard-set the alpha byte. The benign edge
+        // case is `background_opacity == 0.0`: opacity_byte is also 0,
+        // so the rewrite is a no-op (still fully transparent default
+        // bg) and there is no observable ambiguity. If a future code
+        // path injects an `0x......00` value into cell.bg without
+        // meaning the sentinel, it would be silently rewritten — keep
+        // the producers honest.
         let opacity_byte: u8 = (config.background_opacity.clamp(0.0, 1.0) * 255.0).round() as u8;
         let apply_opacity = |bg: u32| -> u32 {
             if (bg & 0xFF) == 0 {

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -246,13 +246,18 @@ impl Renderer {
             return Ok(());
         }
 
+        // Build the new RT first, but defer the swap. If the staging
+        // ring recreate fails after we've already replaced rt_texture /
+        // rtv, render() would CopyResource between mismatched-size
+        // textures (UB in D3D11). Recreate the ring while the old RT
+        // is still active, then commit both in one go.
         let (rt_texture, rtv) = create_rt_texture(&self.device, width_px, height_px)?;
-        self.rt_texture = rt_texture;
-        self.rtv = rtv;
         self.staging_ring
             .lock()
             .expect("staging_ring mutex poisoned in resize()")
             .recreate(&self.device, width_px, height_px)?;
+        self.rt_texture = rt_texture;
+        self.rtv = rtv;
         self.width_px = width_px;
         self.height_px = height_px;
         *self
@@ -712,14 +717,18 @@ impl StagingRing {
     }
 
     fn recreate(&mut self, device: &ID3D11Device, width: u32, height: u32) -> Result<()> {
-        self.slots.clear();
+        // Allocate the new slots locally first; only swap into `self`
+        // after every fallible call has succeeded so a mid-loop failure
+        // leaves the ring usable at its old dimensions.
+        let mut new_slots = Vec::with_capacity(Self::DEPTH);
         for _ in 0..Self::DEPTH {
-            self.slots.push(StagingSlot {
+            new_slots.push(StagingSlot {
                 texture: create_staging_texture(device, width, height)?,
                 in_flight: false,
                 seq: 0,
             });
         }
+        self.slots = new_slots;
         self.next_idx = 0;
         self.next_seq = 0;
         self.width = width;

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -35,11 +35,11 @@ use windows::Win32::Graphics::Direct3D::{
 };
 use windows::Win32::Graphics::Direct3D11::{
     D3D11_BIND_RENDER_TARGET, D3D11_BIND_SHADER_RESOURCE, D3D11_CPU_ACCESS_READ,
-    D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_MAP_READ, D3D11_MAPPED_SUBRESOURCE,
-    D3D11_RENDER_TARGET_VIEW_DESC, D3D11_RTV_DIMENSION_TEXTURE2D, D3D11_SDK_VERSION,
-    D3D11_TEX2D_RTV, D3D11_TEXTURE2D_DESC, D3D11_USAGE_DEFAULT, D3D11_USAGE_STAGING,
-    D3D11_VIEWPORT, D3D11CreateDevice, ID3D11Device, ID3D11DeviceContext,
-    ID3D11RenderTargetView, ID3D11Texture2D,
+    D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_MAP_FLAG_DO_NOT_WAIT, D3D11_MAP_READ,
+    D3D11_MAPPED_SUBRESOURCE, D3D11_RENDER_TARGET_VIEW_DESC, D3D11_RTV_DIMENSION_TEXTURE2D,
+    D3D11_SDK_VERSION, D3D11_TEX2D_RTV, D3D11_TEXTURE2D_DESC, D3D11_USAGE_DEFAULT,
+    D3D11_USAGE_STAGING, D3D11_VIEWPORT, D3D11CreateDevice, ID3D11Device,
+    ID3D11DeviceContext, ID3D11RenderTargetView, ID3D11Texture2D,
 };
 use windows::Win32::Graphics::DirectWrite::{
     DWRITE_FACTORY_TYPE_SHARED, DWriteCreateFactory, IDWriteFactory,
@@ -47,6 +47,7 @@ use windows::Win32::Graphics::DirectWrite::{
 use windows::Win32::Graphics::Dxgi::Common::{
     DXGI_FORMAT_B8G8R8A8_UNORM, DXGI_SAMPLE_DESC,
 };
+use windows::Win32::Graphics::Dxgi::DXGI_ERROR_WAS_STILL_DRAWING;
 
 use super::vt::ScreenSnapshot;
 use atlas::{GlyphCache, GlyphKey};
@@ -100,7 +101,14 @@ pub struct Renderer {
     context: ID3D11DeviceContext,
     rt_texture: ID3D11Texture2D,
     rtv: ID3D11RenderTargetView,
-    staging: ID3D11Texture2D,
+    /// 2-slot staging ring. We CopyResource the freshly drawn rt_texture
+    /// into the next ring slot, then in the FOLLOWING `render()` call
+    /// drain the OLDEST in-flight slot non-blocking. This trades ~1
+    /// frame of latency for an unblocked render thread — the GPU has a
+    /// full prepaint cycle (~16ms) to finish the copy before we Map(),
+    /// so `D3D11_MAP_FLAG_DO_NOT_WAIT` almost always succeeds first try.
+    /// See `StagingRing` for the state machine.
+    staging_ring: Mutex<StagingRing>,
     _dwrite: IDWriteFactory,
 
     pipeline: std::sync::Mutex<Pipeline>,
@@ -132,6 +140,11 @@ pub enum RenderOutcome {
     Unchanged,
     /// Fresh BGRA bytes, ready to hand to GPUI as an `ImageSource`.
     Rendered(FrameBgra),
+    /// GPU work was submitted but the staging ring has nothing ready to
+    /// drain non-blocking. Caller should reuse the prior image and
+    /// schedule another prepaint so we can drain the in-flight slot
+    /// without stalling the render thread on `Map()`.
+    Pending,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -173,8 +186,8 @@ impl Renderer {
         let (rt_texture, rtv) = create_rt_texture(&device, width, height)?;
         log::info!("Renderer: RT texture + RTV created");
 
-        let staging = create_staging_texture(&device, width, height)?;
-        log::info!("Renderer: staging texture created");
+        let staging_ring = StagingRing::new(&device, width, height)?;
+        log::info!("Renderer: staging ring ({} slots) created", StagingRing::DEPTH);
 
         let dwrite: IDWriteFactory =
             unsafe { DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED) }
@@ -213,7 +226,7 @@ impl Renderer {
             context,
             rt_texture,
             rtv,
-            staging,
+            staging_ring: Mutex::new(staging_ring),
             _dwrite: dwrite,
             pipeline: std::sync::Mutex::new(pipeline),
             atlas: Mutex::new(atlas),
@@ -234,10 +247,12 @@ impl Renderer {
         }
 
         let (rt_texture, rtv) = create_rt_texture(&self.device, width_px, height_px)?;
-        let staging = create_staging_texture(&self.device, width_px, height_px)?;
         self.rt_texture = rt_texture;
         self.rtv = rtv;
-        self.staging = staging;
+        self.staging_ring
+            .lock()
+            .expect("staging_ring mutex poisoned in resize()")
+            .recreate(&self.device, width_px, height_px)?;
         self.width_px = width_px;
         self.height_px = height_px;
         *self
@@ -295,8 +310,23 @@ impl Renderer {
     }
 
     /// Render one frame and return a BGRA byte buffer sized to the
-    /// current render target. Returns `Unchanged` when nothing has moved
-    /// since the last call (caller reuses its cached image).
+    /// current render target.
+    ///
+    /// Three outcomes:
+    ///
+    /// * `Unchanged` — nothing has moved since the last call AND the ring
+    ///   has nothing in flight; caller reuses its cached image.
+    /// * `Rendered` — fresh BGRA bytes, drained from a slot that was
+    ///   submitted in a PRIOR call (so the GPU has had a full prepaint
+    ///   cycle to finish; `Map(DO_NOT_WAIT)` succeeds without stalling).
+    /// * `Pending` — we just submitted a fresh draw, but no prior slot
+    ///   was in flight to drain. Caller should reuse the prior image and
+    ///   schedule another prepaint so we can drain this slot next frame.
+    ///
+    /// The ordering inside the call is deliberately drain → submit:
+    /// draining first frees the slot we're about to overwrite, and
+    /// guarantees we never lose a frame to ring overflow even if the
+    /// caller calls us many times back-to-back.
     pub fn render(
         &self,
         snapshot: &ScreenSnapshot,
@@ -311,55 +341,113 @@ impl Renderer {
             .generation
             .wrapping_mul(0x9E37_79B9_7F4A_7C15)
             .wrapping_add(sel_hash);
-        {
+        let needs_draw = {
             let mut last = self
                 .last_generation
                 .lock()
                 .expect("last_generation mutex poisoned in render()");
             if *last == combined {
-                return Ok(RenderOutcome::Unchanged);
+                false
+            } else {
+                *last = combined;
+                true
             }
-            *last = combined;
-        }
-
-        let vp = D3D11_VIEWPORT {
-            TopLeftX: 0.0,
-            TopLeftY: 0.0,
-            Width: self.width_px as f32,
-            Height: self.height_px as f32,
-            MinDepth: 0.0,
-            MaxDepth: 1.0,
         };
-        // Multiply alpha by background_opacity so transparent cells
-        // composite with the backdrop (Mica / DComp). Pre-multiply RGB
-        // so the BGRA readback handed to GPUI behaves correctly under
-        // GPUI's premultiplied-alpha blend (otherwise translucent
-        // pixels look washed out / haloed against the visual beneath).
-        let opacity = config.background_opacity.clamp(0.0, 1.0);
-        let clear = [
-            config.clear_color[0] * opacity,
-            config.clear_color[1] * opacity,
-            config.clear_color[2] * opacity,
-            config.clear_color[3] * opacity,
-        ];
-        unsafe {
-            self.context.RSSetViewports(Some(&[vp]));
-            self.context
-                .OMSetRenderTargets(Some(&[Some(self.rtv.clone())]), None);
-            self.context
-                .ClearRenderTargetView(&self.rtv, &clear);
+
+        let mut ring = self
+            .staging_ring
+            .lock()
+            .expect("staging_ring mutex poisoned in render()");
+
+        // Snapshot which slot is the oldest in-flight BEFORE we submit a
+        // new one. That slot is the one whose GPU CopyResource has had
+        // the longest coast time — i.e., the only one we should try to
+        // drain non-blocking.
+        let drain_target = ring.oldest_in_flight();
+
+        let drained: Option<Vec<u8>> = if let Some(idx) = drain_target {
+            match ring.try_drain(&self.context, idx)? {
+                Some(bytes) => Some(bytes),
+                None => {
+                    // GPU somehow took longer than a full prepaint cycle.
+                    // Block to keep moving — better to stall once than to
+                    // leak in-flight slots indefinitely.
+                    ring.block_drain(&self.context, idx)?
+                }
+            }
+        } else {
+            None
+        };
+
+        if needs_draw {
+            let vp = D3D11_VIEWPORT {
+                TopLeftX: 0.0,
+                TopLeftY: 0.0,
+                Width: self.width_px as f32,
+                Height: self.height_px as f32,
+                MinDepth: 0.0,
+                MaxDepth: 1.0,
+            };
+            // Multiply alpha by background_opacity so transparent cells
+            // composite with the backdrop (Mica / DComp). Pre-multiply
+            // RGB so the BGRA readback handed to GPUI behaves correctly
+            // under GPUI's premultiplied-alpha blend (otherwise
+            // translucent pixels look washed out / haloed against the
+            // visual beneath).
+            let opacity = config.background_opacity.clamp(0.0, 1.0);
+            let clear = [
+                config.clear_color[0] * opacity,
+                config.clear_color[1] * opacity,
+                config.clear_color[2] * opacity,
+                config.clear_color[3] * opacity,
+            ];
+            unsafe {
+                self.context.RSSetViewports(Some(&[vp]));
+                self.context
+                    .OMSetRenderTargets(Some(&[Some(self.rtv.clone())]), None);
+                self.context.ClearRenderTargetView(&self.rtv, &clear);
+            }
+
+            if !snapshot.cells.is_empty() {
+                self.draw_cells(snapshot, config)?;
+            }
+
+            // Submit GPU CopyResource into the ring's next slot. The
+            // command joins the same context queue as the draws above,
+            // so by the next prepaint the GPU will have run them all
+            // and the staging texture will be ready to Map().
+            ring.submit_copy(&self.context, &self.rt_texture);
         }
 
-        if !snapshot.cells.is_empty() {
-            self.draw_cells(snapshot, config)?;
+        if let Some(bytes) = drained {
+            return Ok(RenderOutcome::Rendered(FrameBgra {
+                bytes,
+                width: self.width_px,
+                height: self.height_px,
+            }));
         }
 
-        let bytes = self.readback_rt()?;
-        Ok(RenderOutcome::Rendered(FrameBgra {
-            bytes,
-            width: self.width_px,
-            height: self.height_px,
-        }))
+        if needs_draw {
+            // We submitted a fresh slot but had nothing prior to drain.
+            // Signal the caller to come back — the slot will be ready
+            // next prepaint.
+            return Ok(RenderOutcome::Pending);
+        }
+
+        // No new draw and nothing prior was drained. If a slot is still
+        // in flight from somewhere (unlikely after the drain pass above,
+        // but safe to handle) flush it so we don't strand the trail.
+        if let Some(idx) = ring.oldest_in_flight()
+            && let Some(bytes) = ring.block_drain(&self.context, idx)?
+        {
+            return Ok(RenderOutcome::Rendered(FrameBgra {
+                bytes,
+                width: self.width_px,
+                height: self.height_px,
+            }));
+        }
+
+        Ok(RenderOutcome::Unchanged)
     }
 
     fn draw_cells(&self, snapshot: &ScreenSnapshot, config: &RendererConfig) -> Result<()> {
@@ -561,23 +649,153 @@ impl Renderer {
         Ok(())
     }
 
-    fn readback_rt(&self) -> Result<Vec<u8>> {
-        let width = self.width_px as usize;
-        let height = self.height_px as usize;
-        let row_bytes = width * 4;
-        let mut out = vec![0u8; row_bytes * height];
+}
 
+/// One slot in the readback ring.
+struct StagingSlot {
+    texture: ID3D11Texture2D,
+    /// `true` once a `CopyResource` has been queued into this slot but
+    /// before the next `Map()` drains it. Drained slots can be safely
+    /// overwritten by the next `submit_copy`.
+    in_flight: bool,
+    /// Monotonic submit counter — used to find the OLDEST in-flight
+    /// slot when picking a drain target. (`next_idx` alone wraps and
+    /// can't disambiguate "oldest" from "newest" once both are in
+    /// flight.)
+    seq: u64,
+}
+
+/// Two-slot staging ring. See `Renderer::render` for the state machine.
+///
+/// Capacity = 2 is chosen deliberately: any time `render()` runs we
+/// drain the oldest in-flight slot first, then submit a fresh copy. So
+/// at most one slot is in flight when leaving `render()`. We carry a
+/// second slot only so that the *next* call has a place to submit
+/// without waiting for the slot it's about to drain — i.e., to avoid
+/// reusing the very slot we're mapping.
+struct StagingRing {
+    slots: Vec<StagingSlot>,
+    next_idx: usize,
+    next_seq: u64,
+    width: u32,
+    height: u32,
+}
+
+impl StagingRing {
+    const DEPTH: usize = 2;
+
+    fn new(device: &ID3D11Device, width: u32, height: u32) -> Result<Self> {
+        let mut slots = Vec::with_capacity(Self::DEPTH);
+        for _ in 0..Self::DEPTH {
+            slots.push(StagingSlot {
+                texture: create_staging_texture(device, width, height)?,
+                in_flight: false,
+                seq: 0,
+            });
+        }
+        Ok(Self {
+            slots,
+            next_idx: 0,
+            next_seq: 0,
+            width,
+            height,
+        })
+    }
+
+    fn recreate(&mut self, device: &ID3D11Device, width: u32, height: u32) -> Result<()> {
+        self.slots.clear();
+        for _ in 0..Self::DEPTH {
+            self.slots.push(StagingSlot {
+                texture: create_staging_texture(device, width, height)?,
+                in_flight: false,
+                seq: 0,
+            });
+        }
+        self.next_idx = 0;
+        self.next_seq = 0;
+        self.width = width;
+        self.height = height;
+        Ok(())
+    }
+
+    fn submit_copy(&mut self, ctx: &ID3D11DeviceContext, source: &ID3D11Texture2D) {
+        let idx = self.next_idx;
         unsafe {
-            self.context.CopyResource(&self.staging, &self.rt_texture);
+            ctx.CopyResource(&self.slots[idx].texture, source);
+        }
+        let slot = &mut self.slots[idx];
+        slot.in_flight = true;
+        slot.seq = self.next_seq;
+        self.next_seq = self.next_seq.wrapping_add(1);
+        self.next_idx = (self.next_idx + 1) % self.slots.len();
+    }
+
+    /// Slot with the lowest `seq` among in-flight slots, or `None` when
+    /// the ring is idle.
+    fn oldest_in_flight(&self) -> Option<usize> {
+        let mut best: Option<(usize, u64)> = None;
+        for (i, slot) in self.slots.iter().enumerate() {
+            if !slot.in_flight {
+                continue;
+            }
+            match best {
+                None => best = Some((i, slot.seq)),
+                Some((_, s)) if slot.seq < s => best = Some((i, slot.seq)),
+                _ => {}
+            }
+        }
+        best.map(|(i, _)| i)
+    }
+
+    /// Non-blocking drain: returns `Ok(Some(bytes))` if the slot is
+    /// ready, `Ok(None)` if the GPU is still drawing into it.
+    fn try_drain(
+        &mut self,
+        ctx: &ID3D11DeviceContext,
+        idx: usize,
+    ) -> Result<Option<Vec<u8>>> {
+        self.drain_with_flags(ctx, idx, D3D11_MAP_FLAG_DO_NOT_WAIT.0 as u32)
+    }
+
+    /// Blocking drain: waits for the GPU to finish the slot's copy,
+    /// then maps it. Used as a fallback when the GPU somehow exceeds a
+    /// full prepaint cycle to drain `try_drain`'s target.
+    fn block_drain(
+        &mut self,
+        ctx: &ID3D11DeviceContext,
+        idx: usize,
+    ) -> Result<Option<Vec<u8>>> {
+        self.drain_with_flags(ctx, idx, 0)
+    }
+
+    fn drain_with_flags(
+        &mut self,
+        ctx: &ID3D11DeviceContext,
+        idx: usize,
+        flags: u32,
+    ) -> Result<Option<Vec<u8>>> {
+        let width = self.width as usize;
+        let height = self.height as usize;
+        let slot = &mut self.slots[idx];
+        if !slot.in_flight {
+            return Ok(None);
         }
 
         let mut mapped = D3D11_MAPPED_SUBRESOURCE::default();
-        unsafe {
-            self.context
-                .Map(&self.staging, 0, D3D11_MAP_READ, 0, Some(&mut mapped))
+        let map_result = unsafe {
+            ctx.Map(&slot.texture, 0, D3D11_MAP_READ, flags, Some(&mut mapped))
+        };
+        if let Err(err) = map_result {
+            if err.code() == DXGI_ERROR_WAS_STILL_DRAWING {
+                return Ok(None);
+            }
+            return Err(anyhow::anyhow!(
+                "Map(staging slot {idx}) failed: {err}"
+            ));
         }
-        .context("Map(staging) failed")?;
 
+        let row_bytes = width * 4;
+        let mut out = vec![0u8; row_bytes * height];
         let src_pitch = mapped.RowPitch as usize;
         for y in 0..height {
             unsafe {
@@ -588,11 +806,11 @@ impl Renderer {
                 );
             }
         }
-
         unsafe {
-            self.context.Unmap(&self.staging, 0);
+            ctx.Unmap(&slot.texture, 0);
         }
-        Ok(out)
+        slot.in_flight = false;
+        Ok(Some(out))
     }
 }
 

--- a/crates/con-ghostty/src/windows/render/shaders.hlsl
+++ b/crates/con-ghostty/src/windows/render/shaders.hlsl
@@ -132,13 +132,23 @@ float4 ps_main(VSOut i) : SV_Target {
     // sample all three channels for subpixel antialiasing.
     float3 coverage = atlas.Sample(samp, i.atlasUV).rgb;
 
-    // Inverse handling: swap fg/bg when attr bit 4 is set.
+    // Inverse handling: swap fg/bg when attr bit 4 is set (SGR 7 or
+    // a selected cell via the CPU-side XOR). After the swap the new
+    // `fg.a` inherits the original bg's alpha — which the CPU rewrites
+    // to `background_opacity` for default-bg cells so Mica can show
+    // through. For an inverse cell we don't want Mica behind the
+    // glyph: the whole point of inverse is a solid highlight, and
+    // translucent glyph pixels against a solid block would render
+    // text visibly semi-transparent. Pin both channels to 1.0 after
+    // swap so inverse / selection cells paint opaque.
     float4 fg = i.fg;
     float4 bg = i.bg;
     if (i.attrs & 16u) {
         float4 tmp = fg;
         fg = bg;
         bg = tmp;
+        fg.a = 1.0;
+        bg.a = 1.0;
     }
 
     // Underline / strikethrough: draw a 1-pixel-tall fg band inside

--- a/crates/con-ghostty/src/windows/render/shaders.hlsl
+++ b/crates/con-ghostty/src/windows/render/shaders.hlsl
@@ -172,5 +172,13 @@ float4 ps_main(VSOut i) : SV_Target {
     rgb.r = lerp(bg.r, fg.r, comp.r);
     rgb.g = lerp(bg.g, fg.g, comp.g);
     rgb.b = lerp(bg.b, fg.b, comp.b);
-    return float4(rgb, 1.0);
+    // Output alpha follows the maximum coverage so glyph pixels stay
+    // opaque while the cell's background takes the bg.a (which the
+    // renderer drops to `background_opacity` for default-bg cells so
+    // Mica / DComp visuals beneath show through). GPUI's compositor
+    // expects premultiplied alpha — multiply the lerped RGB by the
+    // output alpha so translucent pixels don't look washed out.
+    float a_cov = max(comp.r, max(comp.g, comp.b));
+    float alpha = lerp(bg.a, fg.a, a_cov);
+    return float4(rgb * alpha, alpha);
 }

--- a/crates/con-ghostty/src/windows/vt.rs
+++ b/crates/con-ghostty/src/windows/vt.rs
@@ -420,21 +420,39 @@ unsafe fn apply_theme_to_terminal(terminal: GhosttyTerminal, theme: &ThemeColors
         g: theme.palette[i][1],
         b: theme.palette[i][2],
     });
+    // GHOSTTY_SUCCESS = 0; non-zero return means the option was rejected
+    // (enum drift after a libghostty bump, invalid value, etc.). Log it
+    // so a silent palette regression is visible instead of debugging
+    // "why didn't my colors update".
+    let check = |rc: GhosttyResult, what: &'static str| {
+        if rc != 0 {
+            log::warn!("ghostty_terminal_set({what}) failed: rc={rc}");
+        }
+    };
     unsafe {
-        let _ = ghostty_terminal_set(
-            terminal,
-            GhosttyTerminalOption::ColorForeground,
-            &fg as *const _ as *const c_void,
+        check(
+            ghostty_terminal_set(
+                terminal,
+                GhosttyTerminalOption::ColorForeground,
+                &fg as *const _ as *const c_void,
+            ),
+            "ColorForeground",
         );
-        let _ = ghostty_terminal_set(
-            terminal,
-            GhosttyTerminalOption::ColorBackground,
-            &bg as *const _ as *const c_void,
+        check(
+            ghostty_terminal_set(
+                terminal,
+                GhosttyTerminalOption::ColorBackground,
+                &bg as *const _ as *const c_void,
+            ),
+            "ColorBackground",
         );
-        let _ = ghostty_terminal_set(
-            terminal,
-            GhosttyTerminalOption::ColorPalette,
-            palette.as_ptr() as *const c_void,
+        check(
+            ghostty_terminal_set(
+                terminal,
+                GhosttyTerminalOption::ColorPalette,
+                palette.as_ptr() as *const c_void,
+            ),
+            "ColorPalette",
         );
     }
 }

--- a/crates/con-ghostty/src/windows/vt.rs
+++ b/crates/con-ghostty/src/windows/vt.rs
@@ -60,6 +60,19 @@ pub enum GhosttyTerminalData {
     Title = 12,
 }
 
+/// `GHOSTTY_TERMINAL_OPT_*` keys for `ghostty_terminal_set`. Only the
+/// color knobs we use today; integer values mirror `terminal.h` at the
+/// pinned revision (re-confirm on GHOSTTY_REV bumps).
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub enum GhosttyTerminalOption {
+    ColorForeground = 11,
+    ColorBackground = 12,
+    ColorCursor = 13,
+    /// `GhosttyColorRgb[256]*` — full 256-entry palette.
+    ColorPalette = 14,
+}
+
 /// `GHOSTTY_RENDER_STATE_DATA_*` keys for `ghostty_render_state_get`.
 /// `RowIterator` (4) binds an existing row-iterator handle to this state.
 #[repr(C)]
@@ -282,6 +295,16 @@ unsafe extern "C" {
         key: GhosttyTerminalData,
         out: *mut c_void,
     ) -> GhosttyResult;
+    /// `value` semantics depend on `option`:
+    ///   - color knobs (FG/BG/CURSOR): pointer to a single `GhosttyColorRgb`
+    ///   - palette: pointer to `GhosttyColorRgb[256]`
+    /// Passing `value = NULL` clears the override and restores the
+    /// built-in defaults.
+    pub fn ghostty_terminal_set(
+        terminal: GhosttyTerminal,
+        option: GhosttyTerminalOption,
+        value: *const c_void,
+    ) -> GhosttyResult;
 
     /// Query whether a terminal mode is currently set. `out_value` is a
     /// `bool` (1 byte). Returns `GHOSTTY_SUCCESS` on success.
@@ -342,6 +365,80 @@ unsafe extern "C" {
     ) -> GhosttyResult;
 }
 
+// ── Theme ──────────────────────────────────────────────────────────────
+
+/// Default colors handed to libghostty via `ghostty_terminal_set`.
+///
+/// libghostty owns the SGR-color resolution: it looks up palette
+/// indices, applies bold/bright remaps, and falls back to the default
+/// fg/bg for unstyled cells. Pushing the user's theme in here means
+/// `read_cell` doesn't need any special-casing — every cell's fg/bg
+/// already arrives themed.
+#[derive(Debug, Clone)]
+pub struct ThemeColors {
+    pub fg: [u8; 3],
+    pub bg: [u8; 3],
+    /// Full 256-entry palette. Indices 0–15 are the user's ANSI
+    /// theme; 16–231 form the standard xterm 6×6×6 cube; 232–255 form
+    /// the 24-step grayscale ramp.
+    pub palette: [[u8; 3]; 256],
+}
+
+impl ThemeColors {
+    /// Build a 256-color palette from a 16-entry ANSI base.
+    pub fn from_ansi16(fg: [u8; 3], bg: [u8; 3], ansi16: [[u8; 3]; 16]) -> Self {
+        let mut palette = [[0u8; 3]; 256];
+        for i in 0..16 {
+            palette[i] = ansi16[i];
+        }
+        // 16..232: 6×6×6 RGB cube. xterm formula: x in 0..6 maps to
+        //   0 if x==0 else 55 + 40*x.
+        let step = |x: u8| -> u8 {
+            if x == 0 { 0 } else { 55 + 40 * x }
+        };
+        for i in 16..232 {
+            let idx = (i - 16) as u8;
+            let r = idx / 36;
+            let g = (idx / 6) % 6;
+            let b = idx % 6;
+            palette[i] = [step(r), step(g), step(b)];
+        }
+        // 232..256: grayscale ramp 8, 18, 28, …, 238.
+        for i in 232..256 {
+            let v = 8u8.saturating_add(((i - 232) as u8).saturating_mul(10));
+            palette[i] = [v, v, v];
+        }
+        Self { fg, bg, palette }
+    }
+}
+
+unsafe fn apply_theme_to_terminal(terminal: GhosttyTerminal, theme: &ThemeColors) {
+    let fg = GhosttyColorRgb { r: theme.fg[0], g: theme.fg[1], b: theme.fg[2] };
+    let bg = GhosttyColorRgb { r: theme.bg[0], g: theme.bg[1], b: theme.bg[2] };
+    let palette: [GhosttyColorRgb; 256] = std::array::from_fn(|i| GhosttyColorRgb {
+        r: theme.palette[i][0],
+        g: theme.palette[i][1],
+        b: theme.palette[i][2],
+    });
+    unsafe {
+        let _ = ghostty_terminal_set(
+            terminal,
+            GhosttyTerminalOption::ColorForeground,
+            &fg as *const _ as *const c_void,
+        );
+        let _ = ghostty_terminal_set(
+            terminal,
+            GhosttyTerminalOption::ColorBackground,
+            &bg as *const _ as *const c_void,
+        );
+        let _ = ghostty_terminal_set(
+            terminal,
+            GhosttyTerminalOption::ColorPalette,
+            palette.as_ptr() as *const c_void,
+        );
+    }
+}
+
 // ── Snapshot (renderer's view) ─────────────────────────────────────────
 
 #[repr(C)]
@@ -394,7 +491,7 @@ struct VtInner {
 unsafe impl Send for VtInner {}
 
 impl VtScreen {
-    pub fn new(cols: u16, rows: u16) -> anyhow::Result<Self> {
+    pub fn new(cols: u16, rows: u16, theme: Option<&ThemeColors>) -> anyhow::Result<Self> {
         let mut terminal: GhosttyTerminal = std::ptr::null_mut();
         let options = GhosttyTerminalOptions {
             cols,
@@ -465,6 +562,13 @@ impl VtScreen {
             );
         }
 
+        if let Some(theme) = theme {
+            // SAFETY: terminal handle owned, valid; theme is borrowed
+            // for the duration of the call (palette is copied by the
+            // C side before returning).
+            unsafe { apply_theme_to_terminal(terminal, theme) };
+        }
+
         Ok(Self {
             inner: Arc::new(Mutex::new(VtInner {
                 terminal,
@@ -477,6 +581,15 @@ impl VtScreen {
                 scratch: Vec::with_capacity(cols as usize * rows as usize),
             })),
         })
+    }
+
+    /// Replace the default fg/bg/palette. Bumps the snapshot
+    /// generation so the next prepaint repaints with the new colors.
+    pub fn set_theme(&self, theme: &ThemeColors) {
+        let mut inner = self.inner.lock();
+        // SAFETY: terminal valid; theme borrowed for the call.
+        unsafe { apply_theme_to_terminal(inner.terminal, theme) };
+        inner.generation = inner.generation.wrapping_add(1);
     }
 
     /// Feed bytes from the PTY into the parser. Non-reentrant per
@@ -830,13 +943,19 @@ fn read_cell(
     // explicit-black on a non-black bg, which is rare).
     let is_default = |c: GhosttyColorRgb| c.r == 0 && c.g == 0 && c.b == 0;
     let fg = if is_default(fg) { default_fg } else { fg };
-    let bg = if is_default(bg) { default_bg } else { bg };
+    let bg_was_default = is_default(bg);
+    let bg = if bg_was_default { default_bg } else { bg };
 
     // Pack RGB into the 0xRRGGBBAA u32 our HLSL `unpackRGBA` expects
     // (high byte = R, low byte = A). A=0xFF (opaque).
-    let pack = |c: GhosttyColorRgb| -> u32 {
-        ((c.r as u32) << 24) | ((c.g as u32) << 16) | ((c.b as u32) << 8) | 0xFF
+    let pack = |c: GhosttyColorRgb, a: u8| -> u32 {
+        ((c.r as u32) << 24) | ((c.g as u32) << 16) | ((c.b as u32) << 8) | (a as u32)
     };
+    // Default-bg cells carry alpha=0 as a sentinel — the renderer
+    // rewrites it to `background_opacity * 255` before pushing the
+    // instance, so Mica / DComp visuals beneath show through unstyled
+    // regions while explicit SGR backgrounds stay solid.
+    let bg_alpha: u8 = if bg_was_default { 0 } else { 0xFF };
 
     // Pack style flags into the attrs byte the renderer (and HLSL
     // pixel shader) interpret. Underline is an `int` upstream
@@ -861,8 +980,8 @@ fn read_cell(
 
     Cell {
         codepoint,
-        fg: pack(fg),
-        bg: pack(bg),
+        fg: pack(fg, 0xFF),
+        bg: pack(bg, bg_alpha),
         attrs,
         _pad: [0; 3],
     }

--- a/crates/con-ghostty/src/windows/vt.rs
+++ b/crates/con-ghostty/src/windows/vt.rs
@@ -592,6 +592,17 @@ impl VtScreen {
         inner.generation = inner.generation.wrapping_add(1);
     }
 
+    /// Force the next `snapshot()` to report a new generation so the
+    /// renderer's `needs_draw` gate treats the frame as dirty even
+    /// though no VT bytes or theme changes landed. Used by opacity-
+    /// only appearance updates, where `config.background_opacity`
+    /// changes on the renderer side but the VT screen itself is
+    /// untouched.
+    pub fn bump_generation(&self) {
+        let mut inner = self.inner.lock();
+        inner.generation = inner.generation.wrapping_add(1);
+    }
+
     /// Feed bytes from the PTY into the parser. Non-reentrant per
     /// upstream: do not call from inside a registered callback.
     pub fn feed(&self, bytes: &[u8]) {
@@ -936,14 +947,22 @@ fn read_cell(
         }
     }
 
-    // Substitute the palette's default fg/bg when the cell reports
-    // (0,0,0) — ghostty's convention for "unstyled, use default". A
-    // proper fix reads STYLE_ID and inspects the color mode, but this
-    // heuristic is good enough for first-pass rendering (we lose
-    // explicit-black on a non-black bg, which is rare).
-    let is_default = |c: GhosttyColorRgb| c.r == 0 && c.g == 0 && c.b == 0;
-    let fg = if is_default(fg) { default_fg } else { fg };
-    let bg_was_default = is_default(bg);
+    // Substitute the palette's default fg/bg when the cell's style
+    // reports no SGR override (tag == GHOSTTY_STYLE_COLOR_NONE). The
+    // row_cells FG_COLOR / BG_COLOR accessors return (0,0,0) for
+    // unstyled cells, so without this substitution default-bg cells
+    // would paint pure black. Keying off the style tag (not the RGB
+    // value) is the correct test: an explicit `SGR 40` or
+    // `48;2;0;0;0` sets tag = PALETTE(0) / RGB(0,0,0) while still
+    // requesting solid black — the old `rgb == (0,0,0)` heuristic
+    // misclassified those as "default" and, combined with the
+    // alpha-sentinel below, made them translucent under
+    // background_opacity < 1. See libghostty's
+    // `GHOSTTY_STYLE_COLOR_NONE = 0` in ghostty/vt/style.h.
+    const STYLE_COLOR_TAG_NONE: u32 = 0;
+    let fg_was_default = style.fg_color.tag == STYLE_COLOR_TAG_NONE;
+    let bg_was_default = style.bg_color.tag == STYLE_COLOR_TAG_NONE;
+    let fg = if fg_was_default { default_fg } else { fg };
     let bg = if bg_was_default { default_bg } else { bg };
 
     // Pack RGB into the 0xRRGGBBAA u32 our HLSL `unpackRGBA` expects


### PR DESCRIPTION
## Summary

Two cheap wins for the Windows terminal port that were missing:

- **Theme wiring** — `WindowsGhosttyApp::new` was accepting `_colors` and ignoring it; SGR colors fell back to libghostty's built-in defaults. Now pushes the user's `TerminalTheme` palette into libghostty via `ghostty_terminal_set(COLOR_FOREGROUND / BACKGROUND / PALETTE)`. Builds a full 256-color palette from the 16-entry ANSI base using the standard xterm 6×6×6 cube + 24-step grayscale ramp. Live theme switches forward through a new `RenderSession::set_appearance` to the running VT and renderer config — no pane restart needed.
- **Transparency** — Mica backdrop is already enabled at the window level (`apply_windows_backdrop`), but the terminal pane was painting opaque BGRA on top, so it never showed through. The VT layer now marks default-bg cells with sentinel `alpha=0`, the renderer rewrites that to `background_opacity * 255` and pre-multiplies the D3D11 clear color by the same opacity. The HLSL pixel shader emits premultiplied output (`rgb * alpha, alpha`) so GPUI's compositor blends the pane correctly over Mica. Cells with explicit SGR backgrounds keep `alpha=0xFF`, so styled regions stay solid.
- **Ring-buffer readback** — 2-frame staging ring + `D3D11_MAP_FLAG_DO_NOT_WAIT` so the render thread never blocks on `Map()`. Adds ~1 frame of latency but removes the per-frame GPU→CPU sync stall.
- **`terminal_blur` setting wired end-to-end** — toggles DWM `DWMWA_SYSTEMBACKDROP_TYPE` between `DWMSBT_TRANSIENTWINDOW` (Acrylic) and `DWMSBT_MAINWINDOW` (Mica) at window creation and live on settings save. Known limitation: actual Gaussian blur does not yet render because GPUI's DComp tree has no backdrop brush — tracked in #55.

## Test plan

- [x] Windows CI build green on `wcheck` / `wbuild`.
- [x] Launch a fresh `con-app.exe`, confirm pwsh banner uses the user's theme colors (Flexoki Light by default).
- [x] Switch theme via Settings → confirm running pane repaints with new palette without restart.
- [x] Set `terminal.opacity = 0.85` in config → confirm Mica show-through behind unstyled cells, while a `cmd.exe` `color 4F` (or any SGR-set bg) cell stays solid.
- [x] Confirm cursor swap still inverts correctly after the new alpha pipe.
- [x] Toggle `terminal_blur` → log reports `applied DWM Acrylic backdrop` / `Mica backdrop`; transparency remains stable across toggles (actual blur pending #55).

Closes part of #34. Follow-up: #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Windows rendering (D3D11 readback, shader alpha, VT color plumbing) and DWM window attributes; issues could manifest as visual glitches or stalls/crashes on specific GPU/OS combinations.
> 
> **Overview**
> Improves the Windows terminal port by wiring the user’s terminal theme and background opacity through the libghostty-vt → VT snapshot → D3D11 renderer pipeline, enabling translucent default backgrounds to composite correctly over the window backdrop.
> 
> Adds a non-blocking GPU readback path using a 2-slot staging ring (`D3D11_MAP_FLAG_DO_NOT_WAIT`) with a new `RenderOutcome::Pending` to avoid stalling the render thread, and updates the HLSL shader to output premultiplied alpha while keeping selection/inverse and cursor rendering opaque.
> 
> Extends Windows window-backdrop handling to support live switching between Acrylic and Mica based on `terminal_blur` (apply on open and re-apply on theme updates), with fallback logging when the DWM attribute is unsupported. Also defaults the Zig build of `libghostty-vt` to `-Doptimize=ReleaseFast` (overridable via env var).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2abe03b2191c6745d1007eb02c295122c2652f4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows backdrop blur toggle between Acrylic (with blur) and Mica (no blur) modes
  * Terminal color theme and background opacity customization
  * Dynamic appearance updates now properly reflected in the terminal render

* **Improvements**
  * Enhanced rendering pipeline performance with optimized staging and pending state handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->