### PR TITLE
fix: complete pane close shortcuts on windows and linux

### DIFF
--- a/.github/workflows/ci-portable.yml
+++ b/.github/workflows/ci-portable.yml
@@ -16,19 +16,21 @@ name: ci-portable
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "postmortem/**"
-      - "LICENSE"
-      - ".gitignore"
+    paths:
+      - ".github/workflows/ci-portable.yml"
+      - ".cargo/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "assets/**"
+      - "crates/**"
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "postmortem/**"
-      - "LICENSE"
-      - ".gitignore"
+    paths:
+      - ".github/workflows/ci-portable.yml"
+      - ".cargo/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "assets/**"
+      - "crates/**"
 
 env:
   CARGO_TERM_COLOR: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ con is still pre-release, so entries may group related beta work while the produ
 **Interface**
 - Completed pane-close keyboard handling instead of only showing dead UI. `Close Pane` is now a real configurable shortcut in Settings, and Windows/Linux pane split defaults now use `Alt+D` / `Alt+Shift+D` instead of fragile symbol-based bindings.
 - `Close Pane` now escalates cleanly when nothing smaller remains to close: last pane closes the tab, and the last tab quits the app.
+- Fixed the last-pane quit path so quitting through `Close Pane` or terminal-exit escalation uses the same session save and surface teardown path as the normal app quit action.
 
 **Terminal — Windows Backend (preview)**
 - Reduced the first-frame flash when splitting a new pane on Windows. Brand-new panes now paint their configured terminal background while the first renderer image is still warming up, instead of briefly showing a transparent hole.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ con is still pre-release, so entries may group related beta work while the produ
 **Interface**
 - Completed pane-close keyboard handling instead of only showing dead UI. `Close Pane` is now a real configurable shortcut in Settings, and Windows/Linux pane split defaults now use `Alt+D` / `Alt+Shift+D` instead of fragile symbol-based bindings.
 
+**Terminal — Windows Backend (preview)**
+- Reduced the first-frame flash when splitting a new pane on Windows. Brand-new panes now paint their configured terminal background while the first renderer image is still warming up, instead of briefly showing a transparent hole.
+
 ## [v0.1.0-beta.37] - 2026-04-24
 
 ### Improved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ con is still pre-release, so entries may group related beta work while the produ
 
 **Interface**
 - Completed pane-close keyboard handling instead of only showing dead UI. `Close Pane` is now a real configurable shortcut in Settings, and Windows/Linux pane split defaults now use `Alt+D` / `Alt+Shift+D` instead of fragile symbol-based bindings.
+- `Close Pane` now escalates cleanly when nothing smaller remains to close: last pane closes the tab, and the last tab quits the app.
 
 **Terminal — Windows Backend (preview)**
 - Reduced the first-frame flash when splitting a new pane on Windows. Brand-new panes now paint their configured terminal background while the first renderer image is still warming up, instead of briefly showing a transparent hole.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ con is still pre-release, so entries may group related beta work while the produ
 ### Fixed
 
 **Interface**
-- Completed pane-close keyboard handling instead of only showing dead UI. `Close Pane` is now a real configurable shortcut in Settings, and Windows/Linux pane split defaults now use `Alt+D` / `Alt+Shift+D` instead of fragile symbol-based bindings.
+- Completed pane-close keyboard handling instead of only showing dead UI. `Close Pane` is now a real configurable shortcut in Settings, with app-level defaults that do not collide with terminal EOF (`Cmd+Opt+W` on macOS, `Alt+Shift+W` on Windows/Linux). Windows/Linux pane split defaults now use `Alt+D` / `Alt+Shift+D` instead of fragile symbol-based bindings.
 - `Close Pane` now escalates cleanly when nothing smaller remains to close: last pane closes the tab, and the last tab quits the app.
 - Fixed the last-pane quit path so quitting through `Close Pane` or terminal-exit escalation uses the same session save and surface teardown path as the normal app quit action.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
-## [Unreleased]
+## [v0.1.0-beta.38] - 2026-04-24
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ con is still pre-release, so entries may group related beta work while the produ
 - Completed pane-close keyboard handling instead of only showing dead UI. `Close Pane` is now a real configurable shortcut in Settings, with app-level defaults that do not collide with terminal EOF (`Cmd+Opt+W` on macOS, `Alt+Shift+W` on Windows/Linux). Windows/Linux pane split defaults now use `Alt+D` / `Alt+Shift+D` instead of fragile symbol-based bindings.
 - `Close Pane` now escalates cleanly when nothing smaller remains to close: last pane closes the tab, and the last tab quits the app.
 - Fixed the last-pane quit path so quitting through `Close Pane` or terminal-exit escalation uses the same session save and surface teardown path as the normal app quit action.
+- Fixed the command palette scroll behavior on all platforms. Mouse-wheel scrolling and scrollbar dragging no longer snap back to the selected row on every repaint.
 
 **Terminal — Windows Backend (preview)**
 - Reduced the first-frame flash when splitting a new pane on Windows. Brand-new panes now paint their configured terminal background while the first renderer image is still warming up, instead of briefly showing a transparent hole.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## [Unreleased]
+
+### Fixed
+
+**Interface**
+- Completed pane-close keyboard handling instead of only showing dead UI. `Close Pane` is now a real configurable shortcut in Settings, and Windows/Linux pane split defaults now use `Alt+D` / `Alt+Shift+D` instead of fragile symbol-based bindings.
+
 ## [v0.1.0-beta.37] - 2026-04-24
 
 ### Improved

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -303,7 +303,7 @@ Important consequence:
 - [x] Cmd+1..9 tab switching
 - [x] Session persistence (tabs, active tab, agent panel state)
 - [x] Kitty keyboard protocol (CSI u encoding, push/pop/query flags)
-- [x] Split panes (horizontal Cmd+D, vertical Cmd+Shift+D, pane tree)
+- [x] Split panes (macOS: Cmd+D / Cmd+Shift+D, Windows/Linux: Alt+D / Alt+Shift+D, pane tree)
 
 ### Phase 2: Agent Harness
 

--- a/crates/con-app/src/command_palette.rs
+++ b/crates/con-app/src/command_palette.rs
@@ -118,6 +118,7 @@ pub struct CommandPalette {
     query: Entity<InputState>,
     query_text: String,
     selected_index: usize,
+    reveal_selected: bool,
     focus_handle: FocusHandle,
     scroll_handle: ScrollHandle,
     ui_opacity: f32,
@@ -148,6 +149,7 @@ impl CommandPalette {
             query,
             query_text: String::new(),
             selected_index: 0,
+            reveal_selected: false,
             focus_handle: cx.focus_handle(),
             scroll_handle: ScrollHandle::new(),
             ui_opacity: 0.90,
@@ -162,6 +164,7 @@ impl CommandPalette {
                 .set_target(1.0, std::time::Duration::from_millis(180));
             self.query_text.clear();
             self.selected_index = 0;
+            self.reveal_selected = true;
             self.query.update(cx, |s, cx| {
                 s.set_value("", window, cx);
                 // Focus the input directly so the user can type immediately
@@ -235,7 +238,12 @@ impl Render for CommandPalette {
         }
 
         // Read current query text from input state
+        let previous_query = self.query_text.clone();
         self.query_text = self.query.read(cx).value().to_string();
+        if self.query_text != previous_query {
+            self.selected_index = 0;
+            self.reveal_selected = true;
+        }
         let actions = self.filtered_actions();
         let selected = if !actions.is_empty() {
             self.selected_index.min(actions.len().saturating_sub(1))
@@ -347,8 +355,10 @@ impl Render for CommandPalette {
             );
         }
 
-        // Scroll selected item into view
-        self.scroll_handle.scroll_to_item(selected);
+        if self.reveal_selected && !actions.is_empty() {
+            self.scroll_handle.scroll_to_item(selected);
+            self.reveal_selected = false;
+        }
 
         let backdrop = div()
             .id("palette-backdrop")
@@ -396,12 +406,14 @@ impl Render for CommandPalette {
                             } else {
                                 this.selected_index - 1
                             };
+                            this.reveal_selected = true;
                             cx.notify();
                         }
                     }
                     "down" => {
                         if count > 0 {
                             this.selected_index = (this.selected_index + 1) % count;
+                            this.reveal_selected = true;
                             cx.notify();
                         }
                     }

--- a/crates/con-app/src/command_palette.rs
+++ b/crates/con-app/src/command_palette.rs
@@ -253,16 +253,15 @@ impl Render for CommandPalette {
 
         let theme = cx.theme();
 
-        let mut list = div()
+        let mut list_content = div()
             .id("palette-list")
             .flex()
             .flex_col()
-            .max_h(px(320.0))
+            .size_full()
             .py(px(6.0))
             .px(px(6.0))
             .overflow_y_scroll()
-            .track_scroll(&self.scroll_handle)
-            .vertical_scrollbar(&self.scroll_handle);
+            .track_scroll(&self.scroll_handle);
 
         for (i, action) in actions.iter().enumerate() {
             let is_selected = i == selected;
@@ -291,7 +290,7 @@ impl Render for CommandPalette {
                     .into_any_element()
             };
 
-            list = list.child(
+            list_content = list_content.child(
                 div()
                     .id(SharedString::from(format!("palette-{}", action.id)))
                     .flex()
@@ -318,6 +317,12 @@ impl Render for CommandPalette {
                             this.select_action(cx);
                         }),
                     )
+                    .on_mouse_move(cx.listener(move |this, _: &MouseMoveEvent, _, cx| {
+                        if this.selected_index != idx {
+                            this.selected_index = idx;
+                            cx.notify();
+                        }
+                    }))
                     .child(
                         div()
                             .flex()
@@ -345,7 +350,7 @@ impl Render for CommandPalette {
         }
 
         if actions.is_empty() {
-            list = list.child(
+            list_content = list_content.child(
                 div()
                     .px(px(16.0))
                     .py(px(12.0))
@@ -359,6 +364,13 @@ impl Render for CommandPalette {
             self.scroll_handle.scroll_to_item(selected);
             self.reveal_selected = false;
         }
+
+        let list = div()
+            .relative()
+            .max_h(px(320.0))
+            .min_h_0()
+            .child(list_content)
+            .vertical_scrollbar(&self.scroll_handle);
 
         let backdrop = div()
             .id("palette-backdrop")

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -79,6 +79,7 @@ actions!(
         ToggleAgentPanel,
         ToggleInputBar,
         CloseTab,
+        ClosePane,
         SplitRight,
         SplitDown,
         FocusInput,
@@ -733,6 +734,7 @@ pub(crate) fn bind_app_keybindings(cx: &mut App, kb: &KeybindingConfig) {
         KeyBinding::new("secondary-shift-[", PreviousTab, None),
         KeyBinding::new(&kb.toggle_agent, ToggleAgentPanel, None),
         KeyBinding::new(&kb.close_tab, CloseTab, None),
+        KeyBinding::new(&kb.close_pane, ClosePane, None),
         KeyBinding::new(&kb.settings, settings_panel::ToggleSettings, None),
         KeyBinding::new(
             &kb.command_palette,
@@ -754,6 +756,7 @@ pub(crate) fn bind_app_keybindings(cx: &mut App, kb: &KeybindingConfig) {
         KeyBinding::new("secondary-shift-[", PreviousTab, Some("Input")),
         KeyBinding::new(&kb.toggle_agent, ToggleAgentPanel, Some("Input")),
         KeyBinding::new(&kb.close_tab, CloseTab, Some("Input")),
+        KeyBinding::new(&kb.close_pane, ClosePane, Some("Input")),
         KeyBinding::new(&kb.settings, settings_panel::ToggleSettings, Some("Input")),
         KeyBinding::new(
             &kb.command_palette,
@@ -1063,6 +1066,7 @@ fn main() {
                     MenuItem::action("New Window", NewWindow),
                     MenuItem::action("New Tab", NewTab),
                     MenuItem::action("Close Tab", CloseTab),
+                    MenuItem::action("Close Pane", ClosePane),
                     MenuItem::separator(),
                     MenuItem::action("Split Right", SplitRight),
                     MenuItem::action("Split Down", SplitDown),

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -1823,6 +1823,7 @@ impl SettingsPanel {
             "new_window" => self.config.keybindings.new_window = binding,
             "new_tab" => self.config.keybindings.new_tab = binding,
             "close_tab" => self.config.keybindings.close_tab = binding,
+            "close_pane" => self.config.keybindings.close_pane = binding,
             "next_tab" => self.config.keybindings.next_tab = binding,
             "previous_tab" => self.config.keybindings.previous_tab = binding,
             "settings" => self.config.keybindings.settings = binding,
@@ -1848,6 +1849,7 @@ impl SettingsPanel {
             "new_window" => &self.config.keybindings.new_window,
             "new_tab" => &self.config.keybindings.new_tab,
             "close_tab" => &self.config.keybindings.close_tab,
+            "close_pane" => &self.config.keybindings.close_pane,
             "next_tab" => &self.config.keybindings.next_tab,
             "previous_tab" => &self.config.keybindings.previous_tab,
             "settings" => &self.config.keybindings.settings,
@@ -3741,8 +3743,11 @@ impl SettingsPanel {
             ("Quit", "quit"),
         ];
 
-        let pane_keys: &[(&str, &str)] =
-            &[("Split Right", "split_right"), ("Split Down", "split_down")];
+        let pane_keys: &[(&str, &str)] = &[
+            ("Split Right", "split_right"),
+            ("Split Down", "split_down"),
+            ("Close Pane", "close_pane"),
+        ];
 
         let build_card = |keys: &[(&str, &str)],
                           recording: &Option<String>,
@@ -3991,8 +3996,7 @@ impl SettingsPanel {
                 .flex_col()
                 .gap(px(8.0))
                 .child(group_label("Panes", &theme))
-                .child(pane_card)
-                .child(card(theme, card_opacity).child(key_row("Close Pane", "ctrl-d", theme))),
+                .child(pane_card),
         )
         .child(
             div()

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -585,6 +585,24 @@ impl GhosttyView {
 
         false
     }
+
+    fn placeholder_background(&self) -> Option<Hsla> {
+        let config = self.app.renderer_config();
+        let opacity = config.background_opacity.clamp(0.0, 1.0);
+        if opacity <= f32::EPSILON {
+            return None;
+        }
+
+        Some(
+            Rgba {
+                r: config.clear_color[0].clamp(0.0, 1.0),
+                g: config.clear_color[1].clamp(0.0, 1.0),
+                b: config.clear_color[2].clamp(0.0, 1.0),
+                a: opacity,
+            }
+            .into(),
+        )
+    }
 }
 
 /// Wrap a BGRA readback buffer as a `RenderImage`. `RenderImage`
@@ -718,6 +736,7 @@ impl Render for GhosttyView {
         }
 
         let theme = cx.theme();
+        let placeholder_background = self.placeholder_background();
         let entity = cx.entity().downgrade();
         // `ObjectFit::Fill` keeps the image quad exactly equal to the
         // element's bounds. The default `Contain` applies aspect-ratio
@@ -740,7 +759,7 @@ impl Render for GhosttyView {
             .min_w_0()
             .min_h_0()
             .track_focus(&self.focus_handle)
-            .bg(theme.background.opacity(0.0))
+            .bg(placeholder_background.unwrap_or_else(|| theme.background.opacity(0.0)))
             .on_key_down(cx.listener(|this, event: &KeyDownEvent, window, cx| {
                 if !this.focus_handle.is_focused(window) {
                     return;

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -736,7 +736,11 @@ impl Render for GhosttyView {
         }
 
         let theme = cx.theme();
-        let placeholder_background = self.placeholder_background();
+        let placeholder_background = if self.cached_image.is_none() {
+            self.placeholder_background()
+        } else {
+            None
+        };
         let entity = cx.entity().downgrade();
         // `ObjectFit::Fill` keeps the image quad exactly equal to the
         // element's bounds. The default `Contain` applies aspect-ratio

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -5820,17 +5820,22 @@ impl ConWorkspace {
 
             let surviving_terminals: Vec<TerminalPane> =
                 pane_tree.all_terminals().into_iter().cloned().collect();
-            for terminal in &surviving_terminals {
-                terminal.set_native_view_visible(true, cx);
-                terminal.ensure_surface(window, cx);
-                terminal.notify(cx);
+            let tab_is_visible = tab_idx == self.active_tab;
+            if tab_is_visible {
+                for terminal in &surviving_terminals {
+                    terminal.set_native_view_visible(true, cx);
+                    terminal.ensure_surface(window, cx);
+                    terminal.notify(cx);
+                }
             }
 
             if let Some(closing) = closing {
                 cx.on_next_frame(window, move |_workspace, _window, cx| {
                     closing.shutdown_surface(cx);
-                    for terminal in &surviving_terminals {
-                        terminal.notify(cx);
+                    if tab_is_visible {
+                        for terminal in &surviving_terminals {
+                            terminal.notify(cx);
+                        }
                     }
                 });
             }

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -230,8 +230,8 @@ use crate::ghostty_view::{
     GhosttyView,
 };
 use crate::{
-    CloseTab, CycleInputMode, FocusInput, NewTab, NextTab, PreviousTab, Quit, SplitDown,
-    SplitRight, ToggleAgentPanel, TogglePaneScopePicker,
+    ClosePane, CloseTab, CycleInputMode, FocusInput, NewTab, NextTab, PreviousTab, Quit,
+    SplitDown, SplitRight, ToggleAgentPanel, TogglePaneScopePicker,
 };
 use con_agent::{AgentConfig, Conversation, ProviderKind, TerminalExecRequest, TerminalExecResponse};
 use con_core::config::Config;
@@ -5774,6 +5774,71 @@ impl ConWorkspace {
         }
     }
 
+    fn close_pane(&mut self, _: &ClosePane, window: &mut Window, cx: &mut Context<Self>) {
+        if !self.has_active_tab() {
+            return;
+        }
+
+        let pane_id = self.tabs[self.active_tab].pane_tree.focused_pane_id();
+        let _ = self.close_pane_in_tab(self.active_tab, pane_id, window, cx);
+    }
+
+    fn close_pane_in_tab(
+        &mut self,
+        tab_idx: usize,
+        pane_id: usize,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if tab_idx >= self.tabs.len() || self.tabs[tab_idx].pane_tree.pane_count() <= 1 {
+            return false;
+        }
+
+        let mut focus_after_close = None;
+        {
+            let pane_tree = &mut self.tabs[tab_idx].pane_tree;
+            let closing = pane_tree
+                .pane_terminals()
+                .into_iter()
+                .find(|(candidate_pane_id, _)| *candidate_pane_id == pane_id)
+                .map(|(_, terminal)| terminal);
+
+            if closing.is_none() || !pane_tree.close_pane(pane_id) {
+                return false;
+            }
+
+            let surviving_terminals: Vec<TerminalPane> =
+                pane_tree.all_terminals().into_iter().cloned().collect();
+            for terminal in &surviving_terminals {
+                terminal.set_native_view_visible(true, cx);
+                terminal.ensure_surface(window, cx);
+                terminal.notify(cx);
+            }
+
+            if let Some(closing) = closing {
+                cx.on_next_frame(window, move |_workspace, _window, cx| {
+                    closing.shutdown_surface(cx);
+                    for terminal in &surviving_terminals {
+                        terminal.notify(cx);
+                    }
+                });
+            }
+
+            if tab_idx == self.active_tab {
+                focus_after_close = Some(pane_tree.focused_terminal().clone());
+            }
+        }
+
+        if let Some(focused) = focus_after_close {
+            focused.focus(window, cx);
+            self.sync_active_terminal_focus_states(cx);
+        }
+
+        self.save_session(cx);
+        cx.notify();
+        true
+    }
+
     fn activate_tab(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
         if index >= self.tabs.len() || index == self.active_tab {
             return;
@@ -5939,42 +6004,10 @@ impl ConWorkspace {
         }
 
         if self.tabs[tab_idx].pane_tree.pane_count() > 1 {
-            let mut focus_after_close = None;
-            {
-                let pane_tree = &mut self.tabs[tab_idx].pane_tree;
-                // Close the specific pane whose process exited, not the focused pane.
-                if let Some(pane_id) = pane_tree.pane_id_for_entity(entity_id) {
-                    let closing = pane_tree
-                        .all_terminals()
-                        .into_iter()
-                        .find(|terminal| terminal.entity_id() == entity_id)
-                        .cloned();
-                    pane_tree.close_pane(pane_id);
-                    let surviving_terminals: Vec<TerminalPane> =
-                        pane_tree.all_terminals().into_iter().cloned().collect();
-                    for terminal in &surviving_terminals {
-                        terminal.set_native_view_visible(true, cx);
-                        terminal.ensure_surface(window, cx);
-                        terminal.notify(cx);
-                    }
-                    if let Some(closing) = closing {
-                        cx.on_next_frame(window, move |_workspace, _window, cx| {
-                            closing.shutdown_surface(cx);
-                            for terminal in &surviving_terminals {
-                                terminal.notify(cx);
-                            }
-                        });
-                    }
-                }
-                if tab_idx == self.active_tab {
-                    focus_after_close = Some(pane_tree.focused_terminal().clone());
-                }
-            }
-
-            if let Some(focused) = focus_after_close {
-                focused.focus(window, cx);
-                self.sync_active_terminal_focus_states(cx);
-            }
+            let Some(pane_id) = self.tabs[tab_idx].pane_tree.pane_id_for_entity(entity_id) else {
+                return;
+            };
+            let _ = self.close_pane_in_tab(tab_idx, pane_id, window, cx);
         } else if self.tabs.len() > 1 {
             // Last pane in this tab — close the tab.
             self.close_tab_by_index(tab_idx, window, cx);
@@ -6830,6 +6863,7 @@ impl Render for ConWorkspace {
             .on_action(cx.listener(Self::next_tab))
             .on_action(cx.listener(Self::previous_tab))
             .on_action(cx.listener(Self::close_tab))
+            .on_action(cx.listener(Self::close_pane))
             .on_action(cx.listener(Self::split_right))
             .on_action(cx.listener(Self::split_down))
             .on_action(cx.listener(Self::focus_input))

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -3078,8 +3078,7 @@ impl ConWorkspace {
                 cx.dispatch_action(&crate::CheckForUpdates);
             }
             "quit" => {
-                self.cancel_all_sessions();
-                cx.quit();
+                self.quit(&Quit, window, cx);
             }
             _ => {}
         }
@@ -5790,8 +5789,7 @@ impl ConWorkspace {
             return;
         }
 
-        self.cancel_all_sessions();
-        cx.quit();
+        self.quit(&Quit, window, cx);
     }
 
     fn close_pane_in_tab(
@@ -6029,8 +6027,7 @@ impl ConWorkspace {
             self.close_tab_by_index(tab_idx, window, cx);
         } else {
             // Last pane in last tab — quit the app.
-            self.cancel_all_sessions();
-            cx.quit();
+            self.quit(&Quit, window, cx);
         }
         cx.notify();
     }

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -5779,8 +5779,19 @@ impl ConWorkspace {
             return;
         }
 
-        let pane_id = self.tabs[self.active_tab].pane_tree.focused_pane_id();
-        let _ = self.close_pane_in_tab(self.active_tab, pane_id, window, cx);
+        if self.tabs[self.active_tab].pane_tree.pane_count() > 1 {
+            let pane_id = self.tabs[self.active_tab].pane_tree.focused_pane_id();
+            let _ = self.close_pane_in_tab(self.active_tab, pane_id, window, cx);
+            return;
+        }
+
+        if self.tabs.len() > 1 {
+            self.close_tab_by_index(self.active_tab, window, cx);
+            return;
+        }
+
+        self.cancel_all_sessions();
+        cx.quit();
     }
 
     fn close_pane_in_tab(

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -97,16 +97,14 @@ impl Default for AppearanceConfig {
 
 // Default keybindings are chosen per platform. On macOS the `secondary-`
 // modifier token (⌘) is the right primary: Cmd+<letter> doesn't collide
-// with anything the terminal expects. On Windows `secondary-` resolves
-// to `Ctrl`, and bare Ctrl+<letter> is already a meaningful byte to
-// every POSIX/PowerShell shell (Ctrl+L = clear, Ctrl+C = SIGINT, Ctrl+I
-// = Tab, Ctrl+D = EOF, Ctrl+W = kill-word, ...). Binding app actions
-// to those steals them from the shell, which is exactly the feedback
-// a previous session missed. So for Windows we prefer Ctrl+Shift+
-// <letter> for actions that share a letter with a common terminal key,
-// matching Windows Terminal's own convention. Non-letter bindings
-// (Ctrl+`, Ctrl+,, Ctrl+;, Ctrl+') stay on bare Ctrl because those
-// keys don't produce control characters.
+// with anything the terminal expects. On Windows/Linux `secondary-`
+// resolves to `Ctrl`, and bare Ctrl+<letter> often has shell meaning
+// (Ctrl+L = clear, Ctrl+C = SIGINT, Ctrl+I = Tab, ...), so most app
+// actions avoid that space. Pane split/close is the one explicit
+// exception here: those shortcuts are window-management commands in Con
+// itself, not shell editing commands, and issue #67 calls out that the
+// Windows/Linux defaults need to be deliberate and user-visible rather
+// than half-wired placeholders.
 #[cfg(target_os = "macos")]
 fn default_toggle_agent() -> String {
     "secondary-l".into()
@@ -148,6 +146,10 @@ fn default_close_tab() -> String {
     "ctrl-shift-w".into()
 }
 
+fn default_close_pane() -> String {
+    "ctrl-d".into()
+}
+
 fn default_next_tab() -> String {
     "ctrl-tab".into()
 }
@@ -180,16 +182,7 @@ fn default_split_right() -> String {
 }
 #[cfg(not(target_os = "macos"))]
 fn default_split_right() -> String {
-    // Windows Terminal's "split pane right" is the user-visible
-    // `Alt+Shift+=`. GPUI's Windows key mapper resolves `VK_OEM_PLUS`
-    // with shift held to the *shifted* character `+` and zeroes the
-    // shift modifier, so the binding string must describe what the OS
-    // actually delivers: `alt-+`. Authoring it as `alt-shift-=` stores
-    // the binding as `key="=" modifiers=alt+shift`, which will never
-    // match the inbound `key="+" modifiers=alt` and the keystroke
-    // falls through to the terminal. Ctrl+D is EOF so we can't use
-    // secondary-d here.
-    "alt-+".into()
+    "alt-d".into()
 }
 
 #[cfg(target_os = "macos")]
@@ -198,12 +191,7 @@ fn default_split_down() -> String {
 }
 #[cfg(not(target_os = "macos"))]
 fn default_split_down() -> String {
-    // Mirrors Windows Terminal's user-visible `Alt+Shift+-`. GPUI's
-    // Windows key mapper resolves `VK_OEM_MINUS` with shift held to
-    // `_` and zeroes shift, so we author the binding as `alt-_` to
-    // match what the OS actually delivers. See `default_split_right`
-    // for the same reasoning applied to `+`.
-    "alt-_".into()
+    "alt-shift-d".into()
 }
 
 #[cfg(target_os = "macos")]
@@ -240,6 +228,7 @@ pub struct KeybindingConfig {
     pub new_window: String,
     pub new_tab: String,
     pub close_tab: String,
+    pub close_pane: String,
     pub next_tab: String,
     pub previous_tab: String,
     pub settings: String,
@@ -262,6 +251,7 @@ impl Default for KeybindingConfig {
             new_window: default_new_window(),
             new_tab: default_new_tab(),
             close_tab: default_close_tab(),
+            close_pane: default_close_pane(),
             next_tab: default_next_tab(),
             previous_tab: default_previous_tab(),
             settings: default_settings(),

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -100,11 +100,10 @@ impl Default for AppearanceConfig {
 // with anything the terminal expects. On Windows/Linux `secondary-`
 // resolves to `Ctrl`, and bare Ctrl+<letter> often has shell meaning
 // (Ctrl+L = clear, Ctrl+C = SIGINT, Ctrl+I = Tab, ...), so most app
-// actions avoid that space. Pane split/close is the one explicit
-// exception here: those shortcuts are window-management commands in Con
-// itself, not shell editing commands, and issue #67 calls out that the
-// Windows/Linux defaults need to be deliberate and user-visible rather
-// than half-wired placeholders.
+// actions avoid that space. Pane-management shortcuts therefore stay in
+// app-level modifier space instead of borrowing terminal control
+// characters like Ctrl+D, which terminals consume as EOF before Con's
+// keybindings ever see them.
 #[cfg(target_os = "macos")]
 fn default_toggle_agent() -> String {
     "secondary-l".into()
@@ -146,8 +145,13 @@ fn default_close_tab() -> String {
     "ctrl-shift-w".into()
 }
 
+#[cfg(target_os = "macos")]
 fn default_close_pane() -> String {
-    "ctrl-d".into()
+    "secondary-alt-w".into()
+}
+#[cfg(not(target_os = "macos"))]
+fn default_close_pane() -> String {
+    "alt-shift-w".into()
 }
 
 fn default_next_tab() -> String {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Close Pane keyboard shortcut is now configurable via Settings.

* **Bug Fixes**
  * Pane-close keyboard handling is now fully functional.

* **Changes**
  * Updated default pane split keyboard shortcuts for Windows/Linux (Alt+D and Alt+Shift+D).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes pane/tab teardown and quit paths (session save + surface shutdown) and adjusts default keybindings across platforms, which could introduce focus/teardown regressions.
> 
> **Overview**
> Implements a real `Close Pane` action end-to-end: adds a configurable keybinding + menu item, wires it into the workspace, and defines escalation behavior (close focused pane → close tab → quit app).
> 
> Refactors pane teardown so both terminal-process-exit cleanup and the new shortcut use a shared `close_pane_in_tab` path, and routes palette/other quit triggers through the same `quit` handler to unify session save + surface shutdown.
> 
> Updates Windows/Linux default split bindings to `Alt+D` / `Alt+Shift+D`, and reduces Windows pane-split first-frame flash by painting a placeholder background until the first rendered frame arrives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3023ea152defaec201b50f7677ece6efab0f926d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->