### PR TITLE
[codex] Support terminal media paste and drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ## `origin/main`
 
+### Added
+
+**Terminal**
+
+- Added terminal file-drop and file-path clipboard paste. Dropped files now paste quoted paths into the active terminal pane instead of being ignored.
+- Added image clipboard forwarding for TUI agents such as Codex. When the clipboard contains image bytes, Con forwards a native Ctrl+V keypress so the TUI can attach the image through its own OS-clipboard workflow.
+- Added conservative file-URI clipboard parsing so Linux file-manager copies exposed as `text/uri-list` paste as quoted file paths instead of raw `file://` text.
+- Hardened terminal Copy/Paste action handling on Windows and Linux so menu/command-dispatched paste uses the same path as the terminal keyboard shortcut.
+
 ---
 
 ## `v0.1.0-beta.43` - 2026-04-28

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -300,6 +300,7 @@ Important consequence:
 - [x] CWD display in input bar from OSC 7
 - [x] Mouse text selection (click-drag, auto-copy, Cmd+C copy)
 - [x] Clipboard paste (Cmd+V) with bracketed paste mode support
+- [x] Terminal media ingress: file drops / file-path clipboard paste as quoted paths, and image clipboard paste forwarded to TUI apps via raw Ctrl+V
 - [x] Cmd+1..9 tab switching
 - [x] Session persistence (tabs, active tab, agent panel state)
 - [x] Kitty keyboard protocol (CSI u encoding, push/pop/query flags)

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -25,6 +25,10 @@ use con_ghostty::{
 };
 use gpui::*;
 
+use crate::terminal_paste::{
+    TerminalPastePayload, payload_from_clipboard, payload_from_external_paths,
+};
+
 // Actions to intercept Tab/Shift-Tab before Root's focus-cycling handler.
 actions!(ghostty, [ConsumeTab, ConsumeTabPrev]);
 
@@ -203,6 +207,43 @@ impl GhosttyView {
         }
 
         changed
+    }
+
+    fn send_terminal_paste_payload(&self, payload: TerminalPastePayload) -> bool {
+        let Some(terminal) = &self.terminal else {
+            return false;
+        };
+
+        match payload {
+            TerminalPastePayload::Text(text) if !text.is_empty() => {
+                terminal.send_text(&text);
+                true
+            }
+            TerminalPastePayload::ForwardCtrlV => {
+                terminal.send_key(ffi::ghostty_input_key_s {
+                    action: ffi::ghostty_input_action_e::GHOSTTY_ACTION_PRESS,
+                    mods: ffi::GHOSTTY_MODS_CTRL,
+                    consumed_mods: 0,
+                    keycode: 0x09, // kVK_ANSI_V
+                    text: std::ptr::null(),
+                    unshifted_codepoint: 'v' as u32,
+                    composing: false,
+                });
+                true
+            }
+            TerminalPastePayload::Text(_) => false,
+        }
+    }
+
+    fn paste_from_clipboard(&self, cx: &mut Context<Self>) -> bool {
+        let Some(payload) = cx
+            .read_from_clipboard()
+            .and_then(|item| payload_from_clipboard(&item))
+        else {
+            return false;
+        };
+
+        self.send_terminal_paste_payload(payload)
     }
 
     pub fn pump_deferred_work(&mut self, cx: &mut Context<Self>) -> bool {
@@ -757,14 +798,8 @@ impl GhosttyView {
                     return true;
                 }
                 "v" => {
-                    if let Some(text) = cx
-                        .read_from_clipboard()
-                        .and_then(|item| item.text().map(|s| s.to_string()))
-                    {
-                        if !text.is_empty() {
-                            terminal.send_text(&text);
-                            cx.notify();
-                        }
+                    if self.paste_from_clipboard(cx) {
+                        cx.notify();
                     }
                     return true;
                 }
@@ -1175,20 +1210,20 @@ impl Render for GhosttyView {
                 }
             }))
             .on_action(cx.listener(|this, _: &crate::Paste, _window, cx| {
-                let Some(terminal) = &this.terminal else {
-                    return;
-                };
-                let Some(text) = cx
-                    .read_from_clipboard()
-                    .and_then(|item| item.text().map(|s| s.to_string()))
-                else {
-                    return;
-                };
-                if text.is_empty() {
-                    return;
+                if this.paste_from_clipboard(cx) {
+                    cx.notify();
                 }
-                terminal.send_text(&text);
-                cx.notify();
+            }))
+            .drag_over::<ExternalPaths>(|style, _, _, _| style)
+            .on_drop(cx.listener(|this, paths: &ExternalPaths, window, cx| {
+                let Some(payload) = payload_from_external_paths(paths) else {
+                    return;
+                };
+                window.focus(&this.focus_handle, cx);
+                if this.send_terminal_paste_payload(payload) {
+                    cx.emit(GhosttyFocusChanged);
+                    cx.notify();
+                }
             }))
             .on_mouse_down(
                 gpui::MouseButton::Left,

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -26,7 +26,8 @@ use gpui_component::ActiveTheme;
 
 use crate::terminal_links::{self, TerminalLink};
 use crate::terminal_paste::{
-    TerminalPastePayload, payload_from_clipboard, payload_from_external_paths,
+    TerminalPastePayload, copy_selection_to_clipboard, payload_from_clipboard,
+    payload_from_external_paths,
 };
 
 const DEFAULT_FONT_SIZE: f32 = 14.0;
@@ -684,22 +685,6 @@ fn paste_from_clipboard(terminal: &GhosttyTerminal, cx: &mut App) -> bool {
     };
 
     send_terminal_paste_payload(terminal, payload);
-    true
-}
-
-fn copy_selection_to_clipboard(terminal: &GhosttyTerminal, cx: &mut App) -> bool {
-    if !terminal.has_selection() {
-        return false;
-    }
-
-    let Some(selection) = terminal
-        .selection_text()
-        .filter(|selection| !selection.is_empty())
-    else {
-        return false;
-    };
-
-    cx.write_to_clipboard(ClipboardItem::new_string(selection));
     true
 }
 

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -25,6 +25,9 @@ use gpui::*;
 use gpui_component::ActiveTheme;
 
 use crate::terminal_links::{self, TerminalLink};
+use crate::terminal_paste::{
+    TerminalPastePayload, payload_from_clipboard, payload_from_external_paths,
+};
 
 const DEFAULT_FONT_SIZE: f32 = 14.0;
 const MIN_FONT_SIZE_PX: f32 = 12.0;
@@ -517,23 +520,18 @@ impl GhosttyView {
         if keystroke.modifiers.control
             && keystroke.modifiers.shift
             && !keystroke.modifiers.alt
-            && keystroke.key == "v"
+            && !keystroke.modifiers.platform
         {
-            if let Some(text) = cx
-                .read_from_clipboard()
-                .and_then(|item| item.text().map(|s| s.to_string()))
-                .filter(|text| !text.is_empty())
-            {
-                if terminal.is_bracketed_paste() {
-                    let mut wrapped = String::with_capacity(text.len() + 12);
-                    wrapped.push_str("\x1b[200~");
-                    wrapped.push_str(&text);
-                    wrapped.push_str("\x1b[201~");
-                    terminal.send_text(&wrapped);
-                } else {
-                    terminal.send_text(&text);
+            match keystroke.key.as_str() {
+                "c" => {
+                    copy_selection_to_clipboard(terminal, cx);
+                    return true;
                 }
-                return true;
+                "v" => {
+                    paste_from_clipboard(terminal, cx);
+                    return true;
+                }
+                _ => {}
             }
         }
 
@@ -652,6 +650,57 @@ impl GhosttyView {
         self.row_cache_style = Some(style);
         self.row_cache_shape = Some(shape);
     }
+}
+
+fn send_paste(terminal: &GhosttyTerminal, text: &str) {
+    if text.is_empty() {
+        return;
+    }
+
+    if terminal.is_bracketed_paste() {
+        let mut wrapped = String::with_capacity(text.len() + 12);
+        wrapped.push_str("\x1b[200~");
+        wrapped.push_str(text);
+        wrapped.push_str("\x1b[201~");
+        terminal.send_text(&wrapped);
+    } else {
+        terminal.send_text(text);
+    }
+}
+
+fn send_terminal_paste_payload(terminal: &GhosttyTerminal, payload: TerminalPastePayload) {
+    match payload {
+        TerminalPastePayload::Text(text) => send_paste(terminal, &text),
+        TerminalPastePayload::ForwardCtrlV => terminal.send_text("\x16"),
+    }
+}
+
+fn paste_from_clipboard(terminal: &GhosttyTerminal, cx: &mut App) -> bool {
+    let Some(payload) = cx
+        .read_from_clipboard()
+        .and_then(|item| payload_from_clipboard(&item))
+    else {
+        return false;
+    };
+
+    send_terminal_paste_payload(terminal, payload);
+    true
+}
+
+fn copy_selection_to_clipboard(terminal: &GhosttyTerminal, cx: &mut App) -> bool {
+    if !terminal.has_selection() {
+        return false;
+    }
+
+    let Some(selection) = terminal
+        .selection_text()
+        .filter(|selection| !selection.is_empty())
+    else {
+        return false;
+    };
+
+    cx.write_to_clipboard(ClipboardItem::new_string(selection));
+    true
 }
 
 impl Focusable for GhosttyView {
@@ -798,6 +847,31 @@ impl Render for GhosttyView {
                     terminal.send_text("\x1b[Z");
                 }
                 cx.notify();
+            }))
+            .on_action(cx.listener(|this, _: &crate::Copy, _window, cx| {
+                if let Some(terminal) = &this.terminal {
+                    copy_selection_to_clipboard(terminal, cx);
+                }
+            }))
+            .on_action(cx.listener(|this, _: &crate::Paste, _window, cx| {
+                let _ = this.ensure_session(cx);
+                if let Some(terminal) = &this.terminal
+                    && paste_from_clipboard(terminal, cx)
+                {
+                    cx.notify();
+                }
+            }))
+            .drag_over::<ExternalPaths>(|style, _, _, _| style)
+            .on_drop(cx.listener(|this, paths: &ExternalPaths, window, cx| {
+                let Some(payload) = payload_from_external_paths(paths) else {
+                    return;
+                };
+                window.focus(&this.focus_handle, cx);
+                let _ = this.ensure_session(cx);
+                if let Some(terminal) = &this.terminal {
+                    send_terminal_paste_payload(terminal, payload);
+                    cx.notify();
+                }
             }))
             .on_key_down(cx.listener(|this, event: &KeyDownEvent, window, cx| {
                 if !this.focus_handle.is_focused(window) {

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -852,6 +852,7 @@ impl Render for GhosttyView {
                     return;
                 };
                 window.focus(&this.focus_handle, cx);
+                cx.emit(GhosttyFocusChanged);
                 let _ = this.ensure_session(cx);
                 if let Some(terminal) = &this.terminal {
                     send_terminal_paste_payload(terminal, payload);

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -55,6 +55,7 @@ mod settings_panel;
 mod sidebar;
 mod terminal_links;
 mod terminal_pane;
+mod terminal_paste;
 mod theme;
 mod updater;
 mod workspace;

--- a/crates/con-app/src/terminal_paste.rs
+++ b/crates/con-app/src/terminal_paste.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+use con_ghostty::GhosttyTerminal;
 use gpui::{ClipboardEntry, ClipboardItem, ExternalPaths};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -23,7 +25,8 @@ pub fn payload_from_clipboard(item: &ClipboardItem) -> Option<TerminalPastePaylo
     }
 
     let text = text_from_entries(item.entries());
-    if let Some(paths) = paths_from_uri_list(&text)
+    if cfg!(target_os = "linux")
+        && let Some(paths) = paths_from_uri_list(&text)
         && !paths.is_empty()
     {
         return quoted_paths_text(&paths).map(TerminalPastePayload::Text);
@@ -38,6 +41,23 @@ pub fn payload_from_clipboard(item: &ClipboardItem) -> Option<TerminalPastePaylo
 
 pub fn payload_from_external_paths(paths: &ExternalPaths) -> Option<TerminalPastePayload> {
     quoted_paths_text(paths.paths()).map(TerminalPastePayload::Text)
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+pub fn copy_selection_to_clipboard(terminal: &GhosttyTerminal, cx: &mut gpui::App) -> bool {
+    if !terminal.has_selection() {
+        return false;
+    }
+
+    let Some(selection) = terminal
+        .selection_text()
+        .filter(|selection| !selection.is_empty())
+    else {
+        return false;
+    };
+
+    cx.write_to_clipboard(ClipboardItem::new_string(selection));
+    true
 }
 
 fn external_paths_from_entries(entries: &[ClipboardEntry]) -> Vec<PathBuf> {
@@ -127,10 +147,29 @@ pub fn quoted_paths_text(paths: &[PathBuf]) -> Option<String> {
     let mut text = String::new();
     for path in paths {
         text.push(' ');
-        text.push_str(&format!("{path:?}"));
+        text.push_str(&quote_path(path));
     }
     text.push(' ');
     Some(text)
+}
+
+#[cfg(windows)]
+fn quote_path(path: &std::path::Path) -> String {
+    let mut quoted = String::new();
+    quoted.push('"');
+    for character in path.display().to_string().chars() {
+        if character == '"' {
+            quoted.push('"');
+        }
+        quoted.push(character);
+    }
+    quoted.push('"');
+    quoted
+}
+
+#[cfg(not(windows))]
+fn quote_path(path: &std::path::Path) -> String {
+    format!("{path:?}")
 }
 
 #[cfg(test)]
@@ -223,6 +262,7 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn linux_file_uri_clipboard_pastes_as_paths() {
         let item = ClipboardItem {
@@ -237,6 +277,22 @@ mod tests {
             Some(TerminalPastePayload::Text(
                 " \"/home/me/diagram one.png\" \"/home/me/main.rs\" ".to_string()
             ))
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn file_uri_clipboard_stays_text_off_linux() {
+        let text = "file:///home/me/diagram%20one.png\nfile:///home/me/main.rs\n";
+        let item = ClipboardItem {
+            entries: vec![ClipboardEntry::String(ClipboardString::new(
+                text.to_string(),
+            ))],
+        };
+
+        assert_eq!(
+            payload_from_clipboard(&item),
+            Some(TerminalPastePayload::Text(text.to_string()))
         );
     }
 
@@ -275,5 +331,16 @@ mod tests {
         };
 
         assert_eq!(payload_from_clipboard(&item), None);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_paths_keep_single_backslashes() {
+        let paths = vec![PathBuf::from(r"C:\Users\me\image file.png")];
+
+        assert_eq!(
+            quoted_paths_text(&paths),
+            Some(r#" "C:\Users\me\image file.png" "#.to_string())
+        );
     }
 }

--- a/crates/con-app/src/terminal_paste.rs
+++ b/crates/con-app/src/terminal_paste.rs
@@ -169,7 +169,16 @@ fn quote_path(path: &std::path::Path) -> String {
 
 #[cfg(not(windows))]
 fn quote_path(path: &std::path::Path) -> String {
-    format!("{path:?}")
+    let mut quoted = String::new();
+    quoted.push('"');
+    for character in path.display().to_string().chars() {
+        if matches!(character, '"' | '\\' | '$' | '`') {
+            quoted.push('\\');
+        }
+        quoted.push(character);
+    }
+    quoted.push('"');
+    quoted
 }
 
 #[cfg(test)]
@@ -190,6 +199,17 @@ mod tests {
         assert_eq!(
             quoted_paths_text(&paths),
             Some(" \"plain.txt\" \"name with spaces.png\" ".to_string())
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn unix_paths_escape_double_quote_expansions() {
+        let paths = vec![PathBuf::from(r#"cost "$HOME".txt"#)];
+
+        assert_eq!(
+            quoted_paths_text(&paths),
+            Some(r#" "cost \"\$HOME\".txt" "#.to_string())
         );
     }
 

--- a/crates/con-app/src/terminal_paste.rs
+++ b/crates/con-app/src/terminal_paste.rs
@@ -1,0 +1,279 @@
+use std::path::PathBuf;
+
+use gpui::{ClipboardEntry, ClipboardItem, ExternalPaths};
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum TerminalPastePayload {
+    Text(String),
+    ForwardCtrlV,
+}
+
+pub fn payload_from_clipboard(item: &ClipboardItem) -> Option<TerminalPastePayload> {
+    let paths = external_paths_from_entries(item.entries());
+    if !paths.is_empty() {
+        return quoted_paths_text(&paths).map(TerminalPastePayload::Text);
+    }
+
+    if item
+        .entries()
+        .iter()
+        .any(|entry| matches!(entry, ClipboardEntry::Image(image) if !image.bytes.is_empty()))
+    {
+        return Some(TerminalPastePayload::ForwardCtrlV);
+    }
+
+    let text = text_from_entries(item.entries());
+    if let Some(paths) = paths_from_uri_list(&text)
+        && !paths.is_empty()
+    {
+        return quoted_paths_text(&paths).map(TerminalPastePayload::Text);
+    }
+
+    if !text.is_empty() {
+        return Some(TerminalPastePayload::Text(text));
+    }
+
+    None
+}
+
+pub fn payload_from_external_paths(paths: &ExternalPaths) -> Option<TerminalPastePayload> {
+    quoted_paths_text(paths.paths()).map(TerminalPastePayload::Text)
+}
+
+fn external_paths_from_entries(entries: &[ClipboardEntry]) -> Vec<PathBuf> {
+    entries
+        .iter()
+        .filter_map(|entry| match entry {
+            ClipboardEntry::ExternalPaths(paths) => Some(paths.paths()),
+            _ => None,
+        })
+        .flatten()
+        .cloned()
+        .collect()
+}
+
+fn text_from_entries(entries: &[ClipboardEntry]) -> String {
+    entries
+        .iter()
+        .filter_map(|entry| match entry {
+            ClipboardEntry::String(string) => Some(string.text.as_str()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn paths_from_uri_list(text: &str) -> Option<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    for line in text.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some(path) = path_from_file_uri(line) else {
+            return None;
+        };
+        paths.push(path);
+    }
+
+    if paths.is_empty() { None } else { Some(paths) }
+}
+
+fn path_from_file_uri(uri: &str) -> Option<PathBuf> {
+    let rest = uri.strip_prefix("file://")?;
+    let path = rest
+        .strip_prefix("localhost/")
+        .map(|path| format!("/{path}"))
+        .unwrap_or_else(|| rest.to_string());
+
+    if !path.starts_with('/') {
+        return None;
+    }
+
+    Some(PathBuf::from(percent_decode(&path)?))
+}
+
+fn percent_decode(text: &str) -> Option<String> {
+    let bytes = text.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' {
+            let hi = *bytes.get(index + 1)?;
+            let lo = *bytes.get(index + 2)?;
+            decoded.push((hex_value(hi)? << 4) | hex_value(lo)?);
+            index += 3;
+        } else {
+            decoded.push(bytes[index]);
+            index += 1;
+        }
+    }
+
+    String::from_utf8(decoded).ok()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+pub fn quoted_paths_text(paths: &[PathBuf]) -> Option<String> {
+    if paths.is_empty() {
+        return None;
+    }
+
+    let mut text = String::new();
+    for path in paths {
+        text.push(' ');
+        text.push_str(&format!("{path:?}"));
+    }
+    text.push(' ');
+    Some(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use gpui::{ClipboardEntry, ClipboardItem, ClipboardString, ExternalPaths, Image, ImageFormat};
+
+    use super::{TerminalPastePayload, payload_from_clipboard, quoted_paths_text};
+
+    #[test]
+    fn quoted_paths_are_space_padded() {
+        let paths = vec![
+            PathBuf::from("plain.txt"),
+            PathBuf::from("name with spaces.png"),
+        ];
+
+        assert_eq!(
+            quoted_paths_text(&paths),
+            Some(" \"plain.txt\" \"name with spaces.png\" ".to_string())
+        );
+    }
+
+    #[test]
+    fn clipboard_text_becomes_text_payload() {
+        let item = ClipboardItem {
+            entries: vec![ClipboardEntry::String(ClipboardString::new(
+                "echo hello".to_string(),
+            ))],
+        };
+
+        assert_eq!(
+            payload_from_clipboard(&item),
+            Some(TerminalPastePayload::Text("echo hello".to_string()))
+        );
+    }
+
+    #[test]
+    fn clipboard_paths_win_over_lossy_text_fallback() {
+        let item = ClipboardItem {
+            entries: vec![
+                ClipboardEntry::String(ClipboardString::new(
+                    "lossy platform path text".to_string(),
+                )),
+                ClipboardEntry::ExternalPaths(ExternalPaths(
+                    vec![PathBuf::from("one.txt"), PathBuf::from("two words.txt")].into(),
+                )),
+            ],
+        };
+
+        assert_eq!(
+            payload_from_clipboard(&item),
+            Some(TerminalPastePayload::Text(
+                " \"one.txt\" \"two words.txt\" ".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn clipboard_image_wins_over_text_representation() {
+        let image = Image::from_bytes(ImageFormat::Png, vec![137, 80, 78, 71]);
+        let item = ClipboardItem {
+            entries: vec![
+                ClipboardEntry::String(ClipboardString::new(
+                    "https://example.com/image.png".to_string(),
+                )),
+                ClipboardEntry::Image(image),
+            ],
+        };
+
+        assert_eq!(
+            payload_from_clipboard(&item),
+            Some(TerminalPastePayload::ForwardCtrlV)
+        );
+    }
+
+    #[test]
+    fn copied_image_and_code_files_paste_as_paths() {
+        let item = ClipboardItem {
+            entries: vec![ClipboardEntry::ExternalPaths(ExternalPaths(
+                vec![PathBuf::from("diagram.png"), PathBuf::from("main.rs")].into(),
+            ))],
+        };
+
+        assert_eq!(
+            payload_from_clipboard(&item),
+            Some(TerminalPastePayload::Text(
+                " \"diagram.png\" \"main.rs\" ".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn linux_file_uri_clipboard_pastes_as_paths() {
+        let item = ClipboardItem {
+            entries: vec![ClipboardEntry::String(ClipboardString::new(
+                "# copied files\nfile:///home/me/diagram%20one.png\nfile:///home/me/main.rs\n"
+                    .to_string(),
+            ))],
+        };
+
+        assert_eq!(
+            payload_from_clipboard(&item),
+            Some(TerminalPastePayload::Text(
+                " \"/home/me/diagram one.png\" \"/home/me/main.rs\" ".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn ordinary_file_url_text_stays_text_when_mixed_with_words() {
+        let text = "see file:///home/me/main.rs";
+        let item = ClipboardItem {
+            entries: vec![ClipboardEntry::String(ClipboardString::new(
+                text.to_string(),
+            ))],
+        };
+
+        assert_eq!(
+            payload_from_clipboard(&item),
+            Some(TerminalPastePayload::Text(text.to_string()))
+        );
+    }
+
+    #[test]
+    fn image_only_clipboard_forwards_native_paste_to_tui() {
+        let image = Image::from_bytes(ImageFormat::Png, vec![137, 80, 78, 71]);
+        let item = ClipboardItem {
+            entries: vec![ClipboardEntry::Image(image)],
+        };
+
+        assert_eq!(
+            payload_from_clipboard(&item),
+            Some(TerminalPastePayload::ForwardCtrlV)
+        );
+    }
+
+    #[test]
+    fn empty_image_clipboard_is_ignored() {
+        let item = ClipboardItem {
+            entries: vec![ClipboardEntry::Image(Image::empty())],
+        };
+
+        assert_eq!(payload_from_clipboard(&item), None);
+    }
+}

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -49,6 +49,9 @@ use image::{Frame, RgbaImage};
 use smallvec::SmallVec;
 
 use crate::terminal_links::{self, TerminalLink};
+use crate::terminal_paste::{
+    TerminalPastePayload, payload_from_clipboard, payload_from_external_paths,
+};
 use con_ghostty::windows::host_view::{MouseEventMods, RenderSession};
 use con_ghostty::windows::render::{FrameBgra, RenderOutcome};
 
@@ -958,22 +961,11 @@ impl GhosttyView {
         {
             match keystroke.key.as_str() {
                 "c" => {
-                    if terminal.has_selection() {
-                        if let Some(selection) = terminal.selection_text() {
-                            cx.write_to_clipboard(ClipboardItem::new_string(selection));
-                        }
-                    }
+                    copy_selection_to_clipboard(terminal, cx);
                     return true;
                 }
                 "v" => {
-                    if let Some(text) = cx
-                        .read_from_clipboard()
-                        .and_then(|item| item.text().map(|s| s.to_string()))
-                    {
-                        if !text.is_empty() {
-                            send_paste(terminal, &text);
-                        }
-                    }
+                    paste_from_clipboard(terminal, cx);
                     return true;
                 }
                 _ => {}
@@ -1183,6 +1175,42 @@ fn send_paste(terminal: &GhosttyTerminal, text: &str) {
     }
 }
 
+fn send_terminal_paste_payload(terminal: &GhosttyTerminal, payload: TerminalPastePayload) {
+    match payload {
+        TerminalPastePayload::Text(text) if !text.is_empty() => send_paste(terminal, &text),
+        TerminalPastePayload::ForwardCtrlV => terminal.send_text("\x16"),
+        TerminalPastePayload::Text(_) => {}
+    }
+}
+
+fn paste_from_clipboard(terminal: &GhosttyTerminal, cx: &mut App) -> bool {
+    let Some(payload) = cx
+        .read_from_clipboard()
+        .and_then(|item| payload_from_clipboard(&item))
+    else {
+        return false;
+    };
+
+    send_terminal_paste_payload(terminal, payload);
+    true
+}
+
+fn copy_selection_to_clipboard(terminal: &GhosttyTerminal, cx: &mut App) -> bool {
+    if !terminal.has_selection() {
+        return false;
+    }
+
+    let Some(selection) = terminal
+        .selection_text()
+        .filter(|selection| !selection.is_empty())
+    else {
+        return false;
+    };
+
+    cx.write_to_clipboard(ClipboardItem::new_string(selection));
+    true
+}
+
 impl Focusable for GhosttyView {
     fn focus_handle(&self, _cx: &App) -> FocusHandle {
         self.focus_handle.clone()
@@ -1238,6 +1266,31 @@ impl Render for GhosttyView {
                 }
                 if let Some(terminal) = &this.terminal {
                     terminal.send_text("\x1b[Z");
+                }
+            }))
+            .on_action(cx.listener(|this, _: &crate::Copy, _window, cx| {
+                if let Some(terminal) = &this.terminal {
+                    copy_selection_to_clipboard(terminal, cx);
+                }
+            }))
+            .on_action(cx.listener(|this, _: &crate::Paste, _window, cx| {
+                let _ = this.ensure_session(cx);
+                if let Some(terminal) = &this.terminal
+                    && paste_from_clipboard(terminal, cx)
+                {
+                    cx.notify();
+                }
+            }))
+            .drag_over::<ExternalPaths>(|style, _, _, _| style)
+            .on_drop(cx.listener(|this, paths: &ExternalPaths, window, cx| {
+                let Some(payload) = payload_from_external_paths(paths) else {
+                    return;
+                };
+                window.focus(&this.focus_handle, cx);
+                let _ = this.ensure_session(cx);
+                if let Some(terminal) = &this.terminal {
+                    send_terminal_paste_payload(terminal, payload);
+                    cx.notify();
                 }
             }))
             .on_key_down(cx.listener(|this, event: &KeyDownEvent, window, cx| {

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -1271,6 +1271,7 @@ impl Render for GhosttyView {
                     return;
                 };
                 window.focus(&this.focus_handle, cx);
+                cx.emit(GhosttyFocusChanged);
                 if let Some(terminal) = &this.terminal {
                     send_terminal_paste_payload(terminal, payload);
                     cx.notify();

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -50,7 +50,8 @@ use smallvec::SmallVec;
 
 use crate::terminal_links::{self, TerminalLink};
 use crate::terminal_paste::{
-    TerminalPastePayload, payload_from_clipboard, payload_from_external_paths,
+    TerminalPastePayload, copy_selection_to_clipboard, payload_from_clipboard,
+    payload_from_external_paths,
 };
 use con_ghostty::windows::host_view::{MouseEventMods, RenderSession};
 use con_ghostty::windows::render::{FrameBgra, RenderOutcome};
@@ -1192,22 +1193,6 @@ fn paste_from_clipboard(terminal: &GhosttyTerminal, cx: &mut App) -> bool {
     };
 
     send_terminal_paste_payload(terminal, payload);
-    true
-}
-
-fn copy_selection_to_clipboard(terminal: &GhosttyTerminal, cx: &mut App) -> bool {
-    if !terminal.has_selection() {
-        return false;
-    }
-
-    let Some(selection) = terminal
-        .selection_text()
-        .filter(|selection| !selection.is_empty())
-    else {
-        return false;
-    };
-
-    cx.write_to_clipboard(ClipboardItem::new_string(selection));
     true
 }
 

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -1274,7 +1274,6 @@ impl Render for GhosttyView {
                 }
             }))
             .on_action(cx.listener(|this, _: &crate::Paste, _window, cx| {
-                let _ = this.ensure_session(cx);
                 if let Some(terminal) = &this.terminal
                     && paste_from_clipboard(terminal, cx)
                 {
@@ -1287,7 +1286,6 @@ impl Render for GhosttyView {
                     return;
                 };
                 window.focus(&this.focus_handle, cx);
-                let _ = this.ensure_session(cx);
                 if let Some(terminal) = &this.terminal {
                     send_terminal_paste_payload(terminal, payload);
                     cx.notify();

--- a/docs/impl/terminal-rendering.md
+++ b/docs/impl/terminal-rendering.md
@@ -75,6 +75,34 @@ At the app level, con already does that. The remaining migration work is about r
 
 This distinction matters. Ghostty's embedded API is designed around wakeup-driven ticking, not "tick it every N milliseconds and hope that is close enough."
 
+## Clipboard, Drop, And Media Ingress
+
+Terminal-host clipboard support is an input contract, not an image-rendering
+protocol. Con handles the three ingress paths separately:
+
+- Text clipboard paste is forwarded through the terminal paste path so shells and
+  editors still get bracketed-paste behavior where the backend supports it.
+- File drops and file-path clipboard entries are converted into quoted paths
+  with surrounding spaces, matching Zed's terminal behavior and avoiding GPUI's
+  lossy path-to-text fallback for multi-file clipboard contents.
+- File-manager clipboard text that arrives as a Linux-style `text/uri-list`
+  is parsed only when every non-comment line is a local `file://` URI; mixed
+  prose stays ordinary text.
+- Image clipboard entries are not converted to files by Con. Instead, Con
+  forwards a raw Ctrl+V keypress to the TUI. Agent TUIs such as Codex can then
+  read the OS clipboard directly and attach the image using their native flow.
+
+If a clipboard item contains both image bytes and a text representation, image
+bytes win. If it contains file paths, paths win. That gives predictable behavior
+for the two common agent workflows: copy an actual image to attach it, or
+copy/drag image and code files to paste their paths.
+
+This is intentionally separate from output-side inline graphics protocols. On
+macOS, full embedded Ghostty owns any inline graphics support it exposes. On the
+Windows and Linux preview backends, Con's portable renderers still need explicit
+work before they can display Kitty graphics, Sixel, or iTerm2/OSC 1337 image
+output.
+
 ## What con reads from Ghostty
 
 Today con relies on these Ghostty-facing facts:

--- a/docs/impl/terminal-rendering.md
+++ b/docs/impl/terminal-rendering.md
@@ -78,7 +78,7 @@ This distinction matters. Ghostty's embedded API is designed around wakeup-drive
 ## Clipboard, Drop, And Media Ingress
 
 Terminal-host clipboard support is an input contract, not an image-rendering
-protocol. Con handles the three ingress paths separately:
+protocol. Con handles these ingress paths separately:
 
 - Text clipboard paste is forwarded through the terminal paste path so shells and
   editors still get bracketed-paste behavior where the backend supports it.


### PR DESCRIPTION
## Summary

- Add a shared terminal paste/drop adapter that preserves the intended payload type instead of flattening every clipboard item to text.
- Paste copied or dropped files as quoted paths, including image and code files.
- Forward image clipboard entries as native Ctrl+V so TUI agents such as Codex can attach from the OS clipboard.
- Wire the same terminal Copy/Paste and file-drop behavior through macOS, Windows, and Linux views, including conservative Linux `text/uri-list` parsing.

## Validation

- `RUSTFLAGS='-D warnings' cargo test -p con terminal_paste`\n- `RUSTFLAGS='-D warnings' cargo check -p con`\n- `git diff --check HEAD`\n- Manual macOS test by Weyl.\n\n## Notes\n\n- This PR covers terminal input/media ingress. Output-side inline image protocols for the portable Windows/Linux renderers, such as Kitty graphics, Sixel, and iTerm2/OSC 1337, remain separate renderer work.\n- Local macOS cross-target checks for Windows/Linux were blocked before Con code by missing platform C toolchains; CI should validate those target-gated paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 45b5d6ee7ad1dd746d2ed48e10c06ff01cbfa22d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal now accepts dropped files, pasting them as quoted paths for shell input
  * Image clipboard content is forwarded to terminal TUIs via native paste keystroke
  * Linux file path clipboard entries paste as quoted paths instead of raw URI text

* **Improvements**
  * Copy/Paste behavior unified across Windows and Linux for menu and command dispatch

<!-- end of auto-generated comment: release notes by coderabbit.ai -->