### PR TITLE
linux: cache styled rows in preview renderer

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -1,0 +1,194 @@
+name: Finalize release
+
+# Promotes a draft release to public once every platform-specific
+# release workflow (release-linux.yml, release-macos.yml,
+# release-windows.yml) has reported a `success` conclusion for the
+# same tag.
+#
+# Why this exists
+# ---------------
+# The three platform release workflows are independent (each fans out
+# from `push: tags`). They share a single GitHub release: whichever
+# job calls `gh release create` first wins the create, and the others
+# just upload to it. Until this workflow existed, the create call
+# also published the release immediately, so the moment the FASTEST
+# platform finished its `publish` job the release became visible at
+# `/releases/latest` — even though the other two platforms still
+# hadn't uploaded their assets. Fresh installs hit the symptom
+#
+#   irm https://nowled.ge/con-ps1 | iex
+#   ✗ no ZIP found for windows-x86_64
+#
+# (the tag was "latest" but only the Linux tarball was attached).
+#
+# Fix shape
+# ---------
+# release-{linux,macos,windows}.yml now create the release with
+# `--draft`. Drafts are invisible to `/releases/latest`, the public
+# REST API, and the public UI listing — install.sh / install.ps1
+# behave as if the tag does not exist yet, which is the correct
+# answer while assets are still uploading.
+#
+# This workflow watches the three release workflows and flips the
+# draft to public via `gh release edit --draft=false` only after all
+# three have a `success` workflow_run for the same `head_sha`. If
+# one platform fails, the draft stays a draft (intentional — better
+# to block than to ship an incomplete release; the maintainer can
+# either re-run the failing job or flip the draft manually via the
+# UI once the situation is understood).
+#
+# Notes on workflow_run semantics
+# -------------------------------
+# - `workflow_run` only fires when the file is on the default branch.
+#   That matches every other tag-driven workflow in this repo.
+# - For tag pushes, `github.event.workflow_run.head_branch` is the
+#   tag name (e.g. `v0.1.0-beta.35`). We use it to derive the tag,
+#   and we use `head_sha` to correlate runs across the three sibling
+#   workflows.
+# - `gh release edit --draft=false` is idempotent for an already-
+#   published release, so concurrent finalize runs (which can fire
+#   roughly simultaneously when the slowest two platforms finish
+#   close together) are safe.
+
+on:
+  workflow_run:
+    workflows:
+      - "Release Linux"
+      - "Release macOS"
+      - "Release Windows"
+    types:
+      - completed
+
+permissions:
+  contents: write
+  actions: read
+
+# Serialize finalize attempts per-tag so two near-simultaneous
+# triggering completions don't both call `gh release edit` at the
+# same instant. Cheap insurance — the operation is idempotent, but
+# this also avoids two concurrent runs racing to compute the
+# "all green?" result with a stale cache.
+concurrency:
+  group: release-finalize-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  finalize:
+    name: Promote draft when all platforms ship
+    runs-on: ubuntu-latest
+
+    # Skip everything that didn't come from a `push` to a tag —
+    # workflow_run fires for every conclusion (cancelled, skipped,
+    # failure, success) and for every event type the source workflow
+    # accepts. We only care about tag-push completions.
+    if: >-
+      github.event.workflow_run.event == 'push' &&
+      startsWith(github.event.workflow_run.head_branch, 'v')
+
+    steps:
+      - name: Resolve tag and head sha
+        id: ctx
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          TRIGGER_WORKFLOW: ${{ github.event.workflow_run.name }}
+          TRIGGER_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        run: |
+          set -euo pipefail
+          echo "Triggered by: $TRIGGER_WORKFLOW (conclusion=$TRIGGER_CONCLUSION)"
+          echo "Tag:          $HEAD_BRANCH"
+          echo "Head SHA:     $HEAD_SHA"
+          echo "tag=$HEAD_BRANCH" >>"$GITHUB_OUTPUT"
+          echo "sha=$HEAD_SHA"   >>"$GITHUB_OUTPUT"
+
+      - name: Wait for all three platform workflows to succeed
+        id: gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ steps.ctx.outputs.sha }}
+        # Strategy: for each of the three release workflow files,
+        # query its workflow_runs filtered by head_sha and event=push.
+        # If at least one of those runs has conclusion=success, that
+        # platform is "done". If all three are done, we promote.
+        # Otherwise we exit cleanly — the next sibling's completion
+        # will trigger another finalize attempt.
+        #
+        # We don't use `--branch` because for tag pushes that filter
+        # is inconsistent across GitHub's REST surface in some
+        # corner cases; head_sha is unambiguous (all three sibling
+        # workflows run on exactly the same commit the tag points
+        # at).
+        run: |
+          set -euo pipefail
+
+          workflows=(
+            "release-linux.yml"
+            "release-macos.yml"
+            "release-windows.yml"
+          )
+
+          all_done=1
+          for wf in "${workflows[@]}"; do
+            # `gh api` paginates with --paginate; cap the page size
+            # to avoid scanning the whole history for an old tag.
+            # The triggering run is recent, so the matching siblings
+            # are also in the last few pages of runs for that file.
+            runs_json=$(gh api \
+              "repos/${GH_REPO}/actions/workflows/${wf}/runs?head_sha=${HEAD_SHA}&event=push&per_page=20")
+
+            success_count=$(jq -r \
+              '[.workflow_runs[] | select(.conclusion == "success")] | length' \
+              <<<"$runs_json")
+
+            total_count=$(jq -r '.total_count' <<<"$runs_json")
+
+            echo "${wf}: head_sha=${HEAD_SHA} total=${total_count} success=${success_count}"
+
+            if [[ "$success_count" -lt 1 ]]; then
+              all_done=0
+            fi
+          done
+
+          if [[ "$all_done" -eq 1 ]]; then
+            echo "ready=true" >>"$GITHUB_OUTPUT"
+            echo "All three platform workflows succeeded for $HEAD_SHA — ready to promote."
+          else
+            echo "ready=false" >>"$GITHUB_OUTPUT"
+            echo "Not all platforms have succeeded yet; waiting for the next sibling's completion."
+          fi
+
+      - name: Promote draft to public release
+        if: steps.gate.outputs.ready == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ steps.ctx.outputs.tag }}
+        # `gh release edit --draft=false` is idempotent: if a
+        # previous finalize run already promoted the release (e.g.
+        # because all three siblings finished within the same
+        # second), this call is a no-op. We still want to call it so
+        # any state drift (someone manually re-drafting via the UI
+        # mid-pipeline) gets corrected.
+        #
+        # We deliberately do NOT touch --prerelease here: the create
+        # step in each platform workflow set it correctly at draft
+        # time (true for *-dev.*, unset otherwise), and re-passing
+        # it would re-introduce the regression where beta tags
+        # appeared as Pre-release in the GitHub UI.
+        run: |
+          set -euo pipefail
+
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::warning::release $TAG no longer exists — nothing to promote"
+            exit 0
+          fi
+
+          is_draft=$(gh release view "$TAG" --json isDraft --jq '.isDraft')
+          if [[ "$is_draft" != "true" ]]; then
+            echo "$TAG is already published — nothing to do."
+            exit 0
+          fi
+
+          echo "Promoting $TAG from draft to public release."
+          gh release edit "$TAG" --draft=false

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -155,31 +155,35 @@ jobs:
           set -euo pipefail
           tag="$GITHUB_REF_NAME"
 
-          # `gh release create` defaults to a stable release.
+          # The release is always created as a --draft. Drafts are
+          # invisible to /releases/latest, the public REST API, and
+          # the GitHub UI release list — so neither install.sh nor
+          # install.ps1 can resolve the tag while the draft is still
+          # missing one or more platforms' assets. That's the race
+          # `irm https://nowled.ge/con-ps1 | iex` hit on
+          # v0.1.0-beta.35: this Linux job won the create+upload
+          # race, the release became `latest` immediately, and a
+          # fresh Windows install fell over with
+          #   ✗ no ZIP found for windows-x86_64
+          # because the Windows publish job hadn't finished yet.
           #
-          # Only `v*-dev.*` tags get marked --prerelease here. Dev
-          # tags are explicitly internal smoke tests of the release
-          # pipeline and must not appear in /releases/latest.
+          # The draft is flipped to public by .github/workflows/
+          # release-finalize.yml, which fires on workflow_run.completed
+          # for any of release-{linux,macos,windows}.yml and only
+          # promotes the draft once all three workflows have a
+          # `success` conclusion for the same tag. If any platform
+          # fails, the draft stays a draft and the user has to either
+          # re-run the failing workflow or flip the draft manually
+          # via the GitHub UI — that's intentional, since shipping
+          # an incomplete release is exactly what broke before.
           #
-          # Beta tags do NOT get --prerelease today: con is in an
-          # all-betas era (no stable v0.1.0 has shipped yet), so the
-          # latest beta IS what every fresh `install.sh` /
-          # `install.ps1` should download. Marking the beta
-          # --prerelease excludes it from /releases/latest entirely
-          # (GitHub returns the prior stable, or 404 if none exists),
-          # which breaks the one-line installer for new users and
-          # was the issue v0.1.0-beta.34 hit (release shipped marked
-          # as Pre-release; the maintainer un-ticked it manually).
-          #
-          # The original channel-divergence concern (a beta-channel
-          # user clicking "Update now" and getting a stable
-          # downgrade) only fires once a stable release is published.
-          # Until then, the in-app notify-only updater's
-          # `CON_INSTALL_VERSION` pin in `apply_update_in_place`
-          # already binds the installer to the appcast's chosen
-          # version on the apply path — the /releases/latest API is
-          # only the fresh-install fallback, which is correctly the
-          # latest beta in the all-betas era.
+          # --prerelease is still set on `v*-dev.*` so that even if
+          # someone manually publishes a dev draft, it can never
+          # appear in /releases/latest. Beta tags are NOT marked
+          # --prerelease: con is in an all-betas era (no stable
+          # v0.1.0 has shipped), so the latest beta IS what every
+          # fresh install.sh / install.ps1 should download once the
+          # finalize step makes the release public.
           #
           # When stable v0.1.0 ships, add `*-beta.*` back to this
           # case so beta and stable channels stop colliding in
@@ -190,7 +194,8 @@ jobs:
           esac
 
           if ! gh release view "$tag" >/dev/null 2>&1; then
-            gh release create "$tag" --title "$tag" --generate-notes "${prerelease_args[@]}"
+            gh release create "$tag" --title "$tag" --generate-notes \
+              --draft "${prerelease_args[@]}"
           fi
 
           while IFS= read -r -d '' file; do

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -134,31 +134,41 @@ jobs:
           set -euo pipefail
           tag="$GITHUB_REF_NAME"
 
-          # `gh release create` defaults to a stable release.
+          # The release is always created as a --draft so that the
+          # tag stays invisible to /releases/latest and to the
+          # one-line installers (install.sh / install.ps1) until
+          # every platform's assets are attached. See the long-form
+          # rationale in release-linux.yml; the short version is that
+          # whichever platform job won the create+upload race used to
+          # flip the release public immediately, leaving fresh
+          # installers chasing
+          #   ✗ no ZIP found for windows-x86_64
+          # (or the macOS/Linux equivalents) until the slower
+          # platforms caught up. That's the bug
+          # `irm https://nowled.ge/con-ps1 | iex` hit on
+          # v0.1.0-beta.35.
           #
-          # Only `v*-dev.*` tags get marked --prerelease here. Dev
-          # tags are explicitly internal smoke tests of the release
-          # pipeline and must not appear in /releases/latest.
+          # Drafts are atomically promoted to public by
+          # .github/workflows/release-finalize.yml once every
+          # release-{linux,macos,windows}.yml workflow_run reports a
+          # `success` conclusion for the same tag. If any platform
+          # fails, the draft stays drafted (intentional — better to
+          # block than to ship an incomplete release).
           #
-          # Beta tags do NOT get --prerelease today: con is in an
-          # all-betas era (no stable v0.1.0 has shipped yet), so the
-          # latest beta IS what every fresh `install.sh` should
-          # download. Marking it --prerelease excludes the release
-          # from /releases/latest entirely and breaks the one-line
-          # installer for new users — that's the regression
-          # v0.1.0-beta.34 hit (the maintainer had to un-tick
-          # "Pre-release" on the GitHub UI manually).
-          #
-          # When stable v0.1.0 ships, add `*-beta.*` back to this
-          # case so beta and stable channels stop colliding in
-          # /releases/latest.
+          # --prerelease is still set on `v*-dev.*` as defence in
+          # depth (in case someone publishes the draft manually).
+          # Beta tags are NOT marked --prerelease today: con is in an
+          # all-betas era and the latest beta IS what fresh
+          # install.sh should download once the finalize step
+          # promotes the release.
           prerelease_args=()
           case "$tag" in
             *-dev.*) prerelease_args+=(--prerelease) ;;
           esac
 
           if ! gh release view "$tag" >/dev/null 2>&1; then
-            gh release create "$tag" --title "$tag" --generate-notes "${prerelease_args[@]}"
+            gh release create "$tag" --title "$tag" --generate-notes \
+              --draft "${prerelease_args[@]}"
           fi
 
           # Upload files one at a time to avoid GitHub API race conditions.

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -285,33 +285,41 @@ jobs:
           set -euo pipefail
           tag="$GITHUB_REF_NAME"
 
-          # `gh release create` defaults to a stable release.
+          # The release is always created as a --draft. Drafts are
+          # invisible to /releases/latest, the public REST API, and
+          # the GitHub UI release list — so install.ps1 / install.sh
+          # cannot resolve the tag until every platform's assets are
+          # attached. See the matching comment block in
+          # release-linux.yml for the long-form rationale; in short:
+          # one platform finishing first must not flip the release
+          # public while the other two are still uploading, or new
+          # users hit
+          #   ✗ no ZIP found for windows-x86_64
+          # (the bug `irm https://nowled.ge/con-ps1 | iex` reported
+          # on v0.1.0-beta.35).
           #
-          # Only `v*-dev.*` tags get marked --prerelease here. Dev
-          # tags are explicitly internal smoke tests of the release
-          # pipeline and must not appear in /releases/latest.
+          # The draft is promoted to public by
+          # .github/workflows/release-finalize.yml after every
+          # release-{linux,macos,windows}.yml workflow_run reports
+          # `success` for this tag.
           #
-          # Beta tags do NOT get --prerelease today: con is in an
-          # all-betas era (no stable v0.1.0 has shipped yet), so the
-          # latest beta IS what every fresh `install.ps1` should
-          # download. Marking it --prerelease excludes the release
-          # from /releases/latest entirely and breaks the one-line
-          # installer for new users — that's the regression
-          # v0.1.0-beta.34 hit (the maintainer had to un-tick
-          # "Pre-release" on the GitHub UI manually).
-          #
-          # When stable v0.1.0 ships, add `*-beta.*` back to this
-          # case so beta and stable channels stop colliding in
-          # /releases/latest.
+          # --prerelease is still set on `v*-dev.*` for defence in
+          # depth (in case someone publishes the draft manually).
+          # Beta tags are NOT marked --prerelease — con is all-betas
+          # today, so the latest beta IS what fresh install.ps1
+          # should download.
           prerelease_args=()
           case "$tag" in
             *-dev.*) prerelease_args+=(--prerelease) ;;
           esac
 
-          # The macOS job may have already created the release. If not,
-          # create it now so a Windows-only tag still publishes.
+          # The macOS or Linux job may have already created the
+          # draft release. If not, create it now so a Windows-only
+          # tag still drafts (the finalize workflow simply won't
+          # promote it without all three platforms succeeding).
           if ! gh release view "$tag" >/dev/null 2>&1; then
-            gh release create "$tag" --title "$tag" --generate-notes "${prerelease_args[@]}"
+            gh release create "$tag" --title "$tag" --generate-notes \
+              --draft "${prerelease_args[@]}"
           fi
 
           while IFS= read -r -d '' file; do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## [Unreleased]
+
+### Improved
+
+**Terminal — Linux Backend (preview)**
+- Reduced Linux preview renderer CPU cost by caching per-row `StyledText` text/runs in `linux_view` and only rebuilding rows marked dirty by the VT snapshot, plus cursor-affected rows.
+- Documented the remaining Linux performance constraint explicitly: after the row-cache change, the main latency floor is the workspace's 8 ms PTY wake poll and the longer-term fix remains the planned glyph-atlas grid renderer.
+
 ## [v0.1.0-beta.36] - 2026-04-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
-## [Unreleased]
+## [v0.1.0-beta.37] - 2026-04-24
 
 ### Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ con is still pre-release, so entries may group related beta work while the produ
 - Reduced Linux preview renderer CPU cost by caching per-row `StyledText` text/runs in `linux_view` and only rebuilding rows marked dirty by the VT snapshot, plus cursor-affected rows.
 - Documented the remaining Linux performance constraint explicitly: after the row-cache change, the main latency floor is the workspace's 8 ms PTY wake poll and the longer-term fix remains the planned glyph-atlas grid renderer.
 
+### Fixed
+
+**Release pipeline — multi-platform race**
+- Fixed `irm https://nowled.ge/con-ps1 | iex` (and the `install.sh` equivalents) failing with `✗ no ZIP found for windows-x86_64` when the Linux release job won the create-and-upload race ahead of the Windows / macOS jobs. Each `release-{linux,macos,windows}.yml` now creates the GitHub release as `--draft`, so `/releases/latest` and the public REST API stay blind to the tag while assets are uploading. A new `release-finalize.yml` workflow watches all three platform workflows via `workflow_run` and atomically promotes the draft to public only once every platform reports a `success` conclusion for the same `head_sha`. If a platform fails, the draft stays drafted on purpose — better to block than to ship an incomplete release.
+
 ## [v0.1.0-beta.36] - 2026-04-24
 
 ### Fixed

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -16,8 +16,8 @@
 use std::sync::Arc;
 
 use con_ghostty::{
-    Cursor, GhosttyApp, GhosttySplitDirection, GhosttyTerminal, ScreenSnapshot, SurfaceSize,
-    VtCell, ATTR_BOLD, ATTR_INVERSE, ATTR_ITALIC, ATTR_STRIKE, ATTR_UNDERLINE,
+    GhosttyApp, GhosttySplitDirection, GhosttyTerminal, ScreenSnapshot, SurfaceSize, VtCell,
+    VtCursor, ATTR_BOLD, ATTR_INVERSE, ATTR_ITALIC, ATTR_STRIKE, ATTR_UNDERLINE,
 };
 use gpui::*;
 use gpui_component::ActiveTheme;
@@ -69,7 +69,7 @@ pub struct GhosttyView {
     snapshot: Option<ScreenSnapshot>,
     row_cache: Vec<CachedTerminalRow>,
     row_cache_generation: Option<u64>,
-    row_cache_cursor: Option<Cursor>,
+    row_cache_cursor: Option<VtCursor>,
     row_cache_style: Option<RowCacheStyleKey>,
     row_cache_shape: Option<(u16, u16)>,
     /// Latched after the first PTY snapshot that contained any
@@ -703,7 +703,7 @@ struct RowCacheStyleKey {
     line_height: Pixels,
 }
 
-fn cursor_col_for_row(cursor: Cursor, row_idx: usize) -> Option<usize> {
+fn cursor_col_for_row(cursor: VtCursor, row_idx: usize) -> Option<usize> {
     if cursor.visible && usize::from(cursor.row) == row_idx {
         Some(usize::from(cursor.col))
     } else {
@@ -713,7 +713,7 @@ fn cursor_col_for_row(cursor: Cursor, row_idx: usize) -> Option<usize> {
 
 fn rows_needing_refresh(
     snapshot: &ScreenSnapshot,
-    previous_cursor: Option<Cursor>,
+    previous_cursor: Option<VtCursor>,
     force_full_rebuild: bool,
 ) -> Vec<usize> {
     if force_full_rebuild {
@@ -1020,7 +1020,7 @@ fn encode_special_key(key: &str, modifiers: &Modifiers, decckm: bool) -> Option<
 #[cfg(test)]
 mod tests {
     use super::{build_terminal_row, rows_needing_refresh, vt_color_to_hsla};
-    use con_ghostty::{Cursor, ScreenSnapshot, VtCell, ATTR_BOLD, ATTR_INVERSE, ATTR_UNDERLINE};
+    use con_ghostty::{ScreenSnapshot, VtCell, VtCursor, ATTR_BOLD, ATTR_INVERSE, ATTR_UNDERLINE};
     use gpui::{Font, FontFeatures, FontStyle, FontWeight, Hsla, Rgba};
 
     fn base_font() -> Font {
@@ -1088,7 +1088,7 @@ mod tests {
             rows: 3,
             cells: vec![Default::default(); 12],
             dirty_rows: vec![1],
-            cursor: Cursor {
+            cursor: VtCursor {
                 col: 2,
                 row: 2,
                 visible: true,
@@ -1099,7 +1099,7 @@ mod tests {
 
         let mut rows = rows_needing_refresh(
             &snapshot,
-            Some(Cursor {
+            Some(VtCursor {
                 col: 1,
                 row: 0,
                 visible: true,

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -16,8 +16,8 @@
 use std::sync::Arc;
 
 use con_ghostty::{
-    GhosttyApp, GhosttySplitDirection, GhosttyTerminal, ScreenSnapshot, SurfaceSize, VtCell,
-    ATTR_BOLD, ATTR_INVERSE, ATTR_ITALIC, ATTR_STRIKE, ATTR_UNDERLINE,
+    Cursor, GhosttyApp, GhosttySplitDirection, GhosttyTerminal, ScreenSnapshot, SurfaceSize,
+    VtCell, ATTR_BOLD, ATTR_INVERSE, ATTR_ITALIC, ATTR_STRIKE, ATTR_UNDERLINE,
 };
 use gpui::*;
 use gpui_component::ActiveTheme;
@@ -67,6 +67,11 @@ pub struct GhosttyView {
     last_title: Option<String>,
     pending_write: Option<Vec<u8>>,
     snapshot: Option<ScreenSnapshot>,
+    row_cache: Vec<CachedTerminalRow>,
+    row_cache_generation: Option<u64>,
+    row_cache_cursor: Option<Cursor>,
+    row_cache_style: Option<RowCacheStyleKey>,
+    row_cache_shape: Option<(u16, u16)>,
     /// Latched after the first PTY snapshot that contained any
     /// printable content. Used to gate the "Waiting for shell
     /// prompt…" placeholder so it disappears the moment bash echoes
@@ -99,6 +104,11 @@ impl GhosttyView {
             last_title: None,
             pending_write: None,
             snapshot: None,
+            row_cache: Vec::new(),
+            row_cache_generation: None,
+            row_cache_cursor: None,
+            row_cache_style: None,
+            row_cache_shape: None,
             seen_any_output: false,
             pane_bounds: None,
             scale_factor: 1.0,
@@ -158,6 +168,11 @@ impl GhosttyView {
         self.last_title = None;
         self.pending_write = None;
         self.snapshot = None;
+        self.row_cache.clear();
+        self.row_cache_generation = None;
+        self.row_cache_cursor = None;
+        self.row_cache_style = None;
+        self.row_cache_shape = None;
         self.seen_any_output = false;
         self.last_surface_size = None;
     }
@@ -444,6 +459,67 @@ impl GhosttyView {
 
         false
     }
+
+    fn sync_row_cache(
+        &mut self,
+        default_fg: Hsla,
+        default_bg: Hsla,
+        base_font: &Font,
+        font_size: Pixels,
+        line_height: Pixels,
+    ) {
+        let Some(snapshot) = self.snapshot.as_ref() else {
+            self.row_cache.clear();
+            self.row_cache_generation = None;
+            self.row_cache_cursor = None;
+            self.row_cache_style = None;
+            self.row_cache_shape = None;
+            return;
+        };
+
+        let style = RowCacheStyleKey {
+            font_family: base_font.family.clone(),
+            default_fg,
+            default_bg,
+            font_size,
+            line_height,
+        };
+        let shape = (snapshot.cols, snapshot.rows);
+        let force_full_rebuild = self.row_cache_style.as_ref() != Some(&style)
+            || self.row_cache_shape != Some(shape)
+            || self.row_cache.len() != usize::from(snapshot.rows);
+
+        if force_full_rebuild {
+            self.row_cache
+                .resize_with(usize::from(snapshot.rows), CachedTerminalRow::default);
+        }
+
+        let mut rows_to_refresh =
+            if force_full_rebuild || self.row_cache_generation != Some(snapshot.generation) {
+                rows_needing_refresh(snapshot, self.row_cache_cursor, force_full_rebuild)
+            } else {
+                Vec::new()
+            };
+
+        rows_to_refresh.sort_unstable();
+        rows_to_refresh.dedup();
+
+        for row_idx in rows_to_refresh {
+            let row_start = row_idx * usize::from(snapshot.cols);
+            let row_end = row_start + usize::from(snapshot.cols);
+            let Some(cells) = snapshot.cells.get(row_start..row_end) else {
+                break;
+            };
+            let cursor_for_row = cursor_col_for_row(snapshot.cursor, row_idx);
+            self.row_cache[row_idx] =
+                build_terminal_row(cells, default_fg, default_bg, base_font, cursor_for_row);
+        }
+
+        self.row_cache_generation = Some(snapshot.generation);
+        self.row_cache_cursor = Some(snapshot.cursor);
+        self.row_cache_style = Some(style);
+        self.row_cache_shape = Some(shape);
+    }
 }
 
 impl Focusable for GhosttyView {
@@ -484,8 +560,18 @@ impl Render for GhosttyView {
 
         let foreground = theme.foreground;
         let status_color = foreground.opacity(0.5);
+        self.sync_row_cache(
+            foreground,
+            theme.background,
+            &mono_font,
+            px(font_size_px),
+            px(line_height_px),
+        );
 
-        let mut rows: Vec<AnyElement> = Vec::new();
+        let mut rows: Vec<AnyElement> = Vec::with_capacity(
+            usize::from(self.snapshot.as_ref().map_or(0, |snapshot| snapshot.rows))
+                + if status_message.is_some() { 1 } else { 0 },
+        );
         if let Some(message) = status_message {
             rows.push(
                 div()
@@ -499,34 +585,14 @@ impl Render for GhosttyView {
         }
 
         if let Some(snapshot) = self.snapshot.as_ref() {
-            let cursor_col = if snapshot.cursor.visible {
-                Some(usize::from(snapshot.cursor.col))
-            } else {
-                None
-            };
             for row_idx in 0..usize::from(snapshot.rows) {
-                let row_start = row_idx * usize::from(snapshot.cols);
-                let row_end = row_start + usize::from(snapshot.cols);
-                let Some(cells) = snapshot.cells.get(row_start..row_end) else {
-                    break;
-                };
-                let cursor_for_row = if cursor_col.is_some()
-                    && usize::from(snapshot.cursor.row) == row_idx
-                {
-                    cursor_col
-                } else {
-                    None
-                };
-                let row = render_terminal_row(
-                    cells,
-                    foreground,
-                    theme.background,
-                    &mono_font,
-                    px(font_size_px),
-                    px(line_height_px),
-                    cursor_for_row,
-                );
-                rows.push(row);
+                if let Some(row) = self.row_cache.get(row_idx) {
+                    rows.push(render_cached_terminal_row(
+                        row,
+                        px(font_size_px),
+                        px(line_height_px),
+                    ));
+                }
             }
         }
 
@@ -622,20 +688,82 @@ impl Drop for GhosttyView {
     }
 }
 
+#[derive(Clone, Default)]
+struct CachedTerminalRow {
+    text: SharedString,
+    runs: Vec<TextRun>,
+}
+
+#[derive(Clone, PartialEq)]
+struct RowCacheStyleKey {
+    font_family: SharedString,
+    default_fg: Hsla,
+    default_bg: Hsla,
+    font_size: Pixels,
+    line_height: Pixels,
+}
+
+fn cursor_col_for_row(cursor: Cursor, row_idx: usize) -> Option<usize> {
+    if cursor.visible && usize::from(cursor.row) == row_idx {
+        Some(usize::from(cursor.col))
+    } else {
+        None
+    }
+}
+
+fn rows_needing_refresh(
+    snapshot: &ScreenSnapshot,
+    previous_cursor: Option<Cursor>,
+    force_full_rebuild: bool,
+) -> Vec<usize> {
+    if force_full_rebuild {
+        return (0..usize::from(snapshot.rows)).collect();
+    }
+
+    let mut rows = snapshot
+        .dirty_rows
+        .iter()
+        .copied()
+        .filter(|row| *row < snapshot.rows)
+        .map(usize::from)
+        .collect::<Vec<_>>();
+
+    if let Some(previous) = previous_cursor {
+        if previous.visible && previous.row < snapshot.rows {
+            rows.push(usize::from(previous.row));
+        }
+    }
+    if snapshot.cursor.visible && snapshot.cursor.row < snapshot.rows {
+        rows.push(usize::from(snapshot.cursor.row));
+    }
+
+    rows
+}
+
+fn render_cached_terminal_row(
+    row: &CachedTerminalRow,
+    font_size: Pixels,
+    line_height: Pixels,
+) -> AnyElement {
+    div()
+        .text_size(font_size)
+        .line_height(line_height)
+        .child(StyledText::new(row.text.clone()).with_runs(row.runs.clone()))
+        .into_any_element()
+}
+
 /// Build a single GPUI row element from a slice of `VtCell`s. We
 /// collapse runs of cells that share `(fg, bg, attrs)` into one
 /// `TextRun` so each row is a single `StyledText` element. That keeps
 /// allocations bounded by the number of *style changes*, not the cell
 /// count, while still preserving every SGR transition.
-fn render_terminal_row(
+fn build_terminal_row(
     cells: &[VtCell],
     default_fg: Hsla,
     default_bg: Hsla,
     base_font: &Font,
-    font_size: Pixels,
-    line_height: Pixels,
     cursor_col: Option<usize>,
-) -> AnyElement {
+) -> CachedTerminalRow {
     // First pass: find the last column we have to keep. A column
     // matters if it has a real glyph, OR if it carries a non-default
     // background / underline / strikethrough / inverse style, OR if
@@ -649,12 +777,10 @@ fn render_terminal_row(
         .iter()
         .enumerate()
         .rposition(|(col_idx, cell)| {
-            let glyph_present = cell.codepoint != 0
-                && char::from_u32(cell.codepoint).is_some_and(|ch| ch != ' ');
+            let glyph_present =
+                cell.codepoint != 0 && char::from_u32(cell.codepoint).is_some_and(|ch| ch != ' ');
             let styled_blank = (cell.bg & 0xFF) != 0
-                || (cell.attrs
-                    & (ATTR_INVERSE | ATTR_UNDERLINE | ATTR_STRIKE))
-                    != 0;
+                || (cell.attrs & (ATTR_INVERSE | ATTR_UNDERLINE | ATTR_STRIKE)) != 0;
             let cursor_here = cursor_col == Some(col_idx);
             glyph_present || styled_blank || cursor_here
         })
@@ -714,8 +840,9 @@ fn render_terminal_row(
 
     flush_run(&mut runs, &mut active_style, &mut active_run_len);
 
-    if text.is_empty() {
-        text.push('\u{00A0}');
+    let text = if text.is_empty() {
+        let mut fallback = String::with_capacity(1);
+        fallback.push('\u{00A0}');
         runs.push(TextRun {
             len: '\u{00A0}'.len_utf8(),
             font: base_font.clone(),
@@ -724,13 +851,15 @@ fn render_terminal_row(
             underline: None,
             strikethrough: None,
         });
-    }
+        fallback
+    } else {
+        text
+    };
 
-    div()
-        .text_size(font_size)
-        .line_height(line_height)
-        .child(StyledText::new(text).with_runs(runs))
-        .into_any_element()
+    CachedTerminalRow {
+        text: text.into(),
+        runs,
+    }
 }
 
 /// Resolved per-cell style ready to emit as a `TextRun`.
@@ -831,7 +960,11 @@ fn xterm_modifier_param(modifiers: &Modifiers) -> Option<u8> {
     let mask = u8::from(modifiers.shift)
         | (u8::from(modifiers.alt) << 1)
         | (u8::from(modifiers.control) << 2);
-    if mask == 0 { None } else { Some(1 + mask) }
+    if mask == 0 {
+        None
+    } else {
+        Some(1 + mask)
+    }
 }
 
 fn encode_special_key(key: &str, modifiers: &Modifiers, decckm: bool) -> Option<String> {
@@ -886,9 +1019,9 @@ fn encode_special_key(key: &str, modifiers: &Modifiers, decckm: bool) -> Option<
 
 #[cfg(test)]
 mod tests {
-    use super::{render_terminal_row, vt_color_to_hsla};
-    use con_ghostty::{VtCell, ATTR_BOLD, ATTR_INVERSE, ATTR_UNDERLINE};
-    use gpui::{Font, FontFeatures, FontStyle, FontWeight, Hsla, Pixels, Rgba};
+    use super::{build_terminal_row, rows_needing_refresh, vt_color_to_hsla};
+    use con_ghostty::{Cursor, ScreenSnapshot, VtCell, ATTR_BOLD, ATTR_INVERSE, ATTR_UNDERLINE};
+    use gpui::{Font, FontFeatures, FontStyle, FontWeight, Hsla, Rgba};
 
     fn base_font() -> Font {
         Font {
@@ -944,23 +1077,38 @@ mod tests {
             make_cell(' ', 0, 0, 0),
             make_cell('!', ATTR_INVERSE, 0, 0),
         ];
-        let _no_cursor = render_terminal_row(
-            &cells,
-            fg(),
-            bg(),
-            &base_font(),
-            Pixels::from(14.0),
-            Pixels::from(20.0),
-            None,
+        let _no_cursor = build_terminal_row(&cells, fg(), bg(), &base_font(), None);
+        let _with_cursor = build_terminal_row(&cells, fg(), bg(), &base_font(), Some(2));
+    }
+
+    #[test]
+    fn refresh_rows_include_old_and_new_cursor_rows() {
+        let snapshot = ScreenSnapshot {
+            cols: 4,
+            rows: 3,
+            cells: vec![Default::default(); 12],
+            dirty_rows: vec![1],
+            cursor: Cursor {
+                col: 2,
+                row: 2,
+                visible: true,
+            },
+            title: None,
+            generation: 7,
+        };
+
+        let mut rows = rows_needing_refresh(
+            &snapshot,
+            Some(Cursor {
+                col: 1,
+                row: 0,
+                visible: true,
+            }),
+            false,
         );
-        let _with_cursor = render_terminal_row(
-            &cells,
-            fg(),
-            bg(),
-            &base_font(),
-            Pixels::from(14.0),
-            Pixels::from(20.0),
-            Some(2),
-        );
+        rows.sort_unstable();
+        rows.dedup();
+
+        assert_eq!(rows, vec![0, 1, 2]);
     }
 }

--- a/docs/impl/linux-port.md
+++ b/docs/impl/linux-port.md
@@ -70,7 +70,9 @@ What that gives you:
   outside KWin)
 - a snappy paint pipeline: redundant per-tick snapshot refreshes
   and `Vec<Cell>` deep-equality compares were removed, the workspace
-  idle poll loop tightened from 16 ms to 8 ms, and the placeholder
+  idle poll loop tightened from 16 ms to 8 ms, the view now caches
+  per-row `StyledText` text/runs and only rebuilds rows flagged dirty
+  by the VT snapshot (plus cursor-affected rows), and the placeholder
   for "Waiting for shell prompt…" only ever shows before the first
   prompt — alt-screen TUIs (htop, vim, less, fzf) no longer flash
   the placeholder during their startup gap
@@ -272,16 +274,24 @@ With phase 4 landed (preview), the remaining Linux tasks are:
    under the text and pre-rasterizes per-cell glyphs, matching the
    D3D11/DirectWrite path used on Windows. Today's view already
    honors fg / bg / bold / italic / underline / strikethrough /
-   inverse and draws a block cursor, but per-cell metrics still
-   come from layout-time text shaping rather than a fixed cell
-   grid, which limits how dense the renderer can stay on huge
-   panes (the gap shows up first on `top -d 0.1`-class workloads).
+   inverse and draws a block cursor, and the preview path now caches
+   row text/runs so steady-state updates only rebuild dirty rows.
+   The remaining cost is structural: per-cell metrics still come from
+   layout-time text shaping rather than a fixed cell grid, which
+   limits how dense the renderer can stay on huge panes (the gap
+   shows up first on `top -d 0.1`-class workloads).
 2. Finish Linux input correctness: mouse reporting (button + wheel),
    selection (mouse drag → SGR 1006 / X10 reports + clipboard
    integration), and scrollback gestures. DECCKM and bracketed
    paste are already wired through `libghostty-vt` mode tracking
    and exercised by the existing keystroke encoder.
-3. Validate on hardware-accelerated native Linux desktops (Wayland
+3. Replace the workspace's 8 ms idle poll discovery path with a true
+   PTY wake signal into GPUI. The current poll cap was the right
+   preview tradeoff and is already much better than the old 16 ms
+   loop, but it is still the remaining input-to-paint latency floor
+   until the terminal backend can wake the app immediately on new PTY
+   output.
+4. Validate on hardware-accelerated native Linux desktops (Wayland
    on KDE Plasma to confirm `org_kde_kwin_blur`; Wayland on
    GNOME / sway and X11 on each major WM to confirm the
    transparency / CSD / caption-cluster fallback paths). The

--- a/postmortem/2026-04-23-release-multi-platform-draft-finalize.md
+++ b/postmortem/2026-04-23-release-multi-platform-draft-finalize.md
@@ -1,0 +1,80 @@
+# Multi-platform release race — fresh installs see a tag with only one platform's assets
+
+Date: 2026-04-23
+Tag affected: v0.1.0-beta.35 (and every prior multi-platform release; previously masked by the Windows / macOS runs typically finishing within seconds of Linux)
+Branch: `perf`
+
+## What happened
+
+A Windows user ran the documented one-liner
+```
+irm https://nowled.ge/con-ps1 | iex
+```
+shortly after `v0.1.0-beta.35` was tagged and the GitHub Actions release runs started. The installer printed:
+
+```
+   █▀▀ █▀█ █▄ █
+   █▄▄ █▄█ █ ▀█
+
+   ✗  no ZIP found for windows-x86_64
+```
+
+`install.ps1` resolves the latest tag through GitHub's `/releases/latest` API and then looks for a release asset whose name matches `con-*-windows-x86_64.zip`. The API returned the tag for `v0.1.0-beta.35`, but the only asset attached at that moment was the Linux tarball (`con-0.1.0-beta.35-linux-x86_64.tar.gz`).
+
+## Root cause
+
+The three release workflows — `.github/workflows/release-{linux,macos,windows}.yml` — are independent. Each is triggered by `push: tags: v*` and each `publish` job ran:
+
+```bash
+if ! gh release view "$tag" >/dev/null 2>&1; then
+  gh release create "$tag" --title "$tag" --generate-notes "${prerelease_args[@]}"
+fi
+gh release upload "$tag" "$file" --clobber
+```
+
+The first platform to finish its build won the create call, and the release was published immediately as a *public, non-draft* release. From that instant, GitHub's `/releases/latest` returned the tag and `install.ps1` / `install.sh` happily resolved it — even though the other two platforms were still building, packaging, signing, and uploading their assets.
+
+For most beta releases the slowest platform (Windows) finishes within a couple of minutes of the fastest (Linux), so the race window is tight. On `v0.1.0-beta.35` it just happened to land between the Linux upload completing and the Windows upload completing, and a real user hit it.
+
+The Linux build job runs on `ubuntu-22.04`, has a small artifact, and consistently finishes first. Windows runs on `windows-latest`, signs and packages, and consistently finishes last. So the bug was always going to bite — it just bit on `v0.1.0-beta.35` specifically.
+
+## Fix
+
+Switch from "the fastest platform publishes the release" to "the release is staged as a draft and only promoted to public once all three platforms have succeeded".
+
+1. `release-{linux,macos,windows}.yml` now create the release with `--draft`:
+   ```bash
+   gh release create "$tag" --title "$tag" --generate-notes \
+     --draft "${prerelease_args[@]}"
+   ```
+   Drafts are invisible to `/releases/latest`, the public REST API, and the public UI listing. `install.sh` / `install.ps1` behave as if the tag does not exist, which is the correct answer while the release is still being assembled.
+
+2. New workflow `.github/workflows/release-finalize.yml` triggers on `workflow_run.completed` for any of the three release workflows. For each completion it:
+   - Filters out non-tag-push events.
+   - Queries `repos/.../actions/workflows/release-{linux,macos,windows}.yml/runs?head_sha=<sha>&event=push` for each sibling and counts runs with `conclusion == "success"`.
+   - If all three siblings have at least one success for the same `head_sha`, calls `gh release edit "$tag" --draft=false`.
+   - Otherwise exits cleanly — the next sibling's completion will fire another finalize attempt.
+
+3. Concurrency is bounded with a per-tag concurrency group so two near-simultaneous sibling completions don't race the gate computation. `gh release edit --draft=false` is itself idempotent on an already-published release, so this is defence-in-depth, not correctness.
+
+## Why not "delay the publish step"?
+
+A simpler-looking fix is to add a "wait for all sibling workflows to complete" loop inside one of the existing publish jobs. That doesn't work because each workflow only knows about its own runs at the time it's running — there is no place inside `release-windows.yml` where it can correlate against `release-linux.yml`'s run ID without opening a separate API client and polling, which is exactly what `workflow_run` does for free at the platform level.
+
+It also doesn't compose: if the slowest platform fails, the other two would block forever waiting for assets that will never appear, while today's draft-then-promote shape just leaves the release as a draft and lets the maintainer decide whether to re-run or hand-promote.
+
+## Why not "make `install.ps1` tolerate missing assets"?
+
+The installer would have to walk `/releases` (plural), filter by per-platform asset presence, and pick the newest release that has the right asset. That trades one bug for several:
+- Adds API pagination cost on every install.
+- Lets a partial release become "the latest install" forever if the platform with the missing asset never re-runs successfully (silent skew between what shows on GitHub vs. what new users get).
+- Doesn't match user expectation: if the GitHub release page shows a tag, the one-liner should install that tag.
+
+The draft-then-promote approach makes "what the user sees" and "what the installer resolves" the same thing again.
+
+## What we learned
+
+- Treat the moment a release becomes visible at `/releases/latest` as a public commitment, not a side effect of whichever CI job finishes first.
+- `gh release create --draft` is the right primitive for staging multi-platform releases. It's invisible to the public API surface (`/releases/latest`, REST `/releases`, the GitHub UI release list) without being mislabelled as a "Pre-release", which has different downstream semantics (Sparkle channels, RSS readers, anyone keying off `prerelease == true`).
+- `workflow_run` is the right primitive for cross-workflow coordination on the same tag/sha. The constraint that it only fires on the default branch is fine for our case: tags only get pushed against published code, and the finalize workflow file lives in the default branch.
+- Treat "incomplete release stays as a draft" as the correct failure mode: better to block a broken release than to ship one and have the one-liner explode for half the audience.


### PR DESCRIPTION
## What changed

- cache per-row `StyledText` text/runs in the Linux preview terminal renderer
- rebuild only VT-dirty rows plus the old/new cursor rows instead of rebuilding every visible row on each snapshot
- update the Linux port notes and changelog to reflect the new renderer behavior and the remaining performance limits

## Why

The current Linux preview backend is functionally correct, but the view was still paying O(all visible rows) text/run rebuild cost for any terminal change. That was the biggest avoidable cost left inside the current `StyledText`-based renderer.

This patch keeps the current preview architecture and removes that waste without affecting macOS or Windows.

## User impact

- lower CPU cost on Linux during steady-state terminal updates
- better responsiveness in large panes and busy TUIs within the current preview renderer
- clearer documentation of what remains: the 8 ms PTY wake poll is now the main latency floor until Linux gets a real wake path and the planned glyph-atlas grid renderer

## Validation

- `cargo check -p con`
- `git diff --check`
- attempted `cargo check -p con --target x86_64-unknown-linux-gnu`, but this macOS host does not have the Linux cross C toolchain (`x86_64-linux-gnu-gcc`), so `aws-lc-sys` could not complete the cross-target build

## Tracker

- Linux tracker: #18

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release publication semantics by drafting then promoting via a new `workflow_run` gate, which could affect release visibility if the gate logic misfires. Linux renderer changes are localized but touch hot-path rendering and cache invalidation logic.
> 
> **Overview**
> **Prevents incomplete multi-platform releases from becoming public.** The platform release workflows now create GitHub releases as `--draft`, and a new `release-finalize.yml` workflow promotes the draft to public only after Linux/macOS/Windows workflows all report `success` for the same `head_sha`.
> 
> **Reduces Linux preview terminal CPU work.** `linux_view.rs` now caches per-row `StyledText` (text + runs) and rebuilds only VT-dirty rows plus cursor-affected rows, instead of rebuilding every row each snapshot. Documentation and `CHANGELOG.md` are updated, and a postmortem is added describing the release race and the draft/promote fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70225ff3353a5497a3e995b9b80fa808db74f07e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->