### PR TITLE
Linux release pipeline: one-liner installer + tarball + notify-only auto-update

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,0 +1,296 @@
+name: Release Linux
+
+# v0 release pipeline for the Linux preview. Produces a self-contained
+# tarball, attaches it to the same GitHub release the macOS / Windows
+# jobs share (the `v*` tag triggers all three workflows), and publishes
+# a Sparkle-shaped appcast to gh-pages so the in-app notify-only
+# updater can discover new builds.
+#
+# Distribution shape is intentionally similar to the Windows preview:
+# unsigned, no installer, the user grabs `con-<version>-linux-<arch>.tar.gz`,
+# extracts it (or runs `install.sh`), and `con` lives at
+# ~/.local/bin/con. Auto-update applies via the same install.sh
+# pipeline. Real packaging (.deb, AppImage, Flatpak) is a follow-up.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build linux-x86_64
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Derive release metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          channel="stable"
+          if [[ "$version" == *"-beta."* ]]; then
+            channel="beta"
+          elif [[ "$version" == *"-dev."* ]]; then
+            channel="dev"
+          fi
+          echo "version=$version" >>"$GITHUB_OUTPUT"
+          echo "channel=$channel" >>"$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install Zig 0.15.2
+        # Same Zig the linux CI smoke test installs — needed for
+        # con-ghostty's libghostty-vt build.
+        shell: bash
+        run: |
+          set -euo pipefail
+          ZIG_VERSION="0.15.2"
+          ZIG_ARCH="x86_64"
+          ZIG_DIR="zig-${ZIG_ARCH}-linux-${ZIG_VERSION}"
+          ZIG_TARBALL="${ZIG_DIR}.tar.xz"
+          curl -sSfL "https://ziglang.org/download/${ZIG_VERSION}/${ZIG_TARBALL}" -o "/tmp/${ZIG_TARBALL}"
+          mkdir -p "$HOME/.local"
+          tar -xJf "/tmp/${ZIG_TARBALL}" -C "$HOME/.local"
+          echo "$HOME/.local/${ZIG_DIR}" >> "$GITHUB_PATH"
+          "$HOME/.local/${ZIG_DIR}/zig" version
+
+      - name: apt deps for gpui_linux (wayland/x11 + font stack)
+        # Mirror the matrix from .github/workflows/ci-portable.yml so
+        # the release build links against the same set of system libs
+        # as the smoke check.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libxcb-composite0-dev libxcb-dri2-0-dev libxcb-glx0-dev \
+            libxcb-present-dev libxcb-xfixes0-dev libxkbcommon-x11-dev \
+            libwayland-dev libvulkan-dev \
+            libfreetype-dev libfontconfig1-dev
+
+      - name: Build + package release tarball
+        id: package
+        shell: bash
+        # scripts/linux/release.sh:
+        #   - cargo build -p con --release with the channel + version
+        #     baked in via CON_RELEASE_CHANNEL / CON_RELEASE_VERSION
+        #     (option_env! in con-core::release_channel reads them so
+        #     the notify-only updater knows which appcast to poll),
+        #   - strip --strip-debug the ~300 MB debug-laden binary down
+        #     to ~80 MB,
+        #   - stage the binary + LICENSE + README.md + a .desktop
+        #     entry + a 256x256 icon into a versioned dir,
+        #   - tar -czf the staging dir into
+        #     dist/con-<version>-linux-x86_64.tar.gz,
+        #   - emit dist/SHA256SUMS-linux.txt.
+        env:
+          CON_RELEASE_CHANNEL: ${{ steps.meta.outputs.channel }}
+          CON_RELEASE_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          ./scripts/linux/release.sh
+          echo "tarball=dist/con-${{ steps.meta.outputs.version }}-linux-x86_64.tar.gz" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v5
+        with:
+          name: linux-x86_64
+          path: |
+            dist/con-*-linux-x86_64.tar.gz
+            dist/SHA256SUMS-linux.txt
+          if-no-files-found: error
+
+  publish:
+    name: Attach to GitHub release
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          name: linux-x86_64
+          path: release-artifacts
+
+      - name: Create or update release & upload
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        shell: bash
+        # macOS / Windows jobs may have already created the release.
+        # If not, create it now so a Linux-only tag still publishes.
+        run: |
+          set -euo pipefail
+          tag="$GITHUB_REF_NAME"
+
+          if ! gh release view "$tag" >/dev/null 2>&1; then
+            gh release create "$tag" --title "$tag" --generate-notes
+          fi
+
+          while IFS= read -r -d '' file; do
+            echo "Uploading: $file"
+            gh release upload "$tag" "$file" --clobber
+          done < <(find release-artifacts -type f \
+            \( -name '*.tar.gz' -o -name 'SHA256SUMS-linux.txt' \) \
+            -print0)
+
+  update-appcast:
+    name: Update Sparkle appcast (linux-x86_64)
+    # Run on macOS because Sparkle's `sign_update` tool ships only in
+    # the macOS Sparkle distribution. Identical pattern to
+    # release-windows.yml's appcast job — same Ed25519 keypair, same
+    # gh-pages target. The Linux notify-only client (in
+    # crates/con-app/src/updater.rs::notify_impl) verifies the
+    # signature server-side via GitHub Pages publishing today;
+    # in-app verification is a follow-up that mirrors the Windows
+    # hardening work tracked alongside it.
+    runs-on: macos-15
+    needs: build
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Derive release metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          channel="stable"
+          if [[ "$version" == *"-beta."* ]]; then
+            channel="beta"
+          fi
+          marketing="${version%%[-+]*}"
+          echo "version=$version"     >>"$GITHUB_OUTPUT"
+          echo "channel=$channel"     >>"$GITHUB_OUTPUT"
+          echo "marketing=$marketing" >>"$GITHUB_OUTPUT"
+
+      - name: Check Sparkle signing key
+        id: sparkle
+        shell: bash
+        env:
+          SPARKLE_SIGNING_KEY: ${{ secrets.SPARKLE_SIGNING_KEY }}
+        run: |
+          if [[ -z "${SPARKLE_SIGNING_KEY:-}" ]]; then
+            echo "available=false" >>"$GITHUB_OUTPUT"
+            echo "::warning::SPARKLE_SIGNING_KEY not set — skipping appcast update"
+          else
+            echo "available=true" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Download Sparkle tools
+        if: steps.sparkle.outputs.available == 'true'
+        shell: bash
+        run: ./scripts/sparkle/download.sh
+
+      - name: Download Linux release artifact
+        if: steps.sparkle.outputs.available == 'true'
+        uses: actions/download-artifact@v5
+        with:
+          name: linux-x86_64
+          path: release-artifacts
+
+      - name: Checkout gh-pages
+        if: steps.sparkle.outputs.available == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git clone --single-branch --branch gh-pages \
+            "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" \
+            gh-pages 2>/dev/null || {
+            mkdir -p gh-pages/appcast
+            cd gh-pages
+            git init
+            git checkout -b gh-pages
+            git remote add origin \
+              "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
+            echo "con-releases.nowledge.co" > CNAME
+            touch .nojekyll
+            git add CNAME .nojekyll
+            git commit -m "Initialize gh-pages"
+          }
+
+      - name: Sign tarball and update Linux appcast
+        if: steps.sparkle.outputs.available == 'true'
+        shell: bash
+        env:
+          SPARKLE_SIGNING_KEY: ${{ secrets.SPARKLE_SIGNING_KEY }}
+          SPARKLE_DIR: ${{ github.workspace }}/.sparkle
+        run: |
+          set -euo pipefail
+
+          repo="${{ github.repository }}"
+          tag="$GITHUB_REF_NAME"
+          version="${{ steps.meta.outputs.version }}"
+          channel="${{ steps.meta.outputs.channel }}"
+          marketing="${{ steps.meta.outputs.marketing }}"
+          build_number="${{ github.run_number }}"
+
+          mkdir -p gh-pages/appcast
+
+          tarball=$(find release-artifacts -name "*-linux-x86_64.tar.gz" -type f | head -1)
+          if [[ -z "$tarball" ]]; then
+            echo "::warning::No Linux tarball found — skipping"
+            exit 0
+          fi
+
+          sig_output=$(./scripts/sparkle/sign-artifact.sh "$tarball")
+          signature=$(echo "$sig_output" | sed -n 's/.*edSignature="\([^"]*\)".*/\1/p')
+          if [[ -z "$signature" ]]; then
+            echo "::error::Failed to extract Ed25519 signature"
+            echo "sign_update output: $sig_output" >&2
+            exit 1
+          fi
+          length=$(stat -f%z "$tarball")
+          tarball_name=$(basename "$tarball")
+          download_url="https://github.com/${repo}/releases/download/${tag}/${tarball_name}"
+
+          appcast_file="gh-pages/appcast/${channel}-linux-x86_64.xml"
+
+          # Re-use the same appcast generator macOS + Windows use.
+          # Linux has no OS-minimum equivalent in the Sparkle schema
+          # and the notify-only client ignores the field, so feed a
+          # harmless sentinel like the Windows job does.
+          # ITEM_SHORT_VERSION is the string the Linux client compares
+          # against its baked CON_RELEASE_VERSION via the SemVer-aware
+          # is_newer check in updater.rs::notify_impl. Using the full
+          # tag-derived version (0.1.0-beta.31) keeps prerelease
+          # ordering correct.
+          APPCAST_FILE="$appcast_file" \
+          APPCAST_TITLE="con" \
+          APPCAST_LINK="https://con-releases.nowledge.co" \
+          ITEM_TITLE="Version ${version}" \
+          ITEM_VERSION="$build_number" \
+          ITEM_SHORT_VERSION="$version" \
+          ITEM_URL="$download_url" \
+          ITEM_LENGTH="$length" \
+          ITEM_SIGNATURE="$signature" \
+          ITEM_MIN_OS="0.0.0" \
+          ./scripts/sparkle/update-appcast.sh
+
+          echo "Updated appcast: ${channel}-linux-x86_64.xml (build $build_number)"
+
+      - name: Push appcast to gh-pages
+        if: steps.sparkle.outputs.available == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Keep install.sh in sync from main repo. The macOS release
+          # job also copies it, but if a Linux-only tag fires (or the
+          # macOS job hasn't run yet) we still want the latest script.
+          cp "${{ github.workspace }}/scripts/install.sh" install.sh
+          git add appcast/ install.sh
+          if git diff --cached --quiet; then
+            echo "No appcast changes to commit"
+            exit 0
+          fi
+          git commit -m "Update Linux appcast for $GITHUB_REF_NAME"
+          git pull --rebase origin gh-pages 2>/dev/null || true
+          git push origin gh-pages

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -127,8 +127,23 @@ jobs:
           set -euo pipefail
           tag="$GITHUB_REF_NAME"
 
+          # `gh release create` defaults to a stable release. v*-beta.*
+          # and v*-dev.* tags must be marked --prerelease, otherwise
+          # GitHub's `/releases/latest` API includes them and a
+          # stable-channel user's `install.sh` (which queries
+          # /releases/latest) downloads a beta as if it were the next
+          # stable. The Linux notify-only updater also pins via
+          # CON_INSTALL_VERSION on apply, but that pin only kicks in
+          # when the user already saw "Update available" — the
+          # /releases/latest API is what install.sh hits on a fresh
+          # install or when CON_INSTALL_VERSION is unset.
+          prerelease_args=()
+          case "$tag" in
+            *-beta.*|*-dev.*) prerelease_args+=(--prerelease) ;;
+          esac
+
           if ! gh release view "$tag" >/dev/null 2>&1; then
-            gh release create "$tag" --title "$tag" --generate-notes
+            gh release create "$tag" --title "$tag" --generate-notes "${prerelease_args[@]}"
           fi
 
           while IFS= read -r -d '' file; do

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -149,7 +149,11 @@ jobs:
     # in-app verification is a follow-up that mirrors the Windows
     # hardening work tracked alongside it.
     runs-on: macos-15
-    needs: build
+    # `needs: [build, publish]` so the appcast is never updated until
+    # the GitHub release asset it points at is actually attached. If
+    # `publish` fails, the appcast doesn't move and old beta clients
+    # don't chase a 404 on the enclosure URL.
+    needs: [build, publish]
 
     steps:
       - uses: actions/checkout@v5
@@ -161,13 +165,17 @@ jobs:
           set -euo pipefail
           version="${GITHUB_REF_NAME#v}"
           channel="stable"
+          # Channel mapping must match the build job above. A v*-dev.*
+          # tag previously fell through to "stable" here and would have
+          # written the dev build's metadata into stable-linux-x86_64.xml,
+          # notifying stable-channel users about a dev prerelease.
           if [[ "$version" == *"-beta."* ]]; then
             channel="beta"
+          elif [[ "$version" == *"-dev."* ]]; then
+            channel="dev"
           fi
-          marketing="${version%%[-+]*}"
-          echo "version=$version"     >>"$GITHUB_OUTPUT"
-          echo "channel=$channel"     >>"$GITHUB_OUTPUT"
-          echo "marketing=$marketing" >>"$GITHUB_OUTPUT"
+          echo "version=$version" >>"$GITHUB_OUTPUT"
+          echo "channel=$channel" >>"$GITHUB_OUTPUT"
 
       - name: Check Sparkle signing key
         id: sparkle
@@ -206,6 +214,13 @@ jobs:
             cd gh-pages
             git init
             git checkout -b gh-pages
+            # Identity must be configured before the bootstrap
+            # commit, otherwise `git commit` fails on a fresh runner
+            # without a global config and the very first Linux
+            # appcast publish breaks. Match the identity the publish
+            # step further down uses.
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git remote add origin \
               "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
             echo "con-releases.nowledge.co" > CNAME
@@ -227,7 +242,6 @@ jobs:
           tag="$GITHUB_REF_NAME"
           version="${{ steps.meta.outputs.version }}"
           channel="${{ steps.meta.outputs.channel }}"
-          marketing="${{ steps.meta.outputs.marketing }}"
           build_number="${{ github.run_number }}"
 
           mkdir -p gh-pages/appcast

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -134,8 +134,18 @@ jobs:
           set -euo pipefail
           tag="$GITHUB_REF_NAME"
 
+          # `gh release create` defaults to a stable release. v*-beta.*
+          # and v*-dev.* tags must be marked --prerelease, otherwise
+          # GitHub's `/releases/latest` API includes them and the
+          # macOS install.sh / Sparkle / Homebrew tap downstream paths
+          # treat them as the next stable release.
+          prerelease_args=()
+          case "$tag" in
+            *-beta.*|*-dev.*) prerelease_args+=(--prerelease) ;;
+          esac
+
           if ! gh release view "$tag" >/dev/null 2>&1; then
-            gh release create "$tag" --title "$tag" --generate-notes
+            gh release create "$tag" --title "$tag" --generate-notes "${prerelease_args[@]}"
           fi
 
           # Upload files one at a time to avoid GitHub API race conditions.

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -285,10 +285,20 @@ jobs:
           set -euo pipefail
           tag="$GITHUB_REF_NAME"
 
+          # `gh release create` defaults to a stable release. v*-beta.*
+          # and v*-dev.* tags must be marked --prerelease, otherwise
+          # GitHub's `/releases/latest` API includes them and the
+          # Windows install.ps1 / notify-only updater downstream paths
+          # treat them as the next stable release.
+          prerelease_args=()
+          case "$tag" in
+            *-beta.*|*-dev.*) prerelease_args+=(--prerelease) ;;
+          esac
+
           # The macOS job may have already created the release. If not,
           # create it now so a Windows-only tag still publishes.
           if ! gh release view "$tag" >/dev/null 2>&1; then
-            gh release create "$tag" --title "$tag" --generate-notes
+            gh release create "$tag" --title "$tag" --generate-notes "${prerelease_args[@]}"
           fi
 
           while IFS= read -r -d '' file; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Changes here are after `v0.1.0-beta.33`, the latest published beta release.
 - Added Linux theme propagation from app settings into the VT parser at spawn time and during live theme changes.
 - Added Linux client-side decorations, transparent rounded windows, and KWin Wayland backdrop blur where the compositor exposes it.
 
+**Release and Packaging**
+- Linux now has the same one-liner installer + auto-update story as macOS / Windows. The single `install.sh` (`curl -fsSL https://con-releases.nowledge.co/install.sh | sh`) detects the host OS and routes Darwin to the existing DMG flow or Linux to a new tarball flow that drops `con` into `~/.local/bin`, registers a `.desktop` launcher entry, and installs the 256x256 hicolor icon.
+- A new `scripts/linux/release.sh` builds the artifact (`cargo build --release` with `CON_RELEASE_VERSION` / `CON_RELEASE_CHANNEL` baked in via `option_env!`, `--strip-debug`, stage + tar.gz + sha256), and a new `.github/workflows/release-linux.yml` mirrors the Windows release workflow: builds on `ubuntu-latest`, publishes the tarball to the same GitHub release the macOS / Windows jobs share, and updates the Sparkle-shaped appcast at `https://con-releases.nowledge.co/appcast/{channel}-linux-x86_64.xml` so the in-app notify-only updater can discover new builds.
+- Added a notify-only Linux updater that polls the same Sparkle-shaped appcast XML the Windows backend uses, surfaces "Update now" in Settings → Updates, and re-runs `install.sh` with `CON_INSTALL_VERSION` pinned to the appcast's chosen version so beta-channel users do not silently get downgraded to stable when GitHub's `/releases/latest` skips prereleases. Sparkle itself stays macOS-only — Linux follows the Windows model (notify-only checker against the shared XML schema, then re-runs `install.sh` to apply).
+- All three release workflows (`release-macos.yml`, `release-windows.yml`, `release-linux.yml`) now mark `v*-beta.*` and `v*-dev.*` tags as `--prerelease` when calling `gh release create`. Without this, GitHub's `/releases/latest` API treats prerelease tags as the next stable release, so a stable-channel install would download a beta as if it were stable.
+
 ### Improved
 
 **Terminal — Linux Backend (preview)**

--- a/HACKING.md
+++ b/HACKING.md
@@ -101,6 +101,22 @@ For signed macOS release artifacts, use:
 ./scripts/macos/release.sh
 ```
 
+For a Linux release tarball (un-signed; mirrors the Windows
+preview's distribution shape), use:
+
+```bash
+CON_RELEASE_VERSION=0.1.0-beta.X CON_RELEASE_CHANNEL=beta \
+  ./scripts/linux/release.sh
+```
+
+Output lands in `dist/con-<version>-linux-<arch>.tar.gz` with a
+SHA256 sum next to it. The CI workflow at
+`.github/workflows/release-linux.yml` runs the same script on every
+`v*` tag, attaches the tarball to the shared GitHub release, and
+updates the Sparkle-shaped appcast at
+`https://con-releases.nowledge.co/appcast/<channel>-linux-x86_64.xml`
+that the in-app notify-only updater polls.
+
 ## Useful Paths
 
 - `crates/con-app/src` — app shell and GPUI surfaces (the crate directory is `con-app` because `con` is a reserved DOS device name on Windows; the Cargo package and binary are still named `con` on macOS, so `cargo run -p con` works as before — see `docs/impl/windows-port.md`)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ curl -fsSL https://con-releases.nowledge.co/install.sh | sh
 
 Or download the DMG directly from [Releases](https://github.com/nowledge-co/con-terminal/releases).
 
+**Linux** (preview)
+
+```sh
+curl -fsSL https://con-releases.nowledge.co/install.sh | sh
+```
+
+Same one-liner as macOS — `install.sh` detects the OS and routes to either the macOS DMG or the Linux tarball. Installs `con` into `~/.local/bin` and drops a `.desktop` entry into `~/.local/share/applications` so it shows up in your launcher. Or download `con-<version>-linux-x86_64.tar.gz` from the latest [Release](https://github.com/nowledge-co/con-terminal/releases).
+
 **Windows**
 
 ```powershell

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -23,8 +23,25 @@ use gpui::*;
 use gpui_component::ActiveTheme;
 
 const DEFAULT_FONT_SIZE: f32 = 14.0;
+const MIN_FONT_SIZE_PX: f32 = 12.0;
 const DEFAULT_CELL_WIDTH_RATIO: f32 = 0.62;
 const DEFAULT_CELL_HEIGHT_RATIO: f32 = 1.45;
+
+/// Resolved logical font size used for both the cell-grid estimate
+/// (`estimate_surface_size`) and the actual paint (`render`). Both
+/// callers used to clamp differently — paint floored at 12 px,
+/// estimate didn't — which let a sub-12 px config size the PTY grid
+/// to cells smaller than the cells we actually drew, so text
+/// overran the estimated column count and lines wrapped unexpectedly
+/// on the alternate screen. Centralising here keeps them honest.
+fn effective_font_size(configured: f32) -> f32 {
+    let base = if configured > 0.0 {
+        configured
+    } else {
+        DEFAULT_FONT_SIZE
+    };
+    base.max(MIN_FONT_SIZE_PX)
+}
 
 actions!(ghostty, [ConsumeTab, ConsumeTabPrev]);
 
@@ -319,14 +336,14 @@ impl GhosttyView {
         let height_px = ((f32::from(bounds.size.height) * scale_factor).ceil() as u32).max(1);
 
         // Until the real grid renderer lands we estimate the PTY grid
-        // from the configured mono font size so shells and TUIs do not
-        // stay stuck at the initial 80x24 forever.
-        let logical_font_size = if self.initial_font_size > 0.0 {
-            self.initial_font_size
-        } else {
-            DEFAULT_FONT_SIZE
-        };
-        let font_size_px = logical_font_size * scale_factor;
+        // from the configured mono font size so shells and TUIs do
+        // not stay stuck at the initial 80x24 forever. Run through
+        // the same `effective_font_size` clamp `render()` uses so
+        // the grid we ask the PTY for matches the cell size we
+        // actually paint at — picking different floors here would
+        // make text overrun the estimated column count and lines
+        // wrap unexpectedly on the alternate screen.
+        let font_size_px = effective_font_size(self.initial_font_size) * scale_factor;
         let cell_width_px = (font_size_px * DEFAULT_CELL_WIDTH_RATIO).round().max(7.0) as u32;
         let cell_height_px = (font_size_px * DEFAULT_CELL_HEIGHT_RATIO).round().max(14.0) as u32;
         let columns = (width_px / cell_width_px.max(1))
@@ -440,7 +457,7 @@ impl Render for GhosttyView {
         let theme = cx.theme();
         let focus = self.focus_handle.clone();
         let entity = cx.entity().downgrade();
-        let font_size_px = self.initial_font_size.max(12.0);
+        let font_size_px = effective_font_size(self.initial_font_size);
         let line_height_px = (font_size_px * 1.45).round();
         let mono_font = Font {
             family: theme.mono_font_family.clone(),
@@ -619,7 +636,37 @@ fn render_terminal_row(
     line_height: Pixels,
     cursor_col: Option<usize>,
 ) -> AnyElement {
-    let mut text = String::with_capacity(cells.len());
+    // First pass: find the last column we have to keep. A column
+    // matters if it has a real glyph, OR if it carries a non-default
+    // background / underline / strikethrough / inverse style, OR if
+    // it sits under the cursor. Trailing default-styled blanks past
+    // that column are dropped so we don't emit hundreds of empty
+    // cells per row, but trailing *styled* blanks (status bars,
+    // selection highlights, full-width fills) survive — those carry
+    // visual information in their background color and dropping them
+    // would collapse the line paint width.
+    let last_meaningful_col = cells
+        .iter()
+        .enumerate()
+        .rposition(|(col_idx, cell)| {
+            let glyph_present = cell.codepoint != 0
+                && char::from_u32(cell.codepoint).is_some_and(|ch| ch != ' ');
+            let styled_blank = (cell.bg & 0xFF) != 0
+                || (cell.attrs
+                    & (ATTR_INVERSE | ATTR_UNDERLINE | ATTR_STRIKE))
+                    != 0;
+            let cursor_here = cursor_col == Some(col_idx);
+            glyph_present || styled_blank || cursor_here
+        })
+        // `rposition` already returns the index relative to `cells`,
+        // not `iter().enumerate()`'s output. Map it back to a slice
+        // length via +1.
+        .map(|idx| idx + 1)
+        .unwrap_or(0);
+
+    let kept = &cells[..last_meaningful_col];
+
+    let mut text = String::with_capacity(kept.len());
     let mut runs: Vec<TextRun> = Vec::new();
     let mut last_signature: Option<(u32, u32, u8, bool)> = None;
     let mut active_run_len: usize = 0;
@@ -645,7 +692,7 @@ fn render_terminal_row(
         *active_run_len = 0;
     }
 
-    for (col_idx, cell) in cells.iter().enumerate() {
+    for (col_idx, cell) in kept.iter().enumerate() {
         let is_cursor = cursor_col == Some(col_idx);
         let signature = (cell.fg, cell.bg, cell.attrs, is_cursor);
         let style = RowStyle::from_cell(cell, default_fg, default_bg, base_font, is_cursor);
@@ -666,23 +713,6 @@ fn render_terminal_row(
     }
 
     flush_run(&mut runs, &mut active_style, &mut active_run_len);
-
-    if cursor_col.is_none() {
-        let trimmed_end = text.trim_end_matches(' ').len();
-        if trimmed_end < text.len() {
-            let mut to_remove = text.len() - trimmed_end;
-            text.truncate(trimmed_end);
-            while to_remove > 0 {
-                let Some(mut last) = runs.pop() else { break };
-                if last.len > to_remove {
-                    last.len -= to_remove;
-                    runs.push(last);
-                    break;
-                }
-                to_remove -= last.len;
-            }
-        }
-    }
 
     if text.is_empty() {
         text.push('\u{00A0}');
@@ -738,11 +768,17 @@ impl RowStyle {
         }
 
         if is_cursor {
-            // Block cursor (focused): swap fg/bg so the glyph under
-            // the cursor stays legible, like xterm and Ghostty's own
-            // default. Selection / blink-state nuances are deferred
-            // to the proper grid renderer.
-            let cursor_bg = vt_color_to_hsla(cell.fg).unwrap_or(default_fg);
+            // Block cursor (focused): swap the *currently resolved*
+            // fg / bg so the glyph under the cursor stays legible,
+            // like xterm and Ghostty's own default. Crucially we
+            // operate on `fg` / `bg` (post `ATTR_INVERSE`) and *not*
+            // on the raw `cell.fg` / `cell.bg`, so an inverse cell
+            // under the cursor de-inverts to draw the block over
+            // the already-inverted content rather than collapsing
+            // into a single color and turning the glyph invisible
+            // (selected rows in htop, vim status lines, less search
+            // highlights all hit this exact case).
+            let cursor_bg = fg;
             let cursor_fg = bg.unwrap_or(default_bg);
             fg = cursor_fg;
             bg = Some(cursor_bg);

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -2017,17 +2017,25 @@ impl SettingsPanel {
 
         // Build the Updates card (only shown for channels that poll).
         let channel = con_core::release_channel::current();
-        // On Linux (and any other non-macOS-non-Windows target) we have no
-        // update backend, so skip the card even if the channel otherwise
-        // would poll.
+        // On any target outside macOS / Windows / Linux we have no
+        // update backend, so skip the card even if the channel
+        // otherwise would poll.
         #[cfg_attr(
-            all(not(target_os = "macos"), not(target_os = "windows")),
+            all(
+                not(target_os = "macos"),
+                not(target_os = "windows"),
+                not(target_os = "linux")
+            ),
             allow(unused_variables)
         )]
         let show_updates = channel.polls_for_updates();
 
         #[cfg_attr(
-            all(not(target_os = "macos"), not(target_os = "windows")),
+            all(
+                not(target_os = "macos"),
+                not(target_os = "windows"),
+                not(target_os = "linux")
+            ),
             allow(unused_mut)
         )]
         let mut container = section_content(
@@ -2036,7 +2044,7 @@ impl SettingsPanel {
             theme,
         );
 
-        #[cfg(any(target_os = "macos", target_os = "windows"))]
+        #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
         if show_updates {
             let updater_status = crate::updater::status();
             let latest_state = crate::updater::latest_check();
@@ -2211,7 +2219,14 @@ impl SettingsPanel {
                                     .child({
                                         let actions = div().flex().items_center().gap(px(6.0));
 
-                                        #[cfg(target_os = "windows")]
+                                        // The notify-only updater
+                                        // (Windows + Linux) shows
+                                        // "Update now" when the
+                                        // latest state has a fresh
+                                        // version. macOS uses
+                                        // Sparkle's own dialog
+                                        // instead.
+                                        #[cfg(any(target_os = "windows", target_os = "linux"))]
                                         let actions = if matches!(
                                             &latest_state,
                                             crate::updater::CheckState::UpdateAvailable { .. }
@@ -4324,7 +4339,7 @@ impl Render for SettingsPanel {
 
 // ── Update status helpers ─────────────────────────────────────────
 
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 fn update_summary_and_detail(
     state: &crate::updater::CheckState,
     status: crate::updater::UpdaterStatus,
@@ -4354,7 +4369,7 @@ fn update_summary_and_detail(
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 fn update_download_url(state: &crate::updater::CheckState) -> Option<String> {
     match state {
         crate::updater::CheckState::UpdateAvailable { url, .. } => Some(url.clone()),

--- a/crates/con-app/src/theme.rs
+++ b/crates/con-app/src/theme.rs
@@ -274,10 +274,23 @@ fn apply_font_overrides(
 pub fn canonical_terminal_font_family(name: &str) -> String {
     #[cfg(target_os = "linux")]
     {
-        return match name.trim() {
-            "Ioskeley Mono" | "IoskeleyMono" | "Ioskeley-Mono" => "IoskeleyMono".to_string(),
-            other => other.to_string(),
-        };
+        // Normalize aggressively: trim, lowercase, strip whitespace
+        // and hyphens. That way `"Ioskeley Mono"`, `"IoskeleyMono"`,
+        // `"Ioskeley-Mono"`, `"ioskeley mono"`, `" IOSKELEY  MONO "`,
+        // and any other casing / spacing the user might paste into
+        // the config or settings UI all resolve to the registered
+        // TTF family `"IoskeleyMono"`. CosmicText's exact-match
+        // lookup would otherwise miss them and fall back to a
+        // proportional system sans.
+        let key: String = name
+            .chars()
+            .filter(|c| !c.is_whitespace() && *c != '-')
+            .flat_map(|c| c.to_lowercase())
+            .collect();
+        if key == "ioskeleymono" {
+            return "IoskeleyMono".to_string();
+        }
+        return name.to_string();
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/crates/con-app/src/theme.rs
+++ b/crates/con-app/src/theme.rs
@@ -290,7 +290,15 @@ pub fn canonical_terminal_font_family(name: &str) -> String {
         if key == "ioskeleymono" {
             return "IoskeleyMono".to_string();
         }
-        return name.to_string();
+        // Preserve the trim-on-fall-through that the original
+        // helper had before we added the case-insensitive
+        // canonicalization above. A user with accidental
+        // whitespace padding around their custom font name
+        // (common when copy-pasting from a font catalog into the
+        // settings panel or the TOML config) would otherwise hit
+        // CosmicText's exact-match lookup with the padded string
+        // and silently fall back to the system sans.
+        return name.trim().to_string();
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/crates/con-app/src/updater.rs
+++ b/crates/con-app/src/updater.rs
@@ -454,30 +454,54 @@ pub fn apply_update_in_place() {
         Err(_) => None,
     };
 
-    // `sh -c 'export VAR=<v>; curl -fsSL <url> | sh'` is the
-    // pattern that gets the version into both halves of the pipe.
-    // `VAR=value <command>` only sets `VAR` for `<command>`'s
-    // process, so writing `CON_INSTALL_VERSION=... curl ... | sh`
-    // would scope the var to `curl` and the right-hand `sh`
-    // wouldn't see it. `export` lifts it onto the outer shell
-    // before the pipe is built, so both children inherit it.
-    // `setsid` puts the spawned shell in its own session so it
-    // survives `con`'s exit; the trailing `>/dev/null 2>&1
-    // </dev/null` detaches stdio so the script doesn't inherit
-    // our terminal.
+    // Download the script to a tempfile FIRST, then run it. The
+    // obvious-looking `curl ... | sh` pipeline has two problems we
+    // need to dodge:
+    //
+    //   1. POSIX `sh` returns the rightmost command's status, so a
+    //      `curl` failure (404, network error, DNS) silently
+    //      becomes a successful pipeline exit (`sh` reads empty
+    //      input and returns 0). The user clicks "Update now",
+    //      `con` exits as if the install kicked off, and they're
+    //      stranded on the old version with no error surfaced.
+    //   2. `pipefail` would solve (1) but isn't in POSIX —
+    //      depending on it would break on minimal busybox-style
+    //      shells.
+    //
+    // `mktemp && curl -o tmp && sh tmp` short-circuits cleanly via
+    // `&&`: any failure aborts before the next command runs.
+    //
+    // `export CON_INSTALL_VERSION=...` (rather than the
+    // `VAR=value <cmd>` env-prefix form) lifts the var onto the
+    // outer shell so both `curl` and `sh tmp` inherit it.
+    //
+    // `setsid -f` puts the spawned shell in its own session so
+    // it survives `con`'s exit; the trailing `>/dev/null 2>&1
+    // </dev/null` on the spawn detaches stdio so the script
+    // doesn't inherit our terminal.
+    //
+    // Both `install_url` and `version` go through `shell_quote()`
+    // so user-supplied env (`CON_INSTALL_URL`) and appcast-supplied
+    // version strings can't break out of the single-quoted argument
+    // even if they contain `&`, `;`, `$`, etc.
+    let url_arg = shell_quote(install_url.trim());
     let pipeline = match target_version.as_deref() {
         Some(version) => format!(
-            "export CON_INSTALL_VERSION={version}; curl -fsSL {url} | sh >/dev/null 2>&1",
+            "export CON_INSTALL_VERSION={version}; \
+             tmp=$(mktemp) && curl -fsSL {url} -o \"$tmp\" && sh \"$tmp\"; \
+             rc=$?; rm -f \"$tmp\"; exit $rc",
             // Strip any leading 'v' the appcast might carry;
             // install.sh re-adds the prefix when it builds the
             // `/releases/tags/v<version>` URL so a value of either
-            // shape works. shell_quote single-quotes the version
-            // string for safety even though tag-derived SemVer is
-            // ASCII-safe.
+            // shape works.
             version = shell_quote(version.trim_start_matches('v')),
-            url = install_url,
+            url = url_arg,
         ),
-        None => format!("curl -fsSL {url} | sh >/dev/null 2>&1", url = install_url),
+        None => format!(
+            "tmp=$(mktemp) && curl -fsSL {url} -o \"$tmp\" && sh \"$tmp\"; \
+             rc=$?; rm -f \"$tmp\"; exit $rc",
+            url = url_arg,
+        ),
     };
 
     let setsid = which_first(["setsid", "/usr/bin/setsid"]);

--- a/crates/con-app/src/updater.rs
+++ b/crates/con-app/src/updater.rs
@@ -74,7 +74,7 @@ pub fn latest_check() -> CheckState {
     latest_slot().lock().map(|g| g.clone()).unwrap_or(CheckState::Idle)
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 fn set_latest(state: CheckState) {
     if let Ok(mut g) = latest_slot().lock() {
         *g = state;
@@ -119,10 +119,13 @@ impl UpdaterStatus {
     pub fn detail(self) -> &'static str {
         match self {
             Self::Active => {
-                if cfg!(target_os = "windows") {
-                    "Periodic checks against the release feed; download installed manually."
-                } else {
+                if cfg!(target_os = "macos") {
                     "Sparkle is loaded and polling this release channel."
+                } else {
+                    // Windows + Linux: notify-only checker that polls
+                    // the same Sparkle-shaped appcast XML and re-runs
+                    // install.ps1 / install.sh on apply.
+                    "Periodic checks against the release feed; the in-app installer applies the update."
                 }
             }
             Self::Disabled(UpdaterDisabledReason::ChannelDoesNotPoll) => {
@@ -289,7 +292,7 @@ fn init_inner() -> bool {
     }
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 fn init_inner() -> bool {
     let channel = con_core::release_channel::current();
     if !channel.polls_for_updates() {
@@ -304,7 +307,7 @@ fn init_inner() -> bool {
     }
 
     let _ = STATUS.set(UpdaterStatus::Active);
-    windows_impl::spawn_check(channel);
+    notify_impl::spawn_check(channel);
     log::info!(
         "updater: notify-only check started — channel={}",
         channel.name()
@@ -312,7 +315,11 @@ fn init_inner() -> bool {
     true
 }
 
-#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+#[cfg(all(
+    not(target_os = "macos"),
+    not(target_os = "windows"),
+    not(target_os = "linux")
+))]
 fn init_inner() -> bool {
     let _ = STATUS.set(UpdaterStatus::Disabled(
         UpdaterDisabledReason::ChannelDoesNotPoll,
@@ -336,7 +343,7 @@ pub fn check_for_updates() {
     }
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 pub fn check_for_updates() {
     let channel = con_core::release_channel::current();
     if !channel.polls_for_updates() {
@@ -346,10 +353,14 @@ pub fn check_for_updates() {
         );
         return;
     }
-    windows_impl::spawn_check(channel);
+    notify_impl::spawn_check(channel);
 }
 
-#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+#[cfg(all(
+    not(target_os = "macos"),
+    not(target_os = "windows"),
+    not(target_os = "linux")
+))]
 pub fn check_for_updates() {}
 
 /// Re-run `install.ps1` in a new console and exit this process so the
@@ -396,7 +407,109 @@ pub fn apply_update_in_place() {
     }
 }
 
-#[cfg(not(target_os = "windows"))]
+/// Re-run `install.sh` in a detached background process and exit
+/// cleanly so the script can replace `~/.local/bin/con` and any
+/// other staged files. Linux only.
+///
+/// `install.sh` does the full lifecycle: download, sha-check,
+/// extract, drop the .desktop entry, and atomically move the new
+/// binary into place. Move-then-overwrite means the running con
+/// inode survives — the kernel keeps the old text in memory until
+/// this process exits — so re-running con after the installer
+/// finishes picks up the new build. We `setsid -f` to detach so
+/// killing con does not kill the installer.
+///
+/// Unlike Windows, we do **not** open a new terminal here. Linux
+/// has no portable "spawn a visible console" API equivalent to
+/// `CREATE_NEW_CONSOLE`; the user already has a Settings → Updates
+/// card showing the same install command they can paste into any
+/// shell if they want to watch progress.
+#[cfg(target_os = "linux")]
+pub fn apply_update_in_place() {
+    use std::process::{Command, Stdio};
+
+    const INSTALL_URL: &str = "https://con-releases.nowledge.co/install.sh";
+
+    // `sh -c 'curl -fsSL <url> | sh'` mirrors the documented one-liner
+    // exactly. `setsid` puts the spawned shell in its own session so
+    // it survives `con`'s exit; the trailing `>/dev/null 2>&1 </dev/null`
+    // detaches stdio so the script doesn't inherit our terminal.
+    let pipeline = format!(
+        "curl -fsSL {url} | sh >/dev/null 2>&1",
+        url = INSTALL_URL
+    );
+
+    let setsid = which_first(["setsid", "/usr/bin/setsid"]);
+
+    let spawn = if let Some(setsid) = setsid {
+        Command::new(setsid)
+            .arg("-f")
+            .arg("sh")
+            .arg("-c")
+            .arg(&pipeline)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+    } else {
+        // setsid is part of util-linux and present on every modern
+        // distro, but be defensive: fall back to a plain `sh -c`
+        // and let the OS clean it up.
+        Command::new("sh")
+            .arg("-c")
+            .arg(&pipeline)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+    };
+
+    match spawn {
+        Ok(_) => {
+            // Same 400ms grace as Windows: let the installer get its
+            // first network call out before our pending writes
+            // (config, sessions) flush and we drop the exe inode.
+            std::thread::sleep(std::time::Duration::from_millis(400));
+            std::process::exit(0);
+        }
+        Err(e) => {
+            log::error!("updater: failed to spawn install.sh: {e}");
+            set_latest(CheckState::Error(format!(
+                "could not launch installer: {e}"
+            )));
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn which_first<I, S>(candidates: I) -> Option<std::path::PathBuf>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    use std::path::PathBuf;
+    for cand in candidates {
+        let p = PathBuf::from(cand.as_ref());
+        if p.is_absolute() {
+            if p.is_file() {
+                return Some(p);
+            }
+            continue;
+        }
+        // Plain name — search PATH.
+        if let Ok(path_var) = std::env::var("PATH") {
+            for dir in path_var.split(':') {
+                let probe = std::path::Path::new(dir).join(&p);
+                if probe.is_file() {
+                    return Some(probe);
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
 #[allow(dead_code)]
 pub fn apply_update_in_place() {}
 
@@ -412,13 +525,22 @@ pub fn status() -> UpdaterStatus {
         }
         #[cfg(not(target_os = "macos"))]
         {
+            // Windows + Linux notify-only path. `init_inner` flips
+            // STATUS to Active when the channel polls; on Dev / no
+            // network this stays Disabled.
             UpdaterStatus::Disabled(UpdaterDisabledReason::ChannelDoesNotPoll)
         }
     })
 }
 
-#[cfg(target_os = "windows")]
-mod windows_impl {
+/// Cross-platform notify-only updater shared by the Windows and
+/// Linux backends. Polls the Sparkle-shaped appcast XML at
+/// `https://con-releases.nowledge.co/appcast/{channel}-{platform}-{arch}.xml`,
+/// compares the published version against the running binary, and
+/// flips the shared `LATEST` slot. macOS uses Sparkle directly and
+/// doesn't need this path.
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+mod notify_impl {
     use super::{CheckState, set_latest};
     use con_core::release_channel::{self, ReleaseChannel};
 
@@ -439,7 +561,7 @@ mod windows_impl {
             match result {
                 Ok(state) => set_latest(state),
                 Err(e) => {
-                    log::warn!("updater: windows check failed: {e}");
+                    log::warn!("updater: notify-only check failed: {e}");
                     set_latest(CheckState::Error(e));
                 }
             }

--- a/crates/con-app/src/updater.rs
+++ b/crates/con-app/src/updater.rs
@@ -428,7 +428,16 @@ pub fn apply_update_in_place() {
 pub fn apply_update_in_place() {
     use std::process::{Command, Stdio};
 
-    const INSTALL_URL: &str = "https://con-releases.nowledge.co/install.sh";
+    const DEFAULT_INSTALL_URL: &str = "https://con-releases.nowledge.co/install.sh";
+
+    // `CON_INSTALL_URL` overrides the script source for offline /
+    // local-server verification. Same env-only opt-in as
+    // `CON_APPCAST_BASE` — release builds default to the public
+    // gh-pages-served install.sh; tests can point at their own.
+    let install_url = std::env::var("CON_INSTALL_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_INSTALL_URL.to_string());
 
     // `sh -c 'curl -fsSL <url> | sh'` mirrors the documented one-liner
     // exactly. `setsid` puts the spawned shell in its own session so
@@ -436,7 +445,7 @@ pub fn apply_update_in_place() {
     // detaches stdio so the script doesn't inherit our terminal.
     let pipeline = format!(
         "curl -fsSL {url} | sh >/dev/null 2>&1",
-        url = INSTALL_URL
+        url = install_url
     );
 
     let setsid = which_first(["setsid", "/usr/bin/setsid"]);
@@ -588,7 +597,14 @@ mod notify_impl {
             .ok_or_else(|| "appcast missing shortVersionString or enclosure".to_string())?;
 
         let running = crate::app_display_version();
-        if is_newer(&version, &running) {
+        let newer = is_newer(&version, &running);
+        log::info!(
+            "updater: appcast advertises version={version} (running {running}); is_newer={newer}",
+            version = version,
+            running = running,
+            newer = newer,
+        );
+        if newer {
             Ok(CheckState::UpdateAvailable { version, url })
         } else {
             Ok(CheckState::UpToDate)

--- a/crates/con-app/src/updater.rs
+++ b/crates/con-app/src/updater.rs
@@ -439,14 +439,46 @@ pub fn apply_update_in_place() {
         .filter(|value| !value.trim().is_empty())
         .unwrap_or_else(|| DEFAULT_INSTALL_URL.to_string());
 
-    // `sh -c 'curl -fsSL <url> | sh'` mirrors the documented one-liner
-    // exactly. `setsid` puts the spawned shell in its own session so
-    // it survives `con`'s exit; the trailing `>/dev/null 2>&1 </dev/null`
-    // detaches stdio so the script doesn't inherit our terminal.
-    let pipeline = format!(
-        "curl -fsSL {url} | sh >/dev/null 2>&1",
-        url = install_url
-    );
+    // Pull the version the appcast advertised — this is what the
+    // user just clicked "Update now" on. install.sh's default path
+    // queries GitHub's `/releases/latest`, which silently skips
+    // prereleases — so a beta-channel user clicking through to the
+    // installer would otherwise risk getting a stable downgrade
+    // instead of the beta the appcast actually pointed at. Pin the
+    // installer to the exact version the channel resolved to.
+    let target_version = match latest_slot().lock() {
+        Ok(g) => match &*g {
+            CheckState::UpdateAvailable { version, .. } => Some(version.clone()),
+            _ => None,
+        },
+        Err(_) => None,
+    };
+
+    // `sh -c 'export VAR=<v>; curl -fsSL <url> | sh'` is the
+    // pattern that gets the version into both halves of the pipe.
+    // `VAR=value <command>` only sets `VAR` for `<command>`'s
+    // process, so writing `CON_INSTALL_VERSION=... curl ... | sh`
+    // would scope the var to `curl` and the right-hand `sh`
+    // wouldn't see it. `export` lifts it onto the outer shell
+    // before the pipe is built, so both children inherit it.
+    // `setsid` puts the spawned shell in its own session so it
+    // survives `con`'s exit; the trailing `>/dev/null 2>&1
+    // </dev/null` detaches stdio so the script doesn't inherit
+    // our terminal.
+    let pipeline = match target_version.as_deref() {
+        Some(version) => format!(
+            "export CON_INSTALL_VERSION={version}; curl -fsSL {url} | sh >/dev/null 2>&1",
+            // Strip any leading 'v' the appcast might carry;
+            // install.sh re-adds the prefix when it builds the
+            // `/releases/tags/v<version>` URL so a value of either
+            // shape works. shell_quote single-quotes the version
+            // string for safety even though tag-derived SemVer is
+            // ASCII-safe.
+            version = shell_quote(version.trim_start_matches('v')),
+            url = install_url,
+        ),
+        None => format!("curl -fsSL {url} | sh >/dev/null 2>&1", url = install_url),
+    };
 
     let setsid = which_first(["setsid", "/usr/bin/setsid"]);
 
@@ -488,6 +520,16 @@ pub fn apply_update_in_place() {
             )));
         }
     }
+}
+
+/// Single-quote a value safely for inclusion in a `sh -c` script.
+/// Versions are tag-derived (SemVer ASCII), but the quoting is cheap
+/// and prevents accidental injection if the appcast ever serves a
+/// version string with shell metacharacters.
+#[cfg(target_os = "linux")]
+fn shell_quote(value: &str) -> String {
+    let escaped = value.replace('\'', "'\\''");
+    format!("'{escaped}'")
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -85,6 +85,15 @@ fn caption_buttons(
     window: &Window,
     theme: &gpui_component::theme::ThemeColor,
     height: f32,
+    // Linux Close needs a workspace handle so it can call
+    // `prepare_window_close` (cancel sessions, flush state, drop
+    // pending control responses) before yanking the window — same
+    // shutdown path the macOS / Windows X-button hits via
+    // `on_window_should_close`. Windows has its own caption-area
+    // hit-test that runs through the workspace cleanup; on Linux
+    // GPUI's X11 backend doesn't fire that path so we have to
+    // route it explicitly.
+    #[cfg(target_os = "linux")] workspace: gpui::WeakEntity<ConWorkspace>,
 ) -> impl IntoElement {
     use gpui::{div, px, svg, Hsla, ParentElement, Rgba, Styled, WindowControlArea};
     #[cfg(target_os = "linux")]
@@ -145,10 +154,24 @@ fn caption_buttons(
         // dispatches via the WindowControlArea hit-test set above —
         // no extra handler needed there.
         #[cfg(target_os = "linux")]
-        let el = el.on_mouse_down(MouseButton::Left, move |_, window, _cx| match area {
+        let workspace_for_close = workspace.clone();
+        #[cfg(target_os = "linux")]
+        let el = el.on_mouse_down(MouseButton::Left, move |_, window, cx| match area {
             WindowControlArea::Min => window.minimize_window(),
             WindowControlArea::Max => window.zoom_window(),
-            WindowControlArea::Close => window.remove_window(),
+            WindowControlArea::Close => {
+                // Mirror the macOS / Windows close path: run the
+                // workspace cleanup (cancel agent sessions, flush
+                // session save, drop pending control responses,
+                // shut down terminal surfaces) *before* the window
+                // goes away. Without this, clicking the Linux CSD
+                // close button bypasses agent cancellation and
+                // pending control-request responses entirely.
+                let _ = workspace_for_close.update(cx, |workspace, cx| {
+                    workspace.prepare_window_close(cx);
+                });
+                window.remove_window();
+            }
             _ => {}
         });
 
@@ -6669,7 +6692,15 @@ impl Render for ConWorkspace {
         // vertical strip and never occlude terminal content.
         #[cfg(any(target_os = "windows", target_os = "linux"))]
         {
-            top_bar = top_bar.child(caption_buttons(window, theme, top_bar_height));
+            #[cfg(target_os = "linux")]
+            let workspace_handle = cx.weak_entity();
+            top_bar = top_bar.child(caption_buttons(
+                window,
+                theme,
+                top_bar_height,
+                #[cfg(target_os = "linux")]
+                workspace_handle,
+            ));
         }
 
         let mut root = div()

--- a/crates/con-core/src/release_channel.rs
+++ b/crates/con-core/src/release_channel.rs
@@ -60,9 +60,26 @@ impl ReleaseChannel {
     ///
     /// This is stable across releases. The CI pipeline publishes
     /// updated appcasts to the corresponding GitHub Pages path.
+    ///
+    /// `CON_APPCAST_BASE` overrides the host + path prefix at
+    /// runtime — used by release-pipeline integration tests and
+    /// the documented manual-verification flow in
+    /// `docs/impl/linux-port.md` so we can stand up a local HTTP
+    /// server, drop a generated appcast there, and watch the
+    /// notify-only updater transition through `Checking →
+    /// UpdateAvailable → Apply` without touching production. The
+    /// override is plain runtime env, not `option_env!`, so a
+    /// user can opt in without rebuilding. `host_arch()` /
+    /// `host_platform()` still pin the file suffix so the test
+    /// appcast must match the running binary's target.
     pub fn feed_url(self, platform: &str, arch: &str) -> String {
+        let base = std::env::var("CON_APPCAST_BASE")
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| "https://con-releases.nowledge.co/appcast".to_string());
         format!(
-            "https://con-releases.nowledge.co/appcast/{channel}-{platform}-{arch}.xml",
+            "{base}/{channel}-{platform}-{arch}.xml",
+            base = base.trim_end_matches('/'),
             channel = self.name(),
             platform = platform,
             arch = arch,

--- a/crates/con-core/src/release_channel.rs
+++ b/crates/con-core/src/release_channel.rs
@@ -73,13 +73,23 @@ impl ReleaseChannel {
     /// `host_platform()` still pin the file suffix so the test
     /// appcast must match the running binary's target.
     pub fn feed_url(self, platform: &str, arch: &str) -> String {
+        // Trim leading/trailing whitespace AND drop a trailing `/`
+        // before validating non-emptiness. A user pasting
+        // `CON_APPCAST_BASE=" http://localhost:8765/appcast/ "`
+        // into a shell's env should resolve to the same URL as if
+        // they pasted `http://localhost:8765/appcast`. The
+        // `filter` runs after normalization so a value that's
+        // *only* whitespace correctly falls through to the
+        // production default instead of producing a malformed
+        // `/{channel}-{platform}-{arch}.xml` URL.
         let base = std::env::var("CON_APPCAST_BASE")
             .ok()
-            .filter(|value| !value.trim().is_empty())
+            .map(|value| value.trim().trim_end_matches('/').to_string())
+            .filter(|value| !value.is_empty())
             .unwrap_or_else(|| "https://con-releases.nowledge.co/appcast".to_string());
         format!(
             "{base}/{channel}-{platform}-{arch}.xml",
-            base = base.trim_end_matches('/'),
+            base = base,
             channel = self.name(),
             platform = platform,
             arch = arch,

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -151,6 +151,15 @@ unsafe impl Send for LinuxGhosttyApp {}
 unsafe impl Sync for LinuxGhosttyApp {}
 
 fn clamp_opacity(value: f32) -> f32 {
+    // `f32::clamp` propagates NaN, which would then leak into the
+    // pane fill alpha and downstream color math (every Hsla
+    // multiplication also propagates NaN, so a malformed setting
+    // could make the entire pane go black). Settings already
+    // round-trip through serde validation in practice, but we get
+    // the safety belt for free.
+    if !value.is_finite() {
+        return 1.0;
+    }
     value.clamp(0.0, 1.0)
 }
 

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -238,7 +238,9 @@ impl LinuxPtySession {
         self.master
             .lock()
             .resize(pty_size_from_surface(&size))
-            .context("failed to resize linux pty")
+            .context("failed to resize linux pty")?;
+        self.mark_needs_render();
+        Ok(())
     }
 
     pub fn resize(&self, size: SurfaceSize) -> Result<()> {
@@ -255,7 +257,22 @@ impl LinuxPtySession {
         self.master
             .lock()
             .resize(pty_size_from_surface(&size))
-            .context("failed to resize linux pty")
+            .context("failed to resize linux pty")?;
+        self.mark_needs_render();
+        Ok(())
+    }
+
+    /// Stamp the shared `needs_render` flag and wake the workspace
+    /// loop so the next pump tick re-fetches a fresh snapshot. Used
+    /// after resize / theme / mode changes that mutate the parser
+    /// state without going through a PTY-output path. Without this,
+    /// idle-shell resizes silently keep painting the previous grid
+    /// dimensions until new shell output arrives.
+    fn mark_needs_render(&self) {
+        self.shared
+            .needs_render
+            .store(true, Ordering::Release);
+        self.shared.wake();
     }
 
     pub fn write_input(&self, data: &[u8]) -> Result<()> {
@@ -317,8 +334,7 @@ impl LinuxPtySession {
     pub fn set_theme(&self, colors: &TerminalColors) {
         let theme = theme_colors_to_vt(colors);
         self.shared.screen.set_theme(&theme);
-        self.shared.needs_render.store(true, Ordering::Release);
-        self.shared.wake();
+        self.mark_needs_render();
     }
 
     pub fn read_recent_lines(&self, max_lines: usize) -> Vec<String> {

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -355,6 +355,12 @@ impl LinuxPtySession {
 
     pub fn set_dark_mode(&self, dark: bool) {
         self.shared.screen.set_dark_mode(dark);
+        // Same shape as `set_theme` / `resize`: a parser-state mutation
+        // that doesn't go through a PTY-output path. Without
+        // `mark_needs_render` the next pump tick won't re-fetch a
+        // snapshot and Linux panes can keep painting the previous
+        // mode-derived colors until new shell output arrives.
+        self.mark_needs_render();
     }
 
     fn poll_child_status(&self) {

--- a/docs/impl/linux-port-tracker-updates/2026-04-23-release-pipeline.md
+++ b/docs/impl/linux-port-tracker-updates/2026-04-23-release-pipeline.md
@@ -1,0 +1,155 @@
+Linux preview shipped — milestone landing summary
+=================================================
+
+The Linux preview milestone landed in two PRs:
+
+- **#58** (`cursor/linux-styled-cell-renderer-a6bd`, merged) —
+  the runtime backend.
+- **#59** (`cursor/linux-release-pipeline-a6bd`, in review) —
+  one-liner installer + tarball release pipeline + notify-only
+  auto-update.
+
+What ships now
+--------------
+
+The same `con` binary that runs on macOS and Windows now opens on
+Linux with a real terminal pane:
+
+- **Real PTY pane** via Unix PTY + `libghostty-vt` (the shared
+  parser the Windows backend already uses).
+- **Per-row styled-cell paint** in the GPUI window. Each VT row
+  renders as one `StyledText` with one `TextRun` per styled span,
+  collapsing runs of cells that share `(fg, bg, attrs, is_cursor)`.
+  SGR colors, bold (`FontWeight::BOLD`), italic
+  (`FontStyle::Italic`), underline, strikethrough, inverse, and a
+  block cursor (fg/bg swap on the cursor cell, post-inverse-aware so
+  htop's selected row + vim status lines stay legible) all survive
+  into the visible pane. Cell colors decode from the parser's
+  `0xRRGGBBAA` packing into GPUI `Hsla` (alpha=0 means "use the
+  default", matching the Windows pixel-shader contract documented
+  in `vt.rs::read_cell`).
+- **Theme palette synced from settings**:
+  `LinuxGhosttyApp::update_appearance` / `update_colors` now plumb
+  `TerminalColors` (foreground / background / 16-color ANSI palette)
+  into `VtScreen::set_theme` both at session spawn (via
+  `LinuxPtyOptions.theme`) and live from settings.
+- **IoskeleyMono shaping**: a Linux-only
+  `canonical_terminal_font_family()` normalizes the user-facing
+  display name `"Ioskeley Mono"` to the registered TTF family
+  `"IoskeleyMono"` (also case- and whitespace-insensitive after
+  the #59 review-feedback round) so GPUI's `CosmicTextSystem`
+  resolves the embedded font instead of falling back to a
+  proportional sans. macOS / Windows stay byte-identical.
+- **Client-side decorations**: `WindowDecorations::Client` plus the
+  shared `TitlebarOptions` and the `caption_buttons` cluster
+  (minimize / maximize / close) extended to also build on Linux.
+  The X11 backend's `on_hit_test_window_control` is a no-op, so
+  each Linux caption button gets an explicit `on_mouse_down`. The
+  Close button routes through `prepare_window_close` (cancel agent
+  sessions, flush state, drop pending control-request responses)
+  before `remove_window` — same shutdown semantics the macOS /
+  Windows close button uses via `on_window_should_close`.
+- **Transparent ARGB window with rounded corners**:
+  `supports_transparent_main_window()` returns `true` on Linux,
+  GPUI's X11 backend opens against an ARGB depth-32 visual, the
+  workspace root clips to a 14 px corner radius (matching Win11
+  Mica's perceived radius), and the existing per-pane terminal
+  opacity + per-surface UI opacity sliders composite through to
+  the desktop now that the Root background is transparent.
+- **Backdrop blur where the compositor exposes it**: KDE Plasma
+  Wayland gets real `org_kde_kwin_blur` Gaussian blur via
+  `WindowBackgroundAppearance::Blurred`. X11 / mutter / sway have
+  no app-driven backdrop-blur protocol — the toggle still ships
+  there but the visible result is transparency only (documented
+  in `set_linux_window_blur`'s rustdoc).
+- **Snappy paint pipeline**: removed a redundant per-tick
+  snapshot refresh and a 50–200 KB `Vec<Cell>` deep-equality
+  compare from the snapshot path (replaced with a generation-counter
+  compare), and tightened the workspace idle poll loop from 16 ms
+  to 8 ms. Measured: keystroke-echo round-trip via the control
+  socket dropped from 32.6 ms → 16.6 ms mean across 5 runs.
+- **No more "Waiting for shell prompt…" flash on alt-screen TUIs**.
+  A `seen_any_output` latch on the view fixes the placeholder
+  showing every time `htop` / `vim` / `less` / `fzf` cleared the
+  screen via the alternate-screen switch and hadn't drawn their
+  UI yet.
+- **One-line installer** (PR #59):
+    `curl -fsSL https://con-releases.nowledge.co/install.sh | sh`
+  Same one-liner macOS uses; `install.sh` is now a Unix dispatcher
+  that detects the host OS and routes Darwin to the existing DMG
+  flow or Linux to a new tarball flow that drops `con` into
+  `~/.local/bin`, registers a `.desktop` launcher entry, and
+  installs the 256×256 hicolor icon. No sudo.
+- **Notify-only in-app updater** (PR #59): polls the same
+  Sparkle-shaped appcast XML as the Windows backend at
+  `https://con-releases.nowledge.co/appcast/{channel}-linux-x86_64.xml`,
+  surfaces "Update now" in Settings → Updates, and re-runs
+  `install.sh` on apply with the appcast-pinned version
+  (`CON_INSTALL_VERSION`) so beta-channel users never get silently
+  downgraded to stable when GitHub's `/releases/latest` skips
+  prereleases.
+
+Verified end-to-end
+-------------------
+
+Cloud-VM XFCE :1 session (xfwm4 / xfdesktop / xfce4-panel,
+software Vulkan via llvmpipe):
+
+- Full launch flow including `xprop` confirming
+  `_MOTIF_WM_HINTS = 0x2,0,0,0,0` (CSD active) and
+  `_NET_FRAME_EXTENTS = 0,0,0,0` (no server frame).
+- Styled output (red/green/blue/bold-yellow/underlined-und/inverse
+  via printf, dircolors blue ls, full-row inverse highlights).
+- htop in the alternate screen (selected-row inverse cursor
+  visible, F-key footer, real /proc table).
+- Real Linux release pipeline against a local fake-release HTTP
+  server: `release.sh` produced a 39 MB tarball; install.sh
+  installed it; the running binary's notify-only updater fetched
+  the local appcast, parsed the version, transitioned LATEST to
+  `UpdateAvailable`, and `apply_update_in_place` ran install.sh
+  with the appcast-pinned version. The installed binary's sha
+  matched the appcast-pointed tarball byte-for-byte.
+
+Five screenshots in the repo at
+`docs/impl/linux-port-tracker-updates/screenshots/`:
+fresh launch, styled output, rounded transparent window over
+wallpaper + xterm, htop alt-screen blank moment, htop fully
+painted.
+
+Honest caveats
+--------------
+
+- GPU is `llvmpipe` (software Vulkan) and the desktop is XFCE on
+  a cloud VM. Hardware-accelerated Wayland / X11 native sessions
+  on multiple desktop environments (GNOME, KDE) is still the
+  next useful step before "preview" comes off this row on the
+  tracker.
+- Real backdrop blur only renders on KDE Plasma Wayland. On X11
+  / mutter / sway the toggle ships but the visible result is
+  transparency only.
+- The long-term GPUI-owned glyph-atlas grid renderer (matching
+  the D3D11/DirectWrite path Windows uses) is the next backend
+  step. Today's per-row `StyledText` paint covers SGR + bold/
+  italic/underline/strike/inverse + block cursor correctly, but
+  per-cell metrics still come from layout-time text shaping.
+
+What's next (phase 5/6)
+-----------------------
+
+- Glyph-atlas grid renderer.
+- Mouse reporting (button + wheel), selection (drag → SGR 1006 /
+  X10 reports + clipboard integration). DECCKM and bracketed
+  paste are already wired through `libghostty-vt` mode tracking.
+- Hardware-accelerated native-desktop validation pass.
+- Packaging: desktop entry, icon integration, `.deb` / AppImage
+  / Flatpak.
+
+Plan + postmortem
+-----------------
+
+- `docs/impl/linux-port.md` (plan, marked phase 4 ✅ landed
+  preview)
+- `docs/impl/linux-port-tracker-updates/2026-04-23-styled-cell-renderer.md`
+  (full mirror with the visual verification + follow-up fixes
+  from #58 and #59)
+- `postmortem/2026-04-23-linux-styled-cell-renderer.md`

--- a/docs/impl/linux-port.md
+++ b/docs/impl/linux-port.md
@@ -305,13 +305,13 @@ Issue #18 should mirror the Windows tracker:
 
 ### Status updates mirrored to issue #18
 
-The cloud agent integration only has read-only access to GitHub
-issues, so per-PR status updates are written into
-`docs/impl/linux-port-tracker-updates/` first and then copy-pasted
-onto issue #18 by a human. Each file is dated and named after the
-landed milestone. Keep this list in chronological order:
+Per-PR status updates land on issue #18 directly. We also keep
+the same write-up in this directory, dated and named after the
+landed milestone, so the rationale survives outside of GitHub. Keep
+this list in chronological order:
 
-- `docs/impl/linux-port-tracker-updates/2026-04-23-styled-cell-renderer.md` — phase 4 milestone landing. Covers the styled-cell paint over `libghostty-vt`, theme plumbing, block cursor, env-bootstrap notes for a fresh Ubuntu cloud VM, plus the seven follow-on fixes that got the preview to ship-ready state: client-side decorations + caption cluster, IoskeleyMono normalization, transparent + rounded window, KWin Wayland blur, the 16 ms → 8 ms paint-loop tightening (keystroke echo 32.6 ms → 16.6 ms mean), and the alt-screen `seen_any_output` placeholder fix. Corresponds to PR #58.
+- `docs/impl/linux-port-tracker-updates/2026-04-23-styled-cell-renderer.md` — phase 4 milestone landing. Covers the styled-cell paint over `libghostty-vt`, theme plumbing, block cursor, env-bootstrap notes for a fresh Ubuntu cloud VM, plus the seven follow-on fixes that got the preview to ship-ready state: client-side decorations + caption cluster, IoskeleyMono normalization, transparent + rounded window, KWin Wayland blur, the 16 ms → 8 ms paint-loop tightening (keystroke echo 32.6 ms → 16.6 ms mean), and the alt-screen `seen_any_output` placeholder fix. Corresponds to merged PR #58.
+- `docs/impl/linux-port-tracker-updates/2026-04-23-release-pipeline.md` — full milestone summary covering both #58 (runtime backend) and #59 (release pipeline). One-liner installer (`install.sh` Unix dispatcher), tarball release script, `release-linux.yml` workflow, and the notify-only updater extension (Sparkle-shaped appcast XML + `apply_update_in_place` re-runs install.sh with `CON_INSTALL_VERSION` so beta-channel users never get silently downgraded to stable). Corresponds to PR #59.
 
 ## References
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,10 +1,28 @@
 #!/bin/sh
-# con — macOS terminal emulator installer
+# con — Unix terminal emulator installer (macOS + Linux).
 # Usage: curl -fsSL https://con-releases.nowledge.co/install.sh | sh
+#
+# macOS path: download the signed DMG, mount it, copy the bundled
+#   `con*.app` into /Applications, launch it. Same flow that's been
+#   live since the macOS DMG release pipeline shipped.
+# Linux path: download the channel tarball, extract `con` into
+#   ~/.local/bin, drop a `.desktop` entry into ~/.local/share/applications
+#   so it shows up in your launcher, and `chmod +x` the binary. The
+#   binary is self-contained — no shared libs other than the GPUI Linux
+#   runtime apt deps that come pre-installed on every modern desktop
+#   distro.
+#
+# Both paths share the same one-liner UX: pretty banner, channel
+# detection from the GitHub `releases/latest` tag, no sudo unless the
+# install dir actually requires it. The Sparkle-shaped appcast feed
+# at https://con-releases.nowledge.co/appcast/{channel}-{platform}-{arch}.xml
+# is updated by the release CI for each platform; the in-app updater
+# polls it and re-runs this script via `apply_update_in_place()` when
+# the user clicks "Update" in Settings → Updates.
+
 set -eu
 
 REPO="nowledge-co/con-terminal"
-INSTALL_DIR="/Applications"
 
 # ── Colors ──────────────────────────────────────────────────────────────────
 
@@ -25,24 +43,33 @@ fail() { printf "   ${ERR}✗${R}  %s\n" "$*" >&2; exit 1; }
 # ── Banner ──────────────────────────────────────────────────────────────────
 # Exact output from: npx oh-my-logo "con" --palette-colors "#4ea8ff,#a855f7,#ec4899" --filled --block-font tiny --color
 
-printf "\n"
-if [ -t 1 ]; then
-  printf '   \033[38;5;111m█▀\033[38;5;105m▀\033[38;5;141m █▀\033[38;5;177m█\033[38;5;176m █\033[38;5;170m▄\033[38;5;169m \033[38;5;205m█\033[0m\n'
-  printf '   \033[38;5;111m█▄\033[38;5;105m▄\033[38;5;141m █▄\033[38;5;177m█\033[38;5;176m █\033[38;5;170m \033[38;5;169m▀\033[38;5;205m█\033[0m\n'
-else
-  printf '   con\n'
-fi
-printf "\n"
+print_banner() {
+  printf "\n"
+  if [ -t 1 ]; then
+    printf '   \033[38;5;111m█▀\033[38;5;105m▀\033[38;5;141m █▀\033[38;5;177m█\033[38;5;176m █\033[38;5;170m▄\033[38;5;169m \033[38;5;205m█\033[0m\n'
+    printf '   \033[38;5;111m█▄\033[38;5;105m▄\033[38;5;141m █▄\033[38;5;177m█\033[38;5;176m █\033[38;5;170m \033[38;5;169m▀\033[38;5;205m█\033[0m\n'
+  else
+    printf '   con\n'
+  fi
+  printf "\n"
+}
+
+print_banner
 
 # ── Preflight ───────────────────────────────────────────────────────────────
 
-[ "$(uname -s)" = "Darwin" ] || fail "con requires macOS"
+uname_s="$(uname -s)"
+case "$uname_s" in
+  Darwin) os="macos" ;;
+  Linux)  os="linux" ;;
+  *)      fail "unsupported OS: $uname_s (con supports macOS and Linux via this script; Windows uses install.ps1)" ;;
+esac
 
 arch="$(uname -m)"
 case "$arch" in
-  arm64)  dmg_arch="arm64"  ;;
-  x86_64) dmg_arch="x86_64" ;;
-  *)      fail "unsupported architecture: $arch" ;;
+  arm64|aarch64) art_arch="arm64"  ;;
+  x86_64|amd64)  art_arch="x86_64" ;;
+  *)             fail "unsupported architecture: $arch" ;;
 esac
 
 # ── Resolve ─────────────────────────────────────────────────────────────────
@@ -60,70 +87,191 @@ case "$version" in
   *-dev.*)   channel="Dev" ;;
 esac
 
-dmg_url="$(printf '%s' "$release_json" \
+# Asset name pattern depends on the OS — the macOS pipeline emits
+# `con-<version>-macos-<arch>.dmg`, the Linux pipeline emits
+# `con-<version>-linux-<arch>.tar.gz`. Pull the matching enclosure URL
+# straight out of the releases JSON so we don't have to guess the tag
+# format here.
+if [ "$os" = "macos" ]; then
+  asset_pattern="macos-${art_arch}\\.dmg"
+else
+  asset_pattern="linux-${art_arch}\\.tar\\.gz"
+fi
+
+asset_url="$(printf '%s' "$release_json" \
   | grep '"browser_download_url"' \
-  | grep "macos-${dmg_arch}\\.dmg" \
+  | grep "$asset_pattern" \
   | head -1 \
   | sed 's/.*: *"//;s/".*//')"
 
-[ -n "$dmg_url" ] || fail "no DMG found for ${dmg_arch}"
+[ -n "$asset_url" ] || fail "no ${os} ${art_arch} artifact found in latest release ($tag)"
 
 if [ -n "$channel" ]; then
-  pass "${B}con ${channel}${R}  ${DIM}${version} · ${dmg_arch}${R}"
+  pass "${B}con ${channel}${R}  ${DIM}${version} · ${os} · ${art_arch}${R}"
 else
-  pass "${B}con${R}  ${DIM}${version} · ${dmg_arch}${R}"
+  pass "${B}con${R}  ${DIM}${version} · ${os} · ${art_arch}${R}"
 fi
 
 # ── Download ────────────────────────────────────────────────────────────────
 
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
-dmg_path="${tmpdir}/con.dmg"
+
+if [ "$os" = "macos" ]; then
+  archive_path="${tmpdir}/con.dmg"
+else
+  archive_path="${tmpdir}/con.tar.gz"
+fi
 
 printf "   ${DIM}·${R}  downloading"
-curl -fSL "$dmg_url" -o "$dmg_path" 2>/dev/null \
+curl -fSL "$asset_url" -o "$archive_path" 2>/dev/null \
   || fail "download failed"
-size="$(du -h "$dmg_path" | cut -f1 | tr -d ' ')"
+size="$(du -h "$archive_path" | cut -f1 | tr -d ' ')"
 printf "\r\033[K"
 pass "downloaded  ${DIM}${size}${R}"
 
 # ── Install ─────────────────────────────────────────────────────────────────
 
-printf "   ${DIM}·${R}  installing"
+if [ "$os" = "macos" ]; then
+  install_dir="/Applications"
+  printf "   ${DIM}·${R}  installing"
 
-mount_point="${tmpdir}/con-volume"
-mkdir -p "$mount_point"
-hdiutil attach -quiet -nobrowse -mountpoint "$mount_point" "$dmg_path" \
-  || fail "could not mount disk image"
+  mount_point="${tmpdir}/con-volume"
+  mkdir -p "$mount_point"
+  hdiutil attach -quiet -nobrowse -mountpoint "$mount_point" "$archive_path" \
+    || fail "could not mount disk image"
 
-app_src=""
-for f in "$mount_point"/*.app; do
-  [ -d "$f" ] && app_src="$f" && break
-done
-[ -n "$app_src" ] || {
+  app_src=""
+  for f in "$mount_point"/*.app; do
+    [ -d "$f" ] && app_src="$f" && break
+  done
+  [ -n "$app_src" ] || {
+    hdiutil detach -quiet "$mount_point" 2>/dev/null
+    fail "no .app found in disk image"
+  }
+
+  app_name="$(basename "$app_src")"
+  target="${install_dir}/${app_name}"
+
+  if [ -d "$target" ]; then
+    rm -rf "$target" 2>/dev/null \
+      || sudo rm -rf "$target"
+  fi
+
+  cp -R "$app_src" "${install_dir}/" 2>/dev/null \
+    || sudo cp -R "$app_src" "${install_dir}/"
+
   hdiutil detach -quiet "$mount_point" 2>/dev/null
-  fail "no .app found in disk image"
-}
 
-app_name="$(basename "$app_src")"
-target="${INSTALL_DIR}/${app_name}"
+  printf "\r\033[K"
+  pass "installed  ${DIM}${install_dir}/${app_name}${R}"
 
-if [ -d "$target" ]; then
-  rm -rf "$target" 2>/dev/null \
-    || sudo rm -rf "$target"
+  # Launch
+  open_name="${app_name%.app}"
+  printf "\n"
+  if [ -t 1 ]; then
+    printf '   \033[38;5;111m━━\033[38;5;105m━━\033[38;5;141m━━\033[38;5;177m━━\033[38;5;176m━━\033[38;5;170m━━\033[38;5;169m━━\033[38;5;205m━━\033[0m\n'
+  else
+    printf '   ────────────────\n'
+  fi
+  printf "\n"
+  open -a "$open_name" 2>/dev/null && pass "launched — enjoy!" || true
+  printf "\n"
+  exit 0
 fi
 
-cp -R "$app_src" "${INSTALL_DIR}/" 2>/dev/null \
-  || sudo cp -R "$app_src" "${INSTALL_DIR}/"
+# ── Linux install ───────────────────────────────────────────────────────────
+#
+# Per-user install under ~/.local. Matches XDG conventions and avoids
+# requiring sudo. The binary is self-contained; the only runtime
+# dependencies are the GPUI Linux apt packages (libxcb-*, libxkbcommon,
+# libwayland, libvulkan, libfreetype, libfontconfig) that ship on
+# every modern desktop distro by default. We log the recommended apt
+# install line at the end for users on minimal images.
 
-hdiutil detach -quiet "$mount_point" 2>/dev/null
+extract_dir="${tmpdir}/extract"
+mkdir -p "$extract_dir"
+
+printf "   ${DIM}·${R}  extracting"
+tar -xzf "$archive_path" -C "$extract_dir" 2>/dev/null \
+  || fail "could not extract tarball"
+printf "\r\033[K"
+pass "extracted"
+
+# The release tarball contains:
+#   con-<version>-linux-<arch>/
+#     con            (the binary)
+#     LICENSE
+#     README.md
+#     con.desktop
+#     con.png
+staged_root=""
+for d in "$extract_dir"/*; do
+  [ -d "$d" ] && [ -f "$d/con" ] && staged_root="$d" && break
+done
+[ -n "$staged_root" ] || fail "tarball layout unexpected — no con/ binary found"
+
+bin_dir="${HOME}/.local/bin"
+share_dir="${HOME}/.local/share"
+apps_dir="${share_dir}/applications"
+icons_dir="${share_dir}/icons/hicolor/256x256/apps"
+
+mkdir -p "$bin_dir" "$apps_dir" "$icons_dir"
+
+printf "   ${DIM}·${R}  installing"
+
+target_bin="${bin_dir}/con"
+# If con is currently running, the kernel keeps the open exe inode
+# alive even if we replace the file. Move-then-overwrite is the
+# rsync-style pattern that survives self-update — `cp` would fail
+# with `Text file busy` on some kernels.
+if [ -f "$target_bin" ]; then
+  rm -f "$target_bin" 2>/dev/null || true
+fi
+cp "$staged_root/con" "$target_bin"
+chmod +x "$target_bin"
+
+# Desktop entry — handles "con shows up in the launcher" and
+# "double-clicking a `con://` URL". The tarball ships a templated
+# `con.desktop` that points at /usr/local/bin; rewrite the Exec line
+# to the resolved per-user binary path so it works regardless of
+# whether ~/.local/bin is on the user's PATH.
+if [ -f "$staged_root/con.desktop" ]; then
+  sed "s|^Exec=.*|Exec=${target_bin} %U|" "$staged_root/con.desktop" \
+    > "${apps_dir}/con.desktop"
+  chmod 644 "${apps_dir}/con.desktop"
+fi
+
+if [ -f "$staged_root/con.png" ]; then
+  cp "$staged_root/con.png" "${icons_dir}/con.png"
+fi
+
+# Refresh the desktop database so the new .desktop file is picked up
+# by GNOME / KDE / xfce launchers without a logout. Best-effort —
+# headless / minimal environments may not have these tools.
+if command -v update-desktop-database >/dev/null 2>&1; then
+  update-desktop-database "$apps_dir" >/dev/null 2>&1 || true
+fi
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+  gtk-update-icon-cache -f -t -q "${share_dir}/icons/hicolor" >/dev/null 2>&1 || true
+fi
 
 printf "\r\033[K"
-pass "installed  ${DIM}${INSTALL_DIR}/${app_name}${R}"
+pass "installed  ${DIM}${target_bin}${R}"
+
+# ── PATH check ──────────────────────────────────────────────────────────────
+
+case ":${PATH:-}:" in
+  *":${bin_dir}:"*) ;;
+  *)
+    printf "\n"
+    pass "${DIM}note:${R}  ${B}~/.local/bin${R} ${DIM}is not on your PATH yet${R}"
+    printf "          ${DIM}add this to your shell rc:${R}\n"
+    printf "          ${DIM}export PATH=\"\$HOME/.local/bin:\$PATH\"${R}\n"
+    ;;
+esac
 
 # ── Launch ──────────────────────────────────────────────────────────────────
-
-open_name="${app_name%.app}"
 
 printf "\n"
 if [ -t 1 ]; then
@@ -133,6 +281,9 @@ else
 fi
 printf "\n"
 
-open -a "$open_name" 2>/dev/null && pass "launched — enjoy!" || true
-
+# Don't auto-launch on Linux — the user might be on a headless box,
+# in a CI runner, or piping the install through `ssh host -- sh -c
+# "curl ... | sh"` from a desktop shell that has no DISPLAY of its
+# own. Just tell them how to start it.
+pass "run  ${B}con${R}  ${DIM}from any terminal — enjoy!${R}"
 printf "\n"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -239,15 +239,34 @@ mkdir -p "$bin_dir" "$apps_dir" "$icons_dir"
 printf "   ${DIM}·${R}  installing"
 
 target_bin="${bin_dir}/con"
-# If con is currently running, the kernel keeps the open exe inode
-# alive even if we replace the file. Move-then-overwrite is the
-# rsync-style pattern that survives self-update — `cp` would fail
-# with `Text file busy` on some kernels.
-if [ -f "$target_bin" ]; then
-  rm -f "$target_bin" 2>/dev/null || true
-fi
-cp "$staged_root/con" "$target_bin"
-chmod +x "$target_bin"
+# Atomic replace, not rm-then-cp:
+#
+#   1. Stage the new binary to a sibling tempfile in the same dir
+#      (so `mv` is atomic — same filesystem).
+#   2. chmod +x the temp.
+#   3. `mv -f` swaps the directory entry to point at the new
+#      inode in one step.
+#
+# Why not `rm + cp + chmod`? If `cp` or `chmod` fails partway, the
+# user is left without a runnable `~/.local/bin/con` — the in-app
+# updater would have just bricked the install.
+#
+# Why mv works under self-update: when `con` is currently running,
+# the kernel keeps the OLD exe inode alive (mapped pages reference
+# the inode, not the directory entry). `mv -f` only swaps the
+# directory entry; the running con keeps painting on the old
+# inode and the next launch picks up the new binary.
+tmp_bin="${bin_dir}/.con.tmp.$$"
+# Layer the tmp-bin cleanup on top of the existing tmpdir trap (set
+# above when we created `$tmpdir`), don't replace it. Both run on
+# any exit path; mv removes tmp_bin on success so the rm is a no-op.
+trap 'rm -rf "$tmpdir"; rm -f "$tmp_bin"' EXIT
+cp "$staged_root/con" "$tmp_bin" \
+  || fail "could not copy con binary"
+chmod +x "$tmp_bin" \
+  || fail "could not mark con binary executable"
+mv -f "$tmp_bin" "$target_bin" \
+  || fail "could not install con binary"
 
 # Desktop entry — handles "con shows up in the launcher" and
 # "double-clicking a `con://` URL". The tarball ships a templated

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -73,12 +73,30 @@ case "$arch" in
 esac
 
 # ── Resolve ─────────────────────────────────────────────────────────────────
+#
+# `CON_INSTALL_VERSION` lets the in-app `apply_update_in_place` path
+# pin the installer to the exact version the appcast advertised.
+# Without that pin, GitHub's `/releases/latest` silently skips
+# prereleases — a beta-channel user clicking through to "Update
+# now" would otherwise risk getting a stable downgrade. Treat
+# `0.1.0-beta.32`, `v0.1.0-beta.32`, and a stray-whitespace mix of
+# either as equivalent.
 
-release_json="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null)" \
+install_version="${CON_INSTALL_VERSION:-}"
+install_version="$(printf '%s' "$install_version" | tr -d '[:space:]')"
+install_version="${install_version#v}"
+
+if [ -n "$install_version" ]; then
+  release_api="https://api.github.com/repos/${REPO}/releases/tags/v${install_version}"
+else
+  release_api="https://api.github.com/repos/${REPO}/releases/latest"
+fi
+
+release_json="$(curl -fsSL "$release_api" 2>/dev/null)" \
   || fail "could not reach GitHub"
 
 tag="$(printf '%s' "$release_json" | grep '"tag_name"' | head -1 | sed 's/.*: *"//;s/".*//')"
-[ -n "$tag" ] || fail "could not determine latest release"
+[ -n "$tag" ] || fail "could not determine release${install_version:+ for v${install_version}}"
 version="${tag#v}"
 
 channel=""

--- a/scripts/linux/release.sh
+++ b/scripts/linux/release.sh
@@ -152,4 +152,13 @@ fi
 
 echo
 echo "==> done"
-ls -la "${tarball}" ${sha_file:+"$sha_file"}
+# `sha_file` is always non-empty (it's a default-derived path), so the
+# previous `${sha_file:+"$sha_file"}` always expanded — `ls` then
+# failed loudly when checksum generation was skipped because neither
+# sha256sum nor shasum was on PATH. Test for the file's existence
+# instead so the listing matches what was actually produced.
+if [[ -f "$sha_file" ]]; then
+  ls -la "${tarball}" "${sha_file}"
+else
+  ls -la "${tarball}"
+fi

--- a/scripts/linux/release.sh
+++ b/scripts/linux/release.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# Build a Linux release tarball for con. Mirrors the role of
+# `scripts/macos/release.sh` and `release-windows.yml`'s "Package
+# ZIP" step:
+#   - cargo build -p con --release with the channel + version baked
+#     in via CON_RELEASE_CHANNEL / CON_RELEASE_VERSION (the
+#     non-macOS updater path uses option_env!() to read these),
+#   - stage `con` + LICENSE + README.md + a `.desktop` entry +
+#     a 256x256 icon into a versioned directory,
+#   - emit `con-<version>-linux-<arch>.tar.gz` plus a sha256 sum file
+#     so the publish step can attach both to the GitHub release.
+#
+# Designed to be run both from CI (release-linux.yml) and locally
+# (when verifying the artifact shape before tagging). Defaults to
+# the host architecture; `CON_LINUX_ARCH=arm64` lets you label an
+# aarch64 build the same way the macOS pipeline does.
+#
+# Output:
+#   dist/con-<version>-linux-<arch>/         staging dir
+#   dist/con-<version>-linux-<arch>.tar.gz   release artifact
+#   dist/SHA256SUMS-linux.txt                checksum line for the publish step
+#
+# Required env (set by CI; can be overridden locally):
+#   CON_RELEASE_VERSION   full tag-derived version, e.g. 0.1.0-beta.31
+#   CON_RELEASE_CHANNEL   "stable" | "beta" | "dev"
+#
+# Optional:
+#   CON_LINUX_ARCH        "x86_64" (default on x86_64 hosts) | "arm64"
+#   CARGO_TARGET_DIR      forwarded to cargo if set
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$repo_root"
+
+# ── Resolve metadata ────────────────────────────────────────────────────────
+
+version="${CON_RELEASE_VERSION:-}"
+if [[ -z "$version" ]]; then
+  # Local invocation. Pull from the most recent annotated tag if we
+  # can; otherwise fall back to the workspace package version.
+  version="$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || true)"
+  if [[ -z "$version" ]]; then
+    version="$(grep -E '^version' Cargo.toml | head -1 | cut -d'"' -f2)"
+  fi
+fi
+[[ -n "$version" ]] || { echo "could not determine version" >&2; exit 1; }
+
+channel="${CON_RELEASE_CHANNEL:-stable}"
+
+host_arch="$(uname -m)"
+case "${CON_LINUX_ARCH:-$host_arch}" in
+  x86_64|amd64) art_arch="x86_64" ;;
+  arm64|aarch64) art_arch="arm64" ;;
+  *) echo "unsupported arch: ${CON_LINUX_ARCH:-$host_arch}" >&2; exit 1 ;;
+esac
+
+stage_name="con-${version}-linux-${art_arch}"
+stage_dir="dist/${stage_name}"
+tarball="dist/${stage_name}.tar.gz"
+sha_file="dist/SHA256SUMS-linux.txt"
+
+echo "==> con linux release"
+echo "    version : ${version}"
+echo "    channel : ${channel}"
+echo "    arch    : ${art_arch}"
+echo "    tarball : ${tarball}"
+echo
+
+# ── Build ───────────────────────────────────────────────────────────────────
+
+# Match the Windows + macOS pipelines: bake version + channel into
+# the binary at compile time so option_env!() in
+# crates/con-core/src/release_channel.rs picks them up. The Linux
+# updater (added alongside this script) reads the channel to decide
+# which Sparkle-shaped appcast to poll.
+export CON_RELEASE_VERSION="${version}"
+export CON_RELEASE_CHANNEL="${channel}"
+
+echo "==> cargo build -p con --release"
+cargo build -p con --release
+
+# Resolve the actual target dir cargo wrote to. CARGO_TARGET_DIR
+# overrides override the default.
+target_dir="${CARGO_TARGET_DIR:-target}"
+bin_path="${target_dir}/release/con"
+[[ -x "$bin_path" ]] || { echo "build did not produce $bin_path" >&2; exit 1; }
+
+# ── Stage ───────────────────────────────────────────────────────────────────
+
+echo "==> staging ${stage_dir}"
+rm -rf "${stage_dir}"
+mkdir -p "${stage_dir}"
+
+# Strip debug info — drops the binary from ~300 MB to ~80 MB. The
+# macOS pipeline does the equivalent via an Xcode strip phase; the
+# Windows pipeline ships with debug-info stripped at link time.
+cp "$bin_path" "${stage_dir}/con"
+strip --strip-debug "${stage_dir}/con" || true
+
+# Docs.
+[[ -f LICENSE ]] && cp LICENSE "${stage_dir}/"
+[[ -f README.md ]] && cp README.md "${stage_dir}/"
+
+# Desktop entry. The install.sh script rewrites the Exec line to
+# point at the per-user install path before dropping it into
+# ~/.local/share/applications, so the path here is just a default
+# for users who hand-extract the tarball into /usr/local.
+cat > "${stage_dir}/con.desktop" <<'EOF'
+[Desktop Entry]
+Type=Application
+Name=con
+GenericName=Terminal
+Comment=GPU-accelerated terminal emulator with a built-in AI agent harness
+Exec=/usr/local/bin/con %U
+Icon=con
+Terminal=false
+Categories=System;TerminalEmulator;Utility;
+Keywords=terminal;shell;command;cli;ai;agent;
+StartupWMClass=con
+EOF
+
+# 256x256 icon — freedesktop hicolor's bread-and-butter size, and
+# what GNOME / KDE / xfce / wayland launchers all hit-test against
+# first. Pull from the macOS app-icon set we already ship.
+icon_src="assets/Con-macOS-Dark-256x256@2x.png"
+if [[ -f "$icon_src" ]]; then
+  cp "$icon_src" "${stage_dir}/con.png"
+else
+  echo "warning: ${icon_src} missing — Linux tarball ships without an app icon" >&2
+fi
+
+# ── Tarball + checksum ──────────────────────────────────────────────────────
+
+echo "==> packaging ${tarball}"
+tar -C dist -czf "${tarball}" "${stage_name}"
+
+echo "==> sha256"
+sha256_out=""
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256_out="$(cd dist && sha256sum "$(basename "${tarball}")")"
+elif command -v shasum >/dev/null 2>&1; then
+  sha256_out="$(cd dist && shasum -a 256 "$(basename "${tarball}")")"
+else
+  echo "warning: no sha256sum / shasum found — skipping checksum file" >&2
+fi
+if [[ -n "$sha256_out" ]]; then
+  echo "${sha256_out}" > "${sha_file}"
+  echo "    ${sha256_out}"
+fi
+
+echo
+echo "==> done"
+ls -la "${tarball}" ${sha_file:+"$sha_file"}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Linux release pipeline + fix-forward for two waves of review feedback + pre-merge end-to-end verification

Now that [#58](https://github.com/nowledge-co/con-terminal/pull/58)
is merged, this PR is rebased onto `main` and ready for review.
Branch state, in order:

1. `linux: one-liner installer + tarball release pipeline +
   notify-only auto-update` — original PR scope.
2. `linux: address pr #58 review feedback (bugs + nitpicks)` —
   seven actionable findings on #58 that landed in the merged
   Linux preview code.
3. `release: add CON_APPCAST_BASE / CON_INSTALL_URL overrides +
   log appcast result` — env-only verification overrides + one
   log line, used to drive the pre-merge end-to-end verification.
4. `release: address pr #59 review feedback (7 actionable items)` —
   first wave of review on this PR.
5. `linux-port: mirror tracker entry for #59 release pipeline +
   posted #58/#59 milestone summary on issue #18`.
6. `release: address pr #59 review wave 2 (5 actionable items)` —
   second wave of review on this PR.

The milestone summary (covering both #58 and #59) is posted on
issue [#18](https://github.com/nowledge-co/con-terminal/issues/18#issuecomment-4303252173).

### Architecture decision (release pipeline)

**Linux follows the Windows model, not Sparkle.** Sparkle is
macOS-only. The Sparkle **appcast XML format** is portable, and
that's what Windows already reuses: a notify-only checker against
the same XML schema, then `apply_update_in_place()` to re-run the
one-line installer.

| Layer | macOS | Windows | Linux (this PR) |
|---|---|---|---|
| **Artifact** | Signed notarized DMG | Unsigned ZIP | Unsigned `tar.gz` (39 MB stripped) |
| **One-line install** | `curl -fsSL .../install.sh \| sh` | `irm .../install.ps1 \| iex` | **same** `curl -fsSL .../install.sh \| sh` (`install.sh` is now a Unix dispatcher) |
| **In-app updater** | Sparkle (full auto-replace) | Notify-only against Sparkle-shaped appcast → re-runs `install.ps1` | Notify-only against the same XML schema → re-runs `install.sh` with `CON_INSTALL_VERSION` pinned to the appcast's chosen version |
| **Release CI** | `release-macos.yml` | `release-windows.yml` | New `release-linux.yml` (mirrors Windows pipeline 1:1) |

### What landed (commit 1: install / release / updater)

- `scripts/install.sh` — Unix dispatcher.
- `scripts/linux/release.sh` (new) — build + stage + tarball.
- `.github/workflows/release-linux.yml` (new) — mirror of
  `release-windows.yml`.
- `crates/con-app/src/updater.rs` — `windows_impl` →
  `notify_impl`, broadened to `any(windows, linux)`. Linux
  `apply_update_in_place()` variant.
- `crates/con-app/src/settings_panel.rs` — Updates card cfg
  widened to include Linux.

### What landed (commit 2: fix-forward for #58 review)

7 actionable items from Bugbot / Codex / CodeRabbit on the
merged Linux preview code. All Linux-only. Summary in the
prior PR description; details in commit `4cea592`.

### What landed (commit 4: fix-forward for #59 review wave 1)

7 actionable items from Bugbot / CodeRabbit. Highlights:

- **Channel-safety pin** (Major): `apply_update_in_place` reads
  the version from `LATEST` and spawns `sh -c 'export
  CON_INSTALL_VERSION=<v>; ...'`; `install.sh` honors it by
  hitting `/releases/tags/v<version>` instead of
  `/releases/latest`.
- gh-pages bootstrap commit: `git config` before `git commit`.
- `update-appcast needs:` widened from `build` to
  `[build, publish]`.
- `release-linux.yml` channel mapping covers `*-dev.*` (was
  defaulting to stable → would have published dev builds into
  `stable-linux-x86_64.xml`).
- `set_dark_mode` calls `mark_needs_render()`.
- `release.sh` ls listing matches generated artifacts.
- `theme.rs::canonical_terminal_font_family` restored
  `name.trim()` fall-through.

### What landed (commit 6: fix-forward for #59 review wave 2)

| # | Source | Sev | Where | Fix |
|---|---|---|---|---|
| 1 | CodeRabbit | **Major** | `release-{linux,macos,windows}.yml` | `gh release create` now passes `--prerelease` for `v*-beta.*` / `v*-dev.*` tags. **Without this, GitHub's `/releases/latest` API treats beta/dev tags as the next stable release** — every fresh-install via `install.sh` (Linux + macOS) and `install.ps1` (Windows) downloads a beta as if it were stable. The Linux `CON_INSTALL_VERSION` pin only kicks in after an "Update available" notification; the API is what unbothered fresh installs hit. Fix touches all three workflows but is additive (case statement + arg array). |
| 2/8 | CodeRabbit + Bugbot | Med | `updater.rs` | `install_url` now goes through `shell_quote()` like `version` already did. A `CON_INSTALL_URL` containing `&`, `;`, `#`, `$`, etc. would have broken out of the `curl` arg and reinterpreted as shell syntax. Verified against four metacharacter URLs end-to-end. |
| 6 | CodeRabbit | Min | `release_channel.rs` | `CON_APPCAST_BASE` env value is now trimmed (and trailing `/` stripped) before validating non-emptiness. A user pasting `"  http://localhost:8765/appcast/  "` produced a malformed URL before. |
| 7 | CodeRabbit | **Major** | `install.sh` | Atomic install: stage to sibling tempfile → `chmod +x` → `mv -f` to target. Old `rm + cp + chmod` left the user without a runnable binary if `cp` or `chmod` failed mid-install. Verified: failed `cp` leaves the original binary in place; tmp file gets cleaned up by the trap. Self-update behavior preserved (running con keeps the OLD inode mapped; `mv -f` swaps the directory entry; next launch picks up the new build). |
| 9 | Codex | **P1** | `updater.rs` | `apply_update_in_place` no longer uses `curl ... \| sh`. POSIX `sh` returns the rightmost command's status, so a `curl` failure (404, network, DNS) silently became a successful pipeline exit and `con` exited cleanly with no error — leaving the user stranded on the old version after clicking "Update now". Now downloads to a tempfile via `mktemp && curl ... && sh tmp; rc=$?; rm -f tmp; exit $rc`. POSIX-portable (no `pipefail` dependency). Verified: old pattern returns 0 on curl-fail; new pattern correctly propagates curl's exit 7. |

The "outside-diff" CodeRabbit comment about refactoring
`spawn_check` to use a shared tokio runtime is a refactor
suggestion that touches the harness — out of scope. The Windows
path uses the same shape today.

### Pre-merge verification matrix

End-to-end on the cloud-VM:

| Surface | Evidence |
|---|---|
| `scripts/linux/release.sh` | 39 MB tarball, sha256 verified, contents match. |
| `install.sh` Linux dispatcher | sha256 of installed binary matches tarball binary; `.desktop` rewritten; icon installed. Trap-correctness verified across success + failed-cp paths. |
| Notify-only updater + URL builder | `updater: appcast advertises version=X (running Y); is_newer=true` log line, server access log confirms appcast fetched. |
| **Channel-safety pin + apply** (wave 1) | Local server with `/releases/latest` → fake stable v0.1.0 (no asset) and `/releases/tags/v0.1.0-test.99` → real beta. Without pin: install.sh failed `no asset for linux x86_64 in latest release (v0.1.0)`. With pin: hit `/r/tags/v0.1.0-test.99`, installed binary sha matched source byte-for-byte. End-to-end through `apply_update_in_place`. |
| **Atomic install** (wave 2) | Failed-cp test confirms original binary stays in place + tmp file cleaned up by trap. mv-replace-while-running test: inode swaps from 1350748 → 1350749 in the directory entry while the running process keeps painting on the old inode. |
| **shell_quote install_url** (wave 2) | Tested against `?v=1&fmt=raw`, `; rm -rf /`, `#frag`, plain — all four neutralized; the `; rm -rf /` URL would have run as a separate shell command without quoting. |
| **curl-failure propagation** (wave 2) | Old `curl ... \| sh` pattern: curl fails with exit 7, pipeline exits 0. New pattern: curl fails with exit 7, pipeline exits 7. `con` will surface the spawn error instead of silent strand. |
| **--prerelease tag mapping** (wave 2) | Case statement verified against `v0.1.0`, `v0.1.0-beta.32`, `v0.1.0-dev.1`, `v1.2.3-rc.1`, `v1.0.0+build42` — beta/dev only get `--prerelease`, stable / unknown channels stay unmarked. |

### Cross-platform safety

Every change in commits 1, 2, 3, 4, 5 is `#[cfg(target_os = "linux")]`-gated
or in Linux-only files. The two shared-file changes in commit 1
(`updater.rs` mod rename + cfg widening; `release_channel::feed_url`
env read) are byte-identical when `CON_APPCAST_BASE` is unset.

**Wave-2 commit 6 is the first batch that intentionally touches
macOS + Windows release workflows**, but the change is
additive-only:

- Adds a `case` statement that derives `prerelease_args` from the
  tag.
- Adds the array expansion to the `gh release create` line.
- Stable tags (anything not matching `*-beta.*` or `*-dev.*`)
  produce an empty `prerelease_args` array — `gh release create`
  invocation on stable tags is byte-equivalent to before.
- The fix is **necessary** on macOS / Windows too: their
  `install.sh` / `install.ps1` already query `/releases/latest`
  the same way Linux does. Without `--prerelease`, a beta tag
  causes their fresh-install paths to download a beta as if it
  were stable. macOS's Sparkle path doesn't go through
  `/releases/latest` (Sparkle has its own appcast), but
  `install.sh` and Homebrew tap do.

Build matrix:

- `RUSTFLAGS="-D warnings" cargo check -p con` — clean.
- `cargo test -p con-core -p con-ghostty -p con` — **22 unit
  tests pass** (14 con + 3 con-core + 5 con-ghostty).
- `CON_SKIP_GHOSTTY_VT=1 cargo check --target
  x86_64-pc-windows-msvc -p con-ghostty` — clean.
- All three `release-*.yml` YAML loads clean.

### Maintainer follow-up

When ready to merge:

1. Verify `SPARKLE_SIGNING_KEY` repo Secret is set (already used
   by macOS / Windows; same key works for Linux).
2. Merge this PR.
3. Tag the next beta as usual: `git tag v0.1.0-beta.X &&
   git push --tags`. All three release workflows fire off the
   same tag and now correctly mark it `--prerelease`.
4. Confirm the gh-pages publish populates
   `https://con-releases.nowledge.co/appcast/beta-linux-x86_64.xml`
   and the latest `install.sh`.

### Future work (not in this PR)

- Real packaging: `.deb`, AppImage, Flatpak (`docs/impl/linux-port.md`
  phase 6).
- `--target aarch64-unknown-linux-gnu` cross-build —
  `CON_LINUX_ARCH` env hook already supports it.
- In-app Ed25519 signature verification (Windows is in the same
  boat; both verify server-side via GitHub Pages today).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6954c5ad-cb2d-44e0-b506-f54205a0a6bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6954c5ad-cb2d-44e0-b506-f54205a0a6bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated Linux release builds with publishing and channel-specific updater feeds
  * Cross-platform one-line installer (macOS + Linux) with Linux desktop integration
  * In-app notify-only updates on Linux with “Update now” to run the installer

* **Bug Fixes**
  * More consistent font rendering on Linux
  * Reliable PTY resize handling and forced refreshes
  * Opacity edge-case validation
  * Corrected Linux window-close behavior

* **Documentation**
  * Linux install, release, and updater docs added/updated
<!-- end of auto-generated comment: release notes by coderabbit.ai -->