### PR TITLE
feat: add rich Markdown rendering and focus toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ con is still pre-release, so entries may group related beta work while the produ
 - Fixed macOS IME English-mode commits in the terminal so direct ASCII input keeps the normal shell key path and does not disable shell ghost suggestions, while marked CJK composition still uses the IME text path. Buffered ASCII commits are now replayed as per-character key events instead of one synthetic multi-character key.
 
 **Keyboard**
-- Fixed the Input / Terminal toggle fallback so Cmd+I still lands on the bottom input bar if the agent-panel inline input has not initialized yet.
+- Fixed the Input / Terminal toggle fallback so Cmd+I never focuses a hidden input surface. If neither the agent-panel input nor the bottom input bar is visible, Cmd+I now reveals and focuses the bottom input bar.
 
 ## `v0.1.0-beta.39` - 2026-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,20 @@ con is still pre-release, so entries may group related beta work while the produ
 
 **Agent Panel**
 - Added first-class rich Markdown blocks for Mermaid diagrams and LaTeX-style math. Mermaid code fences and display math now render off the UI thread into cached GPUI images with source fallbacks, while inline math uses dedicated math typography instead of being flattened into generic code.
-- Mermaid diagrams now render with light/dark-aware colors, and Mermaid plus display math now use the same cached renderer inside nested Markdown containers such as blockquotes and lists, avoiding source-only fallbacks and repeated source-string allocations during repaint.
+- Mermaid diagrams now render with light/dark-aware colors so diagrams remain readable in both light and dark themes.
 
 **Keyboard**
 - Changed the input focus shortcut into a true Input / Terminal toggle. On macOS, Cmd+I now switches from the terminal to the input surface, then back to the first terminal pane when pressed from the input bar or agent-panel input.
+
+### Fixed
+
+**Agent Panel**
+- Fixed Mermaid and display math inside nested Markdown containers such as blockquotes and lists so they use the same cached rich renderer as top-level blocks instead of falling back to source text.
+- Fixed repeated rich-render source-string allocation during ordinary repaint, reducing avoidable memory churn when scrolling chats with diagrams or formulas.
+- Fixed display-math fallback styling so it uses the neutral block math style instead of inline-math chips inside an already styled block.
+- Consolidated blockquote and list layout rendering for cached rich blocks and fallback Markdown blocks so future spacing and typography changes cannot drift between the two paths.
+
+**Terminal**
 - Fixed macOS IME English-mode commits in the terminal so direct ASCII input keeps the normal shell key path and does not disable shell ghost suggestions, while marked CJK composition still uses the IME text path.
 
 ## `v0.1.0-beta.39` - 2026-04-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
-## [Unreleased]
+## `origin/main`
+
+------
+
+## `v0.1.0-beta.40` - 2026-04-26
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ con is still pre-release, so entries may group related beta work while the produ
 **Agent Panel**
 - Added first-class rich Markdown blocks for Mermaid diagrams and LaTeX-style math. Mermaid code fences and display math now render off the UI thread into cached GPUI images with source fallbacks, while inline math uses dedicated math typography instead of being flattened into generic code.
 
+**Keyboard**
+- Changed the input focus shortcut into a true Input / Terminal toggle. On macOS, Cmd+I now switches from the terminal to the input surface, then back to the first terminal pane when pressed from the input bar or agent-panel input.
+
 ## `v0.1.0-beta.39` - 2026-04-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ con is still pre-release, so entries may group related beta work while the produ
 **Agent Panel**
 - Fixed Mermaid and display math inside nested Markdown containers such as blockquotes and lists so they use the same cached rich renderer as top-level blocks instead of falling back to source text.
 - Fixed inline math detection so hyphenated prose and dollar ranges such as `$end-to-end$` or `$3-5$` are not misread as math.
+- Fixed inline math rendering for identifier-style formulas such as `$theta$` and `$velocity$`.
 - Fixed dark-theme Mermaid diagrams with custom light node fills so missing Mermaid `color:` styles are inferred from fill luminance instead of leaving white text on light shapes.
 - Fixed display math SVGs in dark mode so formulas use theme-aware foreground colors and re-render correctly after theme switches.
 - Fixed rich Mermaid and math render caching during streaming so replacing a parsed Markdown document with equivalent block content no longer discards already-rendered SVG images.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ con is still pre-release, so entries may group related beta work while the produ
 
 **Agent Panel**
 - Fixed Mermaid and display math inside nested Markdown containers such as blockquotes and lists so they use the same cached rich renderer as top-level blocks instead of falling back to source text.
+- Fixed inline math detection so hyphenated prose and dollar ranges such as `$end-to-end$` or `$3-5$` are not misread as math.
 - Fixed dark-theme Mermaid diagrams with custom light node fills so missing Mermaid `color:` styles are inferred from fill luminance instead of leaving white text on light shapes.
 - Fixed display math SVGs in dark mode so formulas use theme-aware foreground colors and re-render correctly after theme switches.
 - Fixed rich Mermaid and math render caching during streaming so replacing a parsed Markdown document with equivalent block content no longer discards already-rendered SVG images.
@@ -27,7 +28,10 @@ con is still pre-release, so entries may group related beta work while the produ
 - Consolidated blockquote and list layout rendering for cached rich blocks and fallback Markdown blocks so future spacing and typography changes cannot drift between the two paths.
 
 **Terminal**
-- Fixed macOS IME English-mode commits in the terminal so direct ASCII input keeps the normal shell key path and does not disable shell ghost suggestions, while marked CJK composition still uses the IME text path.
+- Fixed macOS IME English-mode commits in the terminal so direct ASCII input keeps the normal shell key path and does not disable shell ghost suggestions, while marked CJK composition still uses the IME text path. Buffered ASCII commits are now replayed as per-character key events instead of one synthetic multi-character key.
+
+**Keyboard**
+- Fixed the Input / Terminal toggle fallback so Cmd+I still lands on the bottom input bar if the agent-panel inline input has not initialized yet.
 
 ## `v0.1.0-beta.39` - 2026-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ con is still pre-release, so entries may group related beta work while the produ
 
 **Agent Panel**
 - Added first-class rich Markdown blocks for Mermaid diagrams and LaTeX-style math. Mermaid code fences and display math now render off the UI thread into cached GPUI images with source fallbacks, while inline math uses dedicated math typography instead of being flattened into generic code.
+- Mermaid and display math now use the same cached renderer inside nested Markdown containers such as blockquotes and lists, avoiding source-only fallbacks and repeated source-string allocations during repaint.
 
 **Keyboard**
 - Changed the input focus shortcut into a true Input / Terminal toggle. On macOS, Cmd+I now switches from the terminal to the input surface, then back to the first terminal pane when pressed from the input bar or agent-panel input.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ con is still pre-release, so entries may group related beta work while the produ
 
 **Agent Panel**
 - Fixed Mermaid and display math inside nested Markdown containers such as blockquotes and lists so they use the same cached rich renderer as top-level blocks instead of falling back to source text.
+- Fixed dark-theme Mermaid diagrams with custom light node fills so missing Mermaid `color:` styles are inferred from fill luminance instead of leaving white text on light shapes.
 - Fixed repeated rich-render source-string allocation during ordinary repaint, reducing avoidable memory churn when scrolling chats with diagrams or formulas.
 - Fixed display-math fallback styling so it uses the neutral block math style instead of inline-math chips inside an already styled block.
 - Consolidated blockquote and list layout rendering for cached rich blocks and fallback Markdown blocks so future spacing and typography changes cannot drift between the two paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ con is still pre-release, so entries may group related beta work while the produ
 
 **Agent Panel**
 - Added first-class rich Markdown blocks for Mermaid diagrams and LaTeX-style math. Mermaid code fences and display math now render off the UI thread into cached GPUI images with source fallbacks, while inline math uses dedicated math typography instead of being flattened into generic code.
-- Mermaid and display math now use the same cached renderer inside nested Markdown containers such as blockquotes and lists, avoiding source-only fallbacks and repeated source-string allocations during repaint.
+- Mermaid diagrams now render with light/dark-aware colors, and Mermaid plus display math now use the same cached renderer inside nested Markdown containers such as blockquotes and lists, avoiding source-only fallbacks and repeated source-string allocations during repaint.
 
 **Keyboard**
 - Changed the input focus shortcut into a true Input / Terminal toggle. On macOS, Cmd+I now switches from the terminal to the input surface, then back to the first terminal pane when pressed from the input bar or agent-panel input.
+- Fixed macOS IME English-mode commits in the terminal so direct ASCII input keeps the normal shell key path and does not disable shell ghost suggestions, while marked CJK composition still uses the IME text path.
 
 ## `v0.1.0-beta.39` - 2026-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ## [Unreleased]
 
+### Added
+
+**Agent Panel**
+- Added first-class rich Markdown blocks for Mermaid diagrams and LaTeX-style math. Mermaid code fences and display math now render off the UI thread into cached GPUI images with source fallbacks, while inline math uses dedicated math typography instead of being flattened into generic code.
+
 ## `v0.1.0-beta.39` - 2026-04-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ con is still pre-release, so entries may group related beta work while the produ
 **Agent Panel**
 - Fixed Mermaid and display math inside nested Markdown containers such as blockquotes and lists so they use the same cached rich renderer as top-level blocks instead of falling back to source text.
 - Fixed dark-theme Mermaid diagrams with custom light node fills so missing Mermaid `color:` styles are inferred from fill luminance instead of leaving white text on light shapes.
+- Fixed display math SVGs in dark mode so formulas use theme-aware foreground colors and re-render correctly after theme switches.
+- Fixed rich Mermaid and math render caching during streaming so replacing a parsed Markdown document with equivalent block content no longer discards already-rendered SVG images.
 - Fixed repeated rich-render source-string allocation during ordinary repaint, reducing avoidable memory churn when scrolling chats with diagrams or formulas.
 - Fixed display-math fallback styling so it uses the neutral block math style instead of inline-math chips inside an already styled block.
 - Consolidated blockquote and list layout rendering for cached rich blocks and fallback Markdown blocks so future spacing and typography changes cannot drift between the two paths.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,6 +721,147 @@ dependencies = [
 ]
 
 [[package]]
+name = "boa_ast"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6339a700715bda376f5ea65c76e8fe8fc880930d8b0638cea68e7f3da6538e0a"
+dependencies = [
+ "bitflags 2.11.0",
+ "boa_interner",
+ "boa_macros",
+ "boa_string",
+ "indexmap",
+ "num-bigint",
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
+name = "boa_engine"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1521be326f8a5c8887e95d4ce7f002917a002a23f7b93b9a6a2bf50ed4157824"
+dependencies = [
+ "aligned-vec",
+ "arrayvec",
+ "bitflags 2.11.0",
+ "boa_ast",
+ "boa_gc",
+ "boa_interner",
+ "boa_macros",
+ "boa_parser",
+ "boa_string",
+ "bytemuck",
+ "cfg-if",
+ "cow-utils",
+ "dashmap",
+ "dynify",
+ "fast-float2",
+ "float16",
+ "futures-channel",
+ "futures-concurrency",
+ "futures-lite 2.6.1",
+ "hashbrown 0.16.1",
+ "icu_normalizer",
+ "indexmap",
+ "intrusive-collections",
+ "itertools 0.14.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "num_enum",
+ "paste",
+ "portable-atomic",
+ "rand 0.9.4",
+ "regress",
+ "rustc-hash 2.1.2",
+ "ryu-js",
+ "serde",
+ "serde_json",
+ "small_btree",
+ "static_assertions",
+ "tag_ptr",
+ "tap",
+ "thin-vec",
+ "thiserror 2.0.18",
+ "time",
+ "xsum",
+]
+
+[[package]]
+name = "boa_gc"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17323a98cf2e631afacf1a6d659c1212c48a68bacfa85afab0a66ade80582e51"
+dependencies = [
+ "boa_macros",
+ "boa_string",
+ "hashbrown 0.16.1",
+ "thin-vec",
+]
+
+[[package]]
+name = "boa_interner"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20510b8b02bcde9b0a01cf34c0c308c56156503d1d91cdab4c8cfbd292b747ea"
+dependencies = [
+ "boa_gc",
+ "boa_macros",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "once_cell",
+ "phf 0.13.1",
+ "rustc-hash 2.1.2",
+ "static_assertions",
+]
+
+[[package]]
+name = "boa_macros"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5822cb4f146d243060e588bc5a5f2e709683fdad3d7111f42c48e6b5c921d23d"
+dependencies = [
+ "cfg-if",
+ "cow-utils",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "boa_parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd957fa9fa93e3a001a8aba5a5cd40c2bbfde486378be4c4b472fd304aaddb"
+dependencies = [
+ "bitflags 2.11.0",
+ "boa_ast",
+ "boa_interner",
+ "boa_macros",
+ "fast-float2",
+ "icu_properties",
+ "num-bigint",
+ "num-traits",
+ "regress",
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
+name = "boa_string"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2da1d7f4a76fd9040788a122f0d807910800a7b86f5952e9244848c36511de"
+dependencies = [
+ "fast-float2",
+ "itoa",
+ "paste",
+ "rustc-hash 2.1.2",
+ "ryu-js",
+ "static_assertions",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1135,9 +1276,10 @@ dependencies = [
  "image",
  "log",
  "markdown",
+ "mathjax-svg-rs",
+ "mermaid-rs-renderer",
  "objc",
  "parking_lot",
- "pulldown-cmark",
  "raw-window-handle",
  "reqwest 0.12.28",
  "ropey",
@@ -1458,6 +1600,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cow-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,6 +1699,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1567,6 +1729,15 @@ name = "deflate64"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "derive_more"
@@ -1586,7 +1757,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.1",
  "syn",
  "unicode-xid",
 ]
@@ -1726,6 +1897,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "dynify"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81acb15628a3e22358bf73de5e7e62360b8a777dbcb5fc9ac7dfa9ae73723747"
+dependencies = [
+ "dynify-macros",
+]
+
+[[package]]
+name = "dynify-macros"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec431cd708430d5029356535259c5d645d60edd3d39c54e5eea9782d46caa7d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,7 +1930,7 @@ checksum = "63a1d0de4f2249aa0ff5884d7080814f446bb241a559af6c170a41e878ed2d45"
 dependencies = [
  "cc",
  "memchr",
- "rustc_version",
+ "rustc_version 0.4.1",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
  "winreg 0.55.0",
@@ -1944,6 +2135,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,6 +2239,16 @@ name = "float-ord"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce81f49ae8a0482e4c55ea62ebbd7e5a686af544c00b9d090bba3ff9be97b3d"
+
+[[package]]
+name = "float16"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bffafbd079d520191c7c2779ae9cf757601266cf4167d3f659ff09617ff8483"
+dependencies = [
+ "cfg-if",
+ "rustc_version 0.2.3",
+]
 
 [[package]]
 name = "float_next_after"
@@ -2345,15 +2552,6 @@ checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.4",
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "getopts"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -2794,7 +2992,7 @@ dependencies = [
  "parking_lot",
  "pathfinder_geometry",
  "raw-window-handle",
- "semver",
+ "semver 1.0.28",
  "smallvec",
  "strum",
  "util",
@@ -3246,13 +3444,12 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -3266,6 +3463,7 @@ checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
@@ -3273,43 +3471,48 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "8b24a59706036ba941c9476a55cd57b82b77f38a3c667d637ee7cabbc85eaedc"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
+ "utf16_iter",
+ "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "f5a97b8ac6235e69506e8dacfb2adf38461d2ce6d3e9bd9c94c4cbc3cd4400a4"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
+ "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -3319,6 +3522,8 @@ checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
@@ -3416,6 +3621,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
+name = "include-zstd"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "195b3c87db6a1a1295c6feaff12fb2a4a4c8ddbd059737ca2afb9e98605c2975"
+dependencies = [
+ "include-zstd-derive",
+ "zstd",
+]
+
+[[package]]
+name = "include-zstd-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be236072332ba55da0de65b1f871ecdf5689e44911083138d1e22af21a17ace4"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zstd",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3478,6 +3706,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "intrusive-collections"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+dependencies = [
+ "memoffset",
 ]
 
 [[package]]
@@ -3663,6 +3900,16 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json5"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733a844dbd6fef128e98cb4487b887cb55454d92cd9994b1bafe004fabbe670c"
+dependencies = [
+ "serde",
+ "ucd-trie",
 ]
 
 [[package]]
@@ -3975,7 +4222,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
 dependencies = [
  "log",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
@@ -3992,6 +4239,18 @@ dependencies = [
  "markup5ever",
  "tendril",
  "xml5ever",
+]
+
+[[package]]
+name = "mathjax-svg-rs"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2c39f596739e90fe29a19551185250b30ff074cda25982d670205bad012ee2"
+dependencies = [
+ "boa_engine",
+ "include-zstd",
+ "log",
+ "serde_json",
 ]
 
 [[package]]
@@ -4051,6 +4310,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mermaid-rs-renderer"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b808a8c109e16ba5de1c829bd9326aea0a72c176174ddb681284f56579d892ac"
+dependencies = [
+ "anyhow",
+ "fontdb",
+ "json5",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -4343,6 +4619,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -4370,6 +4647,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -4430,6 +4713,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
  "libc",
 ]
 
@@ -4705,7 +5019,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
 dependencies = [
- "rustc_version",
+ "rustc_version 0.4.1",
 ]
 
 [[package]]
@@ -4740,7 +5054,17 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -4749,8 +5073,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -4759,8 +5083,31 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand 2.4.1",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4768,6 +5115,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -4948,6 +5304,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5046,25 +5408,6 @@ dependencies = [
  "ar_archive_writer",
  "cc",
 ]
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
-dependencies = [
- "bitflags 2.11.0",
- "getopts",
- "memchr",
- "pulldown-cmark-escape",
- "unicase",
-]
-
-[[package]]
-name = "pulldown-cmark-escape"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pxfm"
@@ -5448,6 +5791,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "regress"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
+dependencies = [
+ "hashbrown 0.16.1",
+ "memchr",
+]
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5726,11 +6079,20 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -5875,6 +6237,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "ryu-js"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd29631678d6fb0903b69223673e122c32e9ae559d0960a38d574695ebc0ea15"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6005,6 +6373,15 @@ checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
@@ -6012,6 +6389,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -6299,6 +6682,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "small_btree"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ba60d2df92ba73864714808ca68c059734853e6ab722b40e1cf543ebb3a057a"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6439,7 +6831,7 @@ checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.11.3",
  "precomputed-hash",
  "serde",
 ]
@@ -6450,8 +6842,8 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
 ]
@@ -6694,6 +7086,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tag_ptr"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0e973b34477b7823833469eb0f5a3a60370fef7a453e02d751b59180d0a5a05"
+
+[[package]]
 name = "take-until"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6710,6 +7108,12 @@ dependencies = [
  "libc",
  "objc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -6743,6 +7147,12 @@ checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "thin-vec"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 
 [[package]]
 name = "thiserror"
@@ -6808,6 +7218,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6849,6 +7292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -7596,6 +8040,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "uds_windows"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7740,6 +8190,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -8067,7 +8523,7 @@ dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
- "semver",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -9083,7 +9539,7 @@ dependencies = [
  "id-arena",
  "indexmap",
  "log",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_derive",
  "serde_json",
@@ -9096,6 +9552,12 @@ name = "workspace-hack"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beffa227304dbaea3ad6a06ac674f9bc83a3dec3b7f63eeb442de37e7cb6bb01"
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
@@ -9226,6 +9688,12 @@ name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "xsum"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0637d3a5566a82fa5214bae89087bc8c9fb94cd8e8a3c07feb691bb8d9c632db"
 
 [[package]]
 name = "y4m"
@@ -9529,6 +9997,7 @@ dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -9537,6 +10006,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",
@@ -9569,6 +10039,34 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "ztracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,8 @@ smallvec = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 http = "1"
 rust-embed = { version = "8.7.2", features = ["interpolate-folder-path", "include-exclude"] }
-pulldown-cmark = "0.13"
+mermaid-rs-renderer = { version = "0.2.2", default-features = false }
+mathjax-svg-rs = "0.4.0"
 
 [workspace.lints.clippy]
 # Inherited by gpui-component crates

--- a/crates/con-agent/src/provider.rs
+++ b/crates/con-agent/src/provider.rs
@@ -530,15 +530,14 @@ where
         }
         ProviderKind::GitHubCopilot => {
             let prompt_handler = prompt_handler.clone();
-            let mut builder =
-                copilot::Client::builder()
-                    .oauth()
-                    .on_device_code(move |prompt| {
-                        prompt_handler(OAuthDevicePrompt {
-                            verification_uri: prompt.verification_uri,
-                            user_code: prompt.user_code,
-                        });
+            let mut builder = copilot::Client::builder()
+                .oauth()
+                .on_device_code(move |prompt| {
+                    prompt_handler(OAuthDevicePrompt {
+                        verification_uri: prompt.verification_uri,
+                        user_code: prompt.user_code,
                     });
+                });
             if let Some(dir) = oauth_token_dir(&kind) {
                 builder = builder.token_dir(dir);
             }
@@ -835,7 +834,9 @@ impl Default for SuggestionModelConfig {
 impl AgentConfig {
     pub fn provider_transport_for(&self, provider: &ProviderKind) -> Option<ProviderTransport> {
         match provider {
-            ProviderKind::MiniMax | ProviderKind::MiniMaxAnthropic => self.provider_protocols.minimax,
+            ProviderKind::MiniMax | ProviderKind::MiniMaxAnthropic => {
+                self.provider_protocols.minimax
+            }
             ProviderKind::Moonshot | ProviderKind::MoonshotAnthropic => {
                 self.provider_protocols.moonshot
             }
@@ -894,9 +895,13 @@ impl AgentConfig {
                 Some(ProviderTransport::Anthropic)
             } else if active_provider == &openai_kind {
                 Some(ProviderTransport::OpenAI)
-            } else if providers.get(&anthropic_kind).is_some() && providers.get(&openai_kind).is_none() {
+            } else if providers.get(&anthropic_kind).is_some()
+                && providers.get(&openai_kind).is_none()
+            {
                 Some(ProviderTransport::Anthropic)
-            } else if providers.get(&openai_kind).is_some() && providers.get(&anthropic_kind).is_none() {
+            } else if providers.get(&openai_kind).is_some()
+                && providers.get(&anthropic_kind).is_none()
+            {
                 Some(ProviderTransport::OpenAI)
             } else {
                 None

--- a/crates/con-app/Cargo.toml
+++ b/crates/con-app/Cargo.toml
@@ -56,9 +56,10 @@ rust-embed.workspace = true
 dirs.workspace = true
 chrono.workspace = true
 reqwest.workspace = true
-pulldown-cmark.workspace = true
 markdown = { version = "1.0.0", features = ["serde"] }
 ropey.workspace = true
+mermaid-rs-renderer.workspace = true
+mathjax-svg-rs.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "=0.26.0"

--- a/crates/con-app/src/agent_panel.rs
+++ b/crates/con-app/src/agent_panel.rs
@@ -656,9 +656,8 @@ impl AssistantMessageView {
                 || self.rendered_markdown_blocks == 0
                 || self.rendered_markdown_blocks > self.state_key.content_markdown_blocks
             {
-                self.rendered_markdown_blocks = Self::initial_markdown_block_limit(
-                    self.state_key.content_markdown_blocks,
-                );
+                self.rendered_markdown_blocks =
+                    Self::initial_markdown_block_limit(self.state_key.content_markdown_blocks);
                 self.markdown_hydration_pending = false;
                 self.markdown_block_views.clear();
                 self.markdown_block_view_len = self.state_key.content_markdown_len;
@@ -703,8 +702,7 @@ impl AssistantMessageView {
                     return;
                 }
                 view.rendered_markdown_blocks =
-                    (view.rendered_markdown_blocks + LONG_MARKDOWN_BATCH_BLOCKS)
-                        .min(total_blocks);
+                    (view.rendered_markdown_blocks + LONG_MARKDOWN_BATCH_BLOCKS).min(total_blocks);
                 if view.rendered_markdown_blocks < total_blocks {
                     view.schedule_markdown_hydration(cx);
                 }
@@ -854,13 +852,22 @@ impl AgentPanel {
 
         let has_meaningful_config = |kind: &ProviderKind| {
             config.providers.get(kind).is_some_and(|provider| {
-                provider.model.as_ref().is_some_and(|v| !v.trim().is_empty())
-                    || provider.api_key.as_ref().is_some_and(|v| !v.trim().is_empty())
+                provider
+                    .model
+                    .as_ref()
+                    .is_some_and(|v| !v.trim().is_empty())
+                    || provider
+                        .api_key
+                        .as_ref()
+                        .is_some_and(|v| !v.trim().is_empty())
                     || provider
                         .api_key_env
                         .as_ref()
                         .is_some_and(|v| !v.trim().is_empty())
-                    || provider.base_url.as_ref().is_some_and(|v| !v.trim().is_empty())
+                    || provider
+                        .base_url
+                        .as_ref()
+                        .is_some_and(|v| !v.trim().is_empty())
                     || provider.max_tokens.is_some()
             })
         };
@@ -1044,7 +1051,8 @@ impl AgentPanel {
 
     pub fn clear_messages(&mut self, cx: &mut Context<Self>) {
         self.state.clear();
-        self.message_list_state.splice(0..self.message_list_state.item_count(), 0);
+        self.message_list_state
+            .splice(0..self.message_list_state.item_count(), 0);
         self.assistant_message_views.clear();
         self.showing_history = false;
         cx.notify();
@@ -1246,13 +1254,9 @@ impl AgentPanel {
 
     pub fn set_skills(&mut self, skills: Vec<SkillEntry>, cx: &mut Context<Self>) {
         if self.skills.len() == skills.len()
-            && self
-                .skills
-                .iter()
-                .zip(skills.iter())
-                .all(|(left, right)| {
-                    left.name == right.name && left.description == right.description
-                })
+            && self.skills.iter().zip(skills.iter()).all(|(left, right)| {
+                left.name == right.name && left.description == right.description
+            })
         {
             return;
         }
@@ -1304,10 +1308,9 @@ impl AgentPanel {
             } else {
                 let query = &trimmed[1..].to_lowercase();
                 !query.contains(' ')
-                    && self
-                        .skills
-                        .iter()
-                        .any(|skill| query.is_empty() || skill.name.to_lowercase().starts_with(query))
+                    && self.skills.iter().any(|skill| {
+                        query.is_empty() || skill.name.to_lowercase().starts_with(query)
+                    })
             }
         };
 
@@ -1418,12 +1421,9 @@ impl AgentPanel {
     }
 
     pub fn inline_input_is_focused(&self, window: &Window, cx: &App) -> bool {
-        self.inline_input_state.as_ref().is_some_and(|input| {
-            input
-                .read(cx)
-                .focus_handle(cx)
-                .is_focused(window)
-        })
+        self.inline_input_state
+            .as_ref()
+            .is_some_and(|input| input.read(cx).focus_handle(cx).is_focused(window))
     }
 
     fn should_fallback_handle_inline_history_key(event: &KeystrokeEvent) -> bool {
@@ -1545,7 +1545,8 @@ impl AgentPanel {
 
     fn remeasure_message(&self, msg_idx: usize) {
         if msg_idx < self.message_list_state.item_count() {
-            self.message_list_state.remeasure_items(msg_idx..msg_idx + 1);
+            self.message_list_state
+                .remeasure_items(msg_idx..msg_idx + 1);
         }
     }
 
@@ -1717,10 +1718,9 @@ impl AgentPanel {
 
         cx.spawn(async move |this, cx| {
             let parsed = Arc::new(
-                cx
-                .background_executor()
-                .spawn(async move { ParsedChatMarkdown::parse(&parse_content) })
-                .await,
+                cx.background_executor()
+                    .spawn(async move { ParsedChatMarkdown::parse(&parse_content) })
+                    .await,
             );
             let _ = this.update(cx, |panel, cx| {
                 let mut needs_follow_up = false;
@@ -1763,7 +1763,8 @@ impl AgentPanel {
         }
 
         if self.assistant_message_views.len() <= msg_idx {
-            self.assistant_message_views.resize_with(msg_idx + 1, || None);
+            self.assistant_message_views
+                .resize_with(msg_idx + 1, || None);
         }
 
         let state_key = AssistantMessageStateKey {
@@ -1798,7 +1799,13 @@ impl AgentPanel {
             let snapshot = message.clone();
             let panel = cx.weak_entity();
             let view = cx.new(|_| {
-                AssistantMessageView::new(panel, msg_idx, snapshot, state_key, is_streaming_assistant)
+                AssistantMessageView::new(
+                    panel,
+                    msg_idx,
+                    snapshot,
+                    state_key,
+                    is_streaming_assistant,
+                )
             });
             self.assistant_message_views[msg_idx] = Some(view.clone());
             Some(view)
@@ -3134,11 +3141,7 @@ fn render_assistant_message(
                     theme,
                 ));
             } else {
-                thinking_el = thinking_el.child(
-                    div()
-                        .whitespace_normal()
-                        .child(thinking.clone()),
-                );
+                thinking_el = thinking_el.child(div().whitespace_normal().child(thinking.clone()));
             }
             msg_el = msg_el.child(thinking_el);
         }
@@ -3166,65 +3169,59 @@ fn render_assistant_message(
                 ));
             }
             if let Some(suffix) = unparsed_markdown_suffix(msg) {
-                content_el = content_el.child(
-                    div()
-                        .mt(px(6.0))
-                        .child(render_plain_multiline_text(
-                            suffix,
-                            theme.mono_font_family.clone(),
-                            px(14.0),
-                            px(23.0),
-                            theme.foreground.opacity(0.78),
-                        )),
-                );
+                content_el =
+                    content_el.child(div().mt(px(6.0)).child(render_plain_multiline_text(
+                        suffix,
+                        theme.mono_font_family.clone(),
+                        px(14.0),
+                        px(23.0),
+                        theme.foreground.opacity(0.78),
+                    )));
             }
             if visible_blocks < markdown.block_count() {
                 let remaining = markdown.block_count().saturating_sub(visible_blocks);
                 let more_view = view.clone();
                 content_el = content_el.child(
-                    div()
-                        .mt(px(8.0))
-                        .child(
-                            div()
-                                .id(SharedString::from(format!("assistant-more-{msg_idx}")))
-                                .flex()
-                                .items_center()
-                                .gap(px(6.0))
-                                .px(px(8.0))
-                                .py(px(4.0))
-                                .rounded(px(7.0))
-                                .cursor_pointer()
-                                .bg(theme.muted.opacity(0.05))
-                                .hover(|s| s.bg(theme.muted.opacity(0.09)))
-                                .on_mouse_down(MouseButton::Left, move |_, _, cx| {
-                                    let _ = more_view.update(cx, |view, cx| {
-                                        view.rendered_markdown_blocks =
-                                            (view.rendered_markdown_blocks
-                                                + LONG_MARKDOWN_BATCH_BLOCKS * 2)
-                                                .min(view.state_key.content_markdown_blocks);
-                                        let msg_idx = view.msg_idx;
-                                        let panel = view.panel.clone();
-                                        let _ = panel.update(cx, |panel, cx| {
-                                            panel.remeasure_message(msg_idx);
-                                            cx.notify();
-                                        });
+                    div().mt(px(8.0)).child(
+                        div()
+                            .id(SharedString::from(format!("assistant-more-{msg_idx}")))
+                            .flex()
+                            .items_center()
+                            .gap(px(6.0))
+                            .px(px(8.0))
+                            .py(px(4.0))
+                            .rounded(px(7.0))
+                            .cursor_pointer()
+                            .bg(theme.muted.opacity(0.05))
+                            .hover(|s| s.bg(theme.muted.opacity(0.09)))
+                            .on_mouse_down(MouseButton::Left, move |_, _, cx| {
+                                let _ = more_view.update(cx, |view, cx| {
+                                    view.rendered_markdown_blocks = (view.rendered_markdown_blocks
+                                        + LONG_MARKDOWN_BATCH_BLOCKS * 2)
+                                        .min(view.state_key.content_markdown_blocks);
+                                    let msg_idx = view.msg_idx;
+                                    let panel = view.panel.clone();
+                                    let _ = panel.update(cx, |panel, cx| {
+                                        panel.remeasure_message(msg_idx);
                                         cx.notify();
                                     });
-                                })
-                                .child(
-                                    svg()
-                                        .path("phosphor/caret-down.svg")
-                                        .size(px(10.0))
-                                        .text_color(theme.muted_foreground.opacity(0.55)),
-                                )
-                                .child(
-                                    div()
-                                        .text_size(px(10.5))
-                                        .font_family(theme.mono_font_family.clone())
-                                        .text_color(theme.muted_foreground.opacity(0.58))
-                                        .child(format!("Show more · {remaining} blocks left")),
-                                ),
-                        ),
+                                    cx.notify();
+                                });
+                            })
+                            .child(
+                                svg()
+                                    .path("phosphor/caret-down.svg")
+                                    .size(px(10.0))
+                                    .text_color(theme.muted_foreground.opacity(0.55)),
+                            )
+                            .child(
+                                div()
+                                    .text_size(px(10.5))
+                                    .font_family(theme.mono_font_family.clone())
+                                    .text_color(theme.muted_foreground.opacity(0.58))
+                                    .child(format!("Show more · {remaining} blocks left")),
+                            ),
+                    ),
                 );
             }
         } else {
@@ -3487,7 +3484,9 @@ fn render_assistant_message(
                     let step_panel = panel.clone();
                     step_shell = step_shell.child(
                         step_header_shell
-                            .id(SharedString::from(format!("step-detail-{msg_idx}-{step_idx}")))
+                            .id(SharedString::from(format!(
+                                "step-detail-{msg_idx}-{step_idx}"
+                            )))
                             .cursor_pointer()
                             .hover(|s| s.bg(trace_step_header_hover_surface(theme)))
                             .on_mouse_down(MouseButton::Left, move |_, _, cx| {
@@ -3528,9 +3527,7 @@ fn render_assistant_message(
                         ));
                     step_shell = step_shell.child(
                         detail_block.with_animation(
-                            SharedString::from(format!(
-                                "step-detail-reveal-{msg_idx}-{step_idx}"
-                            )),
+                            SharedString::from(format!("step-detail-reveal-{msg_idx}-{step_idx}")),
                             Animation::new(std::time::Duration::from_millis(170))
                                 .with_easing(ease_out_quint()),
                             |this, delta| this.opacity(delta).pt(px((1.0 - delta) * 6.0)),
@@ -3551,12 +3548,11 @@ fn render_assistant_message(
                                         "step-detail-expand-{msg_idx}-{step_idx}"
                                     )))
                                     .cursor_pointer()
-                                    .hover(|s| {
-                                        s.bg(theme.muted.opacity(0.03)).rounded(px(6.0))
-                                    })
+                                    .hover(|s| s.bg(theme.muted.opacity(0.03)).rounded(px(6.0)))
                                     .on_mouse_down(MouseButton::Left, move |_, _, cx| {
                                         let _ = detail_toggle_panel.update(cx, |this, cx| {
-                                            if let Some(message) = this.state.messages.get_mut(msg_idx)
+                                            if let Some(message) =
+                                                this.state.messages.get_mut(msg_idx)
                                                 && let Some(step) = message.steps.get_mut(step_idx)
                                             {
                                                 step.detail_expanded = !step.detail_expanded;
@@ -3566,15 +3562,9 @@ fn render_assistant_message(
                                             cx.notify();
                                         });
                                     })
-                                    .child(
-                                        div().px(px(2.0)).py(px(2.0)).child(
-                                            render_result_toggle_chrome(
-                                                expanded,
-                                                button_label,
-                                                theme,
-                                            ),
-                                        ),
-                                    ),
+                                    .child(div().px(px(2.0)).py(px(2.0)).child(
+                                        render_result_toggle_chrome(expanded, button_label, theme),
+                                    )),
                             );
                         step_shell = step_shell.child(
                             detail_toggle.with_animation(
@@ -3583,9 +3573,7 @@ fn render_assistant_message(
                                 )),
                                 Animation::new(std::time::Duration::from_millis(185))
                                     .with_easing(ease_out_quint()),
-                                |this, delta| {
-                                    this.opacity(delta).pt(px((1.0 - delta) * 4.0))
-                                },
+                                |this, delta| this.opacity(delta).pt(px((1.0 - delta) * 4.0)),
                             ),
                         );
                     } else {
@@ -3601,14 +3589,11 @@ fn render_assistant_message(
                 steps_el = steps_el.child(step_shell);
             }
 
-            run_card = run_card.child(
-                steps_el.with_animation(
-                    SharedString::from(format!("steps-reveal-{msg_idx}")),
-                    Animation::new(std::time::Duration::from_millis(190))
-                        .with_easing(ease_out_quint()),
-                    |this, delta| this.opacity(delta).pt(px((1.0 - delta) * 8.0)),
-                ),
-            );
+            run_card = run_card.child(steps_el.with_animation(
+                SharedString::from(format!("steps-reveal-{msg_idx}")),
+                Animation::new(std::time::Duration::from_millis(190)).with_easing(ease_out_quint()),
+                |this, delta| this.opacity(delta).pt(px((1.0 - delta) * 8.0)),
+            ));
         }
 
         msg_el = msg_el.child(run_card);
@@ -3713,7 +3698,7 @@ impl AgentPanel {
                                         Input::new(edit_input)
                                             .appearance(false)
                                             .cleanable(false)
-                                            .font_family(theme.mono_font_family.clone())
+                                            .font_family(theme.mono_font_family.clone()),
                                     ),
                             )
                             .child(
@@ -3863,7 +3848,8 @@ impl AgentPanel {
                 );
             }
         } else {
-            let is_streaming_assistant = self.state.streaming && msg_idx + 1 == self.state.messages.len();
+            let is_streaming_assistant =
+                self.state.streaming && msg_idx + 1 == self.state.messages.len();
             if !msg.content.is_empty()
                 && !msg.content_markdown_pending
                 && msg.content_markdown_len < msg.content.len()
@@ -3871,7 +3857,9 @@ impl AgentPanel {
                 self.ensure_content_markdown_async(msg_idx, cx);
             }
 
-            if let Some(view) = self.sync_assistant_message_view(msg_idx, is_streaming_assistant, cx) {
+            if let Some(view) =
+                self.sync_assistant_message_view(msg_idx, is_streaming_assistant, cx)
+            {
                 msg_el = msg_el.child(view);
             }
         }
@@ -4748,23 +4736,18 @@ impl Render for AgentPanel {
                     .vertical_scrollbar(&self.history_scroll_handle),
             );
         } else {
-            let show_jump_to_latest =
-                self.follow_output == FollowOutputState::Detached && !self.is_scrolled_near_bottom();
+            let show_jump_to_latest = self.follow_output == FollowOutputState::Detached
+                && !self.is_scrolled_near_bottom();
             let transcript_surface = div()
                 .relative()
                 .flex_1()
                 .min_h_0()
                 .child(
-                    div()
-                        .size_full()
-                        .min_h_0()
-                        .pl(px(14.0))
-                        .pr(px(34.0))
-                        .child(
-                            messages_content
-                                .opacity(content_reveal)
-                                .pt(vertical_reveal_offset(content_reveal, 10.0)),
-                        ),
+                    div().size_full().min_h_0().pl(px(14.0)).pr(px(34.0)).child(
+                        messages_content
+                            .opacity(content_reveal)
+                            .pt(vertical_reveal_offset(content_reveal, 10.0)),
+                    ),
                 )
                 .vertical_scrollbar(&self.message_list_state);
 
@@ -4832,12 +4815,7 @@ impl Render for AgentPanel {
                                         cx.notify();
                                     }),
                                 )
-                                .child(
-                                    div()
-                                        .w(px(10.0))
-                                        .h(px(10.0))
-                                        .flex_shrink_0(),
-                                )
+                                .child(div().w(px(10.0)).h(px(10.0)).flex_shrink_0())
                                 .child(
                                     div()
                                         .text_size(px(10.5))
@@ -4972,10 +4950,7 @@ impl Render for AgentPanel {
                                 MouseButton::Left,
                                 cx.listener(|this, _, window, cx| {
                                     if let Some(ref input) = this.inline_input_state {
-                                        input
-                                            .read(cx)
-                                            .focus_handle(cx)
-                                            .focus(window, cx);
+                                        input.read(cx).focus_handle(cx).focus(window, cx);
                                     }
                                 }),
                             )
@@ -4987,12 +4962,14 @@ impl Render for AgentPanel {
                                     .min_w(px(120.0))
                                     .font_family(theme.mono_font_family.clone())
                                     .text_size(px(13.0))
-                                    .child(div().w_full().child(
-                                        Input::new(&inline_input)
-                                            .appearance(false)
-                                            .cleanable(false)
-                                            .font_family(theme.mono_font_family.clone())
-                                    )),
+                                    .child(
+                                        div().w_full().child(
+                                            Input::new(&inline_input)
+                                                .appearance(false)
+                                                .cleanable(false)
+                                                .font_family(theme.mono_font_family.clone()),
+                                        ),
+                                    ),
                             )
                             .child(send_button),
                     ),

--- a/crates/con-app/src/agent_panel.rs
+++ b/crates/con-app/src/agent_panel.rs
@@ -1152,7 +1152,7 @@ impl AgentPanel {
         cx.observe_keystrokes(|this, event, window, cx| {
             if !Self::should_fallback_handle_inline_history_key(event)
                 || !this.show_inline_input
-                || !this.is_inline_input_focused(window, cx)
+                || !this.inline_input_is_focused(window, cx)
             {
                 return;
             }
@@ -1417,7 +1417,7 @@ impl AgentPanel {
         true
     }
 
-    fn is_inline_input_focused(&self, window: &Window, cx: &App) -> bool {
+    pub fn inline_input_is_focused(&self, window: &Window, cx: &App) -> bool {
         self.inline_input_state.as_ref().is_some_and(|input| {
             input
                 .read(cx)

--- a/crates/con-app/src/chat_markdown.rs
+++ b/crates/con-app/src/chat_markdown.rs
@@ -594,13 +594,13 @@ impl ChatMarkdownBlockView {
 
     fn render_rich_svg_block(
         &mut self,
-        index: usize,
+        path: &[usize],
         block: &MarkdownBlock,
         style: &ChatMarkdownStyle<'_>,
         cx: &mut gpui::Context<Self>,
     ) -> Option<AnyElement> {
         let key = rich_svg_key_for_block(block, style)?;
-        let render_id = rich_svg_render_id(index, &key);
+        let render_id = rich_svg_render_id(path, &key);
         let (pending, image) = self.ensure_rich_svg_render(key, cx);
         match block {
             MarkdownBlock::Mermaid { code, scale } => Some(render_mermaid_block(
@@ -630,15 +630,33 @@ impl ChatMarkdownBlockView {
         table_scroll_handle: Option<&ScrollHandle>,
         cx: &mut gpui::Context<Self>,
     ) -> AnyElement {
+        let mut path = vec![index];
+        self.render_block_at_path(block, &mut path, style, table_scroll_handle, cx)
+    }
+
+    fn render_block_at_path(
+        &mut self,
+        block: &MarkdownBlock,
+        path: &mut Vec<usize>,
+        style: &ChatMarkdownStyle<'_>,
+        table_scroll_handle: Option<&ScrollHandle>,
+        cx: &mut gpui::Context<Self>,
+    ) -> AnyElement {
+        let index = path.last().copied().unwrap_or(0);
         match block {
             MarkdownBlock::Mermaid { .. } | MarkdownBlock::MathBlock { .. } => self
-                .render_rich_svg_block(index, block, style, cx)
+                .render_rich_svg_block(path, block, style, cx)
                 .unwrap_or_else(|| render_block(block, index, style, table_scroll_handle)),
             MarkdownBlock::BlockQuote(blocks) => {
                 let children = blocks
                     .iter()
                     .enumerate()
-                    .map(|(idx, block)| self.render_block(block, idx, style, None, cx))
+                    .map(|(idx, block)| {
+                        path.push(idx);
+                        let rendered = self.render_block_at_path(block, path, style, None, cx);
+                        path.pop();
+                        rendered
+                    })
                     .collect::<Vec<_>>();
 
                 render_blockquote_children(children, style)
@@ -650,12 +668,19 @@ impl ChatMarkdownBlockView {
             } => {
                 let item_children = items
                     .iter()
-                    .map(|item_blocks| {
+                    .enumerate()
+                    .map(|(item_idx, item_blocks)| {
                         item_blocks
                             .iter()
                             .enumerate()
                             .map(|(nested_idx, nested_block)| {
-                                self.render_block(nested_block, nested_idx, style, None, cx)
+                                path.push(item_idx);
+                                path.push(nested_idx);
+                                let rendered =
+                                    self.render_block_at_path(nested_block, path, style, None, cx);
+                                path.pop();
+                                path.pop();
+                                rendered
                             })
                             .collect::<Vec<_>>()
                     })
@@ -1757,7 +1782,7 @@ fn mermaid_source_for_theme(source: &str, theme_mode: RichSvgThemeMode) -> Cow<'
                 "#F8FAFC"
             };
             let out = rewritten.get_or_insert_with(|| source[..cursor].to_string());
-            let line_without_newline = line.trim_end_matches('\n');
+            let line_without_newline = line.trim_end_matches(|ch| ch == '\r' || ch == '\n');
             out.push_str(line_without_newline);
             out.push_str(",color:");
             out.push_str(text_color);
@@ -1876,14 +1901,19 @@ fn rich_svg_key_for_block(
     }
 }
 
-fn rich_svg_render_id(index: usize, key: &RichSvgRenderKey) -> SharedString {
+fn rich_svg_render_id(path: &[usize], key: &RichSvgRenderKey) -> SharedString {
     let mut hasher = DefaultHasher::new();
     key.hash(&mut hasher);
     let kind = match key.kind {
         RichSvgRenderKind::Mermaid => "mermaid",
         RichSvgRenderKind::Math => "math",
     };
-    SharedString::from(format!("chat-md-{kind}-{index}-{:x}", hasher.finish()))
+    let path = path
+        .iter()
+        .map(usize::to_string)
+        .collect::<Vec<_>>()
+        .join(".");
+    SharedString::from(format!("chat-md-{kind}-{path}-{:x}", hasher.finish()))
 }
 
 fn rich_svg_render_scale(key: &RichSvgRenderKey) -> f32 {
@@ -2472,6 +2502,14 @@ mod tests {
             RichSvgThemeMode::Dark,
         );
         assert!(styled_dark_source.contains("color:#0F172A"));
+        let crlf_styled_dark_source = mermaid_source_for_theme(
+            "flowchart TD\r\n  A{ i < n? }\r\n  style A fill:#e1f5fe,stroke:#03a9f4\r\n",
+            RichSvgThemeMode::Dark,
+        );
+        assert!(
+            crlf_styled_dark_source.contains("style A fill:#e1f5fe,stroke:#03a9f4,color:#0F172A\n")
+        );
+        assert!(!crlf_styled_dark_source.contains("\r,color:"));
 
         let dark_mermaid = mermaid_rs_renderer::render_with_options(
             styled_dark_source.as_ref(),
@@ -2495,6 +2533,20 @@ mod tests {
         let dark_math = math_svg_for_theme(math, RichSvgThemeMode::Dark);
         assert!(dark_math.contains("color=\"#F8FAFC\""));
         assert!(dark_math.contains("fill=\"#F8FAFC\""));
+    }
+
+    #[test]
+    fn rich_svg_render_ids_include_nested_block_path() {
+        let key = RichSvgRenderKey {
+            kind: RichSvgRenderKind::Mermaid,
+            source: "flowchart TD\n  A-->B".into(),
+            metric: 100,
+            theme_mode: RichSvgThemeMode::Light,
+        };
+
+        let first = rich_svg_render_id(&[0, 0, 0], &key);
+        let second = rich_svg_render_id(&[1, 0, 0], &key);
+        assert_ne!(first, second);
     }
 
     #[test]

--- a/crates/con-app/src/chat_markdown.rs
+++ b/crates/con-app/src/chat_markdown.rs
@@ -985,7 +985,6 @@ fn looks_like_inline_math(value: &str) -> bool {
                 | '<'
                 | '>'
                 | '+'
-                | '-'
                 | '*'
                 | '/'
                 | '|'
@@ -996,6 +995,12 @@ fn looks_like_inline_math(value: &str) -> bool {
                 | '{'
                 | '}'
         )
+    }) {
+        return true;
+    }
+
+    if value.as_bytes().windows(3).any(|window| {
+        window[1] == b'-' && window[0].is_ascii_whitespace() && window[2].is_ascii_whitespace()
     }) {
         return true;
     }
@@ -2406,6 +2411,41 @@ mod tests {
         assert!(inlines.iter().any(|inline| {
             matches!(inline, MarkdownInline::Text(text) if text.contains("$5 and $6"))
         }));
+    }
+
+    #[test]
+    fn hyphenated_dollar_text_does_not_become_inline_math() {
+        for source in [
+            "This is $end-to-end$ tested.",
+            "The $X-ray$ scan passed.",
+            "Costs are $3-5$ today.",
+        ] {
+            let blocks = parse_markdown(source);
+            let MarkdownBlock::Paragraph { inlines, .. } = &blocks[0] else {
+                panic!("expected paragraph");
+            };
+
+            assert!(
+                !inlines
+                    .iter()
+                    .any(|inline| matches!(inline, MarkdownInline::Math(_))),
+                "{source}"
+            );
+        }
+    }
+
+    #[test]
+    fn spaced_minus_inline_math_is_supported() {
+        let blocks = parse_markdown("Use $x - y$ for the delta.");
+        let MarkdownBlock::Paragraph { inlines, .. } = &blocks[0] else {
+            panic!("expected paragraph");
+        };
+
+        assert!(
+            inlines
+                .iter()
+                .any(|inline| matches!(inline, MarkdownInline::Math(math) if math == "x - y"))
+        );
     }
 
     #[test]

--- a/crates/con-app/src/chat_markdown.rs
+++ b/crates/con-app/src/chat_markdown.rs
@@ -1,4 +1,6 @@
 use std::cell::RefCell;
+use std::collections::{HashMap, hash_map::DefaultHasher};
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use gpui::{
@@ -38,11 +40,11 @@ enum MarkdownBlock {
         highlight_cache: RefCell<Option<CachedCodeHighlightRuns>>,
     },
     Mermaid {
-        code: String,
+        code: SharedString,
         scale: u32,
     },
     MathBlock {
-        math: String,
+        math: SharedString,
         inline_cache: RefCell<Option<CachedInlineRender>>,
     },
     BlockQuote(Vec<MarkdownBlock>),
@@ -226,17 +228,23 @@ struct CachedInlineRender {
     runs: Vec<TextRun>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum RichSvgRenderKind {
     Mermaid,
     Math,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct RichSvgRenderKey {
     kind: RichSvgRenderKind,
     source: SharedString,
     metric: u32,
+}
+
+struct RichSvgRenderEntry {
+    image: Option<Result<Arc<RenderImage>, SharedString>>,
+    pending: bool,
+    task: Option<Task<()>>,
 }
 
 struct ChatMarkdownStyle<'a> {
@@ -455,10 +463,7 @@ pub struct ChatMarkdownBlockView {
     block_index: usize,
     tone: ChatMarkdownTone,
     table_scroll_handle: ScrollHandle,
-    rich_svg_key: Option<RichSvgRenderKey>,
-    rich_svg_image: Option<Result<Arc<RenderImage>, SharedString>>,
-    rich_svg_pending: bool,
-    rich_svg_task: Option<Task<()>>,
+    rich_svg_renders: HashMap<RichSvgRenderKey, RichSvgRenderEntry>,
 }
 
 impl ChatMarkdownBlockView {
@@ -472,10 +477,7 @@ impl ChatMarkdownBlockView {
             block_index,
             tone,
             table_scroll_handle: ScrollHandle::new(),
-            rich_svg_key: None,
-            rich_svg_image: None,
-            rich_svg_pending: false,
-            rich_svg_task: None,
+            rich_svg_renders: HashMap::new(),
         }
     }
 
@@ -494,43 +496,26 @@ impl ChatMarkdownBlockView {
             self.block_index = block_index;
             self.tone = tone;
             self.table_scroll_handle = ScrollHandle::new();
-            self.rich_svg_key = None;
-            self.rich_svg_image = None;
-            self.rich_svg_pending = false;
-            self.rich_svg_task = None;
+            self.rich_svg_renders.clear();
             cx.notify();
         }
     }
 
     fn ensure_rich_svg_render(
         &mut self,
-        kind: RichSvgRenderKind,
-        source: &str,
-        metric: u32,
+        key: RichSvgRenderKey,
         cx: &mut gpui::Context<Self>,
-    ) {
-        let key = RichSvgRenderKey {
-            kind,
-            source: SharedString::from(source.to_string()),
-            metric,
-        };
-
-        if self.rich_svg_key.as_ref() != Some(&key) {
-            self.rich_svg_key = Some(key.clone());
-            self.rich_svg_image = None;
-            self.rich_svg_pending = false;
-            self.rich_svg_task = None;
+    ) -> (bool, Option<Result<Arc<RenderImage>, SharedString>>) {
+        if let Some(entry) = self.rich_svg_renders.get(&key) {
+            if entry.image.is_some() || entry.pending {
+                return (entry.pending, entry.image.clone());
+            }
         }
 
-        if self.rich_svg_image.is_some() || self.rich_svg_pending {
-            return;
-        }
-
-        self.rich_svg_pending = true;
         let render_key = key.clone();
         let background_key = key.clone();
         let svg_renderer = cx.svg_renderer();
-        self.rich_svg_task = Some(cx.spawn(async move |this, cx| {
+        let task = cx.spawn(async move |this, cx| {
             let result: Result<Arc<RenderImage>, SharedString> = cx
                 .background_spawn(async move {
                     let result: anyhow::Result<Arc<RenderImage>> = (|| {
@@ -560,14 +545,190 @@ impl ChatMarkdownBlockView {
                 .map_err(|error| SharedString::from(error.to_string()));
 
             this.update(cx, |view, cx| {
-                if view.rich_svg_key.as_ref() == Some(&render_key) {
-                    view.rich_svg_image = Some(result);
-                    view.rich_svg_pending = false;
+                if let Some(entry) = view.rich_svg_renders.get_mut(&render_key) {
+                    entry.image = Some(result);
+                    entry.pending = false;
+                    entry.task = None;
                     cx.notify();
                 }
             })
             .ok();
-        }));
+        });
+
+        self.rich_svg_renders.insert(
+            key,
+            RichSvgRenderEntry {
+                image: None,
+                pending: true,
+                task: Some(task),
+            },
+        );
+
+        (true, None)
+    }
+
+    fn render_rich_svg_block(
+        &mut self,
+        index: usize,
+        block: &MarkdownBlock,
+        style: &ChatMarkdownStyle<'_>,
+        cx: &mut gpui::Context<Self>,
+    ) -> Option<AnyElement> {
+        let key = rich_svg_key_for_block(block, style)?;
+        let render_id = rich_svg_render_id(index, &key);
+        let (pending, image) = self.ensure_rich_svg_render(key, cx);
+        match block {
+            MarkdownBlock::Mermaid { code, scale } => Some(render_mermaid_block(
+                render_id,
+                code.as_ref(),
+                *scale,
+                pending,
+                image.as_ref(),
+                style,
+            )),
+            MarkdownBlock::MathBlock { math, .. } => Some(render_math_svg_block(
+                render_id,
+                math.as_ref(),
+                pending,
+                image.as_ref(),
+                style,
+            )),
+            _ => None,
+        }
+    }
+
+    fn render_block(
+        &mut self,
+        block: &MarkdownBlock,
+        index: usize,
+        style: &ChatMarkdownStyle<'_>,
+        table_scroll_handle: Option<&ScrollHandle>,
+        cx: &mut gpui::Context<Self>,
+    ) -> AnyElement {
+        match block {
+            MarkdownBlock::Mermaid { .. } | MarkdownBlock::MathBlock { .. } => self
+                .render_rich_svg_block(index, block, style, cx)
+                .unwrap_or_else(|| render_block(block, index, style, table_scroll_handle)),
+            MarkdownBlock::BlockQuote(blocks) => {
+                let children = blocks
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, block)| self.render_block(block, idx, style, None, cx))
+                    .collect::<Vec<_>>();
+
+                div()
+                    .w_full()
+                    .px(px(10.0))
+                    .py(px(10.0))
+                    .rounded(px(8.0))
+                    .bg(style.quote_background)
+                    .child(
+                        div()
+                            .flex()
+                            .items_start()
+                            .gap(px(9.0))
+                            .child(
+                                div()
+                                    .w(px(3.0))
+                                    .h_full()
+                                    .min_h(px(18.0))
+                                    .bg(style.quote_tint),
+                            )
+                            .child(div().flex().flex_col().gap(style.inner_gap).children(children)),
+                    )
+                    .into_any_element()
+            }
+            MarkdownBlock::List {
+                ordered,
+                start,
+                items,
+            } => {
+                let marker_lane_width = if *ordered {
+                    ordered_list_marker_lane_width(start + items.len().saturating_sub(1))
+                } else {
+                    px(14.0)
+                };
+                let children = items
+                    .iter()
+                    .enumerate()
+                    .map(|(item_idx, item_blocks)| {
+                        let marker = if *ordered {
+                            format!("{}.", start + item_idx)
+                        } else {
+                            "\u{2022}".to_string()
+                        };
+                        let nested_children = item_blocks
+                            .iter()
+                            .enumerate()
+                            .map(|(nested_idx, nested_block)| {
+                                self.render_block(nested_block, nested_idx, style, None, cx)
+                            })
+                            .collect::<Vec<_>>();
+
+                        div()
+                            .w_full()
+                            .flex()
+                            .items_start()
+                            .gap(px(9.0))
+                            .child(
+                                div()
+                                    .flex_none()
+                                    .pt(px(1.0))
+                                    .w(marker_lane_width)
+                                    .text_right()
+                                    .font_family(style.theme.mono_font_family.clone())
+                                    .text_size(style.base_font_size)
+                                    .line_height(style.base_line_height)
+                                    .text_color(style.muted_text_color)
+                                    .child(marker),
+                            )
+                            .child(
+                                div()
+                                    .w_full()
+                                    .min_w_0()
+                                    .flex()
+                                    .flex_col()
+                                    .gap(px(7.0))
+                                    .flex_1()
+                                    .children(nested_children),
+                            )
+                            .into_any_element()
+                    })
+                    .collect::<Vec<_>>();
+
+                div()
+                    .w_full()
+                    .flex()
+                    .flex_col()
+                    .gap(px(7.0))
+                    .children(children)
+                    .into_any_element()
+            }
+            _ => render_block(block, index, style, table_scroll_handle),
+        }
+    }
+
+    fn render_block_with_width(
+        &mut self,
+        block: &MarkdownBlock,
+        index: usize,
+        style: &ChatMarkdownStyle<'_>,
+        table_scroll_handle: Option<&ScrollHandle>,
+        cx: &mut gpui::Context<Self>,
+    ) -> AnyElement {
+        let mut wrapper = div().w_full();
+        if !matches!(
+            block,
+            MarkdownBlock::CodeBlock { .. }
+                | MarkdownBlock::Mermaid { .. }
+                | MarkdownBlock::Table { .. }
+        ) {
+            wrapper = wrapper.max_w(style.content_width);
+        }
+
+        wrapper
+            .child(self.render_block(block, index, style, table_scroll_handle, cx))
+            .into_any_element()
     }
 }
 
@@ -575,52 +736,20 @@ impl Render for ChatMarkdownBlockView {
     fn render(&mut self, _window: &mut Window, cx: &mut gpui::Context<Self>) -> impl IntoElement {
         let theme = cx.theme().clone();
         let style = ChatMarkdownStyle::new(&theme, self.tone);
-        let rich_svg_block = self
-            .document
-            .blocks
-            .get(self.block_index)
-            .and_then(|block| {
-                if let MarkdownBlock::Mermaid { code, scale } = block {
-                    Some((RichSvgRenderKind::Mermaid, code.clone(), *scale))
-                } else if let MarkdownBlock::MathBlock { math, .. } = block {
-                    Some((
-                        RichSvgRenderKind::Math,
-                        math.clone(),
-                        math_font_size_metric(&style),
-                    ))
-                } else {
-                    None
-                }
-            });
-
-        if let Some((kind, source, metric)) = rich_svg_block {
-            self.ensure_rich_svg_render(kind, &source, metric, cx);
-            return match kind {
-                RichSvgRenderKind::Mermaid => render_mermaid_block(
-                    self.block_index,
-                    &source,
-                    metric,
-                    self.rich_svg_pending,
-                    self.rich_svg_image.as_ref(),
-                    &style,
-                ),
-                RichSvgRenderKind::Math => render_math_svg_block(
-                    self.block_index,
-                    &source,
-                    self.rich_svg_pending,
-                    self.rich_svg_image.as_ref(),
-                    &style,
-                ),
-            };
-        }
-
-        self.document
+        let document = self.document.clone();
+        document
             .blocks
             .get(self.block_index)
             .map(|block| {
                 let table_scroll_handle = matches!(block, MarkdownBlock::Table { .. })
-                    .then_some(&self.table_scroll_handle);
-                render_block_with_width(block, self.block_index, &style, table_scroll_handle)
+                    .then_some(self.table_scroll_handle.clone());
+                self.render_block_with_width(
+                    block,
+                    self.block_index,
+                    &style,
+                    table_scroll_handle.as_ref(),
+                    cx,
+                )
             })
             .unwrap_or_else(|| div().into_any_element())
     }
@@ -657,7 +786,7 @@ fn parse_block_node(node: &mdast::Node) -> Option<MarkdownBlock> {
         }),
         mdast::Node::Code(raw) => parse_mermaid_scale(raw.lang.as_deref(), raw.meta.as_deref())
             .map(|scale| MarkdownBlock::Mermaid {
-                code: raw.value.clone(),
+                code: SharedString::from(raw.value.clone()),
                 scale,
             })
             .or_else(|| {
@@ -733,7 +862,7 @@ fn parse_block_node(node: &mdast::Node) -> Option<MarkdownBlock> {
             highlight_cache: RefCell::new(None),
         }),
         mdast::Node::Math(val) => Some(MarkdownBlock::MathBlock {
-            math: val.value.clone(),
+            math: SharedString::from(val.value.clone()),
             inline_cache: RefCell::new(None),
         }),
         mdast::Node::FootnoteDefinition(def) => Some(MarkdownBlock::Paragraph {
@@ -1303,17 +1432,17 @@ fn render_code_block(
 }
 
 fn render_mermaid_block(
-    index: usize,
+    id: SharedString,
     code: &str,
     scale: u32,
     pending: bool,
     image: Option<&Result<Arc<RenderImage>, SharedString>>,
     style: &ChatMarkdownStyle<'_>,
 ) -> AnyElement {
-    let header = render_mermaid_header(index, code, scale, style);
+    let header = render_mermaid_header(id.clone(), code, scale, style);
     let body = match image {
         Some(Ok(image)) => div()
-            .id(("chat-md-mermaid-scroll", index))
+            .id(id)
             .w_full()
             .overflow_x_scroll()
             .child(
@@ -1382,7 +1511,7 @@ fn render_mermaid_block(
 }
 
 fn render_math_svg_block(
-    index: usize,
+    id: SharedString,
     math: &str,
     pending: bool,
     image: Option<&Result<Arc<RenderImage>, SharedString>>,
@@ -1390,7 +1519,7 @@ fn render_math_svg_block(
 ) -> AnyElement {
     let body = match image {
         Some(Ok(image)) => div()
-            .id(("chat-md-math-scroll", index))
+            .id(id)
             .w_full()
             .overflow_x_scroll()
             .child(
@@ -1465,7 +1594,12 @@ fn render_mermaid_code_fallback(
         .rounded(px(13.0))
         .bg(style.code_block_background.opacity(0.98))
         .p(px(1.0))
-        .child(render_mermaid_header(index, code, scale, style))
+        .child(render_mermaid_header(
+            SharedString::from(format!("chat-md-mermaid-fallback-{index}")),
+            code,
+            scale,
+            style,
+        ))
         .child(
             div()
                 .mx(px(10.0))
@@ -1479,7 +1613,7 @@ fn render_mermaid_code_fallback(
 }
 
 fn render_mermaid_header(
-    index: usize,
+    id: SharedString,
     code: &str,
     scale: u32,
     style: &ChatMarkdownStyle<'_>,
@@ -1514,7 +1648,7 @@ fn render_mermaid_header(
                 )
                 .child(div().h(px(1.0)).flex_1().bg(style.rule_color.opacity(0.36)))
                 .child(
-                    Clipboard::new(format!("copy-mermaid-block-{index}"))
+                    Clipboard::new(format!("{}-copy", id.as_ref()))
                         .value(SharedString::from(code.to_string())),
                 ),
         )
@@ -1574,6 +1708,35 @@ fn render_math_source_text(math: &str, style: &ChatMarkdownStyle<'_>) -> AnyElem
 fn math_font_size_metric(style: &ChatMarkdownStyle<'_>) -> u32 {
     let font_size: f32 = (style.code_font_size + px(3.0)).into();
     (font_size * 1000.0).round().max(1.0) as u32
+}
+
+fn rich_svg_key_for_block(
+    block: &MarkdownBlock,
+    style: &ChatMarkdownStyle<'_>,
+) -> Option<RichSvgRenderKey> {
+    match block {
+        MarkdownBlock::Mermaid { code, scale } => Some(RichSvgRenderKey {
+            kind: RichSvgRenderKind::Mermaid,
+            source: code.clone(),
+            metric: *scale,
+        }),
+        MarkdownBlock::MathBlock { math, .. } => Some(RichSvgRenderKey {
+            kind: RichSvgRenderKind::Math,
+            source: math.clone(),
+            metric: math_font_size_metric(style),
+        }),
+        _ => None,
+    }
+}
+
+fn rich_svg_render_id(index: usize, key: &RichSvgRenderKey) -> SharedString {
+    let mut hasher = DefaultHasher::new();
+    key.hash(&mut hasher);
+    let kind = match key.kind {
+        RichSvgRenderKind::Mermaid => "mermaid",
+        RichSvgRenderKind::Math => "math",
+    };
+    SharedString::from(format!("chat-md-{kind}-{index}-{:x}", hasher.finish()))
 }
 
 fn rich_svg_render_scale(key: &RichSvgRenderKey) -> f32 {
@@ -2062,6 +2225,28 @@ mod tests {
         assert!(matches!(
             blocks.get(1),
             Some(MarkdownBlock::MathBlock { math, .. }) if math.contains("e^{i\\pi}")
+        ));
+    }
+
+    #[test]
+    fn parses_nested_mermaid_and_math_blocks() {
+        let blocks = parse_markdown(
+            "> ```mermaid\n> flowchart TD\n>   A-->B\n> ```\n\n- $$\n  x^2\n  $$",
+        );
+        let Some(MarkdownBlock::BlockQuote(quote_blocks)) = blocks.first() else {
+            panic!("expected blockquote");
+        };
+        assert!(matches!(
+            quote_blocks.first(),
+            Some(MarkdownBlock::Mermaid { code, .. }) if code.contains("A-->B")
+        ));
+
+        let Some(MarkdownBlock::List { items, .. }) = blocks.get(1) else {
+            panic!("expected list");
+        };
+        assert!(matches!(
+            items.first().and_then(|item| item.first()),
+            Some(MarkdownBlock::MathBlock { math, .. }) if math.contains("x^2")
         ));
     }
 

--- a/crates/con-app/src/chat_markdown.rs
+++ b/crates/con-app/src/chat_markdown.rs
@@ -1030,6 +1030,10 @@ fn looks_like_inline_math(value: &str) -> bool {
         return true;
     }
 
+    if value.chars().all(|ch| ch.is_alphanumeric() || ch == '-') && value.contains('-') {
+        return false;
+    }
+
     let words = value
         .split_whitespace()
         .map(|word| word.trim_matches(|ch: char| !ch.is_alphanumeric()))
@@ -1043,7 +1047,7 @@ fn looks_like_inline_math(value: &str) -> bool {
         return false;
     }
 
-    value.chars().count() <= 3 && value.chars().any(char::is_alphabetic)
+    words.len() == 1 && value.chars().any(char::is_alphabetic)
 }
 
 fn render_block(
@@ -2489,6 +2493,25 @@ mod tests {
             inlines
                 .iter()
                 .any(|inline| matches!(inline, MarkdownInline::Math(math) if math == "x"))
+        );
+    }
+
+    #[test]
+    fn identifier_inline_math_is_supported() {
+        let blocks = parse_markdown("Use $theta$ and $velocity$ in the formula.");
+        let MarkdownBlock::Paragraph { inlines, .. } = &blocks[0] else {
+            panic!("expected paragraph");
+        };
+
+        assert!(
+            inlines
+                .iter()
+                .any(|inline| matches!(inline, MarkdownInline::Math(math) if math == "theta"))
+        );
+        assert!(
+            inlines
+                .iter()
+                .any(|inline| matches!(inline, MarkdownInline::Math(math) if math == "velocity"))
         );
     }
 

--- a/crates/con-app/src/chat_markdown.rs
+++ b/crates/con-app/src/chat_markdown.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::{HashMap, hash_map::DefaultHasher};
 use std::hash::{Hash, Hasher};
@@ -526,10 +527,16 @@ impl ChatMarkdownBlockView {
                 .background_spawn(async move {
                     let result: anyhow::Result<Arc<RenderImage>> = (|| {
                         let svg = match background_key.kind {
-                            RichSvgRenderKind::Mermaid => mermaid_rs_renderer::render_with_options(
-                                background_key.source.as_ref(),
-                                mermaid_render_options(background_key.theme_mode),
-                            )?,
+                            RichSvgRenderKind::Mermaid => {
+                                let source = mermaid_source_for_theme(
+                                    background_key.source.as_ref(),
+                                    background_key.theme_mode,
+                                );
+                                mermaid_rs_renderer::render_with_options(
+                                    source.as_ref(),
+                                    mermaid_render_options(background_key.theme_mode),
+                                )?
+                            }
                             RichSvgRenderKind::Math => {
                                 let options = mathjax_svg_rs::Options {
                                     font_size: background_key.metric as f64 / 1000.0,
@@ -1690,6 +1697,97 @@ fn mermaid_render_options(theme_mode: RichSvgThemeMode) -> mermaid_rs_renderer::
     options
 }
 
+fn mermaid_source_for_theme(source: &str, theme_mode: RichSvgThemeMode) -> Cow<'_, str> {
+    if !matches!(theme_mode, RichSvgThemeMode::Dark) {
+        return Cow::Borrowed(source);
+    }
+
+    let mut rewritten = None::<String>;
+    let mut cursor = 0;
+    for line in source.split_inclusive('\n') {
+        let trimmed = line.trim_start();
+        let should_rewrite = (trimmed.starts_with("style ") || trimmed.starts_with("classDef "))
+            && mermaid_style_has_key(trimmed, "fill")
+            && !mermaid_style_has_key(trimmed, "color");
+        if should_rewrite
+            && let Some(fill) = mermaid_style_value(trimmed, "fill")
+        {
+            let text_color = if mermaid_fill_is_light(fill) {
+                "#0F172A"
+            } else {
+                "#F8FAFC"
+            };
+            let out = rewritten.get_or_insert_with(|| source[..cursor].to_string());
+            let line_without_newline = line.trim_end_matches('\n');
+            out.push_str(line_without_newline);
+            out.push_str(",color:");
+            out.push_str(text_color);
+            if line.ends_with('\n') {
+                out.push('\n');
+            }
+        } else if let Some(out) = rewritten.as_mut() {
+            out.push_str(line);
+        }
+        cursor += line.len();
+    }
+
+    if cursor < source.len() {
+        if let Some(out) = rewritten.as_mut() {
+            out.push_str(&source[cursor..]);
+        }
+    }
+
+    rewritten.map_or(Cow::Borrowed(source), Cow::Owned)
+}
+
+fn mermaid_style_has_key(line: &str, key: &str) -> bool {
+    mermaid_style_value(line, key).is_some()
+}
+
+fn mermaid_style_value<'a>(line: &'a str, key: &str) -> Option<&'a str> {
+    let styles = if let Some(rest) = line.strip_prefix("style ") {
+        rest.trim_start().split_once(char::is_whitespace)?.1
+    } else if let Some(rest) = line.strip_prefix("classDef ") {
+        rest.trim_start().split_once(char::is_whitespace)?.1
+    } else {
+        return None;
+    };
+
+    styles.trim_start().split(',').find_map(|part| {
+        let (part_key, value) = part.split_once(':')?;
+        (part_key.trim() == key).then(|| value.trim())
+    })
+}
+
+fn mermaid_fill_is_light(fill: &str) -> bool {
+    let Some((r, g, b)) = mermaid_hex_color(fill) else {
+        return false;
+    };
+    let luminance = 0.2126 * f32::from(r) + 0.7152 * f32::from(g) + 0.0722 * f32::from(b);
+    luminance >= 150.0
+}
+
+fn mermaid_hex_color(fill: &str) -> Option<(u8, u8, u8)> {
+    let fill = fill.trim();
+    let hex = fill.strip_prefix('#')?;
+    match hex.len() {
+        3 => {
+            let mut chars = hex.chars();
+            let r = chars.next()?.to_digit(16)? as u8;
+            let g = chars.next()?.to_digit(16)? as u8;
+            let b = chars.next()?.to_digit(16)? as u8;
+            Some((r * 17, g * 17, b * 17))
+        }
+        6 => {
+            let r = u8::from_str_radix(&hex[0..2], 16).ok()?;
+            let g = u8::from_str_radix(&hex[2..4], 16).ok()?;
+            let b = u8::from_str_radix(&hex[4..6], 16).ok()?;
+            Some((r, g, b))
+        }
+        _ => None,
+    }
+}
+
 fn mermaid_dark_theme() -> mermaid_rs_renderer::Theme {
     let mut theme = mermaid_rs_renderer::Theme::modern();
     theme.primary_color = "#1E293B".to_string();
@@ -2295,13 +2393,20 @@ mod tests {
         let mermaid = mermaid_rs_renderer::render("flowchart TD\n  A-->B").unwrap();
         assert!(mermaid.contains("<svg"));
 
+        let styled_dark_source = mermaid_source_for_theme(
+            "flowchart TD\n  A{ i < n? }\n  style A fill:#e1f5fe,stroke:#03a9f4\n",
+            RichSvgThemeMode::Dark,
+        );
+        assert!(styled_dark_source.contains("color:#0F172A"));
+
         let dark_mermaid = mermaid_rs_renderer::render_with_options(
-            "flowchart TD\n  A-->B",
+            styled_dark_source.as_ref(),
             mermaid_render_options(RichSvgThemeMode::Dark),
         )
         .unwrap();
         assert!(dark_mermaid.contains("<svg"));
         assert!(dark_mermaid.contains("#0B1120") || dark_mermaid.contains("#0b1120"));
+        assert!(dark_mermaid.contains("#0F172A") || dark_mermaid.contains("#0f172a"));
 
         let math = mathjax_svg_rs::render_tex(
             r"e^{i\pi}+1=0",

--- a/crates/con-app/src/chat_markdown.rs
+++ b/crates/con-app/src/chat_markdown.rs
@@ -549,12 +549,11 @@ impl ChatMarkdownBlockView {
                                     font_size: background_key.metric as f64 / 1000.0,
                                     horizontal_align: mathjax_svg_rs::HorizontalAlign::Center,
                                 };
-                                let svg =
-                                    mathjax_svg_rs::render_tex(
-                                        background_key.source.as_ref(),
-                                        &options,
-                                    )
-                                    .map_err(anyhow::Error::msg)?;
+                                let svg = mathjax_svg_rs::render_tex(
+                                    background_key.source.as_ref(),
+                                    &options,
+                                )
+                                .map_err(anyhow::Error::msg)?;
                                 math_svg_for_theme(svg, background_key.theme_mode)
                             }
                         };
@@ -1746,9 +1745,7 @@ fn mermaid_source_for_theme(source: &str, theme_mode: RichSvgThemeMode) -> Cow<'
         let should_rewrite = (trimmed.starts_with("style ") || trimmed.starts_with("classDef "))
             && mermaid_style_has_key(trimmed, "fill")
             && !mermaid_style_has_key(trimmed, "color");
-        if should_rewrite
-            && let Some(fill) = mermaid_style_value(trimmed, "fill")
-        {
+        if should_rewrite && let Some(fill) = mermaid_style_value(trimmed, "fill") {
             let text_color = if mermaid_fill_is_light(fill) {
                 "#0F172A"
             } else {

--- a/crates/con-app/src/chat_markdown.rs
+++ b/crates/con-app/src/chat_markdown.rs
@@ -2,9 +2,10 @@ use std::cell::RefCell;
 use std::sync::Arc;
 
 use gpui::{
-    AbsoluteLength, AnyElement, DefiniteLength, FontStyle, FontWeight, Hsla, InteractiveElement,
-    IntoElement, ParentElement, Render, ScrollHandle, SharedString, StatefulInteractiveElement,
-    Styled, StyledText, TextStyle, TextRun, UnderlineStyle, WhiteSpace, Window, div, px,
+    AbsoluteLength, AnyElement, AppContext, DefiniteLength, FontStyle, FontWeight, Hsla,
+    ImageSource, InteractiveElement, IntoElement, ParentElement, Render, RenderImage, ScrollHandle,
+    SharedString, StatefulInteractiveElement, Styled, StyledText, Task, TextRun, TextStyle,
+    UnderlineStyle, WhiteSpace, Window, div, img, px,
 };
 use gpui_component::ActiveTheme as _;
 use gpui_component::clipboard::Clipboard;
@@ -35,6 +36,14 @@ enum MarkdownBlock {
         language: Option<String>,
         code: String,
         highlight_cache: RefCell<Option<CachedCodeHighlightRuns>>,
+    },
+    Mermaid {
+        code: String,
+        scale: u32,
+    },
+    MathBlock {
+        math: String,
+        inline_cache: RefCell<Option<CachedInlineRender>>,
     },
     BlockQuote(Vec<MarkdownBlock>),
     List {
@@ -78,6 +87,19 @@ impl PartialEq for MarkdownBlock {
                     ..
                 },
             ) => language_a == language_b && code_a == code_b,
+            (
+                Self::Mermaid {
+                    code: code_a,
+                    scale: scale_a,
+                },
+                Self::Mermaid {
+                    code: code_b,
+                    scale: scale_b,
+                },
+            ) => code_a == code_b && scale_a == scale_b,
+            (Self::MathBlock { math: math_a, .. }, Self::MathBlock { math: math_b, .. }) => {
+                math_a == math_b
+            }
             (Self::BlockQuote(a), Self::BlockQuote(b)) => a == b,
             (
                 Self::List {
@@ -123,6 +145,7 @@ enum MarkdownTableAlign {
 enum MarkdownInline {
     Text(String),
     Code(String),
+    Math(String),
     Emphasis(Vec<MarkdownInline>),
     Strong(Vec<MarkdownInline>),
     Strikethrough(Vec<MarkdownInline>),
@@ -191,6 +214,8 @@ struct InlineRenderCacheKey {
     strikethrough: bool,
     inline_code_background: Hsla,
     inline_code_text_color: Hsla,
+    inline_math_background: Hsla,
+    math_text_color: Hsla,
     link_color: Hsla,
 }
 
@@ -199,6 +224,19 @@ struct CachedInlineRender {
     key: InlineRenderCacheKey,
     text: SharedString,
     runs: Vec<TextRun>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RichSvgRenderKind {
+    Mermaid,
+    Math,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RichSvgRenderKey {
+    kind: RichSvgRenderKind,
+    source: SharedString,
+    metric: u32,
 }
 
 struct ChatMarkdownStyle<'a> {
@@ -213,6 +251,10 @@ struct ChatMarkdownStyle<'a> {
     muted_text_color: Hsla,
     inline_code_background: Hsla,
     inline_code_text_color: Hsla,
+    inline_math_background: Hsla,
+    math_text_color: Hsla,
+    math_block_background: Hsla,
+    math_block_text_color: Hsla,
     code_block_background: Hsla,
     code_block_body_background: Hsla,
     code_block_language_background: Hsla,
@@ -245,6 +287,10 @@ impl<'a> ChatMarkdownStyle<'a> {
                     .mix_oklab(theme.background, 0.26)
                     .opacity(0.96),
                 inline_code_text_color: theme.foreground.opacity(0.96),
+                inline_math_background: theme.primary.opacity(0.08),
+                math_text_color: theme.primary.mix_oklab(theme.foreground, 0.58),
+                math_block_background: theme.secondary.mix_oklab(theme.background, 0.62),
+                math_block_text_color: theme.foreground.opacity(0.92),
                 code_block_background: theme.secondary.mix_oklab(theme.background, 0.56),
                 code_block_body_background: theme.background.mix_oklab(theme.secondary, 0.90),
                 code_block_language_background: theme
@@ -276,6 +322,10 @@ impl<'a> ChatMarkdownStyle<'a> {
                     .mix_oklab(theme.background, 0.20)
                     .opacity(0.90),
                 inline_code_text_color: theme.foreground.opacity(0.84),
+                inline_math_background: theme.primary.opacity(0.06),
+                math_text_color: theme.primary.mix_oklab(theme.muted_foreground, 0.62),
+                math_block_background: theme.secondary.mix_oklab(theme.background, 0.52),
+                math_block_text_color: theme.foreground.opacity(0.78),
                 code_block_background: theme.secondary.mix_oklab(theme.background, 0.48),
                 code_block_body_background: theme.background.mix_oklab(theme.secondary, 0.84),
                 code_block_language_background: theme
@@ -405,6 +455,10 @@ pub struct ChatMarkdownBlockView {
     block_index: usize,
     tone: ChatMarkdownTone,
     table_scroll_handle: ScrollHandle,
+    rich_svg_key: Option<RichSvgRenderKey>,
+    rich_svg_image: Option<Result<Arc<RenderImage>, SharedString>>,
+    rich_svg_pending: bool,
+    rich_svg_task: Option<Task<()>>,
 }
 
 impl ChatMarkdownBlockView {
@@ -418,6 +472,10 @@ impl ChatMarkdownBlockView {
             block_index,
             tone,
             table_scroll_handle: ScrollHandle::new(),
+            rich_svg_key: None,
+            rich_svg_image: None,
+            rich_svg_pending: false,
+            rich_svg_task: None,
         }
     }
 
@@ -436,8 +494,80 @@ impl ChatMarkdownBlockView {
             self.block_index = block_index;
             self.tone = tone;
             self.table_scroll_handle = ScrollHandle::new();
+            self.rich_svg_key = None;
+            self.rich_svg_image = None;
+            self.rich_svg_pending = false;
+            self.rich_svg_task = None;
             cx.notify();
         }
+    }
+
+    fn ensure_rich_svg_render(
+        &mut self,
+        kind: RichSvgRenderKind,
+        source: &str,
+        metric: u32,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        let key = RichSvgRenderKey {
+            kind,
+            source: SharedString::from(source.to_string()),
+            metric,
+        };
+
+        if self.rich_svg_key.as_ref() != Some(&key) {
+            self.rich_svg_key = Some(key.clone());
+            self.rich_svg_image = None;
+            self.rich_svg_pending = false;
+            self.rich_svg_task = None;
+        }
+
+        if self.rich_svg_image.is_some() || self.rich_svg_pending {
+            return;
+        }
+
+        self.rich_svg_pending = true;
+        let render_key = key.clone();
+        let background_key = key.clone();
+        let svg_renderer = cx.svg_renderer();
+        self.rich_svg_task = Some(cx.spawn(async move |this, cx| {
+            let result: Result<Arc<RenderImage>, SharedString> = cx
+                .background_spawn(async move {
+                    let result: anyhow::Result<Arc<RenderImage>> = (|| {
+                        let svg = match background_key.kind {
+                            RichSvgRenderKind::Mermaid => {
+                                mermaid_rs_renderer::render(background_key.source.as_ref())?
+                            }
+                            RichSvgRenderKind::Math => {
+                                let options = mathjax_svg_rs::Options {
+                                    font_size: background_key.metric as f64 / 1000.0,
+                                    horizontal_align: mathjax_svg_rs::HorizontalAlign::Center,
+                                };
+                                mathjax_svg_rs::render_tex(background_key.source.as_ref(), &options)
+                                    .map_err(anyhow::Error::msg)?
+                            }
+                        };
+                        svg_renderer
+                            .render_single_frame(
+                                svg.as_bytes(),
+                                rich_svg_render_scale(&background_key),
+                            )
+                            .map_err(|error| anyhow::anyhow!("{error}"))
+                    })();
+                    result
+                })
+                .await
+                .map_err(|error| SharedString::from(error.to_string()));
+
+            this.update(cx, |view, cx| {
+                if view.rich_svg_key.as_ref() == Some(&render_key) {
+                    view.rich_svg_image = Some(result);
+                    view.rich_svg_pending = false;
+                    cx.notify();
+                }
+            })
+            .ok();
+        }));
     }
 }
 
@@ -445,6 +575,45 @@ impl Render for ChatMarkdownBlockView {
     fn render(&mut self, _window: &mut Window, cx: &mut gpui::Context<Self>) -> impl IntoElement {
         let theme = cx.theme().clone();
         let style = ChatMarkdownStyle::new(&theme, self.tone);
+        let rich_svg_block = self
+            .document
+            .blocks
+            .get(self.block_index)
+            .and_then(|block| {
+                if let MarkdownBlock::Mermaid { code, scale } = block {
+                    Some((RichSvgRenderKind::Mermaid, code.clone(), *scale))
+                } else if let MarkdownBlock::MathBlock { math, .. } = block {
+                    Some((
+                        RichSvgRenderKind::Math,
+                        math.clone(),
+                        math_font_size_metric(&style),
+                    ))
+                } else {
+                    None
+                }
+            });
+
+        if let Some((kind, source, metric)) = rich_svg_block {
+            self.ensure_rich_svg_render(kind, &source, metric, cx);
+            return match kind {
+                RichSvgRenderKind::Mermaid => render_mermaid_block(
+                    self.block_index,
+                    &source,
+                    metric,
+                    self.rich_svg_pending,
+                    self.rich_svg_image.as_ref(),
+                    &style,
+                ),
+                RichSvgRenderKind::Math => render_math_svg_block(
+                    self.block_index,
+                    &source,
+                    self.rich_svg_pending,
+                    self.rich_svg_image.as_ref(),
+                    &style,
+                ),
+            };
+        }
+
         self.document
             .blocks
             .get(self.block_index)
@@ -458,7 +627,7 @@ impl Render for ChatMarkdownBlockView {
 }
 
 fn parse_markdown(source: &str) -> Vec<MarkdownBlock> {
-    match markdown::to_mdast(source, &ParseOptions::gfm()) {
+    match markdown::to_mdast(source, &chat_parse_options()) {
         Ok(mdast::Node::Root(root)) => root.children.iter().filter_map(parse_block_node).collect(),
         Ok(node) => parse_block_node(&node).into_iter().collect(),
         Err(_) => vec![MarkdownBlock::Paragraph {
@@ -468,24 +637,36 @@ fn parse_markdown(source: &str) -> Vec<MarkdownBlock> {
     }
 }
 
+fn chat_parse_options() -> ParseOptions {
+    let mut options = ParseOptions::gfm();
+    options.constructs.math_flow = true;
+    options.constructs.math_text = true;
+    options
+}
+
 fn parse_block_node(node: &mdast::Node) -> Option<MarkdownBlock> {
     match node {
-        mdast::Node::Paragraph(val) => {
-            Some(MarkdownBlock::Paragraph {
-                inlines: parse_inline_nodes(&val.children),
-                inline_cache: RefCell::new(None),
-            })
-        }
+        mdast::Node::Paragraph(val) => Some(MarkdownBlock::Paragraph {
+            inlines: parse_inline_nodes(&val.children),
+            inline_cache: RefCell::new(None),
+        }),
         mdast::Node::Heading(val) => Some(MarkdownBlock::Heading {
             level: val.depth,
             inlines: parse_inline_nodes(&val.children),
             inline_cache: RefCell::new(None),
         }),
-        mdast::Node::Code(raw) => Some(MarkdownBlock::CodeBlock {
-            language: raw.lang.clone().filter(|lang| !lang.trim().is_empty()),
-            code: raw.value.clone(),
-            highlight_cache: RefCell::new(None),
-        }),
+        mdast::Node::Code(raw) => parse_mermaid_scale(raw.lang.as_deref(), raw.meta.as_deref())
+            .map(|scale| MarkdownBlock::Mermaid {
+                code: raw.value.clone(),
+                scale,
+            })
+            .or_else(|| {
+                Some(MarkdownBlock::CodeBlock {
+                    language: raw.lang.clone().filter(|lang| !lang.trim().is_empty()),
+                    code: raw.value.clone(),
+                    highlight_cache: RefCell::new(None),
+                })
+            }),
         mdast::Node::Blockquote(val) => Some(MarkdownBlock::BlockQuote(
             val.children.iter().filter_map(parse_block_node).collect(),
         )),
@@ -517,12 +698,10 @@ fn parse_block_node(node: &mdast::Node) -> Option<MarkdownBlock> {
                         row.children
                             .iter()
                             .filter_map(|cell| match cell {
-                                mdast::Node::TableCell(cell) => {
-                                    Some(MarkdownTableCell {
-                                        inlines: parse_inline_nodes(&cell.children),
-                                        inline_cache: RefCell::new(None),
-                                    })
-                                }
+                                mdast::Node::TableCell(cell) => Some(MarkdownTableCell {
+                                    inlines: parse_inline_nodes(&cell.children),
+                                    inline_cache: RefCell::new(None),
+                                }),
                                 _ => None,
                             })
                             .collect::<Vec<_>>(),
@@ -553,10 +732,9 @@ fn parse_block_node(node: &mdast::Node) -> Option<MarkdownBlock> {
             code: val.value.clone(),
             highlight_cache: RefCell::new(None),
         }),
-        mdast::Node::Math(val) => Some(MarkdownBlock::CodeBlock {
-            language: None,
-            code: val.value.clone(),
-            highlight_cache: RefCell::new(None),
+        mdast::Node::Math(val) => Some(MarkdownBlock::MathBlock {
+            math: val.value.clone(),
+            inline_cache: RefCell::new(None),
         }),
         mdast::Node::FootnoteDefinition(def) => Some(MarkdownBlock::Paragraph {
             inlines: std::iter::once(MarkdownInline::Text(format!("[{}]: ", def.identifier)))
@@ -577,13 +755,33 @@ fn parse_table_align(align: &markdown::mdast::AlignKind) -> MarkdownTableAlign {
     }
 }
 
+fn parse_mermaid_scale(lang: Option<&str>, meta: Option<&str>) -> Option<u32> {
+    let lang = lang?.trim();
+    if !lang.eq_ignore_ascii_case("mermaid") {
+        return None;
+    }
+
+    Some(
+        meta.and_then(|meta| meta.split_whitespace().next())
+            .and_then(|scale| scale.parse::<u32>().ok())
+            .unwrap_or(100)
+            .clamp(10, 500),
+    )
+}
+
 fn parse_inline_nodes(nodes: &[mdast::Node]) -> Vec<MarkdownInline> {
     let mut inlines = Vec::new();
     for node in nodes {
         match node {
             mdast::Node::Text(val) => push_text_fragments(&mut inlines, &val.value),
             mdast::Node::InlineCode(val) => inlines.push(MarkdownInline::Code(val.value.clone())),
-            mdast::Node::InlineMath(val) => inlines.push(MarkdownInline::Code(val.value.clone())),
+            mdast::Node::InlineMath(val) => {
+                if looks_like_inline_math(&val.value) {
+                    inlines.push(MarkdownInline::Math(val.value.clone()));
+                } else {
+                    push_text_fragments(&mut inlines, &format!("${}$", val.value));
+                }
+            }
             mdast::Node::Emphasis(val) => {
                 inlines.push(MarkdownInline::Emphasis(parse_inline_nodes(&val.children)))
             }
@@ -685,6 +883,52 @@ fn coalesce_inlines(inlines: Vec<MarkdownInline>) -> Vec<MarkdownInline> {
     output
 }
 
+fn looks_like_inline_math(value: &str) -> bool {
+    let value = value.trim();
+    if value.is_empty() {
+        return false;
+    }
+
+    if value.chars().any(|ch| {
+        matches!(
+            ch,
+            '\\' | '^'
+                | '_'
+                | '='
+                | '<'
+                | '>'
+                | '+'
+                | '-'
+                | '*'
+                | '/'
+                | '|'
+                | '('
+                | ')'
+                | '['
+                | ']'
+                | '{'
+                | '}'
+        )
+    }) {
+        return true;
+    }
+
+    let words = value
+        .split_whitespace()
+        .map(|word| word.trim_matches(|ch: char| !ch.is_alphanumeric()))
+        .collect::<Vec<_>>();
+    if words.iter().any(|word| {
+        matches!(
+            word.to_ascii_lowercase().as_str(),
+            "and" | "or" | "the" | "for"
+        )
+    }) {
+        return false;
+    }
+
+    value.chars().count() <= 3 && value.chars().any(char::is_alphabetic)
+}
+
 fn render_block(
     block: &MarkdownBlock,
     index: usize,
@@ -723,6 +967,12 @@ fn render_block(
             code,
             highlight_cache,
         } => render_code_block(index, language, code, highlight_cache, style),
+        MarkdownBlock::Mermaid { code, scale } => {
+            render_mermaid_code_fallback(index, code, *scale, style)
+        }
+        MarkdownBlock::MathBlock { math, inline_cache } => {
+            render_math_block(math, inline_cache, style)
+        }
         MarkdownBlock::BlockQuote(blocks) => div()
             .w_full()
             .px(px(10.0))
@@ -826,7 +1076,12 @@ fn render_block_with_width(
     table_scroll_handle: Option<&ScrollHandle>,
 ) -> AnyElement {
     let mut wrapper = div().w_full();
-    if !matches!(block, MarkdownBlock::CodeBlock { .. } | MarkdownBlock::Table { .. }) {
+    if !matches!(
+        block,
+        MarkdownBlock::CodeBlock { .. }
+            | MarkdownBlock::Mermaid { .. }
+            | MarkdownBlock::Table { .. }
+    ) {
         wrapper = wrapper.max_w(style.content_width);
     }
 
@@ -879,15 +1134,11 @@ fn render_table_block(
         }
 
         let is_header = row_idx == 0;
-        let mut row_el = div()
-            .flex()
-            .items_stretch()
-            .w_full()
-            .bg(if is_header {
-                style.table_border.opacity(0.18)
-            } else {
-                style.table_cell_background
-            });
+        let mut row_el = div().flex().items_stretch().w_full().bg(if is_header {
+            style.table_border.opacity(0.18)
+        } else {
+            style.table_cell_background
+        });
 
         for (col_idx, width) in column_widths.iter().enumerate() {
             if col_idx > 0 {
@@ -895,7 +1146,9 @@ fn render_table_block(
                     div()
                         .w(px(1.0))
                         .flex_none()
-                        .bg(style.table_border.opacity(if is_header { 0.52 } else { 0.34 })),
+                        .bg(style
+                            .table_border
+                            .opacity(if is_header { 0.52 } else { 0.34 })),
                 );
             }
 
@@ -928,7 +1181,11 @@ fn render_table_block(
                 .min_h(px(if is_header { 46.0 } else { 42.0 }))
                 .child(content);
 
-            match aligns.get(col_idx).copied().unwrap_or(MarkdownTableAlign::Left) {
+            match aligns
+                .get(col_idx)
+                .copied()
+                .unwrap_or(MarkdownTableAlign::Left)
+            {
                 MarkdownTableAlign::Right => {
                     cell_el = cell_el.text_right();
                 }
@@ -947,17 +1204,17 @@ fn render_table_block(
     let mut table_frame = div()
         .relative()
         .w_full()
-        .pb(px(if table_scroll_handle.is_some() { 8.0 } else { 0.0 }))
+        .pb(px(if table_scroll_handle.is_some() {
+            8.0
+        } else {
+            0.0
+        }))
         .child(table_scroll.child(table_body));
     if let Some(handle) = table_scroll_handle {
         table_frame = table_frame.horizontal_scrollbar(handle);
     }
 
-    let container = div()
-        .w_full()
-        .flex()
-        .flex_col()
-        .child(table_frame);
+    let container = div().w_full().flex().flex_col().child(table_frame);
 
     container.into_any_element()
 }
@@ -1021,7 +1278,8 @@ fn render_code_block(
                 ),
         );
 
-    let (code_text, code_runs) = cached_highlighted_code_runs(code, language, highlight_cache, style);
+    let (code_text, code_runs) =
+        cached_highlighted_code_runs(code, language, highlight_cache, style);
     let code_column = div()
         .w_full()
         .font_family(style.theme.mono_font_family.clone())
@@ -1042,6 +1300,287 @@ fn render_code_block(
             ),
         )
         .into_any_element()
+}
+
+fn render_mermaid_block(
+    index: usize,
+    code: &str,
+    scale: u32,
+    pending: bool,
+    image: Option<&Result<Arc<RenderImage>, SharedString>>,
+    style: &ChatMarkdownStyle<'_>,
+) -> AnyElement {
+    let header = render_mermaid_header(index, code, scale, style);
+    let body = match image {
+        Some(Ok(image)) => div()
+            .id(("chat-md-mermaid-scroll", index))
+            .w_full()
+            .overflow_x_scroll()
+            .child(
+                div()
+                    .min_w(px(240.0))
+                    .p(px(14.0))
+                    .child(img(ImageSource::Render(image.clone())).flex_none()),
+            )
+            .into_any_element(),
+        Some(Err(error)) => div()
+            .w_full()
+            .flex()
+            .flex_col()
+            .gap(px(8.0))
+            .p(px(14.0))
+            .child(
+                div()
+                    .font_family(style.theme.font_family.clone())
+                    .text_size(px(12.5))
+                    .line_height(px(18.0))
+                    .text_color(style.muted_text_color)
+                    .child(format!("Could not render Mermaid diagram: {error}")),
+            )
+            .child(render_mermaid_source_text(code, style))
+            .into_any_element(),
+        None => div()
+            .w_full()
+            .flex()
+            .flex_col()
+            .gap(px(8.0))
+            .p(px(14.0))
+            .child(
+                div()
+                    .font_family(style.theme.font_family.clone())
+                    .text_size(px(12.5))
+                    .line_height(px(18.0))
+                    .text_color(style.muted_text_color)
+                    .child(if pending {
+                        "Rendering Mermaid diagram..."
+                    } else {
+                        "Mermaid diagram"
+                    }),
+            )
+            .child(render_mermaid_source_text(code, style))
+            .into_any_element(),
+    };
+
+    div()
+        .w_full()
+        .flex()
+        .flex_col()
+        .overflow_hidden()
+        .rounded(px(13.0))
+        .bg(style.code_block_background.opacity(0.98))
+        .p(px(1.0))
+        .child(header)
+        .child(
+            div()
+                .mx(px(10.0))
+                .mb(px(10.0))
+                .rounded(px(10.0))
+                .bg(style.code_block_body_background.opacity(0.985))
+                .child(body),
+        )
+        .into_any_element()
+}
+
+fn render_math_svg_block(
+    index: usize,
+    math: &str,
+    pending: bool,
+    image: Option<&Result<Arc<RenderImage>, SharedString>>,
+    style: &ChatMarkdownStyle<'_>,
+) -> AnyElement {
+    let body = match image {
+        Some(Ok(image)) => div()
+            .id(("chat-md-math-scroll", index))
+            .w_full()
+            .overflow_x_scroll()
+            .child(
+                div()
+                    .min_w(px(180.0))
+                    .px(px(16.0))
+                    .py(px(14.0))
+                    .child(img(ImageSource::Render(image.clone())).flex_none()),
+            )
+            .into_any_element(),
+        Some(Err(error)) => div()
+            .w_full()
+            .flex()
+            .flex_col()
+            .gap(px(8.0))
+            .px(px(16.0))
+            .py(px(13.0))
+            .child(
+                div()
+                    .font_family(style.theme.font_family.clone())
+                    .text_size(px(12.5))
+                    .line_height(px(18.0))
+                    .text_color(style.muted_text_color)
+                    .child(format!("Could not render LaTeX: {error}")),
+            )
+            .child(render_math_source_text(math, style))
+            .into_any_element(),
+        None => div()
+            .w_full()
+            .flex()
+            .flex_col()
+            .gap(px(8.0))
+            .px(px(16.0))
+            .py(px(13.0))
+            .child(
+                div()
+                    .font_family(style.theme.font_family.clone())
+                    .text_size(px(12.5))
+                    .line_height(px(18.0))
+                    .text_color(style.muted_text_color)
+                    .child(if pending {
+                        "Rendering LaTeX..."
+                    } else {
+                        "LaTeX"
+                    }),
+            )
+            .child(render_math_source_text(math, style))
+            .into_any_element(),
+    };
+
+    div()
+        .w_full()
+        .max_w(style.content_width)
+        .overflow_hidden()
+        .rounded(px(12.0))
+        .bg(style.math_block_background.opacity(0.92))
+        .child(body)
+        .into_any_element()
+}
+
+fn render_mermaid_code_fallback(
+    index: usize,
+    code: &str,
+    scale: u32,
+    style: &ChatMarkdownStyle<'_>,
+) -> AnyElement {
+    div()
+        .w_full()
+        .flex()
+        .flex_col()
+        .overflow_hidden()
+        .rounded(px(13.0))
+        .bg(style.code_block_background.opacity(0.98))
+        .p(px(1.0))
+        .child(render_mermaid_header(index, code, scale, style))
+        .child(
+            div()
+                .mx(px(10.0))
+                .mb(px(10.0))
+                .rounded(px(10.0))
+                .bg(style.code_block_body_background.opacity(0.985))
+                .p(px(12.0))
+                .child(render_mermaid_source_text(code, style)),
+        )
+        .into_any_element()
+}
+
+fn render_mermaid_header(
+    index: usize,
+    code: &str,
+    scale: u32,
+    style: &ChatMarkdownStyle<'_>,
+) -> AnyElement {
+    let label = if scale == 100 {
+        "mermaid".to_string()
+    } else {
+        format!("mermaid {scale}%")
+    };
+
+    div()
+        .px(px(14.0))
+        .pt(px(10.0))
+        .pb(px(8.0))
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .gap(px(8.0))
+                .child(
+                    div()
+                        .px(px(8.0))
+                        .py(px(4.0))
+                        .rounded(px(8.0))
+                        .bg(style.code_block_language_background)
+                        .font_family(style.theme.mono_font_family.clone())
+                        .font_weight(FontWeight::MEDIUM)
+                        .text_size(px(10.5))
+                        .line_height(px(11.0))
+                        .text_color(style.code_block_language_text_color)
+                        .child(label),
+                )
+                .child(div().h(px(1.0)).flex_1().bg(style.rule_color.opacity(0.36)))
+                .child(
+                    Clipboard::new(format!("copy-mermaid-block-{index}"))
+                        .value(SharedString::from(code.to_string())),
+                ),
+        )
+        .into_any_element()
+}
+
+fn render_mermaid_source_text(code: &str, style: &ChatMarkdownStyle<'_>) -> AnyElement {
+    let text = code_display_text(code);
+    div()
+        .w_full()
+        .font_family(style.theme.mono_font_family.clone())
+        .text_size(style.code_font_size)
+        .line_height(style.code_line_height)
+        .text_color(style.text_color.opacity(0.82))
+        .child(StyledText::new(SharedString::from(text)))
+        .into_any_element()
+}
+
+fn render_math_block(
+    math: &str,
+    inline_cache: &RefCell<Option<CachedInlineRender>>,
+    style: &ChatMarkdownStyle<'_>,
+) -> AnyElement {
+    let inlines = [MarkdownInline::Math(math.to_string())];
+    let mut text_style = style.code_text_style();
+    text_style.color = style.math_block_text_color;
+    text_style.font_size = (style.code_font_size + px(1.0)).into();
+    text_style.line_height = (style.code_line_height + px(3.0)).into();
+
+    div()
+        .w_full()
+        .max_w(style.content_width)
+        .rounded(px(12.0))
+        .bg(style.math_block_background.opacity(0.92))
+        .px(px(16.0))
+        .py(px(13.0))
+        .child(render_inline_content(
+            &inlines,
+            &text_style,
+            style,
+            inline_cache,
+        ))
+        .into_any_element()
+}
+
+fn render_math_source_text(math: &str, style: &ChatMarkdownStyle<'_>) -> AnyElement {
+    div()
+        .w_full()
+        .font_family(style.theme.mono_font_family.clone())
+        .text_size(style.code_font_size + px(1.0))
+        .line_height(style.code_line_height + px(3.0))
+        .text_color(style.math_block_text_color)
+        .child(StyledText::new(SharedString::from(math.to_string())))
+        .into_any_element()
+}
+
+fn math_font_size_metric(style: &ChatMarkdownStyle<'_>) -> u32 {
+    let font_size: f32 = (style.code_font_size + px(3.0)).into();
+    (font_size * 1000.0).round().max(1.0) as u32
+}
+
+fn rich_svg_render_scale(key: &RichSvgRenderKey) -> f32 {
+    match key.kind {
+        RichSvgRenderKind::Mermaid => key.metric as f32 / 100.0,
+        RichSvgRenderKind::Math => 1.0,
+    }
 }
 
 fn cached_table_layout(
@@ -1112,7 +1651,9 @@ fn table_cell_measure_chars(inlines: &[MarkdownInline]) -> usize {
     inlines
         .iter()
         .map(|inline| match inline {
-            MarkdownInline::Text(text) | MarkdownInline::Code(text) => text
+            MarkdownInline::Text(text)
+            | MarkdownInline::Code(text)
+            | MarkdownInline::Math(text) => text
                 .split_whitespace()
                 .map(|word| word.chars().count())
                 .max()
@@ -1334,6 +1875,8 @@ fn cached_inline_runs(
         strikethrough: base_style.strikethrough.is_some(),
         inline_code_background: style.inline_code_background,
         inline_code_text_color: style.inline_code_text_color,
+        inline_math_background: style.inline_math_background,
+        math_text_color: style.math_text_color,
         link_color: style.link_color,
     };
 
@@ -1387,6 +1930,15 @@ fn append_inline_runs(
                 code_style.font_weight = FontWeight::MEDIUM;
                 code_style.color = style.inline_code_text_color;
                 push_run(text, runs, &code_style, value);
+            }
+            MarkdownInline::Math(value) => {
+                let mut math_style = current_style.clone();
+                math_style.font_family = style.theme.mono_font_family.clone();
+                math_style.background_color = Some(style.inline_math_background);
+                math_style.font_style = FontStyle::Italic;
+                math_style.font_weight = FontWeight::MEDIUM;
+                math_style.color = style.math_text_color;
+                push_run(text, runs, &math_style, value);
             }
             MarkdownInline::Emphasis(children) => {
                 let mut emphasis = current_style.clone();
@@ -1482,6 +2034,82 @@ mod tests {
         assert_eq!(aligns.len(), 2);
         assert_eq!(rows.len(), 2);
         assert!(matches!(aligns[1], MarkdownTableAlign::Right));
+    }
+
+    #[test]
+    fn parses_mermaid_fences_as_diagram_blocks() {
+        let blocks = parse_markdown("```mermaid 140\ngraph TD\n  A-->B\n```");
+        let Some(MarkdownBlock::Mermaid { code, scale }) = blocks.first() else {
+            panic!("expected mermaid block");
+        };
+
+        assert_eq!(*scale, 140);
+        assert!(code.contains("A-->B"));
+    }
+
+    #[test]
+    fn parses_markdown_math_as_first_class_content() {
+        let blocks = parse_markdown("Inline $a^2 + b^2 = c^2$ math.\n\n$$\ne^{i\\pi}+1=0\n$$");
+        let MarkdownBlock::Paragraph { inlines, .. } = &blocks[0] else {
+            panic!("expected paragraph");
+        };
+
+        assert!(
+            inlines
+                .iter()
+                .any(|inline| matches!(inline, MarkdownInline::Math(math) if math.contains("a^2")))
+        );
+        assert!(matches!(
+            blocks.get(1),
+            Some(MarkdownBlock::MathBlock { math, .. }) if math.contains("e^{i\\pi}")
+        ));
+    }
+
+    #[test]
+    fn dollar_amounts_do_not_become_inline_math() {
+        let blocks = parse_markdown("Costs are $5 and $6 today, but `$x$` stays code.");
+        let MarkdownBlock::Paragraph { inlines, .. } = &blocks[0] else {
+            panic!("expected paragraph");
+        };
+
+        assert!(
+            !inlines
+                .iter()
+                .any(|inline| matches!(inline, MarkdownInline::Math(_)))
+        );
+        assert!(inlines.iter().any(|inline| {
+            matches!(inline, MarkdownInline::Text(text) if text.contains("$5 and $6"))
+        }));
+    }
+
+    #[test]
+    fn single_letter_inline_math_is_supported() {
+        let blocks = parse_markdown("Let $x$ be the selected pane.");
+        let MarkdownBlock::Paragraph { inlines, .. } = &blocks[0] else {
+            panic!("expected paragraph");
+        };
+
+        assert!(
+            inlines
+                .iter()
+                .any(|inline| matches!(inline, MarkdownInline::Math(math) if math == "x"))
+        );
+    }
+
+    #[test]
+    fn rich_svg_renderers_produce_svg() {
+        let mermaid = mermaid_rs_renderer::render("flowchart TD\n  A-->B").unwrap();
+        assert!(mermaid.contains("<svg"));
+
+        let math = mathjax_svg_rs::render_tex(
+            r"e^{i\pi}+1=0",
+            &mathjax_svg_rs::Options {
+                font_size: 18.0,
+                horizontal_align: mathjax_svg_rs::HorizontalAlign::Center,
+            },
+        )
+        .unwrap();
+        assert!(math.contains("<svg"));
     }
 
     #[test]

--- a/crates/con-app/src/chat_markdown.rs
+++ b/crates/con-app/src/chat_markdown.rs
@@ -45,7 +45,6 @@ enum MarkdownBlock {
     },
     MathBlock {
         math: SharedString,
-        inline_cache: RefCell<Option<CachedInlineRender>>,
     },
     BlockQuote(Vec<MarkdownBlock>),
     List {
@@ -234,11 +233,18 @@ enum RichSvgRenderKind {
     Math,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum RichSvgThemeMode {
+    Light,
+    Dark,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct RichSvgRenderKey {
     kind: RichSvgRenderKind,
     source: SharedString,
     metric: u32,
+    theme_mode: RichSvgThemeMode,
 }
 
 struct RichSvgRenderEntry {
@@ -520,9 +526,10 @@ impl ChatMarkdownBlockView {
                 .background_spawn(async move {
                     let result: anyhow::Result<Arc<RenderImage>> = (|| {
                         let svg = match background_key.kind {
-                            RichSvgRenderKind::Mermaid => {
-                                mermaid_rs_renderer::render(background_key.source.as_ref())?
-                            }
+                            RichSvgRenderKind::Mermaid => mermaid_rs_renderer::render_with_options(
+                                background_key.source.as_ref(),
+                                mermaid_render_options(background_key.theme_mode),
+                            )?,
                             RichSvgRenderKind::Math => {
                                 let options = mathjax_svg_rs::Options {
                                     font_size: background_key.metric as f64 / 1000.0,
@@ -616,93 +623,27 @@ impl ChatMarkdownBlockView {
                     .map(|(idx, block)| self.render_block(block, idx, style, None, cx))
                     .collect::<Vec<_>>();
 
-                div()
-                    .w_full()
-                    .px(px(10.0))
-                    .py(px(10.0))
-                    .rounded(px(8.0))
-                    .bg(style.quote_background)
-                    .child(
-                        div()
-                            .flex()
-                            .items_start()
-                            .gap(px(9.0))
-                            .child(
-                                div()
-                                    .w(px(3.0))
-                                    .h_full()
-                                    .min_h(px(18.0))
-                                    .bg(style.quote_tint),
-                            )
-                            .child(div().flex().flex_col().gap(style.inner_gap).children(children)),
-                    )
-                    .into_any_element()
+                render_blockquote_children(children, style)
             }
             MarkdownBlock::List {
                 ordered,
                 start,
                 items,
             } => {
-                let marker_lane_width = if *ordered {
-                    ordered_list_marker_lane_width(start + items.len().saturating_sub(1))
-                } else {
-                    px(14.0)
-                };
-                let children = items
+                let item_children = items
                     .iter()
-                    .enumerate()
-                    .map(|(item_idx, item_blocks)| {
-                        let marker = if *ordered {
-                            format!("{}.", start + item_idx)
-                        } else {
-                            "\u{2022}".to_string()
-                        };
-                        let nested_children = item_blocks
+                    .map(|item_blocks| {
+                        item_blocks
                             .iter()
                             .enumerate()
                             .map(|(nested_idx, nested_block)| {
                                 self.render_block(nested_block, nested_idx, style, None, cx)
                             })
-                            .collect::<Vec<_>>();
-
-                        div()
-                            .w_full()
-                            .flex()
-                            .items_start()
-                            .gap(px(9.0))
-                            .child(
-                                div()
-                                    .flex_none()
-                                    .pt(px(1.0))
-                                    .w(marker_lane_width)
-                                    .text_right()
-                                    .font_family(style.theme.mono_font_family.clone())
-                                    .text_size(style.base_font_size)
-                                    .line_height(style.base_line_height)
-                                    .text_color(style.muted_text_color)
-                                    .child(marker),
-                            )
-                            .child(
-                                div()
-                                    .w_full()
-                                    .min_w_0()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(px(7.0))
-                                    .flex_1()
-                                    .children(nested_children),
-                            )
-                            .into_any_element()
+                            .collect::<Vec<_>>()
                     })
                     .collect::<Vec<_>>();
 
-                div()
-                    .w_full()
-                    .flex()
-                    .flex_col()
-                    .gap(px(7.0))
-                    .children(children)
-                    .into_any_element()
+                render_list_children(*ordered, *start, items.len(), item_children, style)
             }
             _ => render_block(block, index, style, table_scroll_handle),
         }
@@ -863,7 +804,6 @@ fn parse_block_node(node: &mdast::Node) -> Option<MarkdownBlock> {
         }),
         mdast::Node::Math(val) => Some(MarkdownBlock::MathBlock {
             math: SharedString::from(val.value.clone()),
-            inline_cache: RefCell::new(None),
         }),
         mdast::Node::FootnoteDefinition(def) => Some(MarkdownBlock::Paragraph {
             inlines: std::iter::once(MarkdownInline::Text(format!("[{}]: ", def.identifier)))
@@ -1099,92 +1039,36 @@ fn render_block(
         MarkdownBlock::Mermaid { code, scale } => {
             render_mermaid_code_fallback(index, code, *scale, style)
         }
-        MarkdownBlock::MathBlock { math, inline_cache } => {
-            render_math_block(math, inline_cache, style)
+        MarkdownBlock::MathBlock { math, .. } => render_math_block(math, style),
+        MarkdownBlock::BlockQuote(blocks) => {
+            let children = blocks
+                .iter()
+                .enumerate()
+                .map(|(idx, block)| render_block(block, idx, style, None))
+                .collect::<Vec<_>>();
+
+            render_blockquote_children(children, style)
         }
-        MarkdownBlock::BlockQuote(blocks) => div()
-            .w_full()
-            .px(px(10.0))
-            .py(px(10.0))
-            .rounded(px(8.0))
-            .bg(style.quote_background)
-            .child(
-                div()
-                    .flex()
-                    .items_start()
-                    .gap(px(9.0))
-                    .child(
-                        div()
-                            .w(px(3.0))
-                            .h_full()
-                            .min_h(px(18.0))
-                            .bg(style.quote_tint),
-                    )
-                    .child(
-                        div().flex().flex_col().gap(style.inner_gap).children(
-                            blocks
-                                .iter()
-                                .enumerate()
-                                .map(|(idx, block)| render_block(block, idx, style, None)),
-                        ),
-                    ),
-            )
-            .into_any_element(),
         MarkdownBlock::List {
             ordered,
             start,
             items,
-        } => div()
-            .w_full()
-            .flex()
-            .flex_col()
-            .gap(px(7.0))
-            .children(items.iter().enumerate().map(|(item_idx, item_blocks)| {
-                let marker = if *ordered {
-                    format!("{}.", start + item_idx)
-                } else {
-                    "\u{2022}".to_string()
-                };
-                let marker_lane_width = if *ordered {
-                    ordered_list_marker_lane_width(start + items.len().saturating_sub(1))
-                } else {
-                    px(14.0)
-                };
+        } => {
+            let item_children = items
+                .iter()
+                .map(|item_blocks| {
+                    item_blocks
+                        .iter()
+                        .enumerate()
+                        .map(|(nested_idx, nested_block)| {
+                            render_block(nested_block, nested_idx, style, None)
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>();
 
-                div()
-                    .w_full()
-                    .flex()
-                    .items_start()
-                    .gap(px(9.0))
-                    .child(
-                        div()
-                            .flex_none()
-                            .pt(px(1.0))
-                            .w(marker_lane_width)
-                            .text_right()
-                            .font_family(style.theme.mono_font_family.clone())
-                            .text_size(style.base_font_size)
-                            .line_height(style.base_line_height)
-                            .text_color(style.muted_text_color)
-                            .child(marker),
-                    )
-                    .child(
-                        div()
-                            .w_full()
-                            .min_w_0()
-                            .flex()
-                            .flex_col()
-                            .gap(px(7.0))
-                            .flex_1()
-                            .children(item_blocks.iter().enumerate().map(
-                                |(nested_idx, nested_block)| {
-                                    render_block(nested_block, nested_idx, style, None)
-                                },
-                            )),
-                    )
-                    .into_any_element()
-            }))
-            .into_any_element(),
+            render_list_children(*ordered, *start, items.len(), item_children, style)
+        }
         MarkdownBlock::Table {
             aligns,
             rows,
@@ -1222,6 +1106,101 @@ fn render_block_with_width(
 fn ordered_list_marker_lane_width(max_marker: usize) -> gpui::Pixels {
     let digits = max_marker.max(1).to_string().len() as f32;
     px(14.0 + digits * 8.0)
+}
+
+fn render_blockquote_children(
+    children: Vec<AnyElement>,
+    style: &ChatMarkdownStyle<'_>,
+) -> AnyElement {
+    div()
+        .w_full()
+        .px(px(10.0))
+        .py(px(10.0))
+        .rounded(px(8.0))
+        .bg(style.quote_background)
+        .child(
+            div()
+                .flex()
+                .items_start()
+                .gap(px(9.0))
+                .child(
+                    div()
+                        .w(px(3.0))
+                        .h_full()
+                        .min_h(px(18.0))
+                        .bg(style.quote_tint),
+                )
+                .child(
+                    div()
+                        .flex()
+                        .flex_col()
+                        .gap(style.inner_gap)
+                        .children(children),
+                ),
+        )
+        .into_any_element()
+}
+
+fn render_list_children(
+    ordered: bool,
+    start: usize,
+    item_count: usize,
+    item_children: Vec<Vec<AnyElement>>,
+    style: &ChatMarkdownStyle<'_>,
+) -> AnyElement {
+    let marker_lane_width = if ordered {
+        ordered_list_marker_lane_width(start + item_count.saturating_sub(1))
+    } else {
+        px(14.0)
+    };
+
+    div()
+        .w_full()
+        .flex()
+        .flex_col()
+        .gap(px(7.0))
+        .children(
+            item_children
+                .into_iter()
+                .enumerate()
+                .map(|(item_idx, nested_children)| {
+                    let marker = if ordered {
+                        format!("{}.", start + item_idx)
+                    } else {
+                        "\u{2022}".to_string()
+                    };
+
+                    div()
+                        .w_full()
+                        .flex()
+                        .items_start()
+                        .gap(px(9.0))
+                        .child(
+                            div()
+                                .flex_none()
+                                .pt(px(1.0))
+                                .w(marker_lane_width)
+                                .text_right()
+                                .font_family(style.theme.mono_font_family.clone())
+                                .text_size(style.base_font_size)
+                                .line_height(style.base_line_height)
+                                .text_color(style.muted_text_color)
+                                .child(marker),
+                        )
+                        .child(
+                            div()
+                                .w_full()
+                                .min_w_0()
+                                .flex()
+                                .flex_col()
+                                .gap(px(7.0))
+                                .flex_1()
+                                .children(nested_children),
+                        )
+                        .into_any_element()
+                }),
+        )
+        .into_any_element()
 }
 
 fn render_table_block(
@@ -1667,17 +1646,7 @@ fn render_mermaid_source_text(code: &str, style: &ChatMarkdownStyle<'_>) -> AnyE
         .into_any_element()
 }
 
-fn render_math_block(
-    math: &str,
-    inline_cache: &RefCell<Option<CachedInlineRender>>,
-    style: &ChatMarkdownStyle<'_>,
-) -> AnyElement {
-    let inlines = [MarkdownInline::Math(math.to_string())];
-    let mut text_style = style.code_text_style();
-    text_style.color = style.math_block_text_color;
-    text_style.font_size = (style.code_font_size + px(1.0)).into();
-    text_style.line_height = (style.code_line_height + px(3.0)).into();
-
+fn render_math_block(math: &str, style: &ChatMarkdownStyle<'_>) -> AnyElement {
     div()
         .w_full()
         .max_w(style.content_width)
@@ -1685,12 +1654,7 @@ fn render_math_block(
         .bg(style.math_block_background.opacity(0.92))
         .px(px(16.0))
         .py(px(13.0))
-        .child(render_inline_content(
-            &inlines,
-            &text_style,
-            style,
-            inline_cache,
-        ))
+        .child(render_math_source_text(math, style))
         .into_any_element()
 }
 
@@ -1710,6 +1674,50 @@ fn math_font_size_metric(style: &ChatMarkdownStyle<'_>) -> u32 {
     (font_size * 1000.0).round().max(1.0) as u32
 }
 
+fn rich_svg_theme_mode(style: &ChatMarkdownStyle<'_>) -> RichSvgThemeMode {
+    if style.theme.is_dark() {
+        RichSvgThemeMode::Dark
+    } else {
+        RichSvgThemeMode::Light
+    }
+}
+
+fn mermaid_render_options(theme_mode: RichSvgThemeMode) -> mermaid_rs_renderer::RenderOptions {
+    let mut options = mermaid_rs_renderer::RenderOptions::default();
+    if matches!(theme_mode, RichSvgThemeMode::Dark) {
+        options.theme = mermaid_dark_theme();
+    }
+    options
+}
+
+fn mermaid_dark_theme() -> mermaid_rs_renderer::Theme {
+    let mut theme = mermaid_rs_renderer::Theme::modern();
+    theme.primary_color = "#1E293B".to_string();
+    theme.primary_text_color = "#F8FAFC".to_string();
+    theme.primary_border_color = "#64748B".to_string();
+    theme.line_color = "#94A3B8".to_string();
+    theme.secondary_color = "#334155".to_string();
+    theme.tertiary_color = "#0F172A".to_string();
+    theme.edge_label_background = "#0F172A".to_string();
+    theme.cluster_background = "#111827".to_string();
+    theme.cluster_border = "#475569".to_string();
+    theme.background = "#0B1120".to_string();
+    theme.sequence_actor_fill = "#1E293B".to_string();
+    theme.sequence_actor_border = "#64748B".to_string();
+    theme.sequence_actor_line = "#64748B".to_string();
+    theme.sequence_note_fill = "#422006".to_string();
+    theme.sequence_note_border = "#B45309".to_string();
+    theme.sequence_activation_fill = "#334155".to_string();
+    theme.sequence_activation_border = "#94A3B8".to_string();
+    theme.text_color = "#E2E8F0".to_string();
+    theme.pie_title_text_color = "#F8FAFC".to_string();
+    theme.pie_section_text_color = "#F8FAFC".to_string();
+    theme.pie_legend_text_color = "#CBD5E1".to_string();
+    theme.pie_stroke_color = "#0F172A".to_string();
+    theme.pie_outer_stroke_color = "#475569".to_string();
+    theme
+}
+
 fn rich_svg_key_for_block(
     block: &MarkdownBlock,
     style: &ChatMarkdownStyle<'_>,
@@ -1719,11 +1727,13 @@ fn rich_svg_key_for_block(
             kind: RichSvgRenderKind::Mermaid,
             source: code.clone(),
             metric: *scale,
+            theme_mode: rich_svg_theme_mode(style),
         }),
         MarkdownBlock::MathBlock { math, .. } => Some(RichSvgRenderKey {
             kind: RichSvgRenderKind::Math,
             source: math.clone(),
             metric: math_font_size_metric(style),
+            theme_mode: RichSvgThemeMode::Light,
         }),
         _ => None,
     }
@@ -2230,9 +2240,8 @@ mod tests {
 
     #[test]
     fn parses_nested_mermaid_and_math_blocks() {
-        let blocks = parse_markdown(
-            "> ```mermaid\n> flowchart TD\n>   A-->B\n> ```\n\n- $$\n  x^2\n  $$",
-        );
+        let blocks =
+            parse_markdown("> ```mermaid\n> flowchart TD\n>   A-->B\n> ```\n\n- $$\n  x^2\n  $$");
         let Some(MarkdownBlock::BlockQuote(quote_blocks)) = blocks.first() else {
             panic!("expected blockquote");
         };
@@ -2285,6 +2294,14 @@ mod tests {
     fn rich_svg_renderers_produce_svg() {
         let mermaid = mermaid_rs_renderer::render("flowchart TD\n  A-->B").unwrap();
         assert!(mermaid.contains("<svg"));
+
+        let dark_mermaid = mermaid_rs_renderer::render_with_options(
+            "flowchart TD\n  A-->B",
+            mermaid_render_options(RichSvgThemeMode::Dark),
+        )
+        .unwrap();
+        assert!(dark_mermaid.contains("<svg"));
+        assert!(dark_mermaid.contains("#0B1120") || dark_mermaid.contains("#0b1120"));
 
         let math = mathjax_svg_rs::render_tex(
             r"e^{i\pi}+1=0",

--- a/crates/con-app/src/chat_markdown.rs
+++ b/crates/con-app/src/chat_markdown.rs
@@ -495,6 +495,11 @@ impl ChatMarkdownBlockView {
         tone: ChatMarkdownTone,
         cx: &mut gpui::Context<Self>,
     ) {
+        let old_block = self.document.blocks.get(self.block_index);
+        let new_block = document.blocks.get(block_index);
+        let block_changed =
+            self.block_index != block_index || self.tone != tone || old_block != new_block;
+
         if self.block_index != block_index
             || self.tone != tone
             || !Arc::ptr_eq(&self.document, &document)
@@ -502,8 +507,10 @@ impl ChatMarkdownBlockView {
             self.document = document;
             self.block_index = block_index;
             self.tone = tone;
-            self.table_scroll_handle = ScrollHandle::new();
-            self.rich_svg_renders.clear();
+            if block_changed {
+                self.table_scroll_handle = ScrollHandle::new();
+                self.rich_svg_renders.clear();
+            }
             cx.notify();
         }
     }
@@ -542,8 +549,13 @@ impl ChatMarkdownBlockView {
                                     font_size: background_key.metric as f64 / 1000.0,
                                     horizontal_align: mathjax_svg_rs::HorizontalAlign::Center,
                                 };
-                                mathjax_svg_rs::render_tex(background_key.source.as_ref(), &options)
-                                    .map_err(anyhow::Error::msg)?
+                                let svg =
+                                    mathjax_svg_rs::render_tex(
+                                        background_key.source.as_ref(),
+                                        &options,
+                                    )
+                                    .map_err(anyhow::Error::msg)?;
+                                math_svg_for_theme(svg, background_key.theme_mode)
                             }
                         };
                         svg_renderer
@@ -1681,6 +1693,31 @@ fn math_font_size_metric(style: &ChatMarkdownStyle<'_>) -> u32 {
     (font_size * 1000.0).round().max(1.0) as u32
 }
 
+fn math_svg_for_theme(svg: String, theme_mode: RichSvgThemeMode) -> String {
+    let color = match theme_mode {
+        RichSvgThemeMode::Light => "#0F172A",
+        RichSvgThemeMode::Dark => "#F8FAFC",
+    };
+    apply_svg_root_color(svg, color)
+}
+
+fn apply_svg_root_color(mut svg: String, color: &str) -> String {
+    let Some(svg_start) = svg.find("<svg") else {
+        return svg;
+    };
+    let Some(tag_end_offset) = svg[svg_start..].find('>') else {
+        return svg;
+    };
+    let tag_end = svg_start + tag_end_offset;
+    let root_tag = &svg[svg_start..tag_end];
+    if root_tag.contains(" color=") || root_tag.contains(" fill=") {
+        return svg;
+    }
+
+    svg.insert_str(tag_end, &format!(" color=\"{color}\" fill=\"{color}\""));
+    svg
+}
+
 fn rich_svg_theme_mode(style: &ChatMarkdownStyle<'_>) -> RichSvgThemeMode {
     if style.theme.is_dark() {
         RichSvgThemeMode::Dark
@@ -1831,7 +1868,7 @@ fn rich_svg_key_for_block(
             kind: RichSvgRenderKind::Math,
             source: math.clone(),
             metric: math_font_size_metric(style),
-            theme_mode: RichSvgThemeMode::Light,
+            theme_mode: rich_svg_theme_mode(style),
         }),
         _ => None,
     }
@@ -2417,6 +2454,10 @@ mod tests {
         )
         .unwrap();
         assert!(math.contains("<svg"));
+
+        let dark_math = math_svg_for_theme(math, RichSvgThemeMode::Dark);
+        assert!(dark_math.contains("color=\"#F8FAFC\""));
+        assert!(dark_math.contains("fill=\"#F8FAFC\""));
     }
 
     #[test]

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -867,9 +867,13 @@ impl InputHandler for GhosttyInputHandler {
             return;
         }
         let _ = self.view.update(cx, |view, _| {
-            view.ime_marked_text = None;
+            let had_marked_text = view.ime_marked_text.take().is_some();
             if let Some(terminal) = &view.terminal {
-                terminal.send_text(text);
+                if !had_marked_text && should_send_ime_insert_as_key_event(text) {
+                    terminal.send_text_as_key_event(text);
+                } else {
+                    terminal.send_text(text);
+                }
                 terminal.refresh();
             }
         });
@@ -942,6 +946,10 @@ impl InputHandler for GhosttyInputHandler {
     fn prefers_ime_for_printable_keys(&mut self, _window: &mut Window, _cx: &mut App) -> bool {
         true
     }
+}
+
+fn should_send_ime_insert_as_key_event(text: &str) -> bool {
+    !text.is_empty() && text.chars().all(|ch| ch.is_ascii() && !ch.is_control())
 }
 
 // ── GPUI → ghostty modifier mapping ─────────────────────────
@@ -1226,5 +1234,19 @@ impl Render for GhosttyView {
                 )
                 .size_full(),
             )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_send_ime_insert_as_key_event;
+
+    #[test]
+    fn direct_ascii_ime_commits_use_key_event_path() {
+        assert!(should_send_ime_insert_as_key_event("abc"));
+        assert!(should_send_ime_insert_as_key_event("A quick test."));
+        assert!(!should_send_ime_insert_as_key_event(""));
+        assert!(!should_send_ime_insert_as_key_event("hello\n"));
+        assert!(!should_send_ime_insert_as_key_event("你好"));
     }
 }

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -49,8 +49,7 @@ const NS_VIEW_LAYER_CONTENTS_REDRAW_DURING_VIEW_RESIZE: isize = 2;
 fn perf_trace_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {
-        std::env::var_os("CON_GHOSTTY_PROFILE")
-            .is_some_and(|v| !v.is_empty() && v != "0")
+        std::env::var_os("CON_GHOSTTY_PROFILE").is_some_and(|v| !v.is_empty() && v != "0")
     })
 }
 
@@ -354,7 +353,8 @@ impl GhosttyView {
             let _: () = msg_send![host, setHasHorizontalScroller:NO];
             let _: () = msg_send![host, setAutohidesScrollers:NO];
             let _: () = msg_send![host, setUsesPredominantAxisScrolling:YES];
-            let _: () = msg_send![host, setAutoresizingMask:NS_VIEW_WIDTH_SIZABLE | NS_VIEW_HEIGHT_SIZABLE];
+            let _: () =
+                msg_send![host, setAutoresizingMask:NS_VIEW_WIDTH_SIZABLE | NS_VIEW_HEIGHT_SIZABLE];
             let _: () = msg_send![host, setAutoresizesSubviews:YES];
             let _: () = msg_send![
                 host,
@@ -621,8 +621,12 @@ impl GhosttyView {
         }
 
         (
-            (logical_size.width * f64::from(self.scale_factor)).max(1.0).round() as u32,
-            (logical_size.height * f64::from(self.scale_factor)).max(1.0).round() as u32,
+            (logical_size.width * f64::from(self.scale_factor))
+                .max(1.0)
+                .round() as u32,
+            (logical_size.height * f64::from(self.scale_factor))
+                .max(1.0)
+                .round() as u32,
         )
     }
 
@@ -1226,7 +1230,9 @@ impl Render for GhosttyView {
                         move |_bounds, _state, window, cx| {
                             window.handle_input(
                                 &focus,
-                                GhosttyInputHandler { view: entity.clone() },
+                                GhosttyInputHandler {
+                                    view: entity.clone(),
+                                },
                                 cx,
                             );
                         }

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -874,7 +874,7 @@ impl InputHandler for GhosttyInputHandler {
             let had_marked_text = view.ime_marked_text.take().is_some();
             if let Some(terminal) = &view.terminal {
                 if !had_marked_text && should_send_ime_insert_as_key_event(text) {
-                    terminal.send_text_as_key_event(text);
+                    send_ime_insert_as_key_events(terminal, text);
                 } else {
                     terminal.send_text(text);
                 }
@@ -954,6 +954,13 @@ impl InputHandler for GhosttyInputHandler {
 
 fn should_send_ime_insert_as_key_event(text: &str) -> bool {
     !text.is_empty() && text.chars().all(|ch| ch.is_ascii() && !ch.is_control())
+}
+
+fn send_ime_insert_as_key_events(terminal: &GhosttyTerminal, text: &str) {
+    for ch in text.chars() {
+        let mut buffer = [0; 4];
+        terminal.send_text_as_key_event(ch.encode_utf8(&mut buffer));
+    }
 }
 
 // ── GPUI → ghostty modifier mapping ─────────────────────────

--- a/crates/con-app/src/global_hotkey.rs
+++ b/crates/con-app/src/global_hotkey.rs
@@ -40,7 +40,10 @@ fn update_registration(keybindings: &KeybindingConfig) {
     let Some(keystroke) = parse_global_hotkey(binding) else {
         unsafe { con_unregister_global_hotkey() };
         if !binding.trim().is_empty() {
-            log::warn!("global hotkey: unsupported binding {:?}, disabling", binding);
+            log::warn!(
+                "global hotkey: unsupported binding {:?}, disabling",
+                binding
+            );
         }
         return;
     };
@@ -78,10 +81,7 @@ fn parse_global_hotkey(binding: &str) -> Option<Keystroke> {
     }
 
     let keystroke = Keystroke::parse(binding).ok()?;
-    if keystroke.key.is_empty()
-        || !keystroke.modifiers.modified()
-        || keystroke.modifiers.function
-    {
+    if keystroke.key.is_empty() || !keystroke.modifiers.modified() || keystroke.modifiers.function {
         return None;
     }
 

--- a/crates/con-app/src/input_bar.rs
+++ b/crates/con-app/src/input_bar.rs
@@ -1229,29 +1229,35 @@ impl Render for InputBar {
                             .flex()
                             .items_center()
                             .gap(px(6.0))
-                            .bg(if all_selected || matches!(self.pane_scope_mode, PaneScopeMode::Custom) {
-                                theme.primary.opacity(0.08)
-                            } else {
-                                theme.title_bar.opacity(self.ui_opacity * 0.94)
-                            })
-                            .hover(|s| {
-                                s.bg(if all_selected || matches!(self.pane_scope_mode, PaneScopeMode::Custom) {
-                                    theme.primary.opacity(0.11)
+                            .bg(
+                                if all_selected
+                                    || matches!(self.pane_scope_mode, PaneScopeMode::Custom)
+                                {
+                                    theme.primary.opacity(0.08)
                                 } else {
-                                    theme.title_bar.opacity(self.ui_opacity)
-                                })
-                            })
-                            .on_mouse_down(MouseButton::Left, cx.listener(|this, _: &MouseDownEvent, window, cx| {
-                                cx.emit(TogglePaneScopePicker);
-                                this.current_input_state()
-                                    .update(cx, |state, cx| state.focus(window, cx));
-                            }))
-                            .child(
-                                svg()
-                                    .path(scope_icon)
-                                    .size(px(11.0))
-                                    .text_color(scope_tint),
+                                    theme.title_bar.opacity(self.ui_opacity * 0.94)
+                                },
                             )
+                            .hover(|s| {
+                                s.bg(
+                                    if all_selected
+                                        || matches!(self.pane_scope_mode, PaneScopeMode::Custom)
+                                    {
+                                        theme.primary.opacity(0.11)
+                                    } else {
+                                        theme.title_bar.opacity(self.ui_opacity)
+                                    },
+                                )
+                            })
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(|this, _: &MouseDownEvent, window, cx| {
+                                    cx.emit(TogglePaneScopePicker);
+                                    this.current_input_state()
+                                        .update(cx, |state, cx| state.focus(window, cx));
+                                }),
+                            )
+                            .child(svg().path(scope_icon).size(px(11.0)).text_color(scope_tint))
                             .child(
                                 div()
                                     .text_size(px(10.5))
@@ -1259,7 +1265,9 @@ impl Render for InputBar {
                                     .font_family(theme.mono_font_family.clone())
                                     .font_weight(FontWeight::MEDIUM)
                                     .text_color(
-                                        if all_selected || matches!(self.pane_scope_mode, PaneScopeMode::Custom) {
+                                        if all_selected
+                                            || matches!(self.pane_scope_mode, PaneScopeMode::Custom)
+                                        {
                                             theme.primary
                                         } else {
                                             theme.muted_foreground.opacity(0.76)

--- a/crates/con-app/src/keycaps.rs
+++ b/crates/con-app/src/keycaps.rs
@@ -76,10 +76,7 @@ pub(crate) fn keycaps_for_stroke(stroke: &Keystroke, theme: &gpui_component::The
         .children(parts.into_iter().map(|part| keycap(part, theme)))
 }
 
-pub(crate) fn keycaps_for_binding(
-    binding: &str,
-    theme: &gpui_component::Theme,
-) -> AnyElement {
+pub(crate) fn keycaps_for_binding(binding: &str, theme: &gpui_component::Theme) -> AnyElement {
     if let Ok(stroke) = Keystroke::parse(binding) {
         keycaps_for_stroke(&stroke, theme).into_any_element()
     } else {

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -226,8 +226,7 @@ fn set_windows_backdrop(window: &mut Window, blur: bool) -> Option<()> {
     use raw_window_handle::{HasWindowHandle, RawWindowHandle};
     use windows::Win32::Foundation::HWND;
     use windows::Win32::Graphics::Dwm::{
-        DwmSetWindowAttribute, DWMSBT_MAINWINDOW, DWMSBT_TRANSIENTWINDOW,
-        DWMWA_SYSTEMBACKDROP_TYPE,
+        DWMSBT_MAINWINDOW, DWMSBT_TRANSIENTWINDOW, DWMWA_SYSTEMBACKDROP_TYPE, DwmSetWindowAttribute,
     };
 
     let handle = HasWindowHandle::window_handle(window).ok()?;
@@ -433,7 +432,9 @@ fn fresh_window_session_with_history() -> Session {
 }
 
 pub(crate) fn toggle_global_summon(cx: &mut App) {
-    let frontmost_window = cx.window_stack().and_then(|windows| windows.last().cloned());
+    let frontmost_window = cx
+        .window_stack()
+        .and_then(|windows| windows.last().cloned());
     let has_windows = frontmost_window.is_some();
 
     #[cfg(target_os = "macos")]
@@ -511,8 +512,8 @@ pub(crate) fn app_display_version() -> String {
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub(crate) fn app_build_number() -> String {
     #[cfg(target_os = "macos")]
-    let build =
-        bundle_info_value(b"CFBundleVersion\0").unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
+    let build = bundle_info_value(b"CFBundleVersion\0")
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
     #[cfg(not(target_os = "macos"))]
     let build = option_env!("CON_RELEASE_VERSION")
         .map(str::to_owned)
@@ -627,14 +628,11 @@ impl Render for AboutView {
                     .justify_center()
                     .gap(px(14.0))
                     .child(
-                        div()
-                            .size(px(88.0))
-                            .p(px(2.0))
-                            .child(
-                                img("Con-macOS-Dark-256x256@2x.png")
-                                    .size_full()
-                                    .object_fit(ObjectFit::Contain),
-                            ),
+                        div().size(px(88.0)).p(px(2.0)).child(
+                            img("Con-macOS-Dark-256x256@2x.png")
+                                .size_full()
+                                .object_fit(ObjectFit::Contain),
+                        ),
                     )
                     .child(
                         div()
@@ -671,18 +669,13 @@ impl Render for AboutView {
                             .child(format!("{} • {}", self.version, self.version_detail)),
                     )
                     .child(
-                        div()
-                            .flex()
-                            .flex_col()
-                            .items_center()
-                            .gap(px(6.0))
-                            .child(
-                                Link::new("about-repo")
-                                    .href(repo_url)
-                                    .text_size(px(12.5))
-                                    .font_family(theme.mono_font_family.clone())
-                                    .child(repo_url),
-                            ),
+                        div().flex().flex_col().items_center().gap(px(6.0)).child(
+                            Link::new("about-repo")
+                                .href(repo_url)
+                                .text_size(px(12.5))
+                                .font_family(theme.mono_font_family.clone())
+                                .child(repo_url),
+                        ),
                     )
                     .child(
                         div()
@@ -892,7 +885,7 @@ fn install_seh_filter() {
             | 0xC000001D  // ILLEGAL_INSTRUCTION
             | 0xC0000094  // INT_DIVIDE_BY_ZERO
             | 0xC0000096  // PRIV_INSTRUCTION
-            | 0xC000013A  // CONTROL_C_EXIT
+            | 0xC000013A // CONTROL_C_EXIT
         );
 
         if interesting {

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -1113,7 +1113,7 @@ fn main() {
                     MenuItem::action("Toggle Input Bar", ToggleInputBar),
                     MenuItem::action("Command Palette", command_palette::ToggleCommandPalette),
                     MenuItem::separator(),
-                    MenuItem::action("Focus Input", FocusInput),
+                    MenuItem::action("Toggle Input / Terminal", FocusInput),
                     MenuItem::action("Cycle Input Mode", CycleInputMode),
                 ],
                 disabled: false,

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -1,6 +1,6 @@
+use con_core::session::{PaneLayoutState, PaneSplitDirection};
 use gpui::*;
 use gpui_component::ActiveTheme;
-use con_core::session::{PaneLayoutState, PaneSplitDirection};
 
 use crate::terminal_pane::TerminalPane;
 
@@ -570,7 +570,7 @@ impl PaneTree {
                                         cb_divider(sid, f32::from(event.position.y));
                                     },
                                 ),
-                        )
+                        ),
                 };
 
                 let make_pane = |child: AnyElement, basis: f32| -> Div {

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -348,7 +348,7 @@ impl SettingsPanel {
     }
 
     fn protocol_switch_hint(provider: &ProviderKind) -> Option<&'static str> {
-        Self::protocol_pair(provider).map(|_| "OpenAI or Anthropic API compatible")
+        Self::protocol_pair(provider).map(|_| "OpenAI- or Anthropic-compatible API")
     }
 
     fn provider_icon_path(provider: &ProviderKind) -> &'static str {

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -1,8 +1,8 @@
-use con_agent::{
-    AgentConfig, OAuthDevicePrompt, ProviderConfig, ProviderKind,
-    SuggestionModelConfig, authorize_oauth_provider, oauth_token_dir,
-};
 use con_agent::provider::{AgentPurpose, ProviderTransport};
+use con_agent::{
+    AgentConfig, OAuthDevicePrompt, ProviderConfig, ProviderKind, SuggestionModelConfig,
+    authorize_oauth_provider, oauth_token_dir,
+};
 use con_core::{
     Config,
     config::{MAX_UI_FONT_SIZE, MIN_UI_FONT_SIZE},
@@ -23,7 +23,15 @@ use crate::motion::{MotionValue, vertical_reveal_offset};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-actions!(settings, [ToggleSettings, SaveSettings, DismissSettings, TabsOrientationChanged]);
+actions!(
+    settings,
+    [
+        ToggleSettings,
+        SaveSettings,
+        DismissSettings,
+        TabsOrientationChanged
+    ]
+);
 
 /// Emitted when the user selects a different terminal theme for live preview.
 pub struct ThemePreview(pub String);
@@ -262,9 +270,7 @@ impl SettingsPanel {
 
     fn provider_api_key_placeholder(provider: &ProviderKind) -> &'static str {
         match provider {
-            ProviderKind::ChatGPT | ProviderKind::GitHubCopilot => {
-                "Override for advanced setups"
-            }
+            ProviderKind::ChatGPT | ProviderKind::GitHubCopilot => "Override for advanced setups",
             _ => "sk-.. or OPENAI_API_KEY",
         }
     }
@@ -279,12 +285,8 @@ impl SettingsPanel {
 
     fn provider_api_key_hint(provider: &ProviderKind) -> &'static str {
         match provider {
-            ProviderKind::ChatGPT => {
-                "Leave blank for ChatGPT OAuth."
-            }
-            ProviderKind::GitHubCopilot => {
-                "Leave blank for GitHub OAuth."
-            }
+            ProviderKind::ChatGPT => "Leave blank for ChatGPT OAuth.",
+            ProviderKind::GitHubCopilot => "Leave blank for GitHub OAuth.",
             _ => "Key or env var name",
         }
     }
@@ -346,8 +348,7 @@ impl SettingsPanel {
     }
 
     fn protocol_switch_hint(provider: &ProviderKind) -> Option<&'static str> {
-        Self::protocol_pair(provider)
-            .map(|_| "OpenAI or Anthropic API compatible")
+        Self::protocol_pair(provider).map(|_| "OpenAI or Anthropic API compatible")
     }
 
     fn provider_icon_path(provider: &ProviderKind) -> &'static str {
@@ -376,12 +377,18 @@ impl SettingsPanel {
 
     fn provider_config_is_meaningful(config: &ProviderConfig) -> bool {
         config.model.as_ref().is_some_and(|v| !v.trim().is_empty())
-            || config.api_key.as_ref().is_some_and(|v| !v.trim().is_empty())
+            || config
+                .api_key
+                .as_ref()
+                .is_some_and(|v| !v.trim().is_empty())
             || config
                 .api_key_env
                 .as_ref()
                 .is_some_and(|v| !v.trim().is_empty())
-            || config.base_url.as_ref().is_some_and(|v| !v.trim().is_empty())
+            || config
+                .base_url
+                .as_ref()
+                .is_some_and(|v| !v.trim().is_empty())
             || config.max_tokens.is_some()
     }
 
@@ -459,11 +466,17 @@ impl SettingsPanel {
         })
     }
 
-    fn preferred_sidebar_provider(config: &Config, clicked_provider: &ProviderKind) -> ProviderKind {
+    fn preferred_sidebar_provider(
+        config: &Config,
+        clicked_provider: &ProviderKind,
+    ) -> ProviderKind {
         let sidebar_provider = Self::sidebar_provider_kind(clicked_provider);
         let transport = config.agent.provider_transport_for(&sidebar_provider);
-        Self::provider_for_transport(&sidebar_provider, transport.unwrap_or(ProviderTransport::OpenAI))
-            .unwrap_or(sidebar_provider)
+        Self::provider_for_transport(
+            &sidebar_provider,
+            transport.unwrap_or(ProviderTransport::OpenAI),
+        )
+        .unwrap_or(sidebar_provider)
     }
 
     fn oauth_state(&self, provider: &ProviderKind) -> Option<&ProviderOAuthState> {
@@ -740,9 +753,16 @@ impl SettingsPanel {
         if seeded.max_tokens.is_none() {
             seeded.max_tokens = source.max_tokens;
         }
-        if seeded.base_url.as_deref().is_none_or(|value| value.trim().is_empty()) {
-            seeded.base_url =
-                Self::mapped_protocol_base_url(source_provider, target_provider, source.base_url.as_deref());
+        if seeded
+            .base_url
+            .as_deref()
+            .is_none_or(|value| value.trim().is_empty())
+        {
+            seeded.base_url = Self::mapped_protocol_base_url(
+                source_provider,
+                target_provider,
+                source.base_url.as_deref(),
+            );
         }
 
         seeded
@@ -777,10 +797,9 @@ impl SettingsPanel {
                     }
                     ENDPOINT_CUSTOM_LABEL => {}
                     _ => {
-                        if let Some((target_provider, preset)) = Self::endpoint_preset_for_label(
-                            &this.selected_provider,
-                            value.as_str(),
-                        ) {
+                        if let Some((target_provider, preset)) =
+                            Self::endpoint_preset_for_label(&this.selected_provider, value.as_str())
+                        {
                             if target_provider != this.selected_provider {
                                 let source_provider = this.selected_provider.clone();
                                 let source_config = this.read_provider_inputs(cx);
@@ -1361,13 +1380,20 @@ impl SettingsPanel {
             });
             self.active_model_select = Self::make_model_select(
                 &agent.provider,
-                &agent.providers.get(&agent.provider).and_then(|pc| pc.model.clone()),
+                &agent
+                    .providers
+                    .get(&agent.provider)
+                    .and_then(|pc| pc.model.clone()),
                 &self.registry,
                 window,
                 cx,
             );
             self.ai_purpose_select.update(cx, |select, cx| {
-                select.set_selected_value(&Self::ai_purpose_label(agent.purpose).to_string(), window, cx);
+                select.set_selected_value(
+                    &Self::ai_purpose_label(agent.purpose).to_string(),
+                    window,
+                    cx,
+                );
             });
             self.suggestion_enabled = agent.suggestion_model.enabled;
             self.suggestion_provider_select.update(cx, |select, cx| {
@@ -1904,7 +1930,9 @@ impl SettingsPanel {
         cx: &mut Context<Self>,
     ) {
         let provider = if Self::protocol_pair(&provider).is_some() {
-            if Self::sidebar_provider_kind(&self.selected_provider) == Self::sidebar_provider_kind(&provider) {
+            if Self::sidebar_provider_kind(&self.selected_provider)
+                == Self::sidebar_provider_kind(&provider)
+            {
                 self.selected_provider.clone()
             } else {
                 Self::preferred_sidebar_provider(&self.config, &provider)
@@ -2740,14 +2768,12 @@ impl SettingsPanel {
                 .gap(px(8.0))
                 .child(group_label("Cursor", &theme))
                 .child(
-                    card(theme, card_opacity).child(
-                        div().px(px(16.0)).child(select_row(
-                            "Cursor Style",
-                            "Choose how the terminal insertion point is drawn.",
-                            &self.cursor_style_select,
-                            theme,
-                        )),
-                    ),
+                    card(theme, card_opacity).child(div().px(px(16.0)).child(select_row(
+                        "Cursor Style",
+                        "Choose how the terminal insertion point is drawn.",
+                        &self.cursor_style_select,
+                        theme,
+                    ))),
                 ),
         );
 
@@ -2821,9 +2847,7 @@ impl SettingsPanel {
                                     con_core::config::TabsOrientation::Horizontal
                                 };
                                 if let Err(err) = this.persist_config() {
-                                    log::warn!(
-                                        "settings: persist tabs_orientation failed: {err}"
-                                    );
+                                    log::warn!("settings: persist tabs_orientation failed: {err}");
                                     this.save_error = Some(err.to_string());
                                     cx.notify();
                                     return;
@@ -3302,12 +3326,8 @@ impl SettingsPanel {
             .child(routing_card)
             .child(behavior_card);
 
-        section_content(
-            "AI",
-            "Model selection and AI harness configuration.",
-            theme,
-        )
-        .child(ai_layout)
+        section_content("AI", "Model selection and AI harness configuration.", theme)
+            .child(ai_layout)
     }
 
     fn render_providers(&mut self, cx: &mut Context<Self>) -> Div {
@@ -3544,19 +3564,27 @@ impl SettingsPanel {
                                                     div()
                                                         .text_size(px(11.0))
                                                         .text_color(theme.muted_foreground)
-                                                        .child(protocol_switch_hint.unwrap_or("Choose the provider transport.")),
+                                                        .child(protocol_switch_hint.unwrap_or(
+                                                            "Choose the provider transport.",
+                                                        )),
                                                 ),
                                         )
                                         .child(
                                             Switch::new(format!(
                                                 "provider-protocol-{}",
-                                                provider_label(&Self::sidebar_provider_kind(&self.selected_provider))
+                                                provider_label(&Self::sidebar_provider_kind(
+                                                    &self.selected_provider
+                                                ))
                                             ))
                                             .checked(anthropic_protocol_enabled)
                                             .label(switch_label)
-                                            .on_click(cx.listener(|this, checked: &bool, window, cx| {
-                                                this.toggle_selected_provider_protocol(*checked, window, cx);
-                                            })),
+                                            .on_click(cx.listener(
+                                                |this, checked: &bool, window, cx| {
+                                                    this.toggle_selected_provider_protocol(
+                                                        *checked, window, cx,
+                                                    );
+                                                },
+                                            )),
                                         ),
                                 )
                                 .into_any_element()
@@ -3566,130 +3594,161 @@ impl SettingsPanel {
                         } else {
                             None
                         })
-                        .children(Self::provider_oauth_label(&self.selected_provider).map(|provider_name| {
-                            let oauth = oauth_state.clone().unwrap_or_default();
-                            let provider_for_click = self.selected_provider.clone();
-                            let prompt = oauth.prompt.clone();
-                            div()
-                                .flex()
-                                .flex_col()
-                                .gap(px(10.0))
-                                .child(
-                                    div()
-                                        .flex()
-                                        .items_center()
-                                        .justify_between()
-                                        .gap(px(12.0))
-                                        .child(
-                                            div()
-                                                .flex()
-                                                .flex_col()
-                                                .gap(px(2.0))
-                                                .child(div().text_sm().child(format!("{provider_name} OAuth")))
-                                                .child(
-                                                    div()
-                                                        .text_size(px(11.0))
-                                                        .text_color(theme.muted_foreground)
-                                                        .child("Device login"),
-                                                ),
-                                        )
-                                        .child(
-                                            Button::new(format!("oauth-connect-{}", provider_label(&self.selected_provider)))
-                                                .label(
-                                                    if oauth.connected {
-                                                        "Reconnect"
-                                                    } else {
-                                                        Self::provider_oauth_button_label(&self.selected_provider).unwrap_or("Sign In")
-                                                    }
-                                                )
+                        .children(Self::provider_oauth_label(&self.selected_provider).map(
+                            |provider_name| {
+                                let oauth = oauth_state.clone().unwrap_or_default();
+                                let provider_for_click = self.selected_provider.clone();
+                                let prompt = oauth.prompt.clone();
+                                div()
+                                    .flex()
+                                    .flex_col()
+                                    .gap(px(10.0))
+                                    .child(
+                                        div()
+                                            .flex()
+                                            .items_center()
+                                            .justify_between()
+                                            .gap(px(12.0))
+                                            .child(
+                                                div()
+                                                    .flex()
+                                                    .flex_col()
+                                                    .gap(px(2.0))
+                                                    .child(
+                                                        div().text_sm().child(format!(
+                                                            "{provider_name} OAuth"
+                                                        )),
+                                                    )
+                                                    .child(
+                                                        div()
+                                                            .text_size(px(11.0))
+                                                            .text_color(theme.muted_foreground)
+                                                            .child("Device login"),
+                                                    ),
+                                            )
+                                            .child(
+                                                Button::new(format!(
+                                                    "oauth-connect-{}",
+                                                    provider_label(&self.selected_provider)
+                                                ))
+                                                .label(if oauth.connected {
+                                                    "Reconnect"
+                                                } else {
+                                                    Self::provider_oauth_button_label(
+                                                        &self.selected_provider,
+                                                    )
+                                                    .unwrap_or("Sign In")
+                                                })
                                                 .small()
                                                 .primary()
                                                 .loading(oauth.in_progress)
                                                 .disabled(oauth.in_progress)
-                                                .on_click(cx.listener(move |this, _, window, cx| {
-                                                    this.start_provider_oauth(provider_for_click.clone(), window, cx);
-                                                })),
-                                        ),
-                                )
-                                .children(oauth.status_message.as_ref().map(|message| {
-                                    div()
-                                        .text_size(px(11.0))
-                                        .text_color(theme.muted_foreground)
-                                        .child(message.clone())
-                                }))
-                                .children(oauth.error_message.as_ref().map(|message| {
-                                    div()
-                                        .text_size(px(11.0))
-                                        .text_color(theme.danger)
-                                        .child(message.clone())
-                                }))
-                                .children(prompt.map(|prompt| {
-                                    div()
-                                        .flex()
-                                        .flex_col()
-                                        .gap(px(8.0))
-                                        .p(px(10.0))
-                                        .rounded(px(8.0))
-                                        .bg(theme.muted.opacity(0.05))
-                                        .child(
-                                            div()
-                                                .text_size(px(11.0))
-                                                .text_color(theme.muted_foreground)
-                                                .child("Browser authorization"),
-                                        )
-                                        .child(
-                                            div()
-                                                .flex()
-                                                .items_center()
-                                                .justify_between()
-                                                .gap(px(8.0))
-                                                .child(
-                                                    div()
-                                                        .flex()
-                                                        .flex_col()
-                                                        .gap(px(2.0))
-                                                        .child(div().text_size(px(11.0)).text_color(theme.muted_foreground).child("Code"))
-                                                        .child(
-                                                            div()
-                                                                .font_weight(FontWeight::SEMIBOLD)
-                                                                .child(prompt.user_code.clone()),
-                                                        ),
-                                                )
-                                                .child(Clipboard::new(format!(
-                                                    "oauth-code-{}",
-                                                    provider_label(&self.selected_provider)
-                                                ))
-                                                .value(SharedString::from(prompt.user_code.clone()))),
-                                        )
-                                        .child(
-                                            div()
-                                                .flex()
-                                                .items_center()
-                                                .justify_between()
-                                                .gap(px(8.0))
-                                                .child(
-                                                    div()
-                                                        .flex_1()
-                                                        .text_size(px(11.0))
-                                                        .text_color(theme.muted_foreground)
-                                                        .child(prompt.verification_uri.clone()),
-                                                )
-                                                .child(
-                                                    Button::new(format!(
-                                                        "oauth-open-{}",
-                                                        provider_label(&self.selected_provider)
-                                                    ))
-                                                    .label("Open Browser")
-                                                    .small()
-                                                    .ghost()
-                                                    .on_click(move |_, _, cx| {
-                                                        cx.open_url(&prompt.verification_uri);
-                                                    }),
-                                                ),
-                                        )
-                                }))
-                                .into_any_element()
-                        }))
+                                                .on_click(cx.listener(
+                                                    move |this, _, window, cx| {
+                                                        this.start_provider_oauth(
+                                                            provider_for_click.clone(),
+                                                            window,
+                                                            cx,
+                                                        );
+                                                    },
+                                                )),
+                                            ),
+                                    )
+                                    .children(oauth.status_message.as_ref().map(|message| {
+                                        div()
+                                            .text_size(px(11.0))
+                                            .text_color(theme.muted_foreground)
+                                            .child(message.clone())
+                                    }))
+                                    .children(oauth.error_message.as_ref().map(|message| {
+                                        div()
+                                            .text_size(px(11.0))
+                                            .text_color(theme.danger)
+                                            .child(message.clone())
+                                    }))
+                                    .children(prompt.map(|prompt| {
+                                        div()
+                                            .flex()
+                                            .flex_col()
+                                            .gap(px(8.0))
+                                            .p(px(10.0))
+                                            .rounded(px(8.0))
+                                            .bg(theme.muted.opacity(0.05))
+                                            .child(
+                                                div()
+                                                    .text_size(px(11.0))
+                                                    .text_color(theme.muted_foreground)
+                                                    .child("Browser authorization"),
+                                            )
+                                            .child(
+                                                div()
+                                                    .flex()
+                                                    .items_center()
+                                                    .justify_between()
+                                                    .gap(px(8.0))
+                                                    .child(
+                                                        div()
+                                                            .flex()
+                                                            .flex_col()
+                                                            .gap(px(2.0))
+                                                            .child(
+                                                                div()
+                                                                    .text_size(px(11.0))
+                                                                    .text_color(
+                                                                        theme.muted_foreground,
+                                                                    )
+                                                                    .child("Code"),
+                                                            )
+                                                            .child(
+                                                                div()
+                                                                    .font_weight(
+                                                                        FontWeight::SEMIBOLD,
+                                                                    )
+                                                                    .child(
+                                                                        prompt.user_code.clone(),
+                                                                    ),
+                                                            ),
+                                                    )
+                                                    .child(
+                                                        Clipboard::new(format!(
+                                                            "oauth-code-{}",
+                                                            provider_label(&self.selected_provider)
+                                                        ))
+                                                        .value(SharedString::from(
+                                                            prompt.user_code.clone(),
+                                                        )),
+                                                    ),
+                                            )
+                                            .child(
+                                                div()
+                                                    .flex()
+                                                    .items_center()
+                                                    .justify_between()
+                                                    .gap(px(8.0))
+                                                    .child(
+                                                        div()
+                                                            .flex_1()
+                                                            .text_size(px(11.0))
+                                                            .text_color(theme.muted_foreground)
+                                                            .child(prompt.verification_uri.clone()),
+                                                    )
+                                                    .child(
+                                                        Button::new(format!(
+                                                            "oauth-open-{}",
+                                                            provider_label(&self.selected_provider)
+                                                        ))
+                                                        .label("Open Browser")
+                                                        .small()
+                                                        .ghost()
+                                                        .on_click(move |_, _, cx| {
+                                                            cx.open_url(&prompt.verification_uri);
+                                                        }),
+                                                    ),
+                                            )
+                                    }))
+                                    .into_any_element()
+                            },
+                        ))
                         .children(if Self::provider_has_oauth(&self.selected_provider) {
                             Some(div().child(row_separator(theme)))
                         } else {
@@ -3710,14 +3769,12 @@ impl SettingsPanel {
                         .children(if endpoint_presets.is_empty() {
                             None
                         } else {
-                            Some(
-                                div().child(select_row(
-                                    "Endpoint Preset",
-                                    "Switch region or protocol",
-                                    &endpoint_preset_select,
-                                    theme,
-                                )),
-                            )
+                            Some(div().child(select_row(
+                                "Endpoint Preset",
+                                "Switch region or protocol",
+                                &endpoint_preset_select,
+                                theme,
+                            )))
                         }),
                 ),
             )
@@ -4060,13 +4117,21 @@ impl SettingsPanel {
                         // Ctrl-only on Windows, so we branch explicitly.
                         .child(key_row(
                             "Copy",
-                            if cfg!(target_os = "macos") { "cmd-c" } else { "ctrl-shift-c" },
+                            if cfg!(target_os = "macos") {
+                                "cmd-c"
+                            } else {
+                                "ctrl-shift-c"
+                            },
                             theme,
                         ))
                         .child(row_separator(theme))
                         .child(key_row(
                             "Paste",
-                            if cfg!(target_os = "macos") { "cmd-v" } else { "ctrl-shift-v" },
+                            if cfg!(target_os = "macos") {
+                                "cmd-v"
+                            } else {
+                                "ctrl-shift-v"
+                            },
                             theme,
                         ))
                         .child(row_separator(theme))
@@ -4413,10 +4478,7 @@ fn update_summary_and_detail(
                 crate::app_display_version()
             ),
         ),
-        CheckState::Error(e) => (
-            "Update check failed".to_string(),
-            e.clone(),
-        ),
+        CheckState::Error(e) => ("Update check failed".to_string(), e.clone()),
         CheckState::Idle => (status.summary().to_string(), status.detail().to_string()),
     }
 }
@@ -4594,14 +4656,11 @@ fn searchable_select_row(
                 ),
         )
         .child(
-            div()
-                .w(px(236.0))
-                .flex_shrink_0()
-                .child(
-                    Select::new(select)
-                        .placeholder(placeholder.to_string())
-                        .small(),
-                ),
+            div().w(px(236.0)).flex_shrink_0().child(
+                Select::new(select)
+                    .placeholder(placeholder.to_string())
+                    .small(),
+            ),
         )
 }
 

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -3784,7 +3784,7 @@ impl SettingsPanel {
             ("Command Palette", "command_palette"),
             ("Toggle Agent", "toggle_agent"),
             ("Toggle Input Bar", "toggle_input_bar"),
-            ("Focus Input", "focus_input"),
+            ("Toggle Input / Terminal", "focus_input"),
             ("Cycle Input Mode", "cycle_input_mode"),
             ("Toggle Pane Scope", "toggle_pane_scope"),
             ("Quit", "quit"),

--- a/crates/con-app/src/sidebar.rs
+++ b/crates/con-app/src/sidebar.rs
@@ -303,10 +303,7 @@ impl SessionSidebar {
                     } else {
                         Some(value.to_string())
                     };
-                    cx.emit(SidebarRename {
-                        session_id,
-                        label,
-                    });
+                    cx.emit(SidebarRename { session_id, label });
                     this.rename = None;
                     cx.notify();
                 }
@@ -490,11 +487,7 @@ impl SessionSidebar {
                 )
                 .on_mouse_down(
                     MouseButton::Middle,
-                    cx.listener(move |_this, _, _, cx| {
-                        cx.emit(SidebarCloseTab {
-                            session_id,
-                        })
-                    }),
+                    cx.listener(move |_this, _, _, cx| cx.emit(SidebarCloseTab { session_id })),
                 )
                 .on_hover(cx.listener(move |this, hovered: &bool, _, cx| {
                     let want = if *hovered { Some(i) } else { None };
@@ -574,7 +567,11 @@ impl SessionSidebar {
         // Anchor the card vertically on the cursor — its row IS the
         // icon under the cursor by construction.
         let cursor = window.mouse_position();
-        let card_height = if session.subtitle.is_some() { 64.0 } else { 44.0 };
+        let card_height = if session.subtitle.is_some() {
+            64.0
+        } else {
+            44.0
+        };
         let min_top = self.leading_top_pad + RAIL_TOP_CONTROLS_HEIGHT + 8.0;
         let top = (f32::from(cursor.y) - card_height / 2.0).max(min_top);
 
@@ -584,19 +581,16 @@ impl SessionSidebar {
         let mono_font = theme.mono_font_family.clone();
         let sys_font = theme.font_family.clone();
 
-        let mut card_inner = div()
-            .px(px(12.0))
-            .py(px(8.0))
-            .child(
-                div()
-                    .text_size(px(12.5))
-                    .line_height(px(16.0))
-                    .font_weight(FontWeight::MEDIUM)
-                    .text_color(name_color)
-                    .font_family(sys_font)
-                    .truncate()
-                    .child(session.name.clone()),
-            );
+        let mut card_inner = div().px(px(12.0)).py(px(8.0)).child(
+            div()
+                .text_size(px(12.5))
+                .line_height(px(16.0))
+                .font_weight(FontWeight::MEDIUM)
+                .text_color(name_color)
+                .font_family(sys_font)
+                .truncate()
+                .child(session.name.clone()),
+        );
 
         if let Some(sub) = session.subtitle.as_ref() {
             card_inner = card_inner.child(
@@ -630,16 +624,14 @@ impl SessionSidebar {
             meta = meta.child(div().child("SSH"));
         }
         if session.needs_attention {
-            meta = meta
-                .child(div().child("·").text_color(meta_color))
-                .child(
-                    div()
-                        .flex()
-                        .items_center()
-                        .gap(px(4.0))
-                        .child(div().size(px(6.0)).rounded_full().bg(theme.primary))
-                        .child(div().child("unread")),
-                );
+            meta = meta.child(div().child("·").text_color(meta_color)).child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap(px(4.0))
+                    .child(div().size(px(6.0)).rounded_full().bg(theme.primary))
+                    .child(div().child("unread")),
+            );
         }
         card_inner = card_inner.child(meta);
 
@@ -765,8 +757,8 @@ impl SessionSidebar {
                     // `total * ROW_HEIGHT + gaps` from the top of
                     // the list bounds.
                     let approx_row_h = ROW_HEIGHT;
-                    let last_row_bottom_estimate = f32::from(event.bounds.origin.y)
-                        + (total as f32) * (approx_row_h + 2.0);
+                    let last_row_bottom_estimate =
+                        f32::from(event.bounds.origin.y) + (total as f32) * (approx_row_h + 2.0);
                     if f32::from(event.event.position.y) >= last_row_bottom_estimate
                         && this.drop_slot != Some(total)
                     {
@@ -853,8 +845,7 @@ impl SessionSidebar {
         // semantics: K means "insert at index K"; slot N means "at
         // the bottom".
         let drop_above = drop_slot == Some(i) && cx.has_active_drag();
-        let drop_below =
-            i + 1 == total && drop_slot == Some(total) && cx.has_active_drag();
+        let drop_below = i + 1 == total && drop_slot == Some(total) && cx.has_active_drag();
 
         let row_h = if session.subtitle.is_some() {
             ROW_HEIGHT
@@ -935,11 +926,7 @@ impl SessionSidebar {
             SharedString::from(format!("panel-tab-close-{i}")),
             "phosphor/x.svg",
             theme,
-            cx.listener(move |_this, _, _, cx| {
-                cx.emit(SidebarCloseTab {
-                    session_id,
-                })
-            }),
+            cx.listener(move |_this, _, _, cx| cx.emit(SidebarCloseTab { session_id })),
         )
         .invisible()
         .group_hover(row_group.clone(), |s| s.visible());
@@ -1036,11 +1023,7 @@ impl SessionSidebar {
             )
             .on_mouse_down(
                 MouseButton::Middle,
-                cx.listener(move |_this, _, _, cx| {
-                    cx.emit(SidebarCloseTab {
-                        session_id,
-                    })
-                }),
+                cx.listener(move |_this, _, _, cx| cx.emit(SidebarCloseTab { session_id })),
             )
             .on_double_click(cx.listener(move |this, _, window, cx| {
                 this.begin_rename(i, window, cx);
@@ -1216,7 +1199,11 @@ fn rail_slot_for_cursor_position(
     rail_slot_from_local_y(local_y, session_count, leading_top_pad)
 }
 
-fn rail_slot_from_local_y(local_y: f32, session_count: usize, leading_top_pad: f32) -> Option<usize> {
+fn rail_slot_from_local_y(
+    local_y: f32,
+    session_count: usize,
+    leading_top_pad: f32,
+) -> Option<usize> {
     if session_count == 0 {
         return None;
     }
@@ -1319,9 +1306,7 @@ fn build_row_context_menu(
             let weak = weak.clone();
             move |_, _, cx| {
                 if let Some(entity) = weak.upgrade() {
-                    entity.update(cx, |_, cx| {
-                        cx.emit(SidebarDuplicate { session_id })
-                    });
+                    entity.update(cx, |_, cx| cx.emit(SidebarDuplicate { session_id }));
                 }
             }
         }));
@@ -1379,9 +1364,7 @@ fn build_row_context_menu(
             let weak = weak.clone();
             move |_, _, cx| {
                 if let Some(entity) = weak.upgrade() {
-                    entity.update(cx, |_, cx| {
-                        cx.emit(SidebarCloseTab { session_id })
-                    });
+                    entity.update(cx, |_, cx| cx.emit(SidebarCloseTab { session_id }));
                 }
             }
         }));
@@ -1390,9 +1373,7 @@ fn build_row_context_menu(
             let weak = weak.clone();
             move |_, _, cx| {
                 if let Some(entity) = weak.upgrade() {
-                    entity.update(cx, |_, cx| {
-                        cx.emit(SidebarCloseOthers { session_id })
-                    });
+                    entity.update(cx, |_, cx| cx.emit(SidebarCloseOthers { session_id }));
                 }
             }
         }));

--- a/crates/con-app/src/stub_view.rs
+++ b/crates/con-app/src/stub_view.rs
@@ -96,7 +96,12 @@ impl GhosttyView {
 
     pub fn set_surface_focus_state(&mut self, _focused: bool) {}
 
-    pub fn ensure_initialized_for_control(&mut self, _window: &mut Window, _cx: &mut Context<Self>) {}
+    pub fn ensure_initialized_for_control(
+        &mut self,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
+    }
 
     pub fn set_visible(&self, _visible: bool) {}
 
@@ -129,11 +134,7 @@ impl Render for GhosttyView {
             .gap(px(10.0))
             .bg(theme.background.opacity(0.9))
             .text_color(theme.foreground.opacity(0.8))
-            .child(
-                div()
-                    .text_lg()
-                    .child("Terminal backend under construction"),
-            )
+            .child(div().text_lg().child("Terminal backend under construction"))
             .child(
                 div()
                     .text_sm()

--- a/crates/con-app/src/terminal_pane.rs
+++ b/crates/con-app/src/terminal_pane.rs
@@ -61,8 +61,9 @@ impl TerminalPane {
     }
 
     pub fn ensure_surface(&self, window: &mut Window, cx: &mut App) {
-        self.entity
-            .update(cx, |view, cx| view.ensure_initialized_for_control(window, cx));
+        self.entity.update(cx, |view, cx| {
+            view.ensure_initialized_for_control(window, cx)
+        });
     }
 
     pub fn set_theme(
@@ -134,11 +135,13 @@ impl TerminalPane {
     }
 
     pub fn drain_surface_state(&self, cx: &mut App) -> bool {
-        self.entity.update(cx, |view, cx| view.drain_surface_state(cx))
+        self.entity
+            .update(cx, |view, cx| view.drain_surface_state(cx))
     }
 
     pub fn pump_surface_deferred_work(&self, cx: &mut App) -> bool {
-        self.entity.update(cx, |view, cx| view.pump_deferred_work(cx))
+        self.entity
+            .update(cx, |view, cx| view.pump_deferred_work(cx))
     }
 
     pub fn sync_window_background_blur(&self, cx: &mut App) {

--- a/crates/con-app/src/updater.rs
+++ b/crates/con-app/src/updater.rs
@@ -71,7 +71,10 @@ pub enum CheckState {
 }
 
 pub fn latest_check() -> CheckState {
-    latest_slot().lock().map(|g| g.clone()).unwrap_or(CheckState::Idle)
+    latest_slot()
+        .lock()
+        .map(|g| g.clone())
+        .unwrap_or(CheckState::Idle)
 }
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]
@@ -178,7 +181,10 @@ fn init_inner() -> bool {
 
     let channel = con_core::release_channel::current();
     if !channel.polls_for_updates() {
-        log::info!("updater: channel={} — skipping Sparkle init", channel.name());
+        log::info!(
+            "updater: channel={} — skipping Sparkle init",
+            channel.name()
+        );
         let _ = STATUS.set(UpdaterStatus::Disabled(
             UpdaterDisabledReason::ChannelDoesNotPoll,
         ));
@@ -239,9 +245,7 @@ fn init_inner() -> bool {
                 let reason = if reason_cstr.is_null() {
                     ""
                 } else {
-                    std::ffi::CStr::from_ptr(reason_cstr)
-                        .to_str()
-                        .unwrap_or("")
+                    std::ffi::CStr::from_ptr(reason_cstr).to_str().unwrap_or("")
                 };
                 log::warn!(
                     "updater: failed to load Sparkle.framework: {} {}",
@@ -266,7 +270,9 @@ fn init_inner() -> bool {
         let feed_url: id = msg_send![info_dict, objectForKey: feed_key];
         if feed_url == nil {
             log::info!("updater: SUFeedURL not set in Info.plist — auto-update disabled");
-            let _ = STATUS.set(UpdaterStatus::Disabled(UpdaterDisabledReason::MissingFeedUrl));
+            let _ = STATUS.set(UpdaterStatus::Disabled(
+                UpdaterDisabledReason::MissingFeedUrl,
+            ));
             return false;
         }
 
@@ -626,7 +632,10 @@ mod notify_impl {
     /// keeps this module fully self-contained.
     pub(super) fn spawn_check(channel: ReleaseChannel) {
         set_latest(CheckState::Checking);
-        let url = channel.feed_url(release_channel::host_platform(), release_channel::host_arch());
+        let url = channel.feed_url(
+            release_channel::host_platform(),
+            release_channel::host_arch(),
+        );
         std::thread::spawn(move || {
             let result = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
@@ -682,7 +691,11 @@ mod notify_impl {
     /// the newest item first, so we only need to parse the head of
     /// the document.
     fn parse_latest(xml: &str) -> Option<(String, String)> {
-        let version = between(xml, "<sparkle:shortVersionString>", "</sparkle:shortVersionString>")?;
+        let version = between(
+            xml,
+            "<sparkle:shortVersionString>",
+            "</sparkle:shortVersionString>",
+        )?;
         let enclosure_start = xml.find("<enclosure")?;
         let enclosure_end = xml[enclosure_start..]
             .find('>')

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -10,10 +10,10 @@ use cocoa::base::id;
 use cocoa::foundation::NSSize;
 use gpui::{prelude::FluentBuilder as _, *};
 use gpui_component::{ActiveTheme, tooltip::Tooltip};
-use serde_json::json;
-use tokio::sync::oneshot;
 #[cfg(target_os = "macos")]
 use objc::{msg_send, sel, sel_impl};
+use serde_json::json;
+use tokio::sync::oneshot;
 
 const AGENT_PANEL_DEFAULT_WIDTH: f32 = 400.0;
 const AGENT_PANEL_MIN_WIDTH: f32 = 200.0;
@@ -28,26 +28,26 @@ const MAX_GLOBAL_INPUT_HISTORY: usize = 240;
 fn perf_trace_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {
-        std::env::var_os("CON_GHOSTTY_PROFILE")
-            .is_some_and(|v| !v.is_empty() && v != "0")
+        std::env::var_os("CON_GHOSTTY_PROFILE").is_some_and(|v| !v.is_empty() && v != "0")
     })
 }
 
-fn chrome_tooltip(label: &str, stroke: Option<Keystroke>, window: &mut Window, cx: &mut App) -> AnyView {
+fn chrome_tooltip(
+    label: &str,
+    stroke: Option<Keystroke>,
+    window: &mut Window,
+    cx: &mut App,
+) -> AnyView {
     let label = label.to_string();
     Tooltip::element(move |_, cx| {
         let theme = cx.theme();
-        let mut content = div()
-            .flex()
-            .items_center()
-            .gap(px(7.0))
-            .child(
-                div()
-                    .text_size(px(12.0))
-                    .line_height(px(16.0))
-                    .text_color(theme.popover_foreground)
-                    .child(label.clone()),
-            );
+        let mut content = div().flex().items_center().gap(px(7.0)).child(
+            div()
+                .text_size(px(12.0))
+                .line_height(px(16.0))
+                .text_color(theme.popover_foreground)
+                .child(label.clone()),
+        );
 
         if let Some(stroke) = stroke.as_ref() {
             content = content.child(crate::keycaps::keycaps_for_stroke(stroke, theme));
@@ -95,9 +95,9 @@ fn caption_buttons(
     // route it explicitly.
     #[cfg(target_os = "linux")] workspace: gpui::WeakEntity<ConWorkspace>,
 ) -> impl IntoElement {
-    use gpui::{div, px, svg, Hsla, ParentElement, Rgba, Styled, WindowControlArea};
     #[cfg(target_os = "linux")]
     use gpui::MouseButton;
+    use gpui::{Hsla, ParentElement, Rgba, Styled, WindowControlArea, div, px, svg};
 
     let close_red: Hsla = Rgba {
         r: 232.0 / 255.0,
@@ -109,10 +109,7 @@ fn caption_buttons(
     let fg = theme.muted_foreground.opacity(0.9);
     let hover_bg = theme.muted.opacity(0.12);
 
-    let button = |id: &'static str,
-                  icon: &'static str,
-                  area: WindowControlArea,
-                  close: bool| {
+    let button = |id: &'static str, icon: &'static str, area: WindowControlArea, close: bool| {
         let hover = if close { close_red } else { hover_bg };
         // All three glyphs rest at the same theme-muted foreground so
         // min/max/close read as one visual row. Only on hover does the
@@ -207,8 +204,7 @@ fn caption_buttons(
 use crate::agent_panel::{
     AgentPanel, CancelRequest, DeleteConversation, InlineInputSubmit,
     InlineSkillAutocompleteChanged, LoadConversation, NewConversation, PanelState,
-    RerunFromMessage, SelectSessionModel, SelectSessionProvider,
-    SetAutoApprove,
+    RerunFromMessage, SelectSessionModel, SelectSessionProvider, SetAutoApprove,
 };
 use crate::command_palette::{
     CommandPalette, PaletteDismissed, PaletteSelect, ToggleCommandPalette,
@@ -220,7 +216,9 @@ use crate::input_bar::{
 use crate::model_registry::ModelRegistry;
 use crate::motion::MotionValue;
 use crate::pane_tree::{PaneTree, SplitDirection, SplitPlacement};
-use crate::settings_panel::{self, SaveSettings, SettingsPanel, TabsOrientationChanged, ThemePreview};
+use crate::settings_panel::{
+    self, SaveSettings, SettingsPanel, TabsOrientationChanged, ThemePreview,
+};
 use crate::sidebar::{
     NewSession, SessionEntry, SessionSidebar, SidebarCloseOthers, SidebarCloseTab,
     SidebarDuplicate, SidebarRename, SidebarReorder, SidebarSelect,
@@ -233,10 +231,12 @@ use crate::ghostty_view::{
     GhosttyView,
 };
 use crate::{
-    ClosePane, CloseTab, CycleInputMode, FocusInput, NewTab, NextTab, PreviousTab, Quit,
-    SplitDown, SplitRight, ToggleAgentPanel, TogglePaneScopePicker,
+    ClosePane, CloseTab, CycleInputMode, FocusInput, NewTab, NextTab, PreviousTab, Quit, SplitDown,
+    SplitRight, ToggleAgentPanel, TogglePaneScopePicker,
 };
-use con_agent::{AgentConfig, Conversation, ProviderKind, TerminalExecRequest, TerminalExecResponse};
+use con_agent::{
+    AgentConfig, Conversation, ProviderKind, TerminalExecRequest, TerminalExecResponse,
+};
 use con_core::config::{Config, TabsOrientation};
 use con_core::control::{
     AgentAskResult, ControlCommand, ControlError, ControlRequestEnvelope, ControlResult,
@@ -1153,9 +1153,12 @@ impl ConWorkspace {
             let tx = tab_summary_tx.clone();
             for (i, tab) in tabs.iter_mut().enumerate() {
                 let terminal = tab.pane_tree.focused_terminal();
-                let cwd = terminal
-                    .current_dir(cx)
-                    .or_else(|| session.tabs.get(i).and_then(|tab_state| tab_state.cwd.clone()));
+                let cwd = terminal.current_dir(cx).or_else(|| {
+                    session
+                        .tabs
+                        .get(i)
+                        .and_then(|tab_state| tab_state.cwd.clone())
+                });
                 let title = Some(tab.title.clone()).filter(|t| !t.is_empty());
                 let pane_id = tab
                     .pane_tree
@@ -1267,7 +1270,11 @@ impl ConWorkspace {
     }
 
     fn sync_tab_strip_motion(&mut self) {
-        let target = if self.horizontal_tabs_visible() { 1.0 } else { 0.0 };
+        let target = if self.horizontal_tabs_visible() {
+            1.0
+        } else {
+            0.0
+        };
         self.tab_strip_motion
             .set_target(target, std::time::Duration::from_millis(180));
     }
@@ -1400,9 +1407,9 @@ impl ConWorkspace {
 
         let raw_handle: raw_window_handle::WindowHandle<'_> =
             match <Window as raw_window_handle::HasWindowHandle>::window_handle(window) {
-            Ok(handle) => handle,
-            Err(_) => return,
-        };
+                Ok(handle) => handle,
+                Err(_) => return,
+            };
         let gpui_nsview = match raw_handle.as_raw() {
             raw_window_handle::RawWindowHandle::AppKit(handle) => handle.ns_view.as_ptr() as id,
             _ => return,
@@ -2596,9 +2603,7 @@ impl ConWorkspace {
                 let current_tab_idx = workspace
                     .pending_control_agent_requests
                     .iter()
-                    .find_map(|(idx, pending)| {
-                        (pending.request_id == request_id).then_some(*idx)
-                    });
+                    .find_map(|(idx, pending)| (pending.request_id == request_id).then_some(*idx));
                 if let Some(current_tab_idx) = current_tab_idx {
                     let pending = workspace
                         .pending_control_agent_requests
@@ -2740,14 +2745,11 @@ impl ConWorkspace {
         let session = self.snapshot_session(cx);
         let history = self.snapshot_global_history();
         let (done_tx, done_rx) = crossbeam_channel::bounded(1);
-        if let Err(err) = self
-            .session_save_tx
-            .send(SessionSaveRequest::Flush(
-                session.clone(),
-                history.clone(),
-                done_tx,
-            ))
-        {
+        if let Err(err) = self.session_save_tx.send(SessionSaveRequest::Flush(
+            session.clone(),
+            history.clone(),
+            done_tx,
+        )) {
             log::warn!("Failed to flush session save queue: {}", err);
             if let Err(save_err) = session.save() {
                 log::warn!("Failed to save session directly during flush: {}", save_err);
@@ -2764,7 +2766,10 @@ impl ConWorkspace {
         if let Err(err) = done_rx.recv_timeout(Duration::from_secs(2)) {
             log::warn!("Timed out waiting for session save flush: {}", err);
             if let Err(save_err) = session.save() {
-                log::warn!("Failed to save session directly after flush timeout: {}", save_err);
+                log::warn!(
+                    "Failed to save session directly after flush timeout: {}",
+                    save_err
+                );
             }
             if let Err(save_err) = history.save() {
                 log::warn!(
@@ -2868,7 +2873,11 @@ impl ConWorkspace {
             ProviderKind::Together,
             ProviderKind::XAI,
         ] {
-            if let Some(model) = config.providers.get(&provider).and_then(|entry| entry.model.clone()) {
+            if let Some(model) = config
+                .providers
+                .get(&provider)
+                .and_then(|entry| entry.model.clone())
+            {
                 model_overrides.push(AgentModelOverrideState { provider, model });
             }
         }
@@ -2891,7 +2900,9 @@ impl ConWorkspace {
             }
             let mut provider_config = config.providers.get_or_default(&override_state.provider);
             provider_config.model = Some(override_state.model.clone());
-            config.providers.set(&override_state.provider, provider_config);
+            config
+                .providers
+                .set(&override_state.provider, provider_config);
         }
 
         config
@@ -3164,18 +3175,24 @@ impl ConWorkspace {
                     .is_some(),
             ) {
                 InputKind::SkillInvoke(name, args) => {
-                    if let Some(desc) =
-                        self.harness
-                            .invoke_skill(session, agent_config.clone(), &name, args.as_deref(), context)
-                    {
+                    if let Some(desc) = self.harness.invoke_skill(
+                        session,
+                        agent_config.clone(),
+                        &name,
+                        args.as_deref(),
+                        context,
+                    ) {
                         self.agent_panel.update(cx, |panel, cx| {
                             panel.add_step(&desc, cx);
                         });
                     }
                 }
-                _ => self
-                    .harness
-                    .send_message(session, agent_config.clone(), event.content.clone(), context),
+                _ => self.harness.send_message(
+                    session,
+                    agent_config.clone(),
+                    event.content.clone(),
+                    context,
+                ),
             }
         } else {
             self.harness
@@ -3561,7 +3578,8 @@ impl ConWorkspace {
             panel.set_provider_name(active_agent_config.provider.clone(), window, cx);
             panel.set_model_name(AgentHarness::active_model_name_for(&active_agent_config));
             panel.set_session_model_options(
-                self.model_registry.models_for(&active_agent_config.provider),
+                self.model_registry
+                    .models_for(&active_agent_config.provider),
                 window,
                 cx,
             );
@@ -3830,10 +3848,13 @@ impl ConWorkspace {
                         let context = self.build_agent_context(cx);
                         let session = &self.tabs[self.active_tab].session;
                         let agent_config = self.active_tab_agent_config();
-                        if let Some(desc) =
-                            self.harness
-                                .invoke_skill(session, agent_config, &name, args.as_deref(), context)
-                        {
+                        if let Some(desc) = self.harness.invoke_skill(
+                            session,
+                            agent_config,
+                            &name,
+                            args.as_deref(),
+                            context,
+                        ) {
                             if !self.agent_panel_open {
                                 self.agent_panel_open = true;
                             }
@@ -5100,9 +5121,13 @@ impl ConWorkspace {
             None
         };
         let base_tile_surface = if theme.is_dark() {
-            theme.title_bar.opacity(if is_focused { 0.84 } else { 0.72 })
+            theme
+                .title_bar
+                .opacity(if is_focused { 0.84 } else { 0.72 })
         } else {
-            theme.background.opacity(if is_focused { 0.96 } else { 0.90 })
+            theme
+                .background
+                .opacity(if is_focused { 0.96 } else { 0.90 })
         };
         let hover_tile_surface = if theme.is_dark() {
             theme.title_bar.opacity(0.90)
@@ -5521,11 +5546,7 @@ impl ConWorkspace {
         cx.notify();
     }
 
-    fn focus_agent_inline_input_next_frame(
-        &mut self,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
+    fn focus_agent_inline_input_next_frame(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         cx.on_next_frame(window, |workspace, window, cx| {
             if !workspace.agent_panel_open || workspace.input_bar_visible {
                 return;
@@ -6015,12 +6036,10 @@ impl ConWorkspace {
             .into_iter()
             .find_map(|(id, terminal)| (id == pane_id).then_some(terminal));
         let cwd = pane.as_ref().and_then(|pane| pane.current_dir(cx));
-        let is_remote = pane
-            .as_ref()
-            .is_some_and(|terminal| {
-                self.effective_remote_host_for_tab(self.active_tab, terminal, cx)
-                    .is_some()
-            });
+        let is_remote = pane.as_ref().is_some_and(|terminal| {
+            self.effective_remote_host_for_tab(self.active_tab, terminal, cx)
+                .is_some()
+        });
 
         if let Some(path_match) =
             self.local_path_completion_for_prefix(self.active_tab, pane_id, &text, cx)
@@ -6219,12 +6238,7 @@ impl ConWorkspace {
     /// `summary_id` (NOT index, since reorders / closes shift the
     /// indexes), update its `ai_label` / `ai_icon`, and republish to
     /// the sidebar.
-    fn apply_tab_summary(
-        &mut self,
-        generation: u64,
-        summary: TabSummary,
-        cx: &mut Context<Self>,
-    ) {
+    fn apply_tab_summary(&mut self, generation: u64, summary: TabSummary, cx: &mut Context<Self>) {
         if generation != self.tab_summary_generation
             || !self.vertical_tabs_active()
             || !self.harness.config().suggestion_model.enabled
@@ -6412,12 +6426,7 @@ impl ConWorkspace {
 
     fn split_down(&mut self, _: &SplitDown, window: &mut Window, cx: &mut Context<Self>) {
         if self.has_active_tab() {
-            self.split_pane(
-                SplitDirection::Vertical,
-                SplitPlacement::After,
-                window,
-                cx,
-            );
+            self.split_pane(SplitDirection::Vertical, SplitPlacement::After, window, cx);
         }
     }
 
@@ -6941,8 +6950,9 @@ impl Render for ConWorkspace {
         // takes the (re-entrant) sidebar borrow before `theme` claims
         // the immutable cx borrow that the rest of `render` relies on.
         let vertical_tabs_overlay = if self.vertical_tabs_active() {
-            self.sidebar
-                .update(cx, |sidebar, cx| sidebar.render_hover_card_overlay(window, cx))
+            self.sidebar.update(cx, |sidebar, cx| {
+                sidebar.render_hover_card_overlay(window, cx)
+            })
         } else {
             None
         };
@@ -7025,13 +7035,15 @@ impl Render for ConWorkspace {
                                     })
                                     .on_mouse_down(
                                         MouseButton::Left,
-                                        cx.listener(move |this, event: &MouseDownEvent, _window, cx| {
-                                            this.release_active_terminal_mouse_selection(cx);
-                                            this.agent_panel_drag = Some((
-                                                f32::from(event.position.x),
-                                                effective_agent_panel_width,
-                                            ));
-                                        }),
+                                        cx.listener(
+                                            move |this, event: &MouseDownEvent, _window, cx| {
+                                                this.release_active_terminal_mouse_selection(cx);
+                                                this.agent_panel_drag = Some((
+                                                    f32::from(event.position.x),
+                                                    effective_agent_panel_width,
+                                                ));
+                                            },
+                                        ),
                                     ),
                             ),
                     )
@@ -7062,11 +7074,7 @@ impl Render for ConWorkspace {
         // (GPUI's hit-test walks buttons first so child clickables
         // still work) and still lets macOS react to
         // `titlebar_double_click`.
-        let leading_pad = if cfg!(target_os = "macos") {
-            78.0
-        } else {
-            8.0
-        };
+        let leading_pad = if cfg!(target_os = "macos") { 78.0 } else { 8.0 };
         let mut top_bar = div()
             .id("tab-bar")
             .flex()
@@ -7400,14 +7408,11 @@ impl Render for ConWorkspace {
                         this.toggle_settings(&settings_panel::ToggleSettings, window, cx);
                     }))
                     .child(
-                        svg()
-                            .path("phosphor/gear.svg")
-                            .size(px(12.0))
-                            .text_color(
-                                theme
-                                    .muted_foreground
-                                    .opacity(0.45 + (0.08 * compact_titlebar_progress)),
-                            ),
+                        svg().path("phosphor/gear.svg").size(px(12.0)).text_color(
+                            theme
+                                .muted_foreground
+                                .opacity(0.45 + (0.08 * compact_titlebar_progress)),
+                        ),
                     ),
             );
         }
@@ -7452,7 +7457,8 @@ impl Render for ConWorkspace {
             root = root.rounded(px(14.0)).overflow_hidden();
         }
 
-        root = root.key_context("ConWorkspace")
+        root = root
+            .key_context("ConWorkspace")
             // Pane drag-to-resize: capture mouse move/up on root so it works
             // even when cursor is over terminal views (which capture mouse events).
             .on_mouse_move({
@@ -7462,8 +7468,8 @@ impl Render for ConWorkspace {
                     if let Some((start_x, start_width)) = this.agent_panel_drag {
                         let delta = start_x - f32::from(event.position.x);
                         let max_width = max_agent_panel_width(win.bounds().size.width.as_f32());
-                        let new_width = (start_width + delta)
-                            .clamp(AGENT_PANEL_MIN_WIDTH, max_width);
+                        let new_width =
+                            (start_width + delta).clamp(AGENT_PANEL_MIN_WIDTH, max_width);
                         if (this.agent_panel_width - new_width).abs() > 1.0 {
                             this.agent_panel_width = new_width;
                             if this.active_tab >= this.tabs.len() {
@@ -7935,48 +7941,46 @@ impl Render for ConWorkspace {
                     );
 
                 let preset_segment = |id: &'static str, label: &'static str, active: bool| {
-                    div()
-                        .flex_1()
-                        .child(
-                            div()
-                                .id(SharedString::from(id))
-                                .h(px(24.0))
-                                .w_full()
-                                .rounded(px(7.0))
-                                .cursor_pointer()
-                                .flex()
-                                .items_center()
-                                .justify_center()
-                                .bg(if active {
-                                    theme.primary.opacity(0.14)
+                    div().flex_1().child(
+                        div()
+                            .id(SharedString::from(id))
+                            .h(px(24.0))
+                            .w_full()
+                            .rounded(px(7.0))
+                            .cursor_pointer()
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .bg(if active {
+                                theme.primary.opacity(0.14)
+                            } else {
+                                theme.transparent
+                            })
+                            .hover(|s| {
+                                s.bg(if active {
+                                    theme.primary.opacity(0.16)
                                 } else {
-                                    theme.transparent
+                                    theme.muted.opacity(0.05)
                                 })
-                                .hover(|s| {
-                                    s.bg(if active {
-                                        theme.primary.opacity(0.16)
+                            })
+                            .child(
+                                div()
+                                    .text_size(px(11.0))
+                                    .line_height(px(13.0))
+                                    .font_family(theme.mono_font_family.clone())
+                                    .font_weight(if active {
+                                        FontWeight::MEDIUM
                                     } else {
-                                        theme.muted.opacity(0.05)
+                                        FontWeight::NORMAL
                                     })
-                                })
-                                .child(
-                                    div()
-                                        .text_size(px(11.0))
-                                        .line_height(px(13.0))
-                                        .font_family(theme.mono_font_family.clone())
-                                        .font_weight(if active {
-                                            FontWeight::MEDIUM
-                                        } else {
-                                            FontWeight::NORMAL
-                                        })
-                                        .text_color(if active {
-                                            theme.primary
-                                        } else {
-                                            theme.muted_foreground.opacity(0.72)
-                                        })
-                                        .child(label),
-                                ),
-                        )
+                                    .text_color(if active {
+                                        theme.primary
+                                    } else {
+                                        theme.muted_foreground.opacity(0.72)
+                                    })
+                                    .child(label),
+                            ),
+                    )
                 };
 
                 let presets_row = div()
@@ -7993,24 +7997,34 @@ impl Render for ConWorkspace {
                             .flex()
                             .items_center()
                             .gap(px(2.0))
-                            .child(preset_segment(
-                                "scope-all",
-                                "All panes",
-                                is_broadcast,
-                            ).on_mouse_down(MouseButton::Left, cx.listener(
-                                |this: &mut ConWorkspace, _: &MouseDownEvent, window, cx| {
-                                    this.set_scope_broadcast(window, cx);
-                                },
-                            )))
-                            .child(preset_segment(
-                                "scope-focused",
-                                "Focused",
-                                is_focused,
-                            ).on_mouse_down(MouseButton::Left, cx.listener(
-                                |this: &mut ConWorkspace, _: &MouseDownEvent, window, cx| {
-                                    this.set_scope_focused(window, cx);
-                                },
-                            ))),
+                            .child(
+                                preset_segment("scope-all", "All panes", is_broadcast)
+                                    .on_mouse_down(
+                                        MouseButton::Left,
+                                        cx.listener(
+                                            |this: &mut ConWorkspace,
+                                             _: &MouseDownEvent,
+                                             window,
+                                             cx| {
+                                                this.set_scope_broadcast(window, cx);
+                                            },
+                                        ),
+                                    ),
+                            )
+                            .child(
+                                preset_segment("scope-focused", "Focused", is_focused)
+                                    .on_mouse_down(
+                                        MouseButton::Left,
+                                        cx.listener(
+                                            |this: &mut ConWorkspace,
+                                             _: &MouseDownEvent,
+                                             window,
+                                             cx| {
+                                                this.set_scope_focused(window, cx);
+                                            },
+                                        ),
+                                    ),
+                            ),
                     )
                     .child(div().flex_1());
 
@@ -8238,10 +8252,7 @@ fn smart_tab_presentation(
     };
 
     // 1. User label always wins for the name.
-    if let Some(label) = user_label
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-    {
+    if let Some(label) = user_label.map(str::trim).filter(|s| !s.is_empty()) {
         let icon = if is_ssh_session {
             "phosphor/globe.svg"
         } else {
@@ -8394,18 +8405,16 @@ fn parse_focused_process(title: &str) -> Option<(String, &'static str)> {
     match lower.as_str() {
         // Bare shells aren't an interesting "process" — fall through
         // so the row gets named by cwd or user label instead.
-        "bash" | "sh" | "zsh" | "fish" | "dash" | "ksh" | "ion" | "nu" | "pwsh"
-        | "powershell" | "cmd" | "tmux" | "screen" => None,
+        "bash" | "sh" | "zsh" | "fish" | "dash" | "ksh" | "ion" | "nu" | "pwsh" | "powershell"
+        | "cmd" | "tmux" | "screen" => None,
 
-        "vim" | "nvim" | "vi" | "neovim" | "nano" | "emacs" | "ed" | "helix" | "hx"
-        | "kakoune" | "kak" | "micro" | "code" | "codium" | "subl" => {
+        "vim" | "nvim" | "vi" | "neovim" | "nano" | "emacs" | "ed" | "helix" | "hx" | "kakoune"
+        | "kak" | "micro" | "code" | "codium" | "subl" => {
             Some((trimmed.to_string(), "phosphor/code.svg"))
         }
 
-        "htop" | "top" | "btop" | "btm" | "atop" | "iotop" | "glances" | "nvtop"
-        | "bashtop" | "ctop" | "k9s" => {
-            Some((trimmed.to_string(), "phosphor/pulse.svg"))
-        }
+        "htop" | "top" | "btop" | "btm" | "atop" | "iotop" | "glances" | "nvtop" | "bashtop"
+        | "ctop" | "k9s" => Some((trimmed.to_string(), "phosphor/pulse.svg")),
 
         "less" | "more" | "most" | "bat" | "cat" | "tail" | "head" | "view" | "man" => {
             Some((trimmed.to_string(), "phosphor/book-open.svg"))
@@ -8413,9 +8422,7 @@ fn parse_focused_process(title: &str) -> Option<(String, &'static str)> {
 
         "ssh" | "mosh" => Some((trimmed.to_string(), "phosphor/globe.svg")),
 
-        "git" | "lazygit" | "tig" | "gh" => {
-            Some((trimmed.to_string(), "phosphor/file-code.svg"))
-        }
+        "git" | "lazygit" | "tig" | "gh" => Some((trimmed.to_string(), "phosphor/file-code.svg")),
 
         _ => Some((trimmed.to_string(), "phosphor/terminal.svg")),
     }

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -5318,12 +5318,67 @@ impl ConWorkspace {
     }
 
     fn focus_input(&mut self, _: &FocusInput, window: &mut Window, cx: &mut Context<Self>) {
+        if self.is_modal_open(cx) {
+            return;
+        }
+
+        if self.is_input_surface_focused(window, cx) {
+            self.focus_first_terminal(window, cx);
+            return;
+        }
+
+        self.focus_preferred_input_surface(window, cx);
+    }
+
+    fn is_input_surface_focused(&self, window: &Window, cx: &App) -> bool {
+        let input_bar_focused =
+            self.input_bar_visible && self.input_bar.focus_handle(cx).is_focused(window);
+        let agent_inline_focused = self.agent_panel_open
+            && self
+                .agent_panel
+                .read(cx)
+                .inline_input_is_focused(window, cx);
+
+        input_bar_focused || agent_inline_focused
+    }
+
+    fn focus_preferred_input_surface(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if !self.input_bar_visible {
+            if self.agent_panel_open {
+                let focused_inline = self
+                    .agent_panel
+                    .update(cx, |panel, cx| panel.focus_inline_input(window, cx));
+                if !focused_inline {
+                    self.focus_agent_inline_input_next_frame(window, cx);
+                }
+                return;
+            }
+
             self.input_bar_visible = true;
             self.save_session(cx);
-            cx.notify();
         }
         self.input_bar.focus_handle(cx).focus(window, cx);
+        cx.notify();
+    }
+
+    fn focus_first_terminal(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if !self.has_active_tab() {
+            return;
+        }
+
+        self.pane_scope_picker_open = false;
+        let Some((pane_id, terminal)) = self.tabs[self.active_tab]
+            .pane_tree
+            .pane_terminals()
+            .into_iter()
+            .next()
+        else {
+            return;
+        };
+        self.tabs[self.active_tab].pane_tree.focus(pane_id);
+        terminal.focus(window, cx);
+        self.sync_active_terminal_focus_states(cx);
+        cx.notify();
     }
 
     fn cycle_input_mode(

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -5382,6 +5382,14 @@ impl ConWorkspace {
             self.input_bar_visible = true;
             self.save_session(cx);
         }
+        self.focus_input_bar_surface(window, cx);
+    }
+
+    fn focus_input_bar_surface(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if !self.input_bar_visible {
+            self.input_bar_visible = true;
+            self.save_session(cx);
+        }
         self.input_bar.focus_handle(cx).focus(window, cx);
         cx.notify();
     }
@@ -5555,7 +5563,7 @@ impl ConWorkspace {
                 .agent_panel
                 .update(cx, |panel, cx| panel.focus_inline_input(window, cx));
             if !focused {
-                workspace.focus_terminal(window, cx);
+                workspace.focus_input_bar_surface(window, cx);
             }
         });
     }

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -5388,6 +5388,8 @@ impl ConWorkspace {
     fn focus_input_bar_surface(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if !self.input_bar_visible {
             self.input_bar_visible = true;
+            self.input_bar_motion
+                .set_target(1.0, std::time::Duration::from_millis(180));
             self.save_session(cx);
         }
         self.input_bar.focus_handle(cx).focus(window, cx);

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -5378,9 +5378,6 @@ impl ConWorkspace {
                 }
                 return;
             }
-
-            self.input_bar_visible = true;
-            self.save_session(cx);
         }
         self.focus_input_bar_surface(window, cx);
     }
@@ -5388,10 +5385,10 @@ impl ConWorkspace {
     fn focus_input_bar_surface(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if !self.input_bar_visible {
             self.input_bar_visible = true;
-            self.input_bar_motion
-                .set_target(1.0, std::time::Duration::from_millis(180));
             self.save_session(cx);
         }
+        self.input_bar_motion
+            .set_target(1.0, std::time::Duration::from_millis(180));
         self.input_bar.focus_handle(cx).focus(window, cx);
         cx.notify();
     }

--- a/crates/con-core/src/suggestions.rs
+++ b/crates/con-core/src/suggestions.rs
@@ -183,7 +183,9 @@ impl SuggestionEngine {
                     );
                     callback(completion);
                 } else {
-                    empty_cache.lock().insert(cache_key_owned.clone(), Instant::now());
+                    empty_cache
+                        .lock()
+                        .insert(cache_key_owned.clone(), Instant::now());
                     log::debug!(
                         target: "con_core::suggestions",
                         "ai suggestion empty result prefix={:?}",
@@ -191,7 +193,9 @@ impl SuggestionEngine {
                     );
                 }
             } else {
-                empty_cache.lock().insert(cache_key_owned.clone(), Instant::now());
+                empty_cache
+                    .lock()
+                    .insert(cache_key_owned.clone(), Instant::now());
             }
             in_flight.lock().remove(&cache_key_owned);
         });

--- a/crates/con-core/src/tab_summary.rs
+++ b/crates/con-core/src/tab_summary.rs
@@ -387,7 +387,10 @@ fn truncate_label(s: &str) -> String {
     if trimmed.chars().count() <= LABEL_MAX_LEN {
         trimmed.to_string()
     } else {
-        let mut out: String = trimmed.chars().take(LABEL_MAX_LEN.saturating_sub(1)).collect();
+        let mut out: String = trimmed
+            .chars()
+            .take(LABEL_MAX_LEN.saturating_sub(1))
+            .collect();
         out.push('…');
         out
     }
@@ -491,7 +494,10 @@ async fn request_summary(
                     Respond with a JSON object only: \
                     {\"label\": \"...\", \"icon\": \"...\"}. \
                     No prose, no code fences, no commentary.";
-    let raw = match provider.complete_with_options(&prompt, preamble, 2048).await {
+    let raw = match provider
+        .complete_with_options(&prompt, preamble, 2048)
+        .await
+    {
         Ok(s) => s,
         Err(e) => {
             log::debug!(
@@ -648,8 +654,7 @@ mod tests {
 
     #[test]
     fn parse_json_skips_invalid_brace_block_before_answer() {
-        let raw =
-            "Use {label, icon} as fields.\n{\"label\": \"Build\", \"icon\": \"terminal\"}";
+        let raw = "Use {label, icon} as fields.\n{\"label\": \"Build\", \"icon\": \"terminal\"}";
         let v = parse_summary_json(raw).unwrap();
         assert_eq!(v.label, "Build");
         assert_eq!(v.icon, "terminal");
@@ -690,18 +695,9 @@ mod tests {
 
     #[test]
     fn icon_keyword_aliases() {
-        assert_eq!(
-            TabIconKind::from_keyword("editor"),
-            Some(TabIconKind::Code)
-        );
-        assert_eq!(
-            TabIconKind::from_keyword("htop"),
-            Some(TabIconKind::Pulse)
-        );
-        assert_eq!(
-            TabIconKind::from_keyword("ssh"),
-            Some(TabIconKind::Globe)
-        );
+        assert_eq!(TabIconKind::from_keyword("editor"), Some(TabIconKind::Code));
+        assert_eq!(TabIconKind::from_keyword("htop"), Some(TabIconKind::Pulse));
+        assert_eq!(TabIconKind::from_keyword("ssh"), Some(TabIconKind::Globe));
         assert_eq!(TabIconKind::from_keyword("sparkle"), None);
     }
 
@@ -745,7 +741,10 @@ mod tests {
             last_dispatch: Some(Instant::now()),
             ..Default::default()
         };
-        assert!(!should_dispatch(&s, 42), "same context after success → skip");
+        assert!(
+            !should_dispatch(&s, 42),
+            "same context after success → skip"
+        );
     }
 
     #[test]

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -15,9 +15,9 @@ use std::ffi::{CStr, CString};
 use std::io::Write;
 use std::os::raw::c_void;
 use std::path::Path;
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, Ordering};
 use std::sync::{Arc, Once};
-use std::sync::OnceLock;
 use std::time::Instant;
 
 use dispatch::Queue;
@@ -321,8 +321,7 @@ static mut GHOSTTY_INIT_RESULT: i32 = -1;
 fn perf_trace_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {
-        std::env::var_os("CON_GHOSTTY_PROFILE")
-            .is_some_and(|v| !v.is_empty() && v != "0")
+        std::env::var_os("CON_GHOSTTY_PROFILE").is_some_and(|v| !v.is_empty() && v != "0")
     })
 }
 
@@ -414,7 +413,9 @@ impl GhosttyApp {
             background_opacity,
             background_opacity_cells: background_opacity.map(|opacity| opacity < 0.999),
             background_blur,
-            cursor_style: cursor_style.map(normalize_cursor_style).map(ToOwned::to_owned),
+            cursor_style: cursor_style
+                .map(normalize_cursor_style)
+                .map(ToOwned::to_owned),
             background_image: background_image.map(ToOwned::to_owned),
             background_image_opacity,
             background_image_position: background_image_position.map(ToOwned::to_owned),
@@ -792,13 +793,7 @@ impl GhosttyTerminal {
         let mut width = 0.0;
         let mut height = 0.0;
         unsafe {
-            ffi::ghostty_surface_ime_point(
-                self.surface,
-                &mut x,
-                &mut y,
-                &mut width,
-                &mut height,
-            );
+            ffi::ghostty_surface_ime_point(self.surface, &mut x, &mut y, &mut width, &mut height);
         }
         ImePoint {
             x,

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -853,7 +853,7 @@ impl GhosttyTerminal {
     /// Unlike `send_text()` which uses `ghostty_surface_text` (triggers bracketed
     /// paste wrapping in mode 2004), this sends via `ghostty_surface_key` with the
     /// `text` field set. Ghostty writes the UTF-8 directly to the PTY.
-    fn send_text_as_key_event(&self, text: &str) {
+    pub fn send_text_as_key_event(&self, text: &str) {
         if let Ok(cstr) = CString::new(text) {
             let key_event = ffi::ghostty_input_key_s {
                 action: ffi::ghostty_input_action_e::GHOSTTY_ACTION_PRESS,

--- a/docs/study/markdown-renderer-architecture.md
+++ b/docs/study/markdown-renderer-architecture.md
@@ -2,11 +2,11 @@
 
 ## Decision
 
-con should keep `pulldown-cmark` as the Markdown parser and continue building a Con-owned renderer/style system on top of it.
+con should use the `markdown` crate's mdast parser for agent-panel Markdown and continue building a Con-owned renderer/style system on top of it.
 
 con should not import Zed's markdown crate directly.
 
-con should not switch to a heavier AST-first parser unless the product genuinely needs AST mutation or CommonMark extensions that `pulldown-cmark` cannot provide cleanly.
+The mdast parser choice is intentional now: GFM tables, display math, and inline math are product requirements, and the renderer benefits from a stable block/inline tree with per-node caches.
 
 ## Why
 
@@ -18,9 +18,7 @@ The current quality gap in Con's chat panel is not Markdown parsing correctness.
 - fenced code blocks need their own surface, language label, and mono treatment
 - lists, blockquotes, and headings need a cleaner style ladder
 
-`pulldown-cmark` already gives us a clean event stream for this.
-
-Upstream explicitly positions it as a pull parser with parsing and rendering separated, and notes that it can also support source offsets when needed. That is the right fit for Con's UI renderer.
+The `markdown` crate gives us a normalized mdast tree with GFM and math constructs, while keeping parsing and rendering separated. That is the right fit for Con's UI renderer because parsed block entities can own cache state without reparsing during ordinary GPUI paints.
 
 ### 2. Zed is not reusable as-is
 
@@ -34,9 +32,9 @@ That makes the long-term answer straightforward:
 
 ### 3. A heavier parser would not solve the UI problem
 
-`comrak` is a reasonable Rust Markdown library when you need an AST and HTML rendering, but Con's current problem is not "we lack an AST." It is "our renderer does not have enough explicit style slots and layout structure."
+`comrak` is a reasonable Rust Markdown library when you need HTML rendering or deeper AST mutation, but Con's current problem is not HTML generation. It is "our renderer must turn a known Markdown tree into cached GPUI text/image blocks without stalling the app."
 
-Switching parsers would add cost and churn without solving the typography problem by itself.
+Switching parsers again would add cost and churn without solving the typography and cache-boundary problem by itself.
 
 ## Recommended Con design
 
@@ -44,13 +42,14 @@ Switching parsers would add cost and churn without solving the typography proble
 
 Keep:
 
-- `pulldown-cmark`
+- `markdown`
 
 Use it for:
 
-- CommonMark event parsing
-- extension flags we actually need
-- optional source-offset tracking later through event ranges
+- mdast parsing
+- GFM tables
+- fenced code blocks
+- math flow and math text constructs
 
 ### Con-owned intermediate representation
 
@@ -63,10 +62,13 @@ Keep or evolve the current custom block/inline model in `chat_markdown.rs` into 
   - list item
   - blockquote
   - fenced code block
+  - mermaid diagram
+  - display math
   - thematic break
 - inline nodes:
   - text
   - code
+  - math
   - emphasis
   - strong
   - strikethrough
@@ -120,6 +122,10 @@ Performance rule:
 
 - long-form chat content must prefer one text layout with styled runs over per-token element trees
 - fenced code blocks must prefer one highlighted text layout per block over one UI row per line
+- mermaid diagram rendering must happen off the UI thread and cache the rendered image by source text + scale
+- display math rendering must happen off the UI thread and cache the rendered image by source text + font-size key
+- inline math should use a conservative false-positive filter so normal prose such as prices does not become math
+- `mathjax-svg-rs` pulls in a real JavaScript/MathJax engine; keep it isolated to the UI crate, render only on a background executor, and revisit only with measured binary-size or cold-start data
 - inline code inside dense prose, lists, or table cells should not force flex-wrapped chip segmentation at chat-message scale
 - decorative inline-code chips are acceptable for short UI copy, not for large agent replies
 - cache parsed/flattened text-run transforms at the markdown data layer before trying view-level caching
@@ -152,13 +158,13 @@ Add source-range support if needed for:
 - hover actions
 - future copy/open behaviors on links or code blocks
 
-`pulldown-cmark` can support that without forcing a parser rewrite.
+The mdast layer can be extended with source-position tracking if we need this later.
 
 ## Conclusion
 
 The long-term elegant path is:
 
-- keep `pulldown-cmark`
+- keep `markdown` mdast parsing
 - keep a Con-owned renderer
 - formalize a real markdown style/render abstraction
 - do not import Zed's GPL markdown crate
@@ -168,7 +174,6 @@ That is the lowest-redundancy, license-safe, long-term architecture.
 
 ## Primary sources
 
-- `pulldown-cmark` upstream README: <https://github.com/pulldown-cmark/pulldown-cmark>
-- `pulldown-cmark` Rust docs: <https://docs.rs/pulldown-cmark/latest/pulldown_cmark/>
+- `markdown` Rust docs: <https://docs.rs/markdown/latest/markdown/>
 - `comrak` Rust docs: <https://docs.rs/comrak/latest/comrak/>
 - CommonMark spec: <https://spec.commonmark.org/>

--- a/docs/study/markdown-renderer-architecture.md
+++ b/docs/study/markdown-renderer-architecture.md
@@ -124,6 +124,7 @@ Performance rule:
 - fenced code blocks must prefer one highlighted text layout per block over one UI row per line
 - mermaid diagram rendering must happen off the UI thread and cache the rendered image by source text + scale
 - display math rendering must happen off the UI thread and cache the rendered image by source text + font-size key
+- nested rich blocks must use the same async image pipeline as top-level rich blocks; source-text fallback is only an error/loading path
 - inline math should use a conservative false-positive filter so normal prose such as prices does not become math
 - `mathjax-svg-rs` pulls in a real JavaScript/MathJax engine; keep it isolated to the UI crate, render only on a background executor, and revisit only with measured binary-size or cold-start data
 - inline code inside dense prose, lists, or table cells should not force flex-wrapped chip segmentation at chat-message scale


### PR DESCRIPTION
## Summary

- Add first-class agent-panel Markdown blocks for Mermaid diagrams and LaTeX math, rendered off the UI thread into cached GPUI SVG images with source/loading/error fallbacks.
- Support rich Mermaid and display math inside nested Markdown containers such as blockquotes and lists.
- Make Mermaid and MathJax SVG output light/dark aware, including dark-mode contrast fixes for custom Mermaid light fills and math formulas.
- Reduce rich-render churn by avoiding repeated source-string allocations and retaining cached SVG renders when streaming reparses equivalent Markdown blocks.
- Change Cmd+I into an Input / Terminal focus toggle, including the agent-panel input.
- Fix macOS IME English-mode ASCII commits so shell ghost suggestions keep working while marked CJK composition still uses the IME path.
- Apply cargo fmt in a dedicated final commit to keep future review diffs clean.

## Release Notes

- Agent replies can now render Mermaid diagrams and LaTeX-style math directly in the chat panel.
- Diagrams and formulas adapt to light and dark themes.
- Cmd+I now toggles focus between the input surface and the first terminal pane.
- macOS IME English mode no longer bypasses normal shell key input behavior.

## Validation

- cargo test -p con chat_markdown --target-dir target/codex-check
- cargo test -p con ghostty_view --target-dir target/codex-check
- cargo check -p con --target-dir target/codex-check
- cargo check -p con --no-default-features --features bin-con-app --target-dir target/codex-check
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new async SVG rendering and caching paths for Mermaid/MathJax in the agent panel and changes macOS terminal IME commit behavior, which could impact rendering performance/memory and input handling across themes.
> 
> **Overview**
> Adds **rich Markdown rendering** in the agent panel for Mermaid fences and LaTeX math: Mermaid diagrams and display math now render off the UI thread into cached GPUI images with loading/error/source fallbacks, include light/dark theme-aware styling, and are supported inside nested containers (blockquotes/lists) with unified layout.
> 
> Improves Markdown parsing/styling by introducing first-class `Mermaid`, `MathBlock`, and inline `Math` tokens, tightening inline-math detection to avoid false positives (e.g., hyphenated prose and dollar ranges), and reducing churn by retaining render caches across streaming reparses.
> 
> Updates keyboard/input behavior by turning the focus shortcut into an **Input ↔ Terminal toggle** (including agent-panel inline input) with a safer fallback when inputs are hidden, and fixes macOS terminal IME commits so ASCII inserts replay as per-character key events to preserve normal shell key paths (ghost suggestions), while non-ASCII composition still uses the IME text path. Also updates dependencies (adds `mermaid-rs-renderer`/`mathjax-svg-rs`, removes `pulldown-cmark`) and records changes in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 515d4c9fc227cb90ecc517ae3c5749220febd5e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Mermaid diagrams in chat with light/dark mode-aware colors.
  * Added LaTeX and inline math rendering in chat messages.
  * Implemented Input/Terminal toggle on macOS via Cmd+I.

* **Bug Fixes**
  * Fixed rich content rendering in nested markdown containers.
  * Improved math detection to prevent false positives with hyphenated text and currency amounts.
  * Fixed dark mode diagram theming and SVG re-rendering after theme switches.
  * Improved macOS IME handling for ASCII and CJK input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->