### PR TITLE
Fix Windows storage paths and renderer hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,270 +2,192 @@
 
 All notable changes to con are documented here.
 
-con is still pre-release, so entries may group larger areas of work while the product shape is stabilizing.
+con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
 ## [Unreleased]
+
+Changes here are after `v0.1.0-beta.33`, the latest published beta release.
+
+### Added
+
+**Terminal — Linux Backend (preview)**
+- Added the first real Linux terminal pane: Unix PTY, shared `libghostty-vt` parser, GPUI styled-cell paint path, and the same app shell/control socket as macOS and Windows.
+- Added Linux styled-cell rendering for SGR colors, bold, italic, underline, strikethrough, inverse, and block cursor state.
+- Added Linux theme propagation from app settings into the VT parser at spawn time and during live theme changes.
+- Added Linux client-side decorations, transparent rounded windows, and KWin Wayland backdrop blur where the compositor exposes it.
+
+### Improved
+
+**Terminal — Linux Backend (preview)**
+- Resolved IoskeleyMono font-family lookup on Linux so the embedded mono font is used instead of a proportional fallback.
+- Reduced Linux terminal latency by replacing a full snapshot equality check with a generation-counter comparison and tightening the idle poll loop.
+
+**Terminal — Windows Backend (preview)**
+- Reduced Windows renderer hot-path work by skipping redundant default-background blank-cell instances, avoiding full-frame zero-fill before D3D readback, and only sorting the instance stream when a frame contains overflowing wide glyphs.
+
+### Fixed
+
+**Terminal — Linux Backend (preview)**
+- Stopped the Linux "Waiting for shell prompt..." placeholder from flashing when long-lived shells enter alt-screen TUIs.
+
+**Terminal — Windows Backend (preview)**
+- Fixed Windows settings, theme, session, history, OAuth, conversation, and global skills paths so they no longer use `con` as a filesystem segment, avoiding Win32 reserved-device-name failures such as `os error 267`.
+
+### Documentation
+
+- Updated the Linux implementation notes, tracker mirror, and postmortem for the first real Linux terminal preview.
+- Updated build-system and Windows-port notes to document the shared `con-paths` crate and the current Windows renderer performance track.
+
+## [v0.1.0-beta.33] - 2026-04-22
+
+### Improved
+
+**Terminal — Windows Backend (preview)**
+- Tuned low-hanging renderer performance issues in the Windows D3D11/DirectWrite path.
+- Wired terminal theme colors, opacity, and transparency into the Windows renderer.
+- Hardened Windows resize/readback behavior, theme switching clear colors, and DWM backdrop behavior across the beta feedback loop.
+
+## [v0.1.0-beta.32] - 2026-04-21
+
+### Added
+
+**Release and Packaging**
+- Added Windows in-place auto-update flow and appcast support.
+
+### Fixed
+
+**Release and Packaging**
+- Preserved the full beta tag in Windows release/appcast version metadata so beta update comparisons do not collapse to `0.1.0`.
+- Made the PowerShell installer ASCII-safe for `irm | iex` usage.
+- Updated release/download documentation for the renamed `con-terminal` repository.
+
+## [v0.1.0-beta.31] - 2026-04-21
 
 ### Added
 
 **Interface**
-- A modeless `About con` window now shows the app icon, release version, build number, release channel, and repository URL.
-- Appearance settings now include a configurable UI font size, separate from terminal font size.
-- con now supports an optional system-wide summon/hide shortcut on macOS. It ships disabled by default so it does not conflict with launchers or existing global shortcuts.
-- `cmd-n` now opens a real new window instead of reusing the current workspace.
-- The bottom command bar now has a pane-scope picker that can target the focused pane, all panes, or an explicit subset of panes.
-- The command bar now supports global command-history suggestions, local path completion for local panes, and an AI suggestion fallback that can be enabled independently.
-
-**Terminal — Ghostty Backend**
-- GPU-accelerated terminal rendering on macOS via Ghostty's Metal engine. Text rendering, scrollback, and compositing all run on the GPU for consistently smooth performance, even with high-throughput output.
-- Full VT compliance out of the box — Kitty keyboard protocol, hyperlinks, sixel graphics, and OSC 133 shell integration are handled natively by Ghostty. No configuration needed.
-- Instant command completion tracking — when a command finishes, con knows the exit code and exactly how long it took. The agent uses this to respond immediately instead of waiting on a timeout.
-- Clipboard integration — copy and paste work natively between the terminal and the system clipboard, including programmatic clipboard access via OSC 52.
-- Ghostty is now the only terminal runtime in con. The old in-app VTE/PTTY fallback path has been removed, so every pane uses the same terminal engine and the same behavior.
-- Embedded Ghostty ticking on macOS now follows Ghostty's wakeup-driven runtime model instead of a host-side polling loop, and the hosted NSView stack now uses native live-resize redraw policies for smoother terminal window resizing.
-- Ghostty panes no longer run their own per-surface 60fps GPUI polling loops. Surface event draining and deferred resize/retry housekeeping now flow through one workspace-level Ghostty wake pump, which removes redundant host-side churn during resize and other heavy terminal activity.
-- The macOS window now adopts Ghostty-style cell-step resize increments from the active terminal surface, reducing pointless intermediate resize states during live drags and moving Con closer to Ghostty's own resize behavior.
-- The normal workspace render path no longer forces fresh terminal observations just to populate pane metadata. Runtime facts are now cached from explicit observation paths and reused by the UI, which avoids reading terminal text during ordinary renders while a heavy TUI is active.
-- The embedded macOS Ghostty host no longer synthesizes a fake scrollbar-at-top state before Ghostty emits real viewport data. The native scroll container now stays inert until Ghostty provides actual scrollbar state, which avoids forcing heavy TUIs through upper scrollback on startup or during reflow.
-
-**Terminal — Linux Backend (preview)**
-- Con now has a real terminal pane on Linux. The same `con` binary that runs on macOS now spawns a Unix PTY, feeds it through the shared `libghostty-vt` parser, and renders styled cells in the GPUI window — no more "backend under construction" placeholder. Same workspace, same agent panel, same control socket at `/tmp/con.sock`, same `con-cli` plumbing as macOS / Windows.
-- Per-row styled-cell paint covers SGR colors, bold (`FontWeight::BOLD`), italic (`FontStyle::Italic`), underline, strikethrough, inverse, and a block cursor (fg/bg swap on the cursor cell). Each VT row collapses runs of cells with identical `(fg, bg, attrs, is_cursor)` into one GPUI `TextRun`, so allocations scale with style changes, not cell count. Cell colors decode from the parser's `0xRRGGBBAA` packing into GPUI `Hsla` (alpha-0 means "use the default", matching the Windows pixel-shader contract). Real-world TUIs like `htop`, `vim`, `less`, `man`, and `fzf` work correctly.
-- Theme palette is plumbed all the way through. `LinuxGhosttyApp::update_appearance` / `update_colors` now forward the user's `TerminalColors` (foreground / background / 16-color ANSI palette) into `VtScreen::set_theme` — both at session spawn (via `LinuxPtyOptions.theme`) and live whenever the user picks a theme in settings. Linux panes stop falling back to the parser's hard-coded grey-on-black default.
-- IoskeleyMono shaping works on Linux. The user-facing display name `"Ioskeley Mono"` (with a space) is normalized to the registered TTF family `"IoskeleyMono"` (no space) before the lookup, so GPUI's `CosmicTextSystem` resolves the embedded font instead of falling back to a system proportional sans. macOS Core Text and Windows DirectWrite continue to fuzzy-resolve both forms; macOS / Windows behavior is byte-identical.
-- Client-side decorations land on Linux. con paints its own top bar (with the same minimize / maximize / close caption cluster Windows uses) instead of stacking the xfwm4 / mutter / kwin titlebar on top of the GPUI shell. The X11 backend's `on_hit_test_window_control` is a no-op, so each Linux caption button gets an explicit `on_mouse_down` handler that calls `window.minimize_window()` / `zoom_window()` / `remove_window()`. Window dragging works via `start_window_move` (`_NET_WM_MOVERESIZE`).
-- Transparent ARGB window with rounded corners. `WindowDecorations::Client` + `WindowBackgroundAppearance::Transparent` opens against the X11 ARGB depth-32 visual (Wayland drops the opaque-region hint), the workspace root clips to a 14px corner radius (matching the Mica radius on Win11), and the existing per-pane "terminal opacity" + per-surface "ui opacity" sliders now actually composite through to the desktop on Linux.
-- Backdrop blur where the compositor exposes it. `WindowBackgroundAppearance::Blurred` lights up `org_kde_kwin_blur` on KDE Plasma Wayland — real Gaussian blur of what's behind the window, indistinguishable from macOS's Metal blend-behind. On X11 / mutter / sway the toggle still ships but the visible result is transparency only (no portable backdrop-blur protocol exists outside KWin).
-- Latency on Linux dropped substantially. Removed a redundant per-tick snapshot refresh and a 50–200 KB `Vec<Cell>` deep-equality compare from the snapshot path (replaced with a generation-counter compare), and tightened the workspace idle poll loop from 16 ms to 8 ms. Measured: keystroke-echo round-trip via the control socket dropped from 32.6 ms → 16.6 ms mean across 5 runs.
-- "Waiting for shell prompt…" no longer flashes when alt-screen TUIs launch. The placeholder previously lit up every time `htop` / `vim` / `less` / `fzf` switched to the alternate screen, even though the PTY had been alive for ages. A `seen_any_output` latch on the view fixes this — placeholder shows only before the first prompt for the lifetime of the session.
-- Plan, postmortem, and tracker mirror in `docs/impl/linux-port.md`, `docs/impl/linux-port-tracker-updates/2026-04-23-styled-cell-renderer.md`, and `postmortem/2026-04-23-linux-styled-cell-renderer.md`. Issue #18 has the full visual proof set (fresh launch, styled output, rounded transparent window, htop alt-screen blank moment, htop fully painted). Phase 4 ("first real terminal surface") is now landed; remaining Linux work is the long-term GPUI-owned glyph-atlas grid renderer (matching the D3D11 / DirectWrite path Windows uses) and packaging (`.deb` / AppImage / Flatpak).
-
-**Terminal — Windows Backend (preview)**
-- Con now has a real, GPU-accelerated terminal pane on Windows. The `con-app.exe` binary drives a `libghostty-vt` parser over a ConPTY-hosted `pwsh.exe`/`cmd.exe`, and the grid is rendered through a D3D11 + DirectWrite atlas pipeline that matches Windows Terminal AtlasEngine's architecture (skyline-packed BGRA8 atlas, single `DrawIndexedInstanced` per frame, grayscale/ClearType AA).
-- IoskeleyMono's full Nerd-Font set (Powerline separators, devicons, Font Awesome, Octicons, Codicons, Material Design icons) now rasterizes correctly inside monospace cells via a three-case atlas strategy — normal glyphs stay in their cell, negative-`leftSideBearing` icons get a widened slot with a pen shift so the ink lands flush at the slot edge, and oversized glyphs scale around the cell centre. oh-my-posh, Starship, and Powerlevel10k prompts render out of the box.
-- Atlas packing is bleed-proof: every glyph rasterization is bracketed by a `PushAxisAlignedClip` + opaque black pre-fill, so ClearType fringe from one atlas neighbour can't contaminate the next. Thin glyphs like `-`, `_`, and `=` render cleanly against any prior atlas state.
-- Wide PUA icons that overflow their cell and the cell cursor now interact correctly — wide instances are stable-sorted after narrow ones so DX11's in-order per-pixel writes let them win against neighbour backgrounds, and the cursor's inverse-colour instance is captured pre-sort and drawn last so it always lands on the intended cell.
-- The Windows renderer now skips redundant default-background blank-cell instances, avoids full-frame zero-fill before D3D readback, and only pays the wide-glyph stable-sort cost when a frame actually contains overflowing glyphs.
-- The local control plane uses Windows Named Pipes (`\\.\pipe\con`) as its transport, so `con-cli` and external automation work the same way they do on macOS.
-- Phase 3c (input/selection polish) and Phase 3d (DirectComposition sibling visual upstream in GPUI) remain the outstanding Windows work; see `docs/impl/windows-port.md` for the full phased plan.
-
-**AI Agent**
-- Per-tab agent sessions — each tab has its own conversation, context, and approval state. Switch tabs freely while the agent works; background tabs keep running and accumulate responses. Your conversation stays with the tab it belongs to, and commands the agent runs always target the correct terminal.
-- Agent conversations persist per-tab across restarts
-- Restored agent conversations now keep the assistant trace too, including thinking text, tool steps, model labels, and durations, instead of collapsing back to plain message bodies after restart.
-- Command duration and exit code are now included in the agent's context. When you ask "what happened?", the agent can tell you a build took 12 seconds and failed with exit code 1 — not just show you the output.
-- A first local automation control plane now ships with `con-cli`. External agents can list tabs and panes, read pane content, run visible shell commands, drive tmux through con's typed tmux adapter, and send prompts into a tab's built-in agent session over a local Unix socket.
-
-### Improved
-
-**Interface**
-- The agent panel can now expand with the window instead of stopping at a fixed width ceiling, while still preserving a minimum terminal area. Wide markdown content such as tables and code blocks now uses the panel's full available width instead of being forced through the prose column.
-- macOS terminal profiling now has a dedicated runbook and opt-in host-path logs, making it easier to distinguish Ghostty core time from Con's embedding/composition cost when diagnosing heavy TUI resize issues.
-- The macOS `xctrace` profiling helper now builds and launches the real `con` binary instead of profiling the `cargo` wrapper process, so resize traces reflect the app under test.
-- The macOS Ghostty runtime is now built with Zig `-Doptimize=ReleaseFast` by default. Embedded debug-grade Ghostty builds made dense TUI startup and resize behavior much slower than standalone Ghostty and invalidated performance comparisons.
+- Added a titlebar gear button on Windows and Linux for opening Settings.
 
 **Release and Packaging**
-- The macOS app bundle, updater, and release pipeline are now documented and exercised as real product surfaces. Local updater testing now runs from a bundled beta app instead of `cargo run`, and version metadata is visible in both Settings and the About window.
-- Workspace dependencies no longer rely on local `3pp/` checkouts at build time. GPUI, gpui-component, Rig, and Ghostty now resolve from upstream git sources or scripted fetches instead of local path dependencies.
-
-**AI Agent**
-- The agent system prompt has been restructured for sharper tool usage. Questions are answered with minimal side effects; tasks are executed carefully with verification. Each tool now has explicit guidelines so the agent picks the right one the first time.
-- `con` currently pins `rig-core` to a maintained fork revision while provider work settles upstream. The build no longer depends on a local source checkout for Rig.
-- Busy/idle detection works on Ghostty panes — the agent waits for a running command to finish before sending another.
-- Pane-aware context is stricter and more honest. con no longer guesses SSH hosts, tmux sessions, or agent CLIs from pane titles or status-line patterns. When the foreground runtime is not proven, it stays `unknown`.
-- Visible shell execution now depends on real Ghostty command boundaries instead of stale cwd or title clues. After any unconfirmed input, con stops trusting shell metadata until shell integration proves a fresh prompt again.
-- con now refuses `terminal_exec` and `batch_exec` on panes that are not proven plain-shell targets. This prevents the built-in agent from typing shell commands into tmux+nvim or other visible TUIs.
-- Pane control state is now typed and shared across the prompt, `list_panes`, and execution guards. The agent now sees each pane's address space, visible target, explicit control attachments, control channels, capabilities, and control notes instead of relying on flat pane heuristics.
-- Pane metadata now also exposes backend observability limits directly. If embedded Ghostty cannot prove foreground command text, alternate-screen state, or remote-host identity for a pane, con says so instead of guessing.
-- The control plane can represent nested targets explicitly, and it now uses `unknown` for unproven foreground targets instead of pretending every ambiguous pane is a TUI.
-- con now exposes a read-only `probe_shell_context` tool on panes with a proven fresh shell prompt. This gives the agent a typed way to ask the live shell for hostname, SSH env, tmux env, tmux session/window/pane ids, and Neovim socket hints instead of guessing from screen text.
-- Pane runtime state is now reducer-backed instead of snapshot-only. con tracks each pane's recent actions, typed shell-context snapshots, and freshness rules, so the agent can reuse truthful causal history without confusing it for the current foreground target.
-- Pane runtime now separates the current verified foreground stack from the last verified shell frame. If con cannot prove what is visible now, it keeps the live target `unknown` and shows the last verified shell context separately instead of pretending history is current state.
-- con now exposes the first native tmux control layer through a proven same-session shell anchor. When a fresh shell probe confirms tmux, the agent can list tmux targets, capture a specific tmux pane, and send tmux-native keys to a chosen tmux pane instead of typing blindly into the outer terminal surface.
-- tmux native control can now also come from fresh shell continuity plus recent con-caused tmux setup. If con just created or targeted a tmux session from a still-fresh shell prompt, that shell can immediately become a tmux control anchor instead of falling back to raw tmux keystrokes first.
-- con can now launch work inside tmux natively through the same typed control anchor. The agent can create a new tmux window or split pane and run a command there, which is the right path for fresh shells, Codex CLI, Claude Code, OpenCode, and long-running jobs inside tmux.
-- tmux-native workflows now have higher-level helpers too. The agent can find likely tmux shell or agent-cli targets without hand-filtering every pane, and it can reuse or create a clean tmux shell target before remote file edits or command work.
-- tmux shell work now has a typed follow-up tool too. Once a clean tmux shell target exists, the agent can run one deterministic shell command there, wait for that shell target to settle, and return a fresh capture instead of manually composing tmux key delivery and capture steps.
-- tmux-native agent CLI workflows now have a typed helper too. The agent can reuse or create a Codex CLI, Claude Code, or OpenCode tmux target directly instead of manually reconstructing that flow from `tmux_list_targets` and `tmux_run_command`.
-- Remote `ssh -> tmux -> shell-work` bootstrap now has a typed one-step helper too. con can reuse or create the SSH pane, ensure the tmux session, and then reuse or create the clean tmux shell target for file work without forcing the agent to reconstruct that path by hand.
-- tmux-native control can now survive one more honest boundary: if con recently prepared tmux from a pane and the current visible screen still looks like a prompt inside that tmux workspace, con can retain the same-session tmux shell anchor long enough to keep tmux-native tools available without pretending the foreground app is fully proven.
-- con can now resolve the best work target across a whole split layout. The agent has a typed helper to choose the right visible shell pane, tmux workspace, tmux shell target, or agent CLI target instead of re-deriving that decision from raw pane lists every turn.
-- Multi-host SSH work now has a typed reuse-or-create helper too. The agent can ask con to reuse an existing SSH pane for a host, or create one with explicit split placement, instead of spawning duplicate remote panes on follow-up turns.
-- Disconnected SSH workspaces now stay visible to typed target resolution too. When one host pane has dropped, con can surface it as a selective-recovery target and point the agent at `ensure_remote_shell_target` for that host instead of pretending no routing information remains.
-- Local coding-agent workflows now have a typed paired-shell helper too. The agent can keep Codex, Claude Code, or OpenCode in one local pane while reusing or creating a separate local shell pane for file edits, test runs, and other shell work.
-- Local coding-agent workflows now have a typed agent-target helper too. con can reuse or launch a local Codex, Claude Code, or OpenCode pane explicitly instead of leaving that choice implicit in model reasoning.
-- Local coding-agent workflows now also have a typed paired-workspace helper. con can reuse or prepare the whole local coding pair for a project path at once: one interactive Codex / Claude Code / OpenCode pane plus one separate shell pane for file/test/git work.
-- Visible agent-cli follow-up turns now wait for output change-and-settle instead of shell-idle semantics, so Codex / Claude Code / OpenCode panes are treated like interactive foreground apps instead of shell prompts with stale shell integration under them.
-- The local paired-coding rule is stricter now: deterministic file writes, test runs, and other direct shell work should stay in the shell lane by default, while the interactive Codex / Claude Code / OpenCode lane is reserved for explicit CLI interaction or clearing a blocking trust/continue prompt.
-- Local coding workspaces are now summarized at the tab level too. The agent can see reusable local shell and agent-cli workspaces, including project-path hints and recent local continuity, instead of rebuilding that routing decision from raw panes every turn.
-- Local coding target reuse is stricter now. A pane that was recently launched for Codex / Claude Code / OpenCode is no longer silently reused as a generic local shell target on follow-up turns.
-- Local coding workspace preparation now normalizes `~` project paths before startup shell quoting, so new local agent and shell panes no longer fail with literal `cd '~/project'` commands.
-- Local coding workspace preparation can now create the requested project directory as part of its own bootstrap, so “prepare a workspace in X” no longer burns the first turn just recovering from a missing local path.
-- Interactive Codex / Claude Code / OpenCode follow-up turns now have a typed tool too. con can send one prompt into an existing local or tmux agent-cli target, wait for that target to settle, and return a fresh snapshot instead of forcing the model to improvise raw `send_keys` plus timing guesses.
-- con now distinguishes tmux-controlled agent CLIs from true native app attachments. Codex and OpenCode both have richer protocol surfaces, but con only treats them as tmux targets unless an explicit launch-integrated attachment is proven.
-- When native tmux control is available, the agent now treats tmux-native target discovery and tmux-native key delivery as the default path. Raw outer-pane `send_keys` is now fallback-only for tmux instead of the first choice.
-- con no longer teaches editor-specific keystroke playbooks in the main agent prompt. The built-in control surface now stays focused on shells, SSH, tmux, and agent CLIs, with generic TUI input only as a fallback.
-- Sending the first agent message no longer performs local `git diff`, project listing, and `AGENTS.md` reads on the UI thread. Workspace enrichment now happens on the harness runtime, reducing visible app stalls when a request starts.
-- Before the model runs, con now performs a deterministic non-intrusive fact pass on the focused pane. It no longer types a visible shell probe into the terminal before the first response. When a real tmux control anchor already exists, con still preloads tmux inventory because that query is silent and read-only.
-- con now derives explicit weak observation hints from the current visible screen, such as prompt-like input near the bottom or htop-like output. These hints are labeled as observations, not facts, so the agent can describe what appears to be on screen without pretending it has backend proof.
-- Session-state answers now explicitly synthesize proven facts, current-screen assessment, and unknowns/limits. When con already has visible-screen observations, the agent is guided to give the best bounded assessment instead of ending with a vague “inspect more closely” fallback.
-- Multi-pane session-state answers now carry a deterministic pane-layout summary. When a tab has split panes, the agent is guided to mention the pane count and the materially different peer panes instead of collapsing the whole terminal state into only the focused pane.
-- When multiple panes are open, the prompt now carries typed work-target hints too. The agent can see which pane is the best visible shell target and which pane is the best tmux workspace before it decides whether to call a resolver tool.
-- SSH workspaces are now tracked across the whole tab, not just the focused pane. con keeps a typed inventory of proven remote hosts and con-managed SSH continuity, so follow-up requests can reuse the right host panes instead of recreating them.
-- Follow-up remote work is now allowed to reuse con-created SSH panes even when fresh shell integration is not currently proven, as long as the pane still looks like a prompt and no tmux or TUI evidence contradicts that continuity.
-- Pane tools now expose both `pane_index` and stable `pane_id`. `pane_index` remains the current visible layout position, while `pane_id` stays stable for the life of that pane inside the tab. Follow-up agent work now prefers `pane_id`, so adding or closing a split does not silently retarget later actions.
-- Stale pane targeting is now explained more clearly too. If a pane was closed or the split layout changed, con returns a direct recovery message that tells the agent to re-run `list_panes` and continue with `pane_id` instead of quietly failing on an old index.
-- con now summarizes the whole tab as typed workspaces. The agent can distinguish a ready remote shell, a tmux workspace, a disconnected SSH pane, or a pane that still needs inspection before it acts.
-- Multi-host remote work now has a higher-level `remote_exec` path. The agent can reuse or create SSH workspaces for multiple hosts and run the same command across them in parallel without manually stitching pane creation and batch execution together.
-- Current-screen SSH state is modeled more cleanly too. Login banners and closed-SSH screens are now captured as observations, which helps the agent tell the difference between a live remote shell and a pane whose remote session already ended.
-- tmux-like screens are now captured as observations too. con can describe a pane as looking like tmux and route tmux-oriented questions toward that pane without pretending it already has native tmux control there.
-- SSH workspace reuse is stricter now. A pane that visibly shows a closed SSH connection or a tmux-like screen is no longer silently reused as a plain remote shell target on follow-up turns.
-- The agent panel now uses quieter run cards with calmer state labels, stronger alignment, and cleaner output blocks. Long tool results still expand inline, but the panel no longer relies on a loud “finished” banner to signal that a run is done.
-- The agent panel now uses stronger Phosphor fill and duotone icons, clearer section labels, and more deliberate spacing so tool traces feel like a composed operator timeline instead of a generic debug inspector.
-- The agent panel trace rows now expand as connected cards instead of detached header-and-output boxes, and model identity is shown as chips instead of awkward raw provider/model strings. That makes long tool traces and provider metadata read more like a composed operator surface and less like debug text.
-- The live agent panel now shows human-readable provider/model labels instead of Rust-style `Thinking("provider:model")` debug text, expanded outputs use quieter inline toggles with a dedicated mono sub-surface, and the default accent path now follows the theme's blue primary token instead of an unintended cyan bias.
-- Expanded agent trace output now reads as a clearer nested surface, with a stronger inner tone for code and log text so the card hierarchy stays legible in long tool runs.
-- Agent trace cards now use distinct theme layers for run groups, tool rows, and inner output blocks. Light and dark themes both keep the title row, body, and nested code/log output visually separate instead of flattening into one tone.
-- The agent panel trace hierarchy is quieter now. Run groups use a very light outer surface, tool rows use the main secondary surface, and expanded code/log output sits on a deeper nested surface so the panel stays layered without looking boxed-in.
-- The agent panel trace stack is quieter and more borderless now. The outer run group no longer reads as a heavy card, while step rows and nested output keep a clear neutral hierarchy without muddy tint stacking.
-- Expanded tool traces now use a calmer nested rhythm: a light step shell, a distinct detail surface when unfolded, and a deeper mono result block inside that detail surface. The structure stays connected, but each layer now reads as a different depth.
-- Run traces now keep a clearer section scope too. The group itself has a faint outer shell again, the section header sits on its own quiet surface, and the inner spacing is looser so expanded steps no longer feel visually jammed together.
-- Step cards and live tool cards now separate header and body more clearly. The title row sits on its own header surface, while expanded detail stays nested below it, so rows like `Read Pane` no longer flatten into the page background.
-- Step headers are now inset within their card shells, so the first layer reads as a true card header instead of a flat strip on the page. Expanded detail keeps its own quieter body surface below that header.
-- Trace cards now use structural shell padding instead of margin tricks. That keeps the header plane visibly inside the card, makes collapsed rows read as real cards, and fixes the awkward hover geometry around titles like `Read Pane`.
-- Trace card layers now use the real theme surface ladder again instead of ultra-low-opacity neutrals. In light mode especially, rows like `Read Pane` should now read as visible cards with a distinct header plane instead of flattening into the page.
-- Run trace groups now sit on their own visible section surface, and structured tool output like `key: value` blocks renders as aligned rows instead of a flat monospace dump. That gives expanded steps a clearer hierarchy and a more legible body layout.
-- Agent traces now use a simpler, more deliberate surface ladder: one quiet section shell, unified step cards, and a single inset content box for expanded output. Header rows, unfolded content, and mono result blocks now align to the same inset instead of drifting into separate mini-cards.
-- Agent trace shells now sit more clearly above the chat background, step cards use rounder geometry, structured shell output enforces monospace styling, and expanded content aligns closer to its step header instead of drifting too far right.
-- Agent panel trace polish now uses calmer custom model chips, tighter radius scaling, stronger monospace treatment for shell-style output, and better text contrast across step headers, details, and expanded result blocks.
-- The unfolded step body now aligns to the card’s icon/title grid instead of drifting inward, and the chat/trace typography uses a cleaner shared scale for prose, captions, chips, and monospace output.
-- The terminal-agent benchmark now includes richer operator playbooks and profiles for local Codex dev loops, dual-host SSH maintenance, and remote tmux edit/run/reuse workflows. It can now execute those operator prompt sequences directly and record the transcript instead of only printing a playbook path.
-- The terminal-agent benchmark now covers local Claude Code and OpenCode dev loops too, so Con can compare the same project-prep, test-run, and follow-up-repair workflow across all three supported local coding CLIs instead of only Codex.
-- The terminal-agent benchmark now also covers richer local git-backed workflows and local interactive session-resume stories for Codex, Claude Code, and OpenCode. Those tracks measure paired shell-plus-CLI continuity across git commits, diff review, and later return-to-the-same-pane follow-up turns.
-- The terminal-agent benchmark now also includes a dual-host SSH recovery track, so Con can be scored on recovering only the disconnected host workspace instead of recreating every remote pane after a failure.
-- The terminal-agent benchmark now has stable scoring rubrics, a scoring tool, a trend-report generator, and a project-local improvement-loop skill so progress can be judged and compared over many iterations instead of living only in screenshots and memory.
-- `con-cli agent ask` and operator benchmark steps can now be bounded with explicit timeouts, so a stuck agent turn fails cleanly instead of hanging the entire automation loop.
-- Control-plane `agent ask` timeouts are now request-scoped. A finished `con-cli agent ask` can no longer leave behind a stale timer that aborts the next request on the same tab.
-- Closing or resetting a tab now clears or reindexes any pending control-plane `agent.ask` state for that tab, so a killed benchmark or closed tab cannot leave behind a stale “tab is busy” entry that poisons the next fresh tab at the same index.
-- The benchmark loop now writes a tracked improvement log entry and trend-chart report, so repeated iterations leave behind comparable notes and a durable progress trail in the repo.
-- Operator benchmark profiles can now start from a fresh conversation and run deterministic visible-shell setup commands before the first prompt, which makes repeated local Codex and SSH/tmux evaluations more stable.
-- Operator benchmark profiles can now also run deterministic local shell setup commands before the first prompt. The built-in operator profiles use that for dependency-free local Python setup and clean tmux-session hygiene on remote hosts.
-- The terminal-agent benchmark now ships an isolated batch runner, so multi-iteration evaluation can launch a fresh Con runtime per run instead of reusing polluted session state.
-- The terminal-agent benchmark now isolates restored session state on macOS too. Fresh iterations use dedicated session and conversation paths, and repeated Ghostty bootstrap launch failures are classified as blocked environment runs instead of misleading scored regressions.
-
-**Terminal**
-- New Ghostty panes now inherit the requested working directory and font size at creation time, which keeps restored tabs and newly opened panes aligned with the workspace state.
-- Split-pane creation and new-tab activation are now off the synchronous session-save path, which reduces visible latency during interactive workspace changes.
-- Split requests now flow through Ghostty's native split action path before con creates the new surface, so pane insertion follows Ghostty split direction semantics instead of treating every split as a purely external GPUI command.
-- Font size changes now apply to existing Ghostty panes immediately, so terminal text updates in place when you save Settings.
-- Terminal theme changes now apply to live Ghostty panes immediately instead of only updating the surrounding con interface.
-- Control-created panes now bootstrap as real Ghostty surfaces immediately instead of staying as uninitialized placeholders until a later render pass. `panes.create` now returns `surface_ready`, `is_alive`, and `has_shell_integration`, which makes CLI- and agent-driven pane setup much more truthful.
-- Control-created tabs now bootstrap their first Ghostty pane through the same visibility and surface-ensure path as normal tab activation, so `tabs.new` no longer leaves automation on a dead first pane.
-- The control plane can now create and close tabs through `con-cli`, and workspace bootstrap now reasserts new or newly focused terminals until Ghostty either comes up or the environment proves it cannot.
-- Split rails now keep a visible resting presence instead of appearing only on hover, so sparse or newly created panes still read as separate terminal workspaces at a glance.
-- Split panes no longer blank out when they lose focus. Embedded Ghostty surfaces are no longer dimmed with GPUI opacity, which restores correct rendering for unfocused split panes while keeping the layout borderless.
-- Con now reasserts visibility for every active-tab Ghostty pane during normal renders, which hardens split layouts against stale hidden-surface state after split churn or overlay transitions.
-- Terminal settings are simpler and more honest. con no longer exposes backend switching or fake scrollback tuning for features that are owned by Ghostty itself.
-
-**Smart Input**
-- Command detection now scans your `$PATH` at startup instead of using a static word list. Any installed program — `hostname`, `terraform`, `kubectl`, or a custom script in `/usr/local/bin` — is correctly recognized as a shell command without manual configuration.
-- Commands with flags (`free -g`, `docker --version`) are now recognized by their syntax — even when the executable isn't on your local PATH.
-- Remote-sensitive classification now only activates when remote identity is proven. When con cannot prove a pane is remote, it stays conservative instead of guessing.
-
-**AI Agent**
-- The agent now sees pane indexes, directories when available, busy status, control notes, and backend limits directly in its context. This reduces pane-targeting mistakes without pretending SSH or tmux identity is known when it is not.
-- Ghostty panes now report `has_shell_integration: true` in the agent's pane list, enabling the agent to use command tracking features.
+- Added Windows PowerShell installer and release palette entries.
 
 ### Fixed
 
-**AI Agent**
-- Fixed agent hanging after receiving a final response from certain providers
-- Fixed empty agent responses appearing as stuck/hanging when providers don't emit text items during streaming
-- Fixed a Unicode logging crash where long tool-result previews could be truncated at an invalid UTF-8 byte boundary
-- Fixed inline `<think>...</think>` reasoning from some models so it now renders in the collapsible reasoning section instead of leaking raw tags into chat output.
-- Fixed ChatGPT Subscription model discovery so it now inherits the full OpenAI `models.dev` catalog instead of falling back to a much shorter local list.
-- Fixed MiniMax and Z.AI provider settings so Anthropic API mode, transport toggles, and matching endpoint presets survive Settings reopen instead of silently falling back.
-- Fixed configured-provider filtering in the agent panel so the session provider picker only shows providers you have actually set up.
-- Fixed conversation history title truncation for CJK text so opening history no longer panics on multibyte characters.
-- Fixed tmux native control helper quoting so tmux list/capture/exec commands no longer leak into the target shell as broken `quote>` input when a quoted tmux target is present
-- Fixed a visible-panel performance regression where assistant messages were reparsed as markdown on every render.
-- Fixed a second visible-panel performance regression where fenced code blocks rebuilt syntax-highlight runs on every render.
-- Aligned embedded Ghostty viewport hosting with standalone Ghostty on macOS by consuming Ghostty scrollbar actions and wrapping each surface in a native scroll container. This keeps bottom anchoring stable during heavy TUI resize instead of briefly jumping into upper scrollback.
-- Removed Con-specific live-resize coalescing from the embedded Ghostty surface path on macOS. Surface resizes now follow Ghostty's own immediate backing-size update model instead of deferring commits behind host-side heuristics.
-- Fixed Ghostty resource packaging and dev-run bootstrap on macOS. Con now embeds Ghostty's `Resources/ghostty` payload into app bundles and points debug runs at the built Ghostty resources so child processes get `xterm-ghostty`, `TERMINFO`, and Ghostty shell integration instead of silently falling back to `xterm-256color`.
+**Terminal — Windows Backend (preview)**
+- Switched Windows builds to the console subsystem behavior needed for terminal process startup.
+- Baked the full release channel/version into the Windows binary for update polling and user-visible version display.
 
-**Terminal**
-- Fixed Windows settings/theme/session/auth persistence paths so they no longer use `con` as a filesystem segment, avoiding Win32 reserved-device-name failures such as `os error 267`.
-- Full terminal emulation with 256-color and truecolor support
-- Split panes — divide your workspace horizontally (Cmd+D) or vertically (Cmd+Shift+D), with drag-to-resize dividers
-- Mouse text selection with click-drag, double-click for words, triple-click for lines, and Cmd+A to select all
-- Scrollback buffer with smooth scroll and a floating indicator showing how far back you are
-- Clipboard integration with Cmd+C / Cmd+V, including bracketed paste mode for safe pasting into editors
-- Cmd+K now clears the current Ghostty screen and scrollback using Ghostty's native action path
-- Fixed a Ghostty theme sync regression where the Settings panel could update con's chrome but leave the terminal on an old palette after a later runtime config update
-- Fixed a shutdown crash in the workspace mouse/resize path when the active tab index outlived the tab list during window teardown
-- Fixed another shutdown-time panic where late workspace renders or actions could still assume an active pane after the last tab was already gone
-- Fixed last-window close teardown for embedded Ghostty surfaces. Closing the final tab or window now shuts down Ghostty surfaces explicitly before window removal instead of relying on late destructor cleanup.
-- Tab management — Cmd+T to open, Cmd+W to close, Cmd+1–9 to switch, Cmd+Shift+[/] to cycle
-- Session restore — your tabs, layout, and panel state are preserved when you relaunch
-- Full compatibility with terminal applications like vim, htop, and tmux (alternate screen, application cursor keys, DEC private modes, Kitty keyboard protocol)
+## [v0.1.0-beta.30] - 2026-04-21
 
-**AI Agent**
-- Built-in AI assistant that works with 13 providers — Anthropic, OpenAI, DeepSeek, Groq, Gemini, Ollama, OpenRouter, Mistral, Together, Cohere, Perplexity, xAI, and any OpenAI-compatible endpoint. Each provider uses its native Rig client for correct API routing and auth.
-- Transparent execution — when the agent runs a command, it executes right in your terminal. You see every keystroke, every output, in real time. No hidden processes.
-- Deep context awareness — the agent sees your working directory, recent output, command history, git branch, uncommitted changes, and project structure. It reasons about what you're actually doing.
-- Seven tools at the agent's disposal: run commands (visibly or in the background), read files, write files, surgically edit specific sections of a file, list project files, and search your codebase
-- Streaming responses you can cancel mid-flight — hit Stop and the partial response is preserved
-- Extended thinking — when the model reasons before responding, you can expand a collapsible section to see its thought process
-- Approval workflow — the agent asks before running commands or modifying files. You stay in control. (Or toggle auto-approve for trusted sessions.)
-- Multi-turn conversations with full context carried across messages
-- Built-in skills: type /explain, /fix, /commit, /test, or /review to trigger purpose-built agent workflows
-- Custom skills via AGENTS.md files in your project
-- Temperature control — set `temperature` in config.toml or the Settings panel to tune model creativity
-- Separate suggestion model — configure `[agent.suggestion_model]` to use a fast, cheap model for inline completions while keeping a powerful model for agent chat
+### Added
 
-**Interface**
-- Smart input bar that auto-detects intent — shell commands go to the terminal, questions go to the agent, /skills invoke workflows
-- The single-tab state now uses a compact titlebar instead of a full tab strip, which recovers terminal space without hiding core window controls.
-- Agent panel (Cmd+L) with structured tool call cards, inline approval dialogs, code block rendering, and a resizable width you can drag to adjust
-- Fixed the agent-panel provider and model menus so long provider/model catalogs open in a bounded scrollable popup instead of getting stuck in an unscrollable header dropdown.
-- The agent panel now keeps live activity visible near the top while a run is in progress, shows a labeled Stop action in the header, and lets you expand long tool results instead of forcing every step into the same short preview.
-- Settings panel (Cmd+,) to configure your provider, model, and preferences
-- Appearance settings now expose terminal blur separately from terminal opacity, so Ghostty glass and blur can be tuned independently.
-- Fixed terminal blur on macOS so changing the blur setting now reapplies Ghostty's window blur to existing terminal windows, instead of only updating the stored config.
-- Fixed shifted punctuation in embedded terminal key handling, so `:` and related keys work correctly in Vim and other TUI apps.
-- Fixed Chinese and other IME text input in embedded terminal panes by routing committed composition text through GPUI's native text-input handler.
-- Clicking Con's Dock icon now reopens a window when the app is still running with zero open windows, instead of forcing `cmd-n`.
-- Added standard macOS app-menu commands for Hide con, Hide Others, and Show All, including their native system shortcuts.
-- Reduced terminal flashing when hiding or showing the bottom input bar and agent panel by removing the full-terminal transition matte from those interactions.
-- Reduced tab transition flashing by removing the full-terminal matte from tab creation/switching and deferring closed-tab surface teardown until the replacement tab is visible.
-- Fixed Appearance slider layout so Terminal Glass and Window Chrome use the same fixed-width control lane.
-- Added a macOS 12 compatibility guard for terminal glass. On Monterey and older, Con now forces the embedded terminal to solid/no-blur to avoid transparent blank windows caused by old WindowServer + embedded Metal composition behavior.
-- Extended the macOS 12 compatibility guard to the whole main window. On Monterey and older, Con now opens an opaque main window with opaque UI chrome instead of relying on transparent GPUI window composition, which avoids the “input bar visible but terminal area transparent” failure still reported on Intel Monterey.
-- Fixed bottom input history navigation across Smart, Shell, and Agent modes. Up/Down now recall submitted input directly, while completion popups still keep their own selection behavior.
-- Fixed terminal IME/cursor polish: printable keys now follow the terminal-safe IME path, IME candidate placement uses Ghostty's real cursor anchor, and Con's cursor style setting now applies to embedded Ghostty panes.
-- Fixed duplicate ASCII input from the terminal IME bridge and added a Cursor Style selector in Appearance settings.
-- Polished Appearance settings by moving Cursor Style into its own Cursor section instead of mixing terminal behavior with font sizing.
-- Restored terminal cursor blinking and tied Ghostty cursor focus visuals to Con's pane scope, including broadcast and custom multi-pane targets.
-- Fixed Chinese IME composition leaving pinyin/preedit text behind in terminal panes.
-- Fixed typing ASCII while a Chinese IME is in English mode by consuming terminal key events explicitly instead of dropping ASCII IME commits.
-- Fixed the side agent-panel composer focus boundary so terminal key forwarding no longer steals typing from the inline agent input after the panel opens.
-- Fixed Up/Down recall so the command bar and side-panel composer recover history even when the underlying input component consumes arrow keys. Render-time shell suggestion sync no longer overwrites persisted global input history.
-- Restored history ghost suggestions from persisted submitted input when per-pane shell command history is incomplete, while keeping AI suggestions separate.
-- Fixed fresh windows and Dock/global-hotkey reopen so they start with persisted command history instead of an empty command bar history.
-- Moved app-wide command history into its own persistence file and hydrated input components during workspace construction, so a fresh app launch does not depend on the first render or a healthy layout session to restore history.
-- Polished Agent-mode command bar text alignment and foreground styling so it lines up with Smart and Shell modes.
-- Polished Settings and chrome controls: Skills rows now have clearer hierarchy and hover feedback, AI Routing rows are aligned with the card grid, Keyboard Shortcuts use separate keycaps per key, and titlebar controls now show shortcut-aware tooltips.
-- Refined the Settings keycap typography and pane-scope picker, removed the misleading "local" pane label, and added configurable Control-Tab / Control-Shift-Tab tab cycling with Cmd-Shift-[ / ] fallbacks.
-- Polished provider setup and pane scope controls for the beta. The provider list now shows provider icons with clear configured/unconfigured state, and the pane-scope picker uses matched frame geometry between the mode switcher and minimap.
-- Fixed command palette dismissal focus. Pressing Escape now returns focus to the active terminal so Cmd-Shift-P can reopen the palette immediately without clicking the terminal first.
-- Fixed the side agent-panel composer empty-state layout so the input keeps the same full-width shell even when no LLM provider is configured.
-- Fixed agent-panel follow-output behavior. New assistant output now keeps the transcript pinned to the latest message only while you are already at the bottom; if you scroll up to inspect earlier context, Con stops force-scrolling and offers a quick Latest jump control instead.
-- Made the agent panel's provider/model selection tab-local. Changing the provider or model in one tab now only affects that tab's session, while global Settings continue to define the defaults and shared provider credentials for new sessions.
-- Hardened the side agent-panel composer initialization so the inline input no longer depends on late render timing before its text field exists, which avoids the intermittent collapsed white-pill composer state some users were seeing.
-- Fixed right-panel composer history navigation so multiline drafts keep normal Up/Down cursor movement, while single-line prompts still support submitted-history recall.
-- Improved markdown table rendering for complex prose tables in the agent panel by using a stable minimum table width with horizontal scrolling instead of collapsing all columns into a narrow wrapped stack.
-- Fixed bottom command-bar history so it only recalls single-line entries. Multiline agent prompts no longer get injected into the single-line command bar and crash GPUI on Up/Down recall.
-- Command palette (Cmd+Shift+P) with fuzzy search for every action
-- Session sidebar showing your open tabs
-- Four built-in terminal color themes — Flexoki Dark, Flexoki Light, Catppuccin Mocha, and Tokyo Night. Switch instantly from Settings, or set your default in config.toml.
+**Terminal — Windows Backend (preview)**
+- Shipped the runtime-validated Phase 3b Windows glyph-atlas renderer: ConPTY plus `libghostty-vt`, D3D11/DirectWrite rendering, HLSL shaders, glyph atlas packing, Nerd Font/PUA handling, wide-glyph ordering, and cursor z-order handling.
+- Promoted Windows from planned work to the first beta surface in the docs.
+
+### Fixed
+
+**Release and Packaging**
+- Hardened the Windows release workflow against Defender interference, Zig/uucode spawn flakes, Windows runner instability, and MAX_PATH-sensitive cache paths.
+- Renamed in-tree repository URLs from `nowledge-co/con` to `nowledge-co/con-terminal`.
+
+## [v0.1.0-beta.29] - 2026-04-21
+
+Tag-only release workflow iteration folded into the `v0.1.0-beta.30` GitHub release notes.
+
+### Changed
+- Renamed repository URLs to `nowledge-co/con-terminal`.
+
+## [v0.1.0-beta.28] - 2026-04-21
+
+Tag-only release workflow iteration folded into the `v0.1.0-beta.30` GitHub release notes.
+
+### Fixed
+- Pinned the Windows release runner to `windows-2022` and added on-failure diagnostics.
+
+## [v0.1.0-beta.27] - 2026-04-21
+
+Tag-only release workflow iteration folded into the `v0.1.0-beta.30` GitHub release notes.
+
+### Fixed
+- Retried Windows release builds around intermittent Zig/uucode spawn failures.
+
+## [v0.1.0-beta.26] - 2026-04-21
+
+Tag-only release workflow iteration folded into the `v0.1.0-beta.30` GitHub release notes.
+
+### Fixed
+- Disabled Defender real-time scanning during Windows release builds.
+
+## [v0.1.0-beta.25] - 2026-04-21
+
+Tag-only release workflow iteration folded into the `v0.1.0-beta.30` GitHub release notes.
+
+### Added
+- Advanced the Windows beta port toward the first published Windows preview.
+
+## [v0.1.0-beta.24] - 2026-04-20
+
+### Improved
+- Shipped CI fixes, documentation updates, and broad UI/terminal polish before the Windows beta push.
+
+## [v0.1.0-beta.23] - 2026-04-20
+
+### Added
+- Landed Windows support phase 0: non-macOS build scaffolding, portability gates, and an initial Windows-renderable terminal path.
+
+## [v0.1.0-beta.22] - 2026-04-16
+
+### Improved
+- Shipped a broad optimization pass across terminal/app behavior.
+
+## [v0.1.0-beta.21] - 2026-04-16
+
+### Added
+- Added Kimi provider support for coding workflows.
+
+### Fixed
+- Fixed Homebrew promotion and release workflow YAML issues.
+
+## [v0.1.0-beta.20] - 2026-04-15
+
+### Added
+- Added Homebrew cask and a one-line install path.
+
+### Improved
+- Shipped another beta optimization pass and Zig CI hardening.
+
+## [v0.1.0-beta.19] - 2026-04-15
+
+### Fixed
+- Polished terminal cursor behavior for CJK IME input.
+
+## [v0.1.0-beta.18] - 2026-04-15
+
+### Added
+- Added early installer work and beta feature polish.
+
+### Fixed
+- Fixed Vim quit handling, IME text input issues, macOS hotkeys, terminal flashing, and Ghostty Zig CI pinning.
+
+## [v0.1.0-beta.14] - 2026-04-14
+
+### Improved
+- Optimized settings, markdown table rendering, and CJK rendering paths.
+
+## [v0.1.0-beta.3] - 2026-04-14
+
+### Added
+- Added configurable UI font size.
+
+### Fixed
+- Fixed a markdown code-block rendering performance issue.
+
+## [v0.1.0-beta.1] - 2026-04-14
+
+### Added
+- Initial public beta of con.
+- Added the first release workflow, app bundle/release infrastructure, documentation, and upstream dependency cleanup.
+
+### Fixed
+- Fixed early Sparkle startup/release-upload issues and ordered-list wrapping alignment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ con is still pre-release, so entries may group larger areas of work while the pr
 - IoskeleyMono's full Nerd-Font set (Powerline separators, devicons, Font Awesome, Octicons, Codicons, Material Design icons) now rasterizes correctly inside monospace cells via a three-case atlas strategy — normal glyphs stay in their cell, negative-`leftSideBearing` icons get a widened slot with a pen shift so the ink lands flush at the slot edge, and oversized glyphs scale around the cell centre. oh-my-posh, Starship, and Powerlevel10k prompts render out of the box.
 - Atlas packing is bleed-proof: every glyph rasterization is bracketed by a `PushAxisAlignedClip` + opaque black pre-fill, so ClearType fringe from one atlas neighbour can't contaminate the next. Thin glyphs like `-`, `_`, and `=` render cleanly against any prior atlas state.
 - Wide PUA icons that overflow their cell and the cell cursor now interact correctly — wide instances are stable-sorted after narrow ones so DX11's in-order per-pixel writes let them win against neighbour backgrounds, and the cursor's inverse-colour instance is captured pre-sort and drawn last so it always lands on the intended cell.
+- The Windows renderer now skips redundant default-background blank-cell instances, avoids full-frame zero-fill before D3D readback, and only pays the wide-glyph stable-sort cost when a frame actually contains overflowing glyphs.
 - The local control plane uses Windows Named Pipes (`\\.\pipe\con`) as its transport, so `con-cli` and external automation work the same way they do on macOS.
 - Phase 3c (input/selection polish) and Phase 3d (DirectComposition sibling visual upstream in GPUI) remain the outstanding Windows work; see `docs/impl/windows-port.md` for the full phased plan.
 
@@ -194,6 +195,7 @@ con is still pre-release, so entries may group larger areas of work while the pr
 - Fixed Ghostty resource packaging and dev-run bootstrap on macOS. Con now embeds Ghostty's `Resources/ghostty` payload into app bundles and points debug runs at the built Ghostty resources so child processes get `xterm-ghostty`, `TERMINFO`, and Ghostty shell integration instead of silently falling back to `xterm-256color`.
 
 **Terminal**
+- Fixed Windows settings/theme/session/auth persistence paths so they no longer use `con` as a filesystem segment, avoiding Win32 reserved-device-name failures such as `os error 267`.
 - Full terminal emulation with 256-color and truecolor support
 - Split panes — divide your workspace horizontally (Cmd+D) or vertically (Cmd+Shift+D), with drag-to-resize dividers
 - Mouse text selection with click-drag, double-click for words, triple-click for lines, and Cmd+A to select all

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,6 +1122,7 @@ dependencies = [
  "con-agent",
  "con-core",
  "con-ghostty",
+ "con-paths",
  "con-terminal",
  "crossbeam-channel",
  "dirs",
@@ -1158,6 +1159,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "con-paths",
  "crossbeam-channel",
  "dirs",
  "futures",
@@ -1192,6 +1194,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "con-agent",
+ "con-paths",
  "crossbeam-channel",
  "dirs",
  "futures",
@@ -1224,8 +1227,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "con-paths"
+version = "0.1.0"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
 name = "con-terminal"
 version = "0.1.0"
+dependencies = [
+ "con-paths",
+]
 
 [[package]]
 name = "concurrent-queue"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "crates/con-app",
     "crates/con-core",
+    "crates/con-paths",
     "crates/con-terminal",
     "crates/con-ghostty",
     "crates/con-agent",
@@ -18,6 +19,7 @@ version = "0.1.0"
 [workspace.dependencies]
 # Internal crates
 con-core = { path = "crates/con-core" }
+con-paths = { path = "crates/con-paths" }
 con-terminal = { path = "crates/con-terminal" }
 con-ghostty = { path = "crates/con-ghostty" }
 con-agent = { path = "crates/con-agent" }

--- a/crates/con-agent/Cargo.toml
+++ b/crates/con-agent/Cargo.toml
@@ -5,6 +5,7 @@ license.workspace = true
 version.workspace = true
 
 [dependencies]
+con-paths.workspace = true
 rig-core.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/con-agent/src/conversation.rs
+++ b/crates/con-agent/src/conversation.rs
@@ -299,11 +299,7 @@ impl Conversation {
         if let Some(path) = std::env::var_os("CON_CONVERSATIONS_DIR") {
             return PathBuf::from(path);
         }
-        dirs::data_dir()
-            .or_else(|| dirs::home_dir().map(|h| h.join(".local/share")))
-            .unwrap_or_else(std::env::temp_dir)
-            .join("con")
-            .join("conversations")
+        con_paths::app_data_dir().join("conversations")
     }
 
     fn conversation_path(id: &str) -> PathBuf {

--- a/crates/con-agent/src/provider.rs
+++ b/crates/con-agent/src/provider.rs
@@ -497,14 +497,7 @@ pub fn oauth_token_dir(kind: &ProviderKind) -> Option<PathBuf> {
         _ => return None,
     };
 
-    Some(
-        dirs::config_dir()
-            .or_else(|| dirs::home_dir().map(|home| home.join(".config")))
-            .unwrap_or_else(std::env::temp_dir)
-            .join("con")
-            .join("auth")
-            .join(provider_dir),
-    )
+    Some(con_paths::app_config_dir().join("auth").join(provider_dir))
 }
 
 pub async fn authorize_oauth_provider<F>(kind: ProviderKind, prompt_handler: F) -> Result<()>

--- a/crates/con-agent/src/skills.rs
+++ b/crates/con-agent/src/skills.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 /// Discovery paths (in priority order):
 ///   1. Project-local: `<cwd>/.con/skills/*/SKILL.md`
 ///   2. Global user:   `~/.config/con/skills/*/SKILL.md`
+///      (`~/.config/con-terminal/skills/*/SKILL.md` on Windows)
 ///
 /// SKILL.md format (YAML frontmatter + markdown body):
 /// ```text
@@ -33,7 +34,7 @@ pub struct Skill {
 pub enum SkillSource {
     /// From <cwd>/.con/skills/
     Project(PathBuf),
-    /// From ~/.config/con/skills/
+    /// From the platform global skills directory.
     Global(PathBuf),
 }
 

--- a/crates/con-app/Cargo.toml
+++ b/crates/con-app/Cargo.toml
@@ -32,6 +32,7 @@ bin-con-app = []
 
 [dependencies]
 con-core.workspace = true
+con-paths.workspace = true
 con-terminal.workspace = true
 con-agent.workspace = true
 con-ghostty.workspace = true

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -1618,32 +1618,7 @@ impl SettingsPanel {
             None => return,
         };
 
-        // Determine theme directory
-        let theme_dir = if cfg!(target_os = "macos") {
-            std::env::var("HOME")
-                .ok()
-                .map(|h| std::path::PathBuf::from(h).join("Library/Application Support/con/themes"))
-        } else {
-            std::env::var("XDG_CONFIG_HOME")
-                .ok()
-                .map(std::path::PathBuf::from)
-                .or_else(|| {
-                    std::env::var("HOME")
-                        .ok()
-                        .map(|h| std::path::PathBuf::from(h).join(".config"))
-                })
-                .map(|p| p.join("con/themes"))
-        };
-
-        let dir = match theme_dir {
-            Some(d) => d,
-            None => {
-                self.custom_theme_status =
-                    Some("Error: could not determine themes directory".into());
-                cx.notify();
-                return;
-            }
-        };
+        let dir = con_terminal::TerminalTheme::user_themes_dir();
 
         // Create directory if needed
         if let Err(e) = std::fs::create_dir_all(&dir) {
@@ -2027,11 +2002,12 @@ impl SettingsPanel {
             ],
             cx,
         );
+        let con_global_skills = con_paths::default_global_skills_path();
         let global_presets = self.render_path_presets(
             "global",
             &global_paths,
             &[
-                ("~/.config/con/skills", "con"),
+                (con_global_skills.as_str(), "con"),
                 ("~/.agents/skills", "Agents"),
             ],
             cx,

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -6136,7 +6136,7 @@ impl Render for ConWorkspace {
             .collect();
 
         let cwd = active_terminal.current_dir(cx);
-        // Scan skills when cwd changes (project-local + global ~/.config/con/skills/)
+        // Scan skills when cwd changes (project-local + platform global skills path).
         if let Some(ref raw_cwd) = cwd {
             self.harness.scan_skills(raw_cwd);
         }

--- a/crates/con-core/Cargo.toml
+++ b/crates/con-core/Cargo.toml
@@ -6,6 +6,7 @@ version.workspace = true
 
 [dependencies]
 con-agent.workspace = true
+con-paths.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 toml.workspace = true

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -299,6 +299,8 @@ pub struct Config {
 /// project_paths = [".con/skills"]
 /// global_paths = ["~/.config/con/skills"]
 /// ```
+/// On Windows, the default global path uses `~/.config/con-terminal/skills`
+/// because `con` is a reserved DOS device name.
 ///
 /// # Sharing with other agents
 /// ```toml
@@ -326,7 +328,10 @@ impl Default for SkillsConfig {
                 ".agents/skills".into(),
                 ".con/skills".into(),
             ],
-            global_paths: vec!["~/.config/con/skills".into(), "~/.agents/skills".into()],
+            global_paths: vec![
+                con_paths::default_global_skills_path(),
+                "~/.agents/skills".into(),
+            ],
         }
     }
 }
@@ -371,10 +376,24 @@ impl Config {
     }
 
     pub fn config_path() -> PathBuf {
-        dirs::config_dir()
-            .or_else(|| dirs::home_dir().map(|h| h.join(".config")))
-            .unwrap_or_else(std::env::temp_dir)
-            .join("con")
-            .join("config.toml")
+        con_paths::config_file()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SkillsConfig;
+
+    #[test]
+    fn default_skill_path_uses_shared_app_path_policy() {
+        let config = SkillsConfig::default();
+        assert_eq!(
+            config.global_paths.first().map(String::as_str),
+            Some(if cfg!(target_os = "windows") {
+                "~/.config/con-terminal/skills"
+            } else {
+                "~/.config/con/skills"
+            })
+        );
     }
 }

--- a/crates/con-core/src/session.rs
+++ b/crates/con-core/src/session.rs
@@ -165,11 +165,7 @@ impl Session {
         if let Some(path) = std::env::var_os("CON_SESSION_PATH") {
             return PathBuf::from(path);
         }
-        dirs::data_dir()
-            .or_else(|| dirs::home_dir().map(|h| h.join(".local/share")))
-            .unwrap_or_else(std::env::temp_dir)
-            .join("con")
-            .join("session.json")
+        con_paths::app_data_dir().join("session.json")
     }
 }
 
@@ -199,10 +195,6 @@ impl GlobalHistoryState {
         if let Some(path) = std::env::var_os("CON_HISTORY_PATH") {
             return PathBuf::from(path);
         }
-        dirs::data_dir()
-            .or_else(|| dirs::home_dir().map(|h| h.join(".local/share")))
-            .unwrap_or_else(std::env::temp_dir)
-            .join("con")
-            .join("history.json")
+        con_paths::app_data_dir().join("history.json")
     }
 }

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -49,7 +49,7 @@ use windows::Win32::Graphics::Dxgi::Common::{
 };
 use windows::Win32::Graphics::Dxgi::DXGI_ERROR_WAS_STILL_DRAWING;
 
-use super::vt::ScreenSnapshot;
+use super::vt::{ATTR_INVERSE, ATTR_STRIKE, ATTR_UNDERLINE, Cell, ScreenSnapshot};
 use atlas::{GlyphCache, GlyphKey};
 use pipeline::{Globals, Instance, Pipeline, instance_for_cell};
 
@@ -493,7 +493,16 @@ impl Renderer {
             .lock()
             .expect("instances mutex poisoned in draw_cells()");
         instances.clear();
-        instances.reserve(snapshot.cells.len());
+        instances.reserve(snapshot.cells.len().saturating_add(1));
+        let cell_w_px = atlas.metrics().cell_width_px;
+
+        let cursor_pos = if snapshot.cursor.visible {
+            Some((snapshot.cursor.col, snapshot.cursor.row))
+        } else {
+            None
+        };
+        let mut cursor_source: Option<Instance> = None;
+        let mut has_wide_glyph = false;
 
         for (i, cell) in snapshot.cells.iter().enumerate() {
             let col = (i % snapshot.cols as usize) as u16;
@@ -508,15 +517,30 @@ impl Renderer {
                 cell.attrs
             };
 
+            let is_cursor_cell = cursor_pos == Some((col, row));
+
+            // The render target clear already paints the pane's default
+            // background. Avoid emitting a bg-only instance for blank
+            // cells when it would be pixel-identical to the clear. This
+            // preserves explicit SGR backgrounds, selection / inverse,
+            // and underline / strike decorations on spaces.
+            if !is_cursor_cell && is_default_blank_cell(cell, effective_attrs, config) {
+                continue;
+            }
+
             if cell.codepoint == 0 || cell.codepoint == 0x20 {
-                instances.push(Instance {
+                let instance = Instance {
                     cell_pos: [col as u32, row as u32],
                     atlas_pos: [0, 0],
                     atlas_size: [0, 0],
                     fg: cell.fg,
                     bg: apply_opacity(cell.bg),
                     attrs: effective_attrs as u32,
-                });
+                };
+                if is_cursor_cell {
+                    cursor_source = Some(instance);
+                }
+                instances.push(instance);
                 continue;
             }
 
@@ -540,48 +564,39 @@ impl Renderer {
                                 "glyph larger than atlas capacity at U+{:04X}; skipping",
                                 cell.codepoint
                             );
-                            instances.push(Instance {
+                            let instance = Instance {
                                 cell_pos: [col as u32, row as u32],
                                 atlas_pos: [0, 0],
                                 atlas_size: [0, 0],
                                 fg: cell.fg,
                                 bg: apply_opacity(cell.bg),
                                 attrs: effective_attrs as u32,
-                            });
+                            };
+                            if is_cursor_cell {
+                                cursor_source = Some(instance);
+                            }
+                            instances.push(instance);
                             continue;
                         }
                     }
                 }
             };
 
-            instances.push(instance_for_cell(
+            let instance = instance_for_cell(
                 col,
                 row,
                 glyph,
                 cell.fg,
                 apply_opacity(cell.bg),
                 effective_attrs,
-            ));
-        }
-        let cell_w_px = atlas.metrics().cell_width_px;
-        drop(atlas);
-
-        // Capture the cursor cell's source instance BEFORE sorting —
-        // the row-major `idx = row * cols + col` mapping is only
-        // valid while `instances` is still in grid order.
-        let cursor_source: Option<Instance> = if snapshot.cursor.visible {
-            let col = snapshot.cursor.col as usize;
-            let row = snapshot.cursor.row as usize;
-            let cols_u = snapshot.cols as usize;
-            let rows_u = snapshot.rows as usize;
-            if col < cols_u && row < rows_u {
-                instances.get(row * cols_u + col).copied()
-            } else {
-                None
+            );
+            has_wide_glyph |= glyph.w as u32 > cell_w_px;
+            if is_cursor_cell {
+                cursor_source = Some(instance);
             }
-        } else {
-            None
-        };
+            instances.push(instance);
+        }
+        drop(atlas);
 
         // Sort so oversized PUA icons render LAST within the grid
         // pass. Their atlas slots are wider than a cell, so their
@@ -592,7 +607,9 @@ impl Renderer {
         // would otherwise paint on top. Stable partition keeps the
         // grid's row-major order within the narrow and wide groups
         // independently — bad ordering would show up as flicker.
-        instances.sort_by_key(|inst| (inst.atlas_size[0] > cell_w_px) as u8);
+        if has_wide_glyph {
+            instances.sort_by_key(|inst| (inst.atlas_size[0] > cell_w_px) as u8);
+        }
 
         // Push the cursor instance AFTER the sort so it always renders
         // last — on top of any wide PUA glyph that might otherwise
@@ -672,7 +689,47 @@ impl Renderer {
         drop(pipeline);
         Ok(())
     }
+}
 
+fn is_default_blank_cell(cell: &Cell, effective_attrs: u8, config: &RendererConfig) -> bool {
+    let is_blank = cell.codepoint == 0 || cell.codepoint == 0x20;
+    if !is_blank {
+        return false;
+    }
+
+    // Default-background cells use alpha=0 as a sentinel. Explicit SGR
+    // backgrounds are opaque and still need a quad, even for spaces.
+    if (cell.bg & 0xFF) != 0 {
+        return false;
+    }
+
+    // Bold / italic have no visual effect on a blank cell, but these
+    // attributes do: underline/strike draw bands, inverse/selection
+    // swaps fg/bg and paints a highlight.
+    if (effective_attrs & (ATTR_UNDERLINE | ATTR_STRIKE | ATTR_INVERSE)) != 0 {
+        return false;
+    }
+
+    let opacity = config.background_opacity.clamp(0.0, 1.0);
+    if opacity <= f32::EPSILON {
+        return true;
+    }
+
+    let clear_rgb = [
+        color_channel_byte(config.clear_color[0]),
+        color_channel_byte(config.clear_color[1]),
+        color_channel_byte(config.clear_color[2]),
+    ];
+    let bg_rgb = [
+        ((cell.bg >> 24) & 0xFF) as u8,
+        ((cell.bg >> 16) & 0xFF) as u8,
+        ((cell.bg >> 8) & 0xFF) as u8,
+    ];
+    clear_rgb == bg_rgb
+}
+
+fn color_channel_byte(v: f32) -> u8 {
+    (v.clamp(0.0, 1.0) * 255.0).round() as u8
 }
 
 /// One slot in the readback ring.
@@ -823,7 +880,8 @@ impl StagingRing {
         }
 
         let row_bytes = width * 4;
-        let mut out = vec![0u8; row_bytes * height];
+        let len = row_bytes * height;
+        let mut out: Vec<u8> = Vec::with_capacity(len);
         let src_pitch = mapped.RowPitch as usize;
         for y in 0..height {
             unsafe {
@@ -833,6 +891,12 @@ impl StagingRing {
                     row_bytes,
                 );
             }
+        }
+        // Every byte has been filled by the row-copy loop above.
+        // Avoiding `vec![0; len]` saves a full-frame memset on the hot
+        // readback path before we immediately overwrite the buffer.
+        unsafe {
+            out.set_len(len);
         }
         unsafe {
             ctx.Unmap(&slot.texture, 0);

--- a/crates/con-paths/Cargo.toml
+++ b/crates/con-paths/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "con-terminal"
+name = "con-paths"
 edition.workspace = true
 license.workspace = true
 version.workspace = true
 
 [dependencies]
-con-paths.workspace = true
+dirs.workspace = true

--- a/crates/con-paths/src/lib.rs
+++ b/crates/con-paths/src/lib.rs
@@ -1,0 +1,66 @@
+//! Shared per-user app paths.
+//!
+//! Windows cannot safely use a bare `con` path segment because `CON` is
+//! a reserved DOS device name. Keep this policy centralized so config,
+//! session, auth, themes, and future storage paths do not drift.
+
+use std::path::PathBuf;
+
+#[cfg(target_os = "windows")]
+pub const APP_DIR_NAME: &str = "con-terminal";
+#[cfg(not(target_os = "windows"))]
+pub const APP_DIR_NAME: &str = "con";
+
+pub fn app_config_dir() -> PathBuf {
+    dirs::config_dir()
+        .or_else(|| dirs::home_dir().map(|home| home.join(".config")))
+        .unwrap_or_else(std::env::temp_dir)
+        .join(APP_DIR_NAME)
+}
+
+pub fn app_data_dir() -> PathBuf {
+    dirs::data_dir()
+        .or_else(|| dirs::home_dir().map(|home| home.join(".local/share")))
+        .unwrap_or_else(std::env::temp_dir)
+        .join(APP_DIR_NAME)
+}
+
+pub fn config_file() -> PathBuf {
+    app_config_dir().join("config.toml")
+}
+
+pub fn default_global_skills_path() -> String {
+    format!("~/.config/{APP_DIR_NAME}/skills")
+}
+
+pub fn user_themes_dir() -> PathBuf {
+    app_config_dir().join("themes")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        APP_DIR_NAME, app_config_dir, app_data_dir, config_file, default_global_skills_path,
+        user_themes_dir,
+    };
+
+    #[test]
+    fn app_paths_use_platform_safe_dir_name() {
+        assert!(app_config_dir().ends_with(APP_DIR_NAME));
+        assert!(app_data_dir().ends_with(APP_DIR_NAME));
+        assert!(config_file().ends_with(std::path::Path::new(APP_DIR_NAME).join("config.toml")));
+        assert!(user_themes_dir().ends_with(std::path::Path::new(APP_DIR_NAME).join("themes")));
+    }
+
+    #[test]
+    fn default_skill_path_uses_platform_safe_dir_name() {
+        assert_eq!(
+            default_global_skills_path(),
+            if cfg!(target_os = "windows") {
+                "~/.config/con-terminal/skills"
+            } else {
+                "~/.config/con/skills"
+            }
+        );
+    }
+}

--- a/crates/con-terminal/src/theme.rs
+++ b/crates/con-terminal/src/theme.rs
@@ -522,25 +522,7 @@ impl TerminalTheme {
     }
 
     pub fn load_user_themes() -> Vec<Self> {
-        let dir = if cfg!(target_os = "macos") {
-            std::env::var("HOME").ok().map(|home| {
-                std::path::PathBuf::from(home).join("Library/Application Support/con/themes")
-            })
-        } else {
-            std::env::var("XDG_CONFIG_HOME")
-                .ok()
-                .map(std::path::PathBuf::from)
-                .or_else(|| {
-                    std::env::var("HOME")
-                        .ok()
-                        .map(|home| std::path::PathBuf::from(home).join(".config"))
-                })
-                .map(|path| path.join("con/themes"))
-        };
-        let dir = match dir {
-            Some(dir) => dir,
-            None => return Vec::new(),
-        };
+        let dir = Self::user_themes_dir();
 
         let entries = match std::fs::read_dir(&dir) {
             Ok(entries) => entries,
@@ -568,6 +550,10 @@ impl TerminalTheme {
         }
 
         themes
+    }
+
+    pub fn user_themes_dir() -> std::path::PathBuf {
+        con_paths::user_themes_dir()
     }
 }
 

--- a/docs/impl/build-system.md
+++ b/docs/impl/build-system.md
@@ -2,7 +2,11 @@
 
 ## Overview
 
-con is a Cargo workspace with one terminal runtime target: embedded Ghostty on macOS.
+con is a Cargo workspace with platform terminal backends:
+
+- macOS embeds full Ghostty with Metal rendering.
+- Windows uses ConPTY plus `libghostty-vt` and a D3D11/DirectWrite renderer.
+- Linux uses a Unix PTY plus `libghostty-vt` and the preview GPUI paint path.
 
 The build no longer includes the old `vte` and `portable-pty` pipeline.
 
@@ -22,6 +26,7 @@ cargo test --workspace
 members = [
     "crates/con-app",
     "crates/con-core",
+    "crates/con-paths",
     "crates/con-terminal",
     "crates/con-ghostty",
     "crates/con-agent",
@@ -35,6 +40,7 @@ members = [
 |-------|---------|
 | `con` | GPUI app shell, tabs, splits, settings, agent panel |
 | `con-core` | harness, config, session persistence |
+| `con-paths` | shared platform-safe per-user app directories |
 | `con-ghostty` | Rust wrapper around libghostty C API |
 | `con-terminal` | terminal theme data and Ghostty palette translation helpers |
 | `con-agent` | built-in AI harness and tools |
@@ -60,9 +66,19 @@ members = [
 
 ## Platform boundary
 
-con currently requires macOS because the product depends on embedded Ghostty.
+The `con` UI binary builds on macOS, Windows, and Linux. Platform-specific
+runtime code is `cfg`-gated:
 
-That is enforced in the binary crate with a compile-time error on non-macOS targets.
+- macOS uses the embedded libghostty surface.
+- Windows uses the `con-app.exe` binary name because `CON` is a reserved DOS
+  device name.
+- Linux keeps the normal `con` binary name.
+
+## Per-user app paths
+
+Use `con-paths` for all user config, data, auth, theme, and skill storage paths.
+Windows cannot safely use a bare `con` path segment, so `con-paths` maps the app
+directory to `con-terminal` on Windows while preserving `con` on macOS and Linux.
 
 ## Ghostty build boundary
 

--- a/docs/impl/windows-port.md
+++ b/docs/impl/windows-port.md
@@ -251,12 +251,10 @@ even read-only, which is why the UI crate now lives at
 cannot be created by most file-creation APIs. The `CON` reservation
 applies regardless of extension.
 
-Today this is latent: the UI binary is macOS-only via a `compile_error!`
-in `crates/con-app/src/main.rs`, so no `con.exe` is ever produced. When
-the Windows backend actually builds, the binary needs a new name on
-Windows only — macOS and Linux should keep the plain `con` muscle
-memory. Cargo does not support per-target `[[bin]] name` in the
-manifest, so the two practical mechanisms are:
+This is implemented with feature-gated twin `[[bin]]` entries: macOS and
+Linux keep the plain `con` binary, while Windows builds `con-app.exe`.
+Cargo does not support per-target `[[bin]] name` in the manifest, so the
+practical mechanisms were:
 
 1. **Feature-gated twin `[[bin]]` entries pointing at the same
    `main.rs`** —
@@ -286,11 +284,8 @@ manifest, so the two practical mechanisms are:
    command-line experience is unchanged. Simpler manifest, more work
    in the packaging scripts.
 
-We recommend mechanism 1 when Windows support lands. It keeps the
-binary-name behavior platform-local and doesn't require external
-installers to hide the difference. Until then, no change is needed —
-the `compile_error!` gate ensures the name only matters on macOS,
-where `con` is a valid filename.
+Mechanism 1 is the active policy. It keeps the binary-name behavior
+platform-local and does not require installers to hide the difference.
 
 ### Hurdle 3 — Host-side Windows-isms
 
@@ -301,8 +296,9 @@ if untouched. The Windows-prep PR series should land these incrementally:
   small transport abstraction backed by Unix sockets on `cfg(unix)` and
   Windows Named Pipes (`\\.\pipe\con-<user>`) on `cfg(windows)`.
 - **Path conventions.** Replace hard-coded `/tmp` fallbacks with
-  `std::env::temp_dir()`. Use `dirs::config_dir()` for config locations
-  (already done in most places).
+  `std::env::temp_dir()`. Use `con-paths` for config, data, auth,
+  theme, and skills storage so Windows gets `con-terminal` instead of
+  the reserved `con` path segment.
 - **Permissions.** Gate `set_permissions(0o600)` and any
   `std::os::unix::*` imports behind `cfg(unix)`.
 - **Bundle metadata.** `bundle_info_value`, `set_dock_icon`,
@@ -335,7 +331,7 @@ phase keeps the macOS build green.
 | 3b | Glyph atlas + grid render | HLSL shaders embedded and runtime-compiled via `D3DCompile`. Skyline-packed (`etagere`) BGRA8 glyph atlas (`con-ghostty/src/windows/render/atlas.rs`), glyphs rasterized via Direct2D `DrawText` with grayscale AA. Three-case PUA rasterization (fits-cell / width-overflow with lsb shift / height-overflow with scale-around-centre) for Nerd-Font icons, plus per-slot `PushAxisAlignedClip` + black pre-fill to prevent ClearType fringe bleeding between atlas neighbours. D3D11 pipeline (`pipeline.rs`): per-instance IA layout, dynamic instance buffer with `Map(WRITE_DISCARD)`, single `DrawIndexedInstanced(6, cell_count)` per frame — matches Windows Terminal AtlasEngine's architecture. Wide PUA instances are stable-sorted after narrow ones so DX11's in-order per-pixel writes let them win overlap with neighbour backgrounds; the cursor inverse-colour instance is captured pre-sort and pushed post-sort so it always draws last. `vt.rs` uses the `ghostty_render_state` API (row iterator + `row_cells_get_multi` + DIRTY row skip) — not the `grid_ref` path that the upstream header explicitly warns against for render loops. | Real glyph rendering on Windows, runtime-validated on real hardware against oh-my-posh prompt stacks and dense hyphen rules. Postmortem: `postmortem/2026-04-21-windows-atlas-pua-rasterization.md`. | ✅ landed (runtime-validated) |
 | 3c | Input + selection | VK_* → xterm escape sequence translation in `host_view::WM_KEYDOWN`; mouse selection / scroll forwarding; clipboard via OSC 52 + Win32 clipboard. | Real terminal interactivity. | — |
 | 3d | (Parallel, upstream) | `WindowsWindow::attach_external_swap_chain_handle(bounds, HANDLE)` PR to `zed-industries/zed`. ~50 LOC. When merged, swap our backend from `CreateSwapChainForHwnd(WS_CHILD HWND)` to `CreateSwapChainForCompositionSurfaceHandle` so DWM composites our visual cleanly with GPUI's. Zero user-visible change except popup Z-order becomes pixel-perfect. | (No con change required pre-merge.) | — |
-| 3e | **Renderer perf tuning** (in progress) | The current pipeline draws into an offscreen D3D11 texture, reads back BGRA bytes (`RenderSession::render_frame`), wraps them as `ImageSource::Render(Arc<RenderImage>)`, and lets GPUI re-upload them into its DComp tree. The GPU→CPU readback per dirty frame plus the CPU→GPU re-upload adds 5–15ms over Windows Terminal's direct-DComp present path. Plan: (1) ✅ wake GPUI from the ConPTY reader thread so freshly arrived shell output paints on the next prepaint instead of waiting for user input; (2) once Phase 3d lands, present the swap chain directly via `attach_external_swap_chain_handle` and drop the readback entirely; (3) profile with PIX / GPUView / ETW to verify Enter→glyph latency parity with WT. | First win in `crates/con-app/src/windows_view.rs` (`wake_tx` + coalescer task). | 🚧 in progress |
+| 3e | **Renderer perf tuning** (in progress) | The current pipeline draws into an offscreen D3D11 texture, reads back BGRA bytes (`RenderSession::render_frame`), wraps them as `ImageSource::Render(Arc<RenderImage>)`, and lets GPUI re-upload them into its DComp tree. The GPU→CPU readback per dirty frame plus the CPU→GPU re-upload adds 5–15ms over Windows Terminal's direct-DComp present path. Landed mitigations: (1) ✅ wake GPUI from the ConPTY reader thread so freshly arrived shell output paints on the next prepaint instead of waiting for user input; (2) ✅ skip default-background blank-cell instances that are already covered by the render-target clear; (3) ✅ avoid a full-frame zero-fill before D3D readback; (4) ✅ only stable-sort the instance stream when a frame actually contains overflowing wide glyphs. Long-term plan: once Phase 3d lands, present the swap chain directly via `attach_external_swap_chain_handle` and drop the readback entirely; profile with PIX / GPUView / ETW to verify Enter→glyph latency parity with WT. | Wins in `crates/con-app/src/windows_view.rs` (`wake_tx` + coalescer task) and `crates/con-ghostty/src/windows/render/mod.rs` (instance/readback hot path). | 🚧 in progress |
 | 4 | Hardening | Multi-pane, splits, IME, focus, resize, copy/paste, drag/drop, OSC 133 shell integration, ligatures | Beta-quality | — |
 | 5 | Distribution | MSI installer, code signing, auto-update (WiX or `cargo dist`), `con-app.exe` rename via feature-gated twin `[[bin]]` | Release-ready | — |
 
@@ -380,6 +376,13 @@ Compared to Windows Terminal's AtlasEngine, two costs are structural:
 The remaining structural cost (the readback) goes away once Phase 3d
 (`attach_external_swap_chain_handle`) lands and we can present the swap
 chain into GPUI's DComp tree directly.
+
+The current Phase 3e mitigations reduce work inside that temporary image
+path without changing rendering semantics: default-background blank cells
+are represented by the clear color, explicit SGR backgrounds and cursor /
+selection / underline state still get instances, readback copies directly
+into the output buffer capacity, and the wide-glyph sort is skipped on
+ordinary text frames.
 
 ### What you can do *today* on Windows after Phase 3b
 

--- a/postmortem/2026-04-23-windows-config-save-reserved-name.md
+++ b/postmortem/2026-04-23-windows-config-save-reserved-name.md
@@ -1,0 +1,19 @@
+# Windows Config Save Reserved Name
+
+## What happened
+
+On Windows, saving settings failed with `os error 267` ("The directory name is invalid"). The visible failure was the settings panel banner when writing `config.toml`.
+
+## Root cause
+
+Several per-user storage paths used a literal `con` path segment, such as `%APPDATA%\con\config.toml` and `%LOCALAPPDATA%\con\session.json`. `CON` is a reserved DOS device name, so Windows path APIs can reject that segment even when it appears inside a longer absolute path.
+
+## Fix applied
+
+Windows now uses `con-terminal` for per-user app directories. macOS and Linux keep the existing `con` paths for compatibility.
+
+The path policy lives in the shared `con-paths` crate so new call sites do not need to rediscover the Windows reserved-name rule. Updated storage paths include config, session state, global history, saved agent conversations, OAuth tokens, and user terminal themes. The settings panel custom-theme save path and skills preset also use the platform-safe directory.
+
+## What we learned
+
+Renaming the GitHub repository and Windows executable was not enough. Any filesystem path segment named `con` can still trigger reserved-name behavior on Windows, so new Windows storage paths must go through the shared app-path helper instead of hard-coding directory names.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk: changes persistence locations for config/session/history/auth/themes/conversations (especially on Windows), which could impact migration/backward compatibility, and tweaks performance-sensitive Windows renderer instance generation/readback logic.
> 
> **Overview**
> **Fixes Windows per-user storage failures caused by the reserved `CON` path segment** by introducing a new shared `con-paths` crate that centralizes app config/data/theme/skills directory resolution (mapping to `con-terminal` on Windows, `con` elsewhere) and migrating call sites in `con-core`, `con-agent`, `con-terminal`, and the settings UI to use it.
> 
> **Improves Windows renderer performance** by skipping redundant default-background blank-cell instances, avoiding a full-frame zero-initialization before D3D readback, and only stable-sorting instances when wide glyphs are present; docs/changelog/postmortem are updated and tests added to lock in the new path policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aec0a363d41e240efbbda812d569616e3b4bc05c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows settings, themes, and session storage paths to avoid reserved filesystem names, resolving OS error 267 on save operations.

* **Performance**
  * Optimized Windows terminal rendering: skips redundant blank-cell background work, reduces D3D readback preparation overhead, and defers wide-glyph sorting unless necessary.

* **Refactor**
  * Centralized platform-specific path resolution into a shared internal crate for consistent, safe filesystem access across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->