### PR TITLE
[codex] Fix agent panel tool trace collapse

### DIFF
--- a/crates/con-app/src/agent_panel.rs
+++ b/crates/con-app/src/agent_panel.rs
@@ -332,13 +332,6 @@ impl PanelState {
             msg.duration_ms = duration_ms;
             self.messages.push(msg);
         }
-        // Auto-collapse steps on completed messages to reduce scroll noise
-        if let Some(last) = self.messages.last_mut() {
-            if !last.steps.is_empty() {
-                last.steps_collapsed = true;
-                last.touch();
-            }
-        }
         // Move active tool calls into the message's step timeline
         for tc in self.tool_calls.drain(..) {
             let args_display = format_tool_args(&tc.tool_name, &tc.args);
@@ -347,7 +340,7 @@ impl PanelState {
                 let formatted = format_tool_result(&tc.tool_name, &result);
                 (StepStatus::Complete, Some(formatted))
             } else {
-                (StepStatus::Running, None)
+                (StepStatus::Complete, None)
             };
             if let Some(last) = self.messages.last_mut() {
                 last.steps.push(StepEntry {
@@ -359,6 +352,14 @@ impl PanelState {
                     detail_expanded: false,
                     duration: tc.duration,
                 });
+                last.touch();
+            }
+        }
+        // Auto-collapse steps on completed messages to reduce scroll noise. This
+        // must happen after live tool calls are moved into the step timeline.
+        if let Some(last) = self.messages.last_mut() {
+            if !last.steps.is_empty() {
+                last.steps_collapsed = true;
                 last.touch();
             }
         }
@@ -502,7 +503,7 @@ struct StepEntry {
     duration: Option<std::time::Duration>,
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 enum StepStatus {
     Running,
     Complete,
@@ -5011,7 +5012,7 @@ fn humanize_model_name(model: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::AgentPanel;
+    use super::{AgentPanel, PanelState, StepStatus};
 
     #[test]
     fn multiline_drafts_disable_inline_history_navigation() {
@@ -5038,6 +5039,40 @@ mod tests {
             text.chars().count() as u32,
             false,
         ));
+    }
+
+    #[test]
+    fn completed_response_collapses_drained_tool_steps() {
+        let mut state = PanelState::new();
+        state.add_message("user", "search the repo");
+        state.add_tool_call("call-1", "search", r#"{"query":"scrollbar"}"#);
+        state.complete_tool_call("call-1", "line one\nline two");
+
+        state.complete_response("Done.", Some("test-model"), Some(42));
+
+        let message = state.messages.last().expect("assistant message");
+        assert_eq!(message.role, "assistant");
+        assert_eq!(message.content, "Done.");
+        assert!(message.steps_collapsed);
+        assert_eq!(message.steps.len(), 1);
+        assert_eq!(message.steps[0].status, StepStatus::Complete);
+        assert!(message.steps[0].detail_collapsed);
+        assert!(state.tool_calls.is_empty());
+    }
+
+    #[test]
+    fn response_complete_does_not_leave_unresolved_tool_steps_live() {
+        let mut state = PanelState::new();
+        state.add_message("user", "read a file");
+        state.add_tool_call("call-1", "file_read", r#"{"path":"Cargo.toml"}"#);
+
+        state.complete_response("Done.", Some("test-model"), Some(42));
+
+        let message = state.messages.last().expect("assistant message");
+        assert!(message.steps_collapsed);
+        assert_eq!(message.steps.len(), 1);
+        assert_eq!(message.steps[0].status, StepStatus::Complete);
+        assert!(state.tool_calls.is_empty());
     }
 }
 

--- a/postmortem/2026-04-28-agent-panel-tool-trace-collapse.md
+++ b/postmortem/2026-04-28-agent-panel-tool-trace-collapse.md
@@ -1,0 +1,28 @@
+# Agent Panel Tool Trace Collapse
+
+## What Happened
+
+After an agent turn with many tool calls, the assistant response could be pushed out of view by an expanded "Actions, probes, and output" trace.
+
+In some completed turns the trace could still show live steps, making the panel look like work was ongoing after the final response had arrived.
+
+## Root Cause
+
+`PanelState::complete_response` auto-collapsed existing steps before it drained the live tool calls into the assistant message's step timeline.
+
+For turns where the only steps were still in `tool_calls`, the collapse check saw an empty step list and did nothing. The drained tool cards then landed expanded by default. Any unresolved tool call drained at response completion was also preserved as `Running`, which kept the completed trace labeled as active.
+
+## Fix Applied
+
+The tool calls are now drained into the assistant message before deciding whether to collapse the trace.
+
+When the final response has arrived, any remaining tool call without a result is finalized as complete instead of left live, since response completion means the turn is no longer actively executing that tool.
+
+Focused tests now cover both behaviors:
+
+- Completed tool calls are collapsed after being drained into the assistant message.
+- Response completion does not leave unresolved tool calls marked live.
+
+## What We Learned
+
+Completion-time UI cleanup needs to run after all transient turn state has been folded into the persisted message state. Otherwise the UI can make the correct cleanup decision against the wrong snapshot.


### PR DESCRIPTION
## Summary

- Fold live tool calls into the assistant message before deciding whether to collapse the completed run trace.
- Mark any leftover tool-call entries as complete when the final response arrives, so completed replies do not continue to show live tool state.
- Add focused agent panel state tests and a postmortem for the regression.

## Root Cause

`PanelState::complete_response` was collapsing the assistant step trace before draining `tool_calls` into the message timeline. For turns where the only visible steps came from tool calls, the collapse check ran against an empty step list, then the drained tool cards remained expanded by default.

## Impact

Completed agent turns with heavy tool use now keep the actual assistant response visible by default, while preserving the trace behind the existing collapsible run card.

## Validation

- `git diff --check`
- `cargo test -p con agent_panel::tests`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI-state change in `PanelState::complete_response` that affects how tool-call steps are finalized and collapsed; risk is low and covered by new unit tests.
> 
> **Overview**
> Ensures completed agent turns **collapse the run trace correctly** by moving tool-call draining into the assistant message *before* running the auto-collapse logic.
> 
> On response completion, any remaining tool calls without results are now **finalized as `Complete`** (not left `Running`), preventing finished replies from showing live activity. Adds targeted `PanelState` tests for both behaviors and includes a short postmortem documenting the regression and fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f06dee44bdfdf3491a2d6ae8f392b4b14b40e85e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the agent's action trace could remain expanded after the final response, now properly collapsing and finalizing all steps upon completion.

* **Documentation**
  * Added postmortem documentation detailing the fix and lesson learned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->