### PR TITLE
Improve settings, tab shortcuts, and provider model discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ con is still pre-release, so entries may group related beta work while the produ
 - Added direct tab selection shortcuts: Cmd+1 through Cmd+9 on macOS, Ctrl+1 through Ctrl+9 on Windows and Linux.
 - Added macOS window cycling with Cmd+Backtick and Cmd+Shift+Backtick.
 - Fixed macOS Cmd+Backtick window cycling when the terminal surface has focus.
+- Fixed macOS Cmd+Backtick window cycling at the native window-event layer so it works even when the embedded terminal NSView is first responder.
 - Fixed macOS Cmd+Backtick window cycling to also handle GPUI's shifted and localized symbol forms (`~`, `<`, `>`), matching the platform's keyboard-layout-aware shortcut behavior.
 - Pane picker shortcuts are now scoped to the picker: open it with the configured pane-scope shortcut, then use bare 1-9 to toggle panes, A for all panes, and F for focused pane. A/F are consumed before the input bar sees them, and global Cmd/Ctrl+1-9 remains reserved for tab switching outside the picker.
 - Fixed closing the last pane in one window so it closes only that window instead of quitting Con and killing sibling windows.
@@ -36,6 +37,10 @@ con is still pre-release, so entries may group related beta work while the produ
 **Keyboard**
 
 - Fixed direct tab selection shortcuts so terminal panes hand Cmd/Ctrl+1-9 back to the app instead of forwarding them to the shell.
+
+**Windowing**
+
+- Fixed new Con windows opening exactly on top of the previous one. New workspace windows now cascade from the active window while staying within the visible display area.
 
 **Terminal, Windows Backend (preview)**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ### Fixed
 
+**Settings**
+
+- Fixed Settings live preview dismissal so unsaved appearance and theme changes are rolled back when the standalone Settings window is closed.
+- Fixed OpenAI-compatible model discovery so fetched model lists are scoped to the configured Base URL instead of leaking across custom endpoints.
+
+**Keyboard**
+
+- Fixed direct tab selection shortcuts so terminal panes hand Cmd/Ctrl+1-9 back to the app instead of forwarding them to the shell.
+
 **Terminal, Windows Backend (preview)**
 
 - Fixed Windows terminal text rendering to avoid RGB color fringing around glyphs. The DirectWrite atlas now uses grayscale antialiasing with neutral coverage compositing, making CJK and mono text look cleaner in screenshots, scaled displays, remote review, and transparent windows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ con is still pre-release, so entries may group related beta work while the produ
 
 **Settings**
 
-- Settings now opens as a separate window. You can adjust appearance, shortcuts, and provider configuration, apply changes, and keep the settings window open while checking the terminal.
+- Settings now opens as a separate window. You can adjust appearance, shortcuts, and provider configuration, save changes, and keep the settings window open while checking the terminal.
+- Appearance controls now preview immediately while Settings stays open. Transparency, blur, background image strength, image layout, terminal font, UI font, and cursor style update live; Save Changes persists the current values.
+- Polished the Settings save action so it uses Con's active theme colors instead of the generic primary button treatment.
 - OpenAI-compatible providers can now fetch available models from the provider's `/models` endpoint when a Base URL and API key are configured.
 
 **Keyboard**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ## `origin/main`
 
+### Added
+
+**Settings**
+
+- Settings now opens as a separate window. You can adjust appearance, shortcuts, and provider configuration, apply changes, and keep the settings window open while checking the terminal.
+- OpenAI-compatible providers can now fetch available models from the provider's `/models` endpoint when a Base URL and API key are configured.
+
+**Keyboard**
+
+- Added direct tab selection shortcuts: Cmd+1 through Cmd+9 on macOS, Ctrl+1 through Ctrl+9 on Windows and Linux.
+- Added macOS window cycling with Cmd+Backtick and Cmd+Shift+Backtick.
+
 ### Fixed
 
 **Terminal, Windows Backend (preview)**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ con is still pre-release, so entries may group related beta work while the produ
 - Fixed Settings live preview dismissal so unsaved appearance and theme changes are rolled back when the standalone Settings window is closed.
 - Fixed OpenAI-compatible model discovery so fetched model lists are scoped to the configured Base URL instead of leaking across custom endpoints.
 - Fixed OpenAI-compatible model discovery so newly fetched models immediately refresh all related Settings pickers, including active and suggestion model selectors.
+- Fixed OpenAI-compatible model discovery for Base URLs with required query parameters, preserving the query while deriving the `/models` endpoint.
 - Fixed standalone Settings cleanup so closing the last workspace window also closes Settings on Windows and Linux instead of leaving an orphaned process.
 - Hardened OpenAI-compatible model discovery URL normalization so incomplete `/chat/completions` paths fail clearly instead of becoming relative `/models` URLs.
 
@@ -42,7 +43,8 @@ con is still pre-release, so entries may group related beta work while the produ
 
 **Windowing**
 
-- Fixed new Con windows opening exactly on top of the previous one. New workspace windows now cascade from the active window while staying within the visible display area.
+- Fixed new Con windows opening exactly on top of the previous one. New workspace windows now cascade from the active window while staying within the visible display area when display bounds are available, and still cascade when the platform cannot report bounds.
+- Unified macOS Window menu cycling with the same native AppKit path used by Cmd+Backtick, so menu actions and keyboard shortcuts share one ordering model.
 
 **Terminal, Windows Backend (preview)**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ con is still pre-release, so entries may group related beta work while the produ
 
 - Added direct tab selection shortcuts: Cmd+1 through Cmd+9 on macOS, Ctrl+1 through Ctrl+9 on Windows and Linux.
 - Added macOS window cycling with Cmd+Backtick and Cmd+Shift+Backtick.
+- Fixed macOS Cmd+Backtick window cycling when the terminal surface has focus.
+- Pane picker shortcuts are now scoped to the picker: open it with the configured pane-scope shortcut, then use bare 1-9 to toggle panes, A for all panes, and F for focused pane. Global Cmd/Ctrl+1-9 remains reserved for tab switching outside the picker.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ con is still pre-release, so entries may group related beta work while the produ
 - Fixed OpenAI-compatible model discovery so fetched model lists are scoped to the configured Base URL instead of leaking across custom endpoints.
 - Fixed OpenAI-compatible model discovery so newly fetched models immediately refresh all related Settings pickers, including active and suggestion model selectors.
 - Fixed OpenAI-compatible model discovery for Base URLs with required query parameters, preserving the query while deriving the `/models` endpoint.
+- Clarified OpenAI-compatible provider setup when `/models` is unavailable: fetching is optional, and users can type the model ID manually.
 - Fixed standalone Settings cleanup so closing the last workspace window also closes Settings on Windows and Linux instead of leaving an orphaned process.
 - Hardened OpenAI-compatible model discovery URL normalization so incomplete `/chat/completions` paths fail clearly instead of becoming relative `/models` URLs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ con is still pre-release, so entries may group related beta work while the produ
 
 - Fixed Settings live preview dismissal so unsaved appearance and theme changes are rolled back when the standalone Settings window is closed.
 - Fixed OpenAI-compatible model discovery so fetched model lists are scoped to the configured Base URL instead of leaking across custom endpoints.
+- Fixed standalone Settings cleanup so closing the last workspace window also closes Settings on Windows and Linux instead of leaving an orphaned process.
+- Hardened OpenAI-compatible model discovery URL normalization so incomplete `/chat/completions` paths fail clearly instead of becoming relative `/models` URLs.
 
 **Keyboard**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ con is still pre-release, so entries may group related beta work while the produ
 - Added macOS window cycling with Cmd+Backtick and Cmd+Shift+Backtick.
 - Fixed macOS Cmd+Backtick window cycling when the terminal surface has focus.
 - Pane picker shortcuts are now scoped to the picker: open it with the configured pane-scope shortcut, then use bare 1-9 to toggle panes, A for all panes, and F for focused pane. Global Cmd/Ctrl+1-9 remains reserved for tab switching outside the picker.
+- Fixed closing the last pane in one window so it closes only that window instead of quitting Con and killing sibling windows.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ con is still pre-release, so entries may group related beta work while the produ
 **Keyboard**
 
 - Fixed direct tab selection shortcuts so terminal panes hand Cmd/Ctrl+1-9 back to the app instead of forwarding them to the shell.
+- Fixed direct tab selection shortcuts so Cmd/Ctrl+1-9 keeps switching tabs while the pane picker is open; pane selection remains on bare 1-9 inside the picker.
 
 **Windowing**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ con is still pre-release, so entries may group related beta work while the produ
 - Added direct tab selection shortcuts: Cmd+1 through Cmd+9 on macOS, Ctrl+1 through Ctrl+9 on Windows and Linux.
 - Added macOS window cycling with Cmd+Backtick and Cmd+Shift+Backtick.
 - Fixed macOS Cmd+Backtick window cycling when the terminal surface has focus.
-- Pane picker shortcuts are now scoped to the picker: open it with the configured pane-scope shortcut, then use bare 1-9 to toggle panes, A for all panes, and F for focused pane. Global Cmd/Ctrl+1-9 remains reserved for tab switching outside the picker.
+- Fixed macOS Cmd+Backtick window cycling to also handle GPUI's shifted and localized symbol forms (`~`, `<`, `>`), matching the platform's keyboard-layout-aware shortcut behavior.
+- Pane picker shortcuts are now scoped to the picker: open it with the configured pane-scope shortcut, then use bare 1-9 to toggle panes, A for all panes, and F for focused pane. A/F are consumed before the input bar sees them, and global Cmd/Ctrl+1-9 remains reserved for tab switching outside the picker.
 - Fixed closing the last pane in one window so it closes only that window instead of quitting Con and killing sibling windows.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ con is still pre-release, so entries may group related beta work while the produ
 
 - Fixed Settings live preview dismissal so unsaved appearance and theme changes are rolled back when the standalone Settings window is closed.
 - Fixed OpenAI-compatible model discovery so fetched model lists are scoped to the configured Base URL instead of leaking across custom endpoints.
+- Fixed OpenAI-compatible model discovery so newly fetched models immediately refresh all related Settings pickers, including active and suggestion model selectors.
 - Fixed standalone Settings cleanup so closing the last workspace window also closes Settings on Windows and Linux instead of leaving an orphaned process.
 - Hardened OpenAI-compatible model discovery URL normalization so incomplete `/chat/completions` paths fail clearly instead of becoming relative `/models` URLs.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,6 +1290,7 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "tracing",
+ "url",
  "uuid",
  "windows 0.61.3",
  "winresource",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ notify = "7.0.0"
 smallvec = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 http = "1"
+url = "2"
 rust-embed = { version = "8.7.2", features = ["interpolate-folder-path", "include-exclude"] }
 mermaid-rs-renderer = { version = "0.2.2", default-features = false }
 mathjax-svg-rs = "0.4.0"

--- a/crates/con-app/Cargo.toml
+++ b/crates/con-app/Cargo.toml
@@ -56,6 +56,7 @@ rust-embed.workspace = true
 dirs.workspace = true
 chrono.workspace = true
 reqwest.workspace = true
+url.workspace = true
 markdown = { version = "1.0.0", features = ["serde"] }
 ropey.workspace = true
 mermaid-rs-renderer.workspace = true

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -814,7 +814,7 @@ impl GhosttyView {
                 // Tab management
                 "q" | "w" | "t" | "," => return false,
                 // Window cycling (cmd-`, cmd-shift-`)
-                "`" | "~" => return false,
+                "`" | "~" | ">" | "<" => return false,
                 // Splits (cmd-d, cmd-shift-d)
                 "d" => return false,
                 // Agent & input

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -813,6 +813,8 @@ impl GhosttyView {
             match keystroke.key.as_str() {
                 // Tab management
                 "q" | "w" | "t" | "," => return false,
+                // Window cycling (cmd-`, cmd-shift-`)
+                "`" | "~" => return false,
                 // Splits (cmd-d, cmd-shift-d)
                 "d" => return false,
                 // Agent & input

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -812,7 +812,9 @@ impl GhosttyView {
         if keystroke.modifiers.platform {
             match keystroke.key.as_str() {
                 // Tab management
-                "q" | "w" | "t" | "," => return false,
+                "q" | "w" | "t" | "," | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" => {
+                    return false;
+                }
                 // Window cycling (cmd-`, cmd-shift-`)
                 "`" | "~" | ">" | "<" => return false,
                 // Splits (cmd-d, cmd-shift-d)

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -517,6 +517,19 @@ impl GhosttyView {
         if keystroke.modifiers.platform {
             return false;
         }
+        // App-level tab selection. Let GPUI dispatch SelectTab1..9
+        // instead of forwarding Ctrl+digit to the shell.
+        if keystroke.modifiers.control
+            && !keystroke.modifiers.shift
+            && !keystroke.modifiers.alt
+            && !keystroke.modifiers.platform
+            && matches!(
+                keystroke.key.as_str(),
+                "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+            )
+        {
+            return false;
+        }
 
         if keystroke.modifiers.control
             && keystroke.modifiers.shift

--- a/crates/con-app/src/macos_windowing.rs
+++ b/crates/con-app/src/macos_windowing.rs
@@ -1,0 +1,7 @@
+unsafe extern "C" {
+    fn con_install_window_cycle_shortcuts();
+}
+
+pub fn install_window_cycle_shortcuts() {
+    unsafe { con_install_window_cycle_shortcuts() };
+}

--- a/crates/con-app/src/macos_windowing.rs
+++ b/crates/con-app/src/macos_windowing.rs
@@ -1,7 +1,12 @@
 unsafe extern "C" {
     fn con_install_window_cycle_shortcuts();
+    fn con_cycle_app_window(reverse: bool);
 }
 
 pub fn install_window_cycle_shortcuts() {
     unsafe { con_install_window_cycle_shortcuts() };
+}
+
+pub fn cycle_app_window(reverse: bool) {
+    unsafe { con_cycle_app_window(reverse) };
 }

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -346,9 +346,11 @@ fn default_workspace_window_bounds(cx: &mut App) -> WindowBounds {
 
     const CASCADE_OFFSET: f32 = 28.0;
 
-    let display_bounds = display_bounds.unwrap_or(fallback_bounds);
     let proposed_origin = base_bounds.origin + point(px(CASCADE_OFFSET), px(CASCADE_OFFSET));
     let proposed_bounds = Bounds::new(proposed_origin, base_bounds.size);
+    let Some(display_bounds) = display_bounds else {
+        return WindowBounds::Windowed(proposed_bounds);
+    };
 
     let display_right = display_bounds.origin.x + display_bounds.size.width;
     let display_bottom = display_bounds.origin.y + display_bounds.size.height;
@@ -526,43 +528,6 @@ pub(crate) fn toggle_global_summon(cx: &mut App) {
             });
         }
     }
-}
-
-#[cfg(target_os = "macos")]
-fn cycle_app_window(cx: &mut App, reverse: bool) {
-    let mut windows = cx.window_stack().unwrap_or_else(|| cx.windows());
-    if windows.len() <= 1 {
-        return;
-    }
-
-    // Keep only handles that still update successfully. Window-stack
-    // snapshots can lag behind just-closed utility windows.
-    windows.retain(|handle| handle.update(cx, |_, _window, _cx| ()).is_ok());
-    if windows.len() <= 1 {
-        return;
-    }
-
-    let active = cx.active_window();
-    let current = active
-        .and_then(|active| {
-            windows
-                .iter()
-                .position(|handle| handle.window_id() == active.window_id())
-        })
-        .unwrap_or(0);
-    // GPUI/macOS reports the stack front-to-back. Cmd+` moves to the
-    // window immediately behind the active one; Shift reverses that.
-    let next = if reverse {
-        current.checked_sub(1).unwrap_or(windows.len() - 1)
-    } else {
-        (current + 1) % windows.len()
-    };
-
-    let target = windows[next];
-    cx.activate(true);
-    let _ = target.update(cx, |_, window, _| {
-        window.activate_window();
-    });
 }
 
 #[cfg(target_os = "macos")]
@@ -1164,12 +1129,12 @@ fn main() {
             toggle_global_summon(cx);
         });
         #[cfg(target_os = "macos")]
-        cx.on_action(|_: &NextWindow, cx: &mut App| {
-            cycle_app_window(cx, false);
+        cx.on_action(|_: &NextWindow, _cx: &mut App| {
+            macos_windowing::cycle_app_window(false);
         });
         #[cfg(target_os = "macos")]
-        cx.on_action(|_: &PreviousWindow, cx: &mut App| {
-            cycle_app_window(cx, true);
+        cx.on_action(|_: &PreviousWindow, _cx: &mut App| {
+            macos_windowing::cycle_app_window(true);
         });
         cx.on_action(|_: &NewTab, cx: &mut App| {
             if cx.active_window().is_none() {

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -17,6 +17,8 @@ mod chat_markdown;
 mod command_palette;
 #[cfg(target_os = "macos")]
 mod global_hotkey;
+#[cfg(target_os = "macos")]
+mod macos_windowing;
 
 // The terminal-view module is selected per platform:
 //   macOS   -> ghostty_view.rs (libghostty + child NSView)
@@ -302,7 +304,7 @@ fn set_windows_backdrop(window: &mut Window, blur: bool) -> Option<()> {
 fn default_window_options(cx: &mut App) -> WindowOptions {
     let transparent = supports_transparent_main_window();
     WindowOptions {
-        window_bounds: Some(WindowBounds::centered(size(px(1200.0), px(800.0)), cx)),
+        window_bounds: Some(default_workspace_window_bounds(cx)),
         titlebar: default_titlebar_options(transparent),
         window_decorations: default_window_decorations(),
         window_background: if transparent {
@@ -313,6 +315,58 @@ fn default_window_options(cx: &mut App) -> WindowOptions {
         ..Default::default()
     }
 }
+
+fn default_workspace_window_bounds(cx: &mut App) -> WindowBounds {
+    let fallback_size = size(px(1200.0), px(800.0));
+    let fallback_bounds = Bounds::centered(None, fallback_size, cx);
+    let fallback_display_bounds = cx.primary_display().map(|display| display.visible_bounds());
+
+    let active_bounds = cx.active_window().and_then(|handle| {
+        handle
+            .update(cx, |_, window, cx| {
+                let bounds = match window.window_bounds() {
+                    WindowBounds::Windowed(bounds) => bounds,
+                    WindowBounds::Maximized(_) | WindowBounds::Fullscreen(_) => {
+                        return None;
+                    }
+                };
+                let display_bounds = window
+                    .display(cx)
+                    .map(|display| display.visible_bounds())
+                    .or(fallback_display_bounds);
+                Some((bounds, display_bounds))
+            })
+            .ok()
+            .flatten()
+    });
+
+    let Some((base_bounds, display_bounds)) = active_bounds else {
+        return WindowBounds::Windowed(fallback_bounds);
+    };
+
+    const CASCADE_OFFSET: f32 = 28.0;
+
+    let display_bounds = display_bounds.unwrap_or(fallback_bounds);
+    let proposed_origin = base_bounds.origin + point(px(CASCADE_OFFSET), px(CASCADE_OFFSET));
+    let proposed_bounds = Bounds::new(proposed_origin, base_bounds.size);
+
+    let display_right = display_bounds.origin.x + display_bounds.size.width;
+    let display_bottom = display_bounds.origin.y + display_bounds.size.height;
+    let window_right = proposed_bounds.origin.x + proposed_bounds.size.width;
+    let window_bottom = proposed_bounds.origin.y + proposed_bounds.size.height;
+
+    let fits_horizontally = window_right <= display_right;
+    let fits_vertically = window_bottom <= display_bottom;
+    let final_origin = match (fits_horizontally, fits_vertically) {
+        (true, true) => proposed_origin,
+        (false, true) => point(display_bounds.origin.x, base_bounds.origin.y),
+        (true, false) => point(base_bounds.origin.x, display_bounds.origin.y),
+        (false, false) => display_bounds.origin,
+    };
+
+    WindowBounds::Windowed(Bounds::new(final_origin, base_bounds.size))
+}
+
 fn default_titlebar_options(transparent: bool) -> Option<TitlebarOptions> {
     Some(TitlebarOptions {
         title: Some("con".into()),
@@ -1099,6 +1153,8 @@ fn main() {
         bind_app_keybindings(cx, &config.keybindings);
         #[cfg(target_os = "macos")]
         global_hotkey::init(cx, &config.keybindings);
+        #[cfg(target_os = "macos")]
+        macos_windowing::install_window_cycle_shortcuts();
 
         cx.on_action(|_: &NewWindow, cx: &mut App| {
             let config = con_core::Config::load().unwrap_or_default();

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -841,19 +841,19 @@ pub(crate) fn bind_app_keybindings(cx: &mut App, kb: &KeybindingConfig) {
         KeyBinding::new("cmd-h", HideApp, None),
         KeyBinding::new("cmd-alt-h", HideOtherApps, None),
         KeyBinding::new("cmd-alt-shift-h", ShowAllApps, None),
-        KeyBinding::new("cmd->", NextWindow, None),
         KeyBinding::new("cmd-`", NextWindow, None),
+        KeyBinding::new("cmd->", NextWindow, None),
+        KeyBinding::new("cmd-shift-`", PreviousWindow, None),
         KeyBinding::new("cmd-~", PreviousWindow, None),
         KeyBinding::new("cmd-<", PreviousWindow, None),
-        KeyBinding::new("cmd-shift-`", PreviousWindow, None),
         KeyBinding::new("cmd-h", HideApp, Some("Input")),
         KeyBinding::new("cmd-alt-h", HideOtherApps, Some("Input")),
         KeyBinding::new("cmd-alt-shift-h", ShowAllApps, Some("Input")),
-        KeyBinding::new("cmd->", NextWindow, Some("Input")),
         KeyBinding::new("cmd-`", NextWindow, Some("Input")),
+        KeyBinding::new("cmd->", NextWindow, Some("Input")),
+        KeyBinding::new("cmd-shift-`", PreviousWindow, Some("Input")),
         KeyBinding::new("cmd-~", PreviousWindow, Some("Input")),
         KeyBinding::new("cmd-<", PreviousWindow, Some("Input")),
-        KeyBinding::new("cmd-shift-`", PreviousWindow, Some("Input")),
     ]);
 }
 

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -77,6 +77,17 @@ actions!(
         NewTab,
         NextTab,
         PreviousTab,
+        SelectTab1,
+        SelectTab2,
+        SelectTab3,
+        SelectTab4,
+        SelectTab5,
+        SelectTab6,
+        SelectTab7,
+        SelectTab8,
+        SelectTab9,
+        NextWindow,
+        PreviousWindow,
         ToggleSummon,
         ToggleAgentPanel,
         ToggleInputBar,
@@ -464,6 +475,44 @@ pub(crate) fn toggle_global_summon(cx: &mut App) {
 }
 
 #[cfg(target_os = "macos")]
+fn cycle_app_window(cx: &mut App, reverse: bool) {
+    let mut windows = cx.window_stack().unwrap_or_else(|| cx.windows());
+    if windows.len() <= 1 {
+        return;
+    }
+
+    // Keep only handles that still update successfully. Window-stack
+    // snapshots can lag behind just-closed utility windows.
+    windows.retain(|handle| handle.update(cx, |_, _window, _cx| ()).is_ok());
+    if windows.len() <= 1 {
+        return;
+    }
+
+    let active = cx.active_window();
+    let current = active
+        .and_then(|active| {
+            windows
+                .iter()
+                .position(|handle| handle.window_id() == active.window_id())
+        })
+        .unwrap_or(0);
+    // GPUI/macOS reports the stack from back to front (the summon
+    // path also treats `last()` as frontmost), so Cmd+` moves to the
+    // window immediately behind the active one. Shift reverses that.
+    let next = if reverse {
+        (current + 1) % windows.len()
+    } else {
+        current.checked_sub(1).unwrap_or(windows.len() - 1)
+    };
+
+    let target = windows[next];
+    cx.activate(true);
+    let _ = target.update(cx, |_, window, _| {
+        window.activate_window();
+    });
+}
+
+#[cfg(target_os = "macos")]
 fn bundle_info_value(key: &'static [u8]) -> Option<String> {
     use objc::{class, msg_send, sel, sel_impl};
     use std::ffi::CStr;
@@ -727,6 +776,15 @@ pub(crate) fn bind_app_keybindings(cx: &mut App, kb: &KeybindingConfig) {
         KeyBinding::new(&kb.previous_tab, PreviousTab, None),
         KeyBinding::new("secondary-shift-]", NextTab, None),
         KeyBinding::new("secondary-shift-[", PreviousTab, None),
+        KeyBinding::new("secondary-1", SelectTab1, None),
+        KeyBinding::new("secondary-2", SelectTab2, None),
+        KeyBinding::new("secondary-3", SelectTab3, None),
+        KeyBinding::new("secondary-4", SelectTab4, None),
+        KeyBinding::new("secondary-5", SelectTab5, None),
+        KeyBinding::new("secondary-6", SelectTab6, None),
+        KeyBinding::new("secondary-7", SelectTab7, None),
+        KeyBinding::new("secondary-8", SelectTab8, None),
+        KeyBinding::new("secondary-9", SelectTab9, None),
         KeyBinding::new(&kb.toggle_agent, ToggleAgentPanel, None),
         KeyBinding::new(&kb.close_tab, CloseTab, None),
         KeyBinding::new(&kb.close_pane, ClosePane, None),
@@ -749,6 +807,15 @@ pub(crate) fn bind_app_keybindings(cx: &mut App, kb: &KeybindingConfig) {
         KeyBinding::new(&kb.previous_tab, PreviousTab, Some("Input")),
         KeyBinding::new("secondary-shift-]", NextTab, Some("Input")),
         KeyBinding::new("secondary-shift-[", PreviousTab, Some("Input")),
+        KeyBinding::new("secondary-1", SelectTab1, Some("Input")),
+        KeyBinding::new("secondary-2", SelectTab2, Some("Input")),
+        KeyBinding::new("secondary-3", SelectTab3, Some("Input")),
+        KeyBinding::new("secondary-4", SelectTab4, Some("Input")),
+        KeyBinding::new("secondary-5", SelectTab5, Some("Input")),
+        KeyBinding::new("secondary-6", SelectTab6, Some("Input")),
+        KeyBinding::new("secondary-7", SelectTab7, Some("Input")),
+        KeyBinding::new("secondary-8", SelectTab8, Some("Input")),
+        KeyBinding::new("secondary-9", SelectTab9, Some("Input")),
         KeyBinding::new(&kb.toggle_agent, ToggleAgentPanel, Some("Input")),
         KeyBinding::new(&kb.close_tab, CloseTab, Some("Input")),
         KeyBinding::new(&kb.close_pane, ClosePane, Some("Input")),
@@ -775,9 +842,13 @@ pub(crate) fn bind_app_keybindings(cx: &mut App, kb: &KeybindingConfig) {
         KeyBinding::new("cmd-h", HideApp, None),
         KeyBinding::new("cmd-alt-h", HideOtherApps, None),
         KeyBinding::new("cmd-alt-shift-h", ShowAllApps, None),
+        KeyBinding::new("cmd-`", NextWindow, None),
+        KeyBinding::new("cmd-shift-`", PreviousWindow, None),
         KeyBinding::new("cmd-h", HideApp, Some("Input")),
         KeyBinding::new("cmd-alt-h", HideOtherApps, Some("Input")),
         KeyBinding::new("cmd-alt-shift-h", ShowAllApps, Some("Input")),
+        KeyBinding::new("cmd-`", NextWindow, Some("Input")),
+        KeyBinding::new("cmd-shift-`", PreviousWindow, Some("Input")),
     ]);
 }
 
@@ -1031,6 +1102,14 @@ fn main() {
         cx.on_action(|_: &ToggleSummon, cx: &mut App| {
             toggle_global_summon(cx);
         });
+        #[cfg(target_os = "macos")]
+        cx.on_action(|_: &NextWindow, cx: &mut App| {
+            cycle_app_window(cx, false);
+        });
+        #[cfg(target_os = "macos")]
+        cx.on_action(|_: &PreviousWindow, cx: &mut App| {
+            cycle_app_window(cx, true);
+        });
         cx.on_action(|_: &NewTab, cx: &mut App| {
             if cx.active_window().is_none() {
                 let config = con_core::Config::load().unwrap_or_default();
@@ -1110,6 +1189,14 @@ fn main() {
                     MenuItem::separator(),
                     MenuItem::action("Toggle Input / Terminal", FocusInput),
                     MenuItem::action("Cycle Input Mode", CycleInputMode),
+                ],
+                disabled: false,
+            },
+            Menu {
+                name: "Window".into(),
+                items: vec![
+                    MenuItem::action("Next Window", NextWindow),
+                    MenuItem::action("Previous Window", PreviousWindow),
                 ],
                 disabled: false,
             },

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -1197,6 +1197,7 @@ fn main() {
                 ],
                 disabled: false,
             },
+            #[cfg(target_os = "macos")]
             Menu {
                 name: "Window".into(),
                 items: vec![

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -447,7 +447,7 @@ fn fresh_window_session_with_history() -> Session {
 pub(crate) fn toggle_global_summon(cx: &mut App) {
     let frontmost_window = cx
         .window_stack()
-        .and_then(|windows| windows.last().cloned());
+        .and_then(|windows| windows.first().cloned());
     let has_windows = frontmost_window.is_some();
 
     #[cfg(target_os = "macos")]
@@ -496,13 +496,12 @@ fn cycle_app_window(cx: &mut App, reverse: bool) {
                 .position(|handle| handle.window_id() == active.window_id())
         })
         .unwrap_or(0);
-    // GPUI/macOS reports the stack from back to front (the summon
-    // path also treats `last()` as frontmost), so Cmd+` moves to the
-    // window immediately behind the active one. Shift reverses that.
+    // GPUI/macOS reports the stack front-to-back. Cmd+` moves to the
+    // window immediately behind the active one; Shift reverses that.
     let next = if reverse {
-        (current + 1) % windows.len()
-    } else {
         current.checked_sub(1).unwrap_or(windows.len() - 1)
+    } else {
+        (current + 1) % windows.len()
     };
 
     let target = windows[next];
@@ -842,12 +841,18 @@ pub(crate) fn bind_app_keybindings(cx: &mut App, kb: &KeybindingConfig) {
         KeyBinding::new("cmd-h", HideApp, None),
         KeyBinding::new("cmd-alt-h", HideOtherApps, None),
         KeyBinding::new("cmd-alt-shift-h", ShowAllApps, None),
+        KeyBinding::new("cmd->", NextWindow, None),
         KeyBinding::new("cmd-`", NextWindow, None),
+        KeyBinding::new("cmd-~", PreviousWindow, None),
+        KeyBinding::new("cmd-<", PreviousWindow, None),
         KeyBinding::new("cmd-shift-`", PreviousWindow, None),
         KeyBinding::new("cmd-h", HideApp, Some("Input")),
         KeyBinding::new("cmd-alt-h", HideOtherApps, Some("Input")),
         KeyBinding::new("cmd-alt-shift-h", ShowAllApps, Some("Input")),
+        KeyBinding::new("cmd->", NextWindow, Some("Input")),
         KeyBinding::new("cmd-`", NextWindow, Some("Input")),
+        KeyBinding::new("cmd-~", PreviousWindow, Some("Input")),
+        KeyBinding::new("cmd-<", PreviousWindow, Some("Input")),
         KeyBinding::new("cmd-shift-`", PreviousWindow, Some("Input")),
     ]);
 }

--- a/crates/con-app/src/model_registry.rs
+++ b/crates/con-app/src/model_registry.rs
@@ -375,10 +375,21 @@ impl ModelRegistry {
 
         if endpoint.ends_with("/chat/completions") {
             endpoint.truncate(endpoint.len() - "/chat/completions".len());
+        } else if endpoint == "chat/completions" {
+            endpoint.clear();
+        }
+
+        if endpoint.trim_matches('/').is_empty() {
+            return Err(anyhow!("Base URL is required"));
         }
 
         if !endpoint.ends_with("/models") {
             endpoint.push_str("/models");
+        }
+
+        let parsed = url::Url::parse(&endpoint).context("Base URL must be an absolute URL")?;
+        if !matches!(parsed.scheme(), "http" | "https") {
+            return Err(anyhow!("Base URL must use http or https"));
         }
 
         Ok(endpoint)
@@ -513,6 +524,8 @@ mod tests {
                 .unwrap(),
             "https://api.example.com/v1/models"
         );
+        assert!(ModelRegistry::openai_compatible_models_url("/chat/completions").is_err());
+        assert!(ModelRegistry::openai_compatible_models_url("chat/completions").is_err());
     }
 
     #[test]

--- a/crates/con-app/src/model_registry.rs
+++ b/crates/con-app/src/model_registry.rs
@@ -4,6 +4,7 @@
 //! models.dev community API. Falls back to hardcoded defaults when
 //! the network is unavailable.
 
+use anyhow::{Context as _, anyhow};
 use con_agent::ProviderKind;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -180,6 +181,16 @@ struct ApiLimit {
     context: Option<u64>,
 }
 
+#[derive(serde::Deserialize)]
+struct OpenAICompatibleModelsResponse {
+    data: Vec<OpenAICompatibleModel>,
+}
+
+#[derive(serde::Deserialize)]
+struct OpenAICompatibleModel {
+    id: String,
+}
+
 // ── Registry ─────────────────────────────────────────────────────────
 
 #[derive(Clone)]
@@ -192,12 +203,14 @@ struct CacheEntry {
 #[derive(Clone)]
 pub struct ModelRegistry {
     inner: Arc<Mutex<Option<CacheEntry>>>,
+    custom: Arc<Mutex<HashMap<ProviderKind, Vec<String>>>>,
 }
 
 impl ModelRegistry {
     pub fn new() -> Self {
         Self {
             inner: Arc::new(Mutex::new(None)),
+            custom: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -205,6 +218,16 @@ impl ModelRegistry {
     /// Falls back to hardcoded defaults if the cache is empty.
     pub fn models_for(&self, provider: &ProviderKind) -> Vec<String> {
         let canonical = canonical_models_provider(provider);
+        {
+            let custom = self.custom.lock().unwrap();
+            if let Some(models) = custom.get(&canonical) {
+                if !models.is_empty() {
+                    let mut models = models.clone();
+                    append_missing_models(&mut models, pinned_models(provider));
+                    return models;
+                }
+            }
+        }
         let guard = self.inner.lock().unwrap();
         if let Some(entry) = guard.as_ref() {
             if let Some(models) = entry.models.get(&canonical) {
@@ -222,6 +245,12 @@ impl ModelRegistry {
             .collect();
         append_missing_models(&mut models, pinned_models(provider));
         models
+    }
+
+    /// Stores models discovered from a user-configured provider endpoint.
+    pub fn set_provider_models(&self, provider: ProviderKind, models: Vec<String>) {
+        let canonical = canonical_models_provider(&provider);
+        self.custom.lock().unwrap().insert(canonical, models);
     }
 
     /// Whether the cache is stale or empty and needs a refresh.
@@ -297,6 +326,68 @@ impl ModelRegistry {
         log::info!("Model registry updated from models.dev");
         Ok(())
     }
+
+    pub fn openai_compatible_models_url(base_url: &str) -> anyhow::Result<String> {
+        let mut endpoint = base_url.trim().trim_end_matches('/').to_string();
+        if endpoint.is_empty() {
+            return Err(anyhow!("Base URL is required"));
+        }
+
+        if endpoint.ends_with("/chat/completions") {
+            endpoint.truncate(endpoint.len() - "/chat/completions".len());
+        }
+
+        if !endpoint.ends_with("/models") {
+            endpoint.push_str("/models");
+        }
+
+        Ok(endpoint)
+    }
+
+    /// Fetch a model list from an OpenAI-compatible endpoint.
+    pub async fn fetch_openai_compatible_models(
+        base_url: &str,
+        api_key: &str,
+    ) -> anyhow::Result<Vec<String>> {
+        let endpoint = Self::openai_compatible_models_url(base_url)?;
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(15))
+            .build()?;
+
+        let resp = client.get(&endpoint).bearer_auth(api_key).send().await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            let detail = body.trim();
+            let detail = if detail.chars().count() > 180 {
+                format!("{}…", detail.chars().take(180).collect::<String>())
+            } else {
+                detail.to_string()
+            };
+            return Err(anyhow!(
+                "Model list request failed with HTTP {status}{}",
+                if detail.is_empty() {
+                    String::new()
+                } else {
+                    format!(": {detail}")
+                }
+            ));
+        }
+
+        let parsed: OpenAICompatibleModelsResponse = resp
+            .json()
+            .await
+            .context("Response was not an OpenAI-compatible model list")?;
+        let mut models: Vec<String> = parsed
+            .data
+            .into_iter()
+            .map(|model| model.id.trim().to_string())
+            .filter(|id| !id.is_empty())
+            .collect();
+        models.sort();
+        models.dedup();
+        Ok(models)
+    }
 }
 
 #[cfg(test)]
@@ -357,6 +448,39 @@ mod tests {
         assert_eq!(
             registry.models_for(&ProviderKind::Moonshot),
             vec!["kimi-k2.5".to_string(), "kimi-for-coding".to_string()]
+        );
+    }
+
+    #[test]
+    fn openai_compatible_models_url_uses_models_endpoint() {
+        assert_eq!(
+            ModelRegistry::openai_compatible_models_url("https://api.example.com/v1").unwrap(),
+            "https://api.example.com/v1/models"
+        );
+        assert_eq!(
+            ModelRegistry::openai_compatible_models_url(
+                "https://api.example.com/v1/chat/completions"
+            )
+            .unwrap(),
+            "https://api.example.com/v1/models"
+        );
+        assert_eq!(
+            ModelRegistry::openai_compatible_models_url("https://api.example.com/v1/models")
+                .unwrap(),
+            "https://api.example.com/v1/models"
+        );
+    }
+
+    #[test]
+    fn custom_models_override_fallback_for_openai_compatible() {
+        let registry = ModelRegistry::new();
+        registry.set_provider_models(
+            ProviderKind::OpenAICompatible,
+            vec!["custom-a".to_string(), "custom-b".to_string()],
+        );
+        assert_eq!(
+            registry.models_for(&ProviderKind::OpenAICompatible),
+            vec!["custom-a".to_string(), "custom-b".to_string()]
         );
     }
 }

--- a/crates/con-app/src/model_registry.rs
+++ b/crates/con-app/src/model_registry.rs
@@ -203,7 +203,7 @@ struct CacheEntry {
 #[derive(Clone)]
 pub struct ModelRegistry {
     inner: Arc<Mutex<Option<CacheEntry>>>,
-    custom: Arc<Mutex<HashMap<ProviderKind, Vec<String>>>>,
+    custom: Arc<Mutex<HashMap<(ProviderKind, String), Vec<String>>>>,
 }
 
 impl ModelRegistry {
@@ -216,11 +216,31 @@ impl ModelRegistry {
 
     /// Returns the cached model list for a provider.
     /// Falls back to hardcoded defaults if the cache is empty.
+    #[cfg(test)]
     pub fn models_for(&self, provider: &ProviderKind) -> Vec<String> {
+        self.models_for_base_url(provider, None)
+    }
+
+    /// Returns the cached model list for a provider scoped to a concrete
+    /// endpoint when one is available.
+    pub fn models_for_base_url(
+        &self,
+        provider: &ProviderKind,
+        base_url: Option<&str>,
+    ) -> Vec<String> {
         let canonical = canonical_models_provider(provider);
         {
             let custom = self.custom.lock().unwrap();
-            if let Some(models) = custom.get(&canonical) {
+            if let Some(endpoint) = base_url.and_then(Self::custom_models_scope) {
+                if let Some(models) = custom.get(&(canonical.clone(), endpoint)) {
+                    if !models.is_empty() {
+                        let mut models = models.clone();
+                        append_missing_models(&mut models, pinned_models(provider));
+                        return models;
+                    }
+                }
+            }
+            if let Some(models) = custom.get(&(canonical.clone(), String::new())) {
                 if !models.is_empty() {
                     let mut models = models.clone();
                     append_missing_models(&mut models, pinned_models(provider));
@@ -248,9 +268,29 @@ impl ModelRegistry {
     }
 
     /// Stores models discovered from a user-configured provider endpoint.
+    #[cfg(test)]
     pub fn set_provider_models(&self, provider: ProviderKind, models: Vec<String>) {
         let canonical = canonical_models_provider(&provider);
-        self.custom.lock().unwrap().insert(canonical, models);
+        self.custom
+            .lock()
+            .unwrap()
+            .insert((canonical, String::new()), models);
+    }
+
+    /// Stores models discovered from a specific user-configured endpoint.
+    pub fn set_provider_models_for_base_url(
+        &self,
+        provider: ProviderKind,
+        base_url: &str,
+        models: Vec<String>,
+    ) -> anyhow::Result<()> {
+        let canonical = canonical_models_provider(&provider);
+        let endpoint = Self::openai_compatible_models_url(base_url)?;
+        self.custom
+            .lock()
+            .unwrap()
+            .insert((canonical, endpoint), models);
+        Ok(())
     }
 
     /// Whether the cache is stale or empty and needs a refresh.
@@ -342,6 +382,10 @@ impl ModelRegistry {
         }
 
         Ok(endpoint)
+    }
+
+    fn custom_models_scope(base_url: &str) -> Option<String> {
+        Self::openai_compatible_models_url(base_url).ok()
     }
 
     /// Fetch a model list from an OpenAI-compatible endpoint.
@@ -481,6 +525,40 @@ mod tests {
         assert_eq!(
             registry.models_for(&ProviderKind::OpenAICompatible),
             vec!["custom-a".to_string(), "custom-b".to_string()]
+        );
+    }
+
+    #[test]
+    fn custom_openai_compatible_models_are_scoped_by_endpoint() {
+        let registry = ModelRegistry::new();
+        registry
+            .set_provider_models_for_base_url(
+                ProviderKind::OpenAICompatible,
+                "https://one.example.com/v1",
+                vec!["one-a".to_string()],
+            )
+            .unwrap();
+        registry
+            .set_provider_models_for_base_url(
+                ProviderKind::OpenAICompatible,
+                "https://two.example.com/v1/chat/completions",
+                vec!["two-a".to_string()],
+            )
+            .unwrap();
+
+        assert_eq!(
+            registry.models_for_base_url(
+                &ProviderKind::OpenAICompatible,
+                Some("https://one.example.com/v1/models")
+            ),
+            vec!["one-a".to_string()]
+        );
+        assert_eq!(
+            registry.models_for_base_url(
+                &ProviderKind::OpenAICompatible,
+                Some("https://two.example.com/v1")
+            ),
+            vec!["two-a".to_string()]
         );
     }
 }

--- a/crates/con-app/src/model_registry.rs
+++ b/crates/con-app/src/model_registry.rs
@@ -368,31 +368,31 @@ impl ModelRegistry {
     }
 
     pub fn openai_compatible_models_url(base_url: &str) -> anyhow::Result<String> {
-        let mut endpoint = base_url.trim().trim_end_matches('/').to_string();
-        if endpoint.is_empty() {
+        let raw = base_url.trim();
+        if raw.is_empty() {
             return Err(anyhow!("Base URL is required"));
         }
 
-        if endpoint.ends_with("/chat/completions") {
-            endpoint.truncate(endpoint.len() - "/chat/completions".len());
-        } else if endpoint == "chat/completions" {
-            endpoint.clear();
-        }
-
-        if endpoint.trim_matches('/').is_empty() {
-            return Err(anyhow!("Base URL is required"));
-        }
-
-        if !endpoint.ends_with("/models") {
-            endpoint.push_str("/models");
-        }
-
-        let parsed = url::Url::parse(&endpoint).context("Base URL must be an absolute URL")?;
+        let mut parsed = url::Url::parse(raw).context("Base URL must be an absolute URL")?;
         if !matches!(parsed.scheme(), "http" | "https") {
             return Err(anyhow!("Base URL must use http or https"));
         }
 
-        Ok(endpoint)
+        let mut path = parsed.path().trim_end_matches('/').to_string();
+        if path.ends_with("/chat/completions") {
+            path.truncate(path.len() - "/chat/completions".len());
+        }
+        if !path.ends_with("/models") {
+            if path.is_empty() || path == "/" {
+                path = "/models".to_string();
+            } else {
+                path.push_str("/models");
+            }
+        }
+
+        parsed.set_path(&path);
+        parsed.set_fragment(None);
+        Ok(parsed.to_string())
     }
 
     fn custom_models_scope(base_url: &str) -> Option<String> {
@@ -523,6 +523,20 @@ mod tests {
             ModelRegistry::openai_compatible_models_url("https://api.example.com/v1/models")
                 .unwrap(),
             "https://api.example.com/v1/models"
+        );
+        assert_eq!(
+            ModelRegistry::openai_compatible_models_url(
+                "https://api.example.com/v1?api-version=2026-04-30"
+            )
+            .unwrap(),
+            "https://api.example.com/v1/models?api-version=2026-04-30"
+        );
+        assert_eq!(
+            ModelRegistry::openai_compatible_models_url(
+                "https://api.example.com/v1/chat/completions?api-version=2026-04-30"
+            )
+            .unwrap(),
+            "https://api.example.com/v1/models?api-version=2026-04-30"
         );
         assert!(ModelRegistry::openai_compatible_models_url("/chat/completions").is_err());
         assert!(ModelRegistry::openai_compatible_models_url("chat/completions").is_err());

--- a/crates/con-app/src/model_registry.rs
+++ b/crates/con-app/src/model_registry.rs
@@ -588,4 +588,18 @@ mod tests {
             vec!["two-a".to_string()]
         );
     }
+
+    #[test]
+    fn openai_compatible_without_discovered_models_uses_manual_entry() {
+        let registry = ModelRegistry::new();
+
+        assert!(
+            registry
+                .models_for_base_url(
+                    &ProviderKind::OpenAICompatible,
+                    Some("https://api.example.com/v1")
+                )
+                .is_empty()
+        );
+    }
 }

--- a/crates/con-app/src/objc/global_hotkey_trampoline.m
+++ b/crates/con-app/src/objc/global_hotkey_trampoline.m
@@ -182,7 +182,7 @@ static NSMutableArray<NSNumber *> *con_current_window_cycle_order(
     return order;
 }
 
-static void con_cycle_app_window(BOOL reverse, NSTimeInterval timestamp) {
+static void con_cycle_app_window_at_time(BOOL reverse, NSTimeInterval timestamp) {
     NSArray<NSWindow *> *windows = con_cycleable_windows();
     NSUInteger count = windows.count;
     if (count < 2) {
@@ -218,6 +218,10 @@ static void con_cycle_app_window(BOOL reverse, NSTimeInterval timestamp) {
     [target makeKeyAndOrderFront:nil];
 }
 
+void con_cycle_app_window(bool reverse) {
+    con_cycle_app_window_at_time(reverse, [NSDate timeIntervalSinceReferenceDate]);
+}
+
 void con_install_window_cycle_shortcuts(void) {
     if (g_con_window_cycle_monitor != nil) {
         return;
@@ -227,7 +231,7 @@ void con_install_window_cycle_shortcuts(void) {
                                                                        handler:^NSEvent *(NSEvent *event) {
         BOOL reverse = NO;
         if (con_should_cycle_window(event, &reverse)) {
-            con_cycle_app_window(reverse, event.timestamp);
+            con_cycle_app_window_at_time(reverse, [NSDate timeIntervalSinceReferenceDate]);
             return nil;
         }
         return event;

--- a/crates/con-app/src/objc/global_hotkey_trampoline.m
+++ b/crates/con-app/src/objc/global_hotkey_trampoline.m
@@ -8,6 +8,9 @@ typedef void (*con_hotkey_callback_t)(void);
 static EventHotKeyRef g_con_hotkey_ref = NULL;
 static EventHandlerRef g_con_hotkey_handler = NULL;
 static con_hotkey_callback_t g_con_hotkey_callback = NULL;
+static id g_con_window_cycle_monitor = nil;
+static NSMutableArray<NSNumber *> *g_con_window_cycle_order = nil;
+static NSTimeInterval g_con_last_window_cycle_timestamp = 0;
 
 static OSStatus con_hotkey_handler(EventHandlerCallRef nextHandler, EventRef event, void *userData) {
     (void)nextHandler;
@@ -90,4 +93,143 @@ void con_unregister_global_hotkey(void) {
 
 bool con_app_is_active(void) {
     return NSApp != nil && [NSApp isActive];
+}
+
+static BOOL con_should_cycle_window(NSEvent *event, BOOL *reverse) {
+    if (event.type != NSEventTypeKeyDown) {
+        return NO;
+    }
+
+    NSEventModifierFlags flags = event.modifierFlags;
+    BOOL command = (flags & NSEventModifierFlagCommand) != 0;
+    BOOL control = (flags & NSEventModifierFlagControl) != 0;
+    BOOL option = (flags & NSEventModifierFlagOption) != 0;
+    BOOL shift = (flags & NSEventModifierFlagShift) != 0;
+
+    if (!command || control || option) {
+        return NO;
+    }
+
+    // Match the physical grave-accent key. AppKit's native Cmd-` shortcut is
+    // window-management, not terminal input, and the embedded Ghostty NSView can
+    // otherwise keep the event from reaching GPUI's keymap.
+    if (event.keyCode != 0x32) {
+        NSString *characters = event.charactersIgnoringModifiers ?: @"";
+        if (![characters isEqualToString:@"`"] && ![characters isEqualToString:@"~"]) {
+            return NO;
+        }
+    }
+
+    if (reverse != NULL) {
+        *reverse = shift;
+    }
+    return YES;
+}
+
+static NSArray<NSWindow *> *con_cycleable_windows(void) {
+    NSMutableArray<NSWindow *> *windows = [NSMutableArray array];
+    for (NSWindow *window in NSApp.orderedWindows) {
+        if (!window.isVisible || window.isMiniaturized || !window.canBecomeKeyWindow) {
+            continue;
+        }
+        [windows addObject:window];
+    }
+    return windows;
+}
+
+static NSWindow *con_find_cycleable_window(NSArray<NSWindow *> *windows, NSInteger window_number) {
+    for (NSWindow *window in windows) {
+        if (window.windowNumber == window_number) {
+            return window;
+        }
+    }
+    return nil;
+}
+
+static NSMutableArray<NSNumber *> *con_rebuild_window_cycle_order(NSArray<NSWindow *> *windows) {
+    NSMutableArray<NSNumber *> *order = [NSMutableArray arrayWithCapacity:windows.count];
+    for (NSWindow *window in windows) {
+        [order addObject:@(window.windowNumber)];
+    }
+    return order;
+}
+
+static NSMutableArray<NSNumber *> *con_current_window_cycle_order(
+    NSArray<NSWindow *> *windows,
+    NSWindow *current,
+    NSTimeInterval timestamp
+) {
+    BOOL expired = timestamp - g_con_last_window_cycle_timestamp > 2.0;
+    NSNumber *current_number = @(current.windowNumber);
+    if (g_con_window_cycle_order == nil ||
+        expired ||
+        ![g_con_window_cycle_order containsObject:current_number]) {
+        return con_rebuild_window_cycle_order(windows);
+    }
+
+    NSMutableArray<NSNumber *> *order = [NSMutableArray arrayWithCapacity:windows.count];
+    for (NSNumber *window_number in g_con_window_cycle_order) {
+        if (con_find_cycleable_window(windows, window_number.integerValue) != nil) {
+            [order addObject:window_number];
+        }
+    }
+    for (NSWindow *window in windows) {
+        NSNumber *window_number = @(window.windowNumber);
+        if (![order containsObject:window_number]) {
+            [order addObject:window_number];
+        }
+    }
+    return order;
+}
+
+static void con_cycle_app_window(BOOL reverse, NSTimeInterval timestamp) {
+    NSArray<NSWindow *> *windows = con_cycleable_windows();
+    NSUInteger count = windows.count;
+    if (count < 2) {
+        return;
+    }
+
+    NSWindow *current = NSApp.keyWindow ?: NSApp.mainWindow ?: windows.firstObject;
+    NSMutableArray<NSNumber *> *order = con_current_window_cycle_order(windows, current, timestamp);
+    NSNumber *current_number = @(current.windowNumber);
+    NSUInteger current_index = [order indexOfObject:current_number];
+    if (current_index == NSNotFound) {
+        order = con_rebuild_window_cycle_order(windows);
+        current_index = [order indexOfObject:current_number];
+        if (current_index == NSNotFound) {
+            current_index = 0;
+        }
+    }
+
+    count = order.count;
+    NSUInteger target_index = reverse
+        ? (current_index == 0 ? count - 1 : current_index - 1)
+        : (current_index + 1) % count;
+
+    NSWindow *target = con_find_cycleable_window(windows, order[target_index].integerValue);
+    if (target == nil) {
+        return;
+    }
+
+    g_con_window_cycle_order = order;
+    g_con_last_window_cycle_timestamp = timestamp;
+
+    [NSApp activateIgnoringOtherApps:YES];
+    [target makeKeyAndOrderFront:nil];
+}
+
+void con_install_window_cycle_shortcuts(void) {
+    if (g_con_window_cycle_monitor != nil) {
+        return;
+    }
+
+    g_con_window_cycle_monitor = [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskKeyDown
+                                                                       handler:^NSEvent *(NSEvent *event) {
+        BOOL reverse = NO;
+        if (con_should_cycle_window(event, &reverse)) {
+            con_cycle_app_window(reverse, event.timestamp);
+            return nil;
+        }
+        return event;
+    }];
 }

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -1947,8 +1947,10 @@ impl SettingsPanel {
                     panel.provider_model_fetching = false;
                     match result {
                         Ok(models) if models.is_empty() => {
-                            panel.provider_model_status =
-                                Some("The endpoint responded, but returned no models.".to_string());
+                            panel.provider_model_status = Some(
+                                "The endpoint responded, but returned no models. Type the model ID manually."
+                                    .to_string(),
+                            );
                             panel.provider_model_status_error = true;
                         }
                         Ok(models) => {
@@ -2002,7 +2004,9 @@ impl SettingsPanel {
                             panel.provider_model_status_error = false;
                         }
                         Err(err) => {
-                            panel.provider_model_status = Some(err.to_string());
+                            panel.provider_model_status = Some(format!(
+                                "Could not fetch models: {err}. Type the model ID manually."
+                            ));
                             panel.provider_model_status_error = true;
                         }
                     }
@@ -3853,7 +3857,7 @@ impl SettingsPanel {
                                 })
                                 .child(
                                     self.provider_model_status.clone().unwrap_or_else(|| {
-                                        "Fetch /models when the provider exposes an OpenAI-compatible model list.".to_string()
+                                        "Optional: fetch /models when the provider exposes a model list. Otherwise, type the model ID manually.".to_string()
                                     }),
                                 ),
                         )

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -89,6 +89,7 @@ const ALL_SECTIONS: &[SettingsSection] = &[
 
 pub struct SettingsPanel {
     visible: bool,
+    standalone: bool,
     config: Config,
     registry: ModelRegistry,
     oauth_runtime: Arc<tokio::runtime::Runtime>,
@@ -114,6 +115,9 @@ pub struct SettingsPanel {
     suggestion_provider_select: Entity<SelectState<SearchableVec<String>>>,
     suggestion_model_select: Entity<SelectState<SearchableVec<String>>>,
     oauth_states: HashMap<ProviderKind, ProviderOAuthState>,
+    provider_model_fetching: bool,
+    provider_model_status: Option<String>,
+    provider_model_status_error: bool,
 
     terminal_font_select: Entity<SelectState<SearchableVec<String>>>,
     ui_font_select: Entity<SelectState<SearchableVec<String>>>,
@@ -1340,6 +1344,7 @@ impl SettingsPanel {
 
         Self {
             visible: false,
+            standalone: false,
             config: config.clone(),
             registry,
             oauth_runtime,
@@ -1363,6 +1368,9 @@ impl SettingsPanel {
             suggestion_provider_select,
             suggestion_model_select,
             oauth_states: HashMap::new(),
+            provider_model_fetching: false,
+            provider_model_status: None,
+            provider_model_status_error: false,
             terminal_font_select,
             ui_font_select,
             cursor_style_select,
@@ -1385,150 +1393,167 @@ impl SettingsPanel {
     }
 
     pub fn toggle(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.standalone = false;
         self.visible = !self.visible;
         self.overlay_motion.set_target(
             if self.visible { 1.0 } else { 0.0 },
             std::time::Duration::from_millis(if self.visible { 220 } else { 180 }),
         );
         if self.visible {
-            let agent = &self.config.agent;
-            let pc = agent.providers.get_or_default(&self.selected_provider);
-            self.load_provider_inputs(&pc, window, cx);
-            self.sync_provider_placeholders(&self.selected_provider, window, cx);
-            self.max_turns_input.update(cx, |s, cx| {
-                s.set_value(&agent.max_turns.to_string(), window, cx)
-            });
-            self.temperature_input.update(cx, |s, cx| {
-                s.set_value(
-                    &agent.temperature.map(|t| t.to_string()).unwrap_or_default(),
-                    window,
-                    cx,
-                )
-            });
-            self.active_provider_select.update(cx, |select, cx| {
-                select.set_selected_value(
-                    &provider_label(&Self::sidebar_provider_kind(&agent.provider)).to_string(),
-                    window,
-                    cx,
-                );
-            });
-            self.active_model_select = Self::make_model_select(
-                &agent.provider,
-                &agent
-                    .providers
-                    .get(&agent.provider)
-                    .and_then(|pc| pc.model.clone()),
-                &self.registry,
-                window,
-                cx,
-            );
-            self.ai_purpose_select.update(cx, |select, cx| {
-                select.set_selected_value(
-                    &Self::ai_purpose_label(agent.purpose).to_string(),
-                    window,
-                    cx,
-                );
-            });
-            self.suggestion_enabled = agent.suggestion_model.enabled;
-            self.suggestion_provider_select.update(cx, |select, cx| {
-                select.set_selected_value(
-                    &Self::suggestion_provider_label(agent.suggestion_model.provider.as_ref()),
-                    window,
-                    cx,
-                );
-            });
-            self.suggestion_model_select = Self::make_model_select(
-                &Self::effective_suggestion_provider(&self.config),
-                &agent.suggestion_model.model,
-                &self.registry,
-                window,
-                cx,
-            );
-            self.auto_approve = agent.auto_approve_tools;
-            self.model_select =
-                Self::make_model_select(&agent.provider, &pc.model, &self.registry, window, cx);
-            self.endpoint_preset_select =
-                Self::make_endpoint_preset_select(&agent.provider, &pc.base_url, window, cx);
-            self.terminal_font_select.update(cx, |select, cx| {
-                select.set_selected_value(
-                    &sanitize_terminal_font_family(&self.config.terminal.font_family),
-                    window,
-                    cx,
-                );
-            });
-            self.ui_font_select.update(cx, |select, cx| {
-                select.set_selected_value(&self.config.appearance.ui_font_family, window, cx);
-            });
-            self.cursor_style_select.update(cx, |select, cx| {
-                select.set_selected_value(
-                    &Self::cursor_style_label(&self.config.terminal.cursor_style).to_string(),
-                    window,
-                    cx,
-                );
-            });
-            self.font_size_input.update(cx, |s, cx| {
-                s.set_value(&self.config.terminal.font_size.to_string(), window, cx)
-            });
-            self.ui_font_size_input.update(cx, |s, cx| {
-                s.set_value(
-                    &Self::clamp_ui_font_size(self.config.appearance.ui_font_size).to_string(),
-                    window,
-                    cx,
-                )
-            });
-            self.terminal_opacity_slider.update(cx, |slider, cx| {
-                slider.set_value(
-                    Self::clamp_terminal_opacity(self.config.appearance.terminal_opacity),
-                    window,
-                    cx,
-                );
-            });
-            self.terminal_blur = self.config.appearance.terminal_blur;
-            self.ui_opacity_slider.update(cx, |slider, cx| {
-                slider.set_value(
-                    Self::clamp_ui_opacity(self.config.appearance.ui_opacity),
-                    window,
-                    cx,
-                );
-            });
-            self.background_image_input.update(cx, |s, cx| {
-                s.set_value(
-                    &self
-                        .config
-                        .appearance
-                        .background_image
-                        .clone()
-                        .unwrap_or_default(),
-                    window,
-                    cx,
-                );
-            });
-            self.background_image_opacity_slider
-                .update(cx, |slider, cx| {
-                    slider.set_value(
-                        Self::clamp_background_image_opacity(
-                            self.config.appearance.background_image_opacity,
-                        ),
-                        window,
-                        cx,
-                    );
-                });
-            self.background_image_position_select
-                .update(cx, |select, cx| {
-                    select.set_selected_value(
-                        &self.config.appearance.background_image_position,
-                        window,
-                        cx,
-                    );
-                });
-            self.background_image_fit_select.update(cx, |select, cx| {
-                select.set_selected_value(&self.config.appearance.background_image_fit, window, cx);
-            });
-            self.background_image_repeat = self.config.appearance.background_image_repeat;
-            self.recording_key = None;
-            self.focus_handle.focus(window, cx);
+            self.refresh_controls_from_config(window, cx);
         }
         cx.notify();
+    }
+
+    pub fn open_standalone(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.standalone = true;
+        self.visible = true;
+        self.overlay_motion
+            .set_target(1.0, std::time::Duration::ZERO);
+        self.refresh_controls_from_config(window, cx);
+        cx.notify();
+    }
+
+    fn refresh_controls_from_config(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let agent = &self.config.agent;
+        let pc = agent.providers.get_or_default(&self.selected_provider);
+        self.load_provider_inputs(&pc, window, cx);
+        self.sync_provider_placeholders(&self.selected_provider, window, cx);
+        self.max_turns_input.update(cx, |s, cx| {
+            s.set_value(&agent.max_turns.to_string(), window, cx)
+        });
+        self.temperature_input.update(cx, |s, cx| {
+            s.set_value(
+                &agent.temperature.map(|t| t.to_string()).unwrap_or_default(),
+                window,
+                cx,
+            )
+        });
+        self.active_provider_select.update(cx, |select, cx| {
+            select.set_selected_value(
+                &provider_label(&Self::sidebar_provider_kind(&agent.provider)).to_string(),
+                window,
+                cx,
+            );
+        });
+        self.active_model_select = Self::make_model_select(
+            &agent.provider,
+            &agent
+                .providers
+                .get(&agent.provider)
+                .and_then(|pc| pc.model.clone()),
+            &self.registry,
+            window,
+            cx,
+        );
+        self.ai_purpose_select.update(cx, |select, cx| {
+            select.set_selected_value(
+                &Self::ai_purpose_label(agent.purpose).to_string(),
+                window,
+                cx,
+            );
+        });
+        self.suggestion_enabled = agent.suggestion_model.enabled;
+        self.suggestion_provider_select.update(cx, |select, cx| {
+            select.set_selected_value(
+                &Self::suggestion_provider_label(agent.suggestion_model.provider.as_ref()),
+                window,
+                cx,
+            );
+        });
+        self.suggestion_model_select = Self::make_model_select(
+            &Self::effective_suggestion_provider(&self.config),
+            &agent.suggestion_model.model,
+            &self.registry,
+            window,
+            cx,
+        );
+        self.auto_approve = agent.auto_approve_tools;
+        self.model_select =
+            Self::make_model_select(&agent.provider, &pc.model, &self.registry, window, cx);
+        self.endpoint_preset_select =
+            Self::make_endpoint_preset_select(&agent.provider, &pc.base_url, window, cx);
+        self.terminal_font_select.update(cx, |select, cx| {
+            select.set_selected_value(
+                &sanitize_terminal_font_family(&self.config.terminal.font_family),
+                window,
+                cx,
+            );
+        });
+        self.ui_font_select.update(cx, |select, cx| {
+            select.set_selected_value(&self.config.appearance.ui_font_family, window, cx);
+        });
+        self.cursor_style_select.update(cx, |select, cx| {
+            select.set_selected_value(
+                &Self::cursor_style_label(&self.config.terminal.cursor_style).to_string(),
+                window,
+                cx,
+            );
+        });
+        self.font_size_input.update(cx, |s, cx| {
+            s.set_value(&self.config.terminal.font_size.to_string(), window, cx)
+        });
+        self.ui_font_size_input.update(cx, |s, cx| {
+            s.set_value(
+                &Self::clamp_ui_font_size(self.config.appearance.ui_font_size).to_string(),
+                window,
+                cx,
+            )
+        });
+        self.terminal_opacity_slider.update(cx, |slider, cx| {
+            slider.set_value(
+                Self::clamp_terminal_opacity(self.config.appearance.terminal_opacity),
+                window,
+                cx,
+            );
+        });
+        self.terminal_blur = self.config.appearance.terminal_blur;
+        self.ui_opacity_slider.update(cx, |slider, cx| {
+            slider.set_value(
+                Self::clamp_ui_opacity(self.config.appearance.ui_opacity),
+                window,
+                cx,
+            );
+        });
+        self.background_image_input.update(cx, |s, cx| {
+            s.set_value(
+                &self
+                    .config
+                    .appearance
+                    .background_image
+                    .clone()
+                    .unwrap_or_default(),
+                window,
+                cx,
+            );
+        });
+        self.background_image_opacity_slider
+            .update(cx, |slider, cx| {
+                slider.set_value(
+                    Self::clamp_background_image_opacity(
+                        self.config.appearance.background_image_opacity,
+                    ),
+                    window,
+                    cx,
+                );
+            });
+        self.background_image_position_select
+            .update(cx, |select, cx| {
+                select.set_selected_value(
+                    &self.config.appearance.background_image_position,
+                    window,
+                    cx,
+                );
+            });
+        self.background_image_fit_select.update(cx, |select, cx| {
+            select.set_selected_value(&self.config.appearance.background_image_fit, window, cx);
+        });
+        self.background_image_repeat = self.config.appearance.background_image_repeat;
+        self.provider_model_fetching = false;
+        self.provider_model_status = None;
+        self.provider_model_status_error = false;
+        self.recording_key = None;
+        self.focus_handle.focus(window, cx);
     }
 
     /// Load a provider's config into the per-provider input fields.
@@ -1761,8 +1786,138 @@ impl SettingsPanel {
         }
     }
 
+    fn resolve_provider_api_key(config: &ProviderConfig) -> Result<String, String> {
+        if let Some(key) = config
+            .api_key
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return Ok(key.to_string());
+        }
+
+        if let Some(env_name) = config
+            .api_key_env
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            return std::env::var(env_name)
+                .map(|value| value.trim().to_string())
+                .map_err(|_| format!("Environment variable {env_name} is not set."))
+                .and_then(|value| {
+                    if value.is_empty() {
+                        Err(format!("Environment variable {env_name} is empty."))
+                    } else {
+                        Ok(value)
+                    }
+                });
+        }
+
+        Err("Enter an API key, or an environment variable name that contains one.".to_string())
+    }
+
+    fn fetch_selected_provider_models(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.selected_provider != ProviderKind::OpenAICompatible || self.provider_model_fetching
+        {
+            return;
+        }
+
+        let provider_config = self.read_provider_inputs(cx);
+        self.config
+            .agent
+            .providers
+            .set(&self.selected_provider, provider_config.clone());
+
+        let Some(base_url) = provider_config
+            .base_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+        else {
+            self.provider_model_status =
+                Some("Enter the provider Base URL, usually ending in /v1.".to_string());
+            self.provider_model_status_error = true;
+            cx.notify();
+            return;
+        };
+
+        let api_key = match Self::resolve_provider_api_key(&provider_config) {
+            Ok(api_key) => api_key,
+            Err(message) => {
+                self.provider_model_status = Some(message);
+                self.provider_model_status_error = true;
+                cx.notify();
+                return;
+            }
+        };
+
+        self.provider_model_fetching = true;
+        self.provider_model_status = Some("Fetching models from the provider…".to_string());
+        self.provider_model_status_error = false;
+        cx.notify();
+
+        let registry = self.registry.clone();
+        let runtime = self.oauth_runtime.clone();
+        cx.spawn_in(window, async move |this, window| {
+            let result = runtime
+                .spawn(async move {
+                    ModelRegistry::fetch_openai_compatible_models(&base_url, &api_key).await
+                })
+                .await
+                .map_err(|err| anyhow::anyhow!("Model fetch task failed: {err}"))
+                .and_then(|result| result);
+
+            let _ = window.update(|window, cx| {
+                let _ = this.update(cx, |panel, cx| {
+                    panel.provider_model_fetching = false;
+                    match result {
+                        Ok(models) if models.is_empty() => {
+                            panel.provider_model_status =
+                                Some("The endpoint responded, but returned no models.".to_string());
+                            panel.provider_model_status_error = true;
+                        }
+                        Ok(models) => {
+                            let count = models.len();
+                            registry.set_provider_models(ProviderKind::OpenAICompatible, models);
+                            if panel.selected_provider == ProviderKind::OpenAICompatible {
+                                let current_model =
+                                    panel.model_input.read(cx).value().trim().to_string();
+                                let current_model =
+                                    (!current_model.is_empty()).then_some(current_model);
+                                panel.model_select = Self::make_model_select(
+                                    &ProviderKind::OpenAICompatible,
+                                    &current_model,
+                                    &registry,
+                                    window,
+                                    cx,
+                                );
+                            }
+                            panel.provider_model_status = Some(format!(
+                                "Fetched {count} model{}.",
+                                if count == 1 { "" } else { "s" }
+                            ));
+                            panel.provider_model_status_error = false;
+                        }
+                        Err(err) => {
+                            panel.provider_model_status = Some(err.to_string());
+                            panel.provider_model_status_error = true;
+                        }
+                    }
+                    cx.notify();
+                });
+            });
+        })
+        .detach();
+    }
+
     pub fn is_visible(&self) -> bool {
         self.visible || self.overlay_motion.is_animating()
+    }
+
+    pub fn is_overlay_visible(&self) -> bool {
+        !self.standalone && self.is_visible()
     }
 
     fn save(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
@@ -1847,9 +2002,11 @@ impl SettingsPanel {
         match self.persist_config() {
             Ok(()) => {
                 self.save_error = None;
-                self.visible = false;
-                self.overlay_motion
-                    .set_target(0.0, std::time::Duration::from_millis(180));
+                if !self.standalone {
+                    self.visible = false;
+                    self.overlay_motion
+                        .set_target(0.0, std::time::Duration::from_millis(180));
+                }
                 cx.emit(SaveSettings);
             }
             Err(e) => {
@@ -2001,6 +2158,9 @@ impl SettingsPanel {
         }
 
         self.selected_provider = provider.clone();
+        self.provider_model_fetching = false;
+        self.provider_model_status = None;
+        self.provider_model_status_error = false;
 
         let pc = self.config.agent.providers.get_or_default(&provider);
         self.load_provider_inputs(&pc, window, cx);
@@ -3381,6 +3541,7 @@ impl SettingsPanel {
         let model_select = self.model_select.clone();
         let endpoint_preset_select = self.endpoint_preset_select.clone();
         let endpoint_presets = Self::provider_endpoint_presets(&self.selected_provider);
+        let can_fetch_models = self.selected_provider == ProviderKind::OpenAICompatible;
         let protocol_switch_label = Self::protocol_switch_label(&self.selected_provider);
         let protocol_switch_hint = Self::protocol_switch_hint(&self.selected_provider);
         let anthropic_protocol_enabled = Self::uses_anthropic_protocol(&self.selected_provider);
@@ -3523,6 +3684,7 @@ impl SettingsPanel {
                         .flex()
                         .items_center()
                         .justify_between()
+                        .gap(px(12.0))
                         .child(
                             div()
                                 .text_sm()
@@ -3560,7 +3722,42 @@ impl SettingsPanel {
                                 .small(),
                         )
                         .child(Input::new(&model_input).small())
-                }),
+                })
+                .children(can_fetch_models.then(|| {
+                    div()
+                        .flex()
+                        .items_center()
+                        .justify_between()
+                        .gap(px(10.0))
+                        .pt(px(2.0))
+                        .child(
+                            div()
+                                .flex_1()
+                                .text_size(px(11.0))
+                                .line_height(px(16.0))
+                                .text_color(if self.provider_model_status_error {
+                                    theme.danger
+                                } else {
+                                    theme.muted_foreground.opacity(0.62)
+                                })
+                                .child(
+                                    self.provider_model_status.clone().unwrap_or_else(|| {
+                                        "Fetch /models when the provider exposes an OpenAI-compatible model list.".to_string()
+                                    }),
+                                ),
+                        )
+                        .child(
+                            Button::new("fetch-openai-compatible-models")
+                                .small()
+                                .ghost()
+                                .label("Fetch Models")
+                                .loading(self.provider_model_fetching)
+                                .disabled(self.provider_model_fetching)
+                                .on_click(cx.listener(|this, _, window, cx| {
+                                    this.fetch_selected_provider_models(window, cx);
+                                })),
+                        )
+                })),
         );
 
         let right_col = div()
@@ -3975,6 +4172,45 @@ impl SettingsPanel {
         let global_summon_recording = recording.as_deref() == Some("global_summon");
         let theme = cx.theme();
 
+        let fixed_tab_card = card(theme, card_opacity).child(
+            div()
+                .flex()
+                .items_center()
+                .justify_between()
+                .gap(px(16.0))
+                .px(px(16.0))
+                .h(px(34.0))
+                .hover(|s| s.bg(theme.muted.opacity(0.025)))
+                .child(
+                    div()
+                        .text_size(px(12.0))
+                        .line_height(px(16.0))
+                        .font_weight(FontWeight::MEDIUM)
+                        .text_color(theme.foreground.opacity(0.86))
+                        .child("Select Tab by Number"),
+                )
+                .child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap(px(6.0))
+                        .child(crate::keycaps::keycaps_for_binding("secondary-1", theme))
+                        .child(
+                            div()
+                                .text_size(px(11.0))
+                                .text_color(theme.muted_foreground.opacity(0.55))
+                                .child("…"),
+                        )
+                        .child(crate::keycaps::keycaps_for_binding("secondary-9", theme)),
+                ),
+        );
+        #[cfg(target_os = "macos")]
+        let fixed_tab_card = fixed_tab_card
+            .child(row_separator(theme))
+            .child(key_row("Next Window", "cmd-`", theme))
+            .child(row_separator(theme))
+            .child(key_row("Previous Window", "cmd-shift-`", theme));
+
         let global_summon_badge = if global_summon_recording {
             div()
                 .min_h(px(28.0))
@@ -4133,6 +4369,14 @@ impl SettingsPanel {
                 .child(div().h(px(8.0)))
                 .child(group_label("General", &theme))
                 .child(general_card),
+        )
+        .child(
+            div()
+                .flex()
+                .flex_col()
+                .gap(px(8.0))
+                .child(group_label("Fixed Shortcuts", &theme))
+                .child(fixed_tab_card),
         )
         .child(
             div()
@@ -4331,6 +4575,155 @@ impl Render for SettingsPanel {
             .p(content_pad)
             .child(content);
 
+        let surface_rounding = if self.standalone { px(0.0) } else { px(12.0) };
+        let surface = div()
+            .id("settings-card")
+            .w(if self.standalone {
+                px(viewport_w)
+            } else {
+                card_width
+            })
+            .h(if self.standalone {
+                px(viewport_h)
+            } else {
+                card_height
+            })
+            .rounded(surface_rounding)
+            .bg(theme.title_bar)
+            .overflow_hidden()
+            .flex()
+            .flex_col()
+            .occlude()
+            .track_focus(&self.focus_handle)
+            .on_key_down(cx.listener(|this, event: &KeyDownEvent, window, cx| {
+                // If recording a keybinding, capture the keystroke.
+                if this.recording_key.is_some() {
+                    this.record_keystroke(&event.keystroke, cx);
+                    return;
+                }
+                match event.keystroke.key.as_str() {
+                    "escape" => {
+                        if this.standalone {
+                            window.remove_window();
+                        } else {
+                            this.save(window, cx);
+                        }
+                    }
+                    "enter" if event.keystroke.modifiers.platform => {
+                        this.save(window, cx);
+                    }
+                    _ => {}
+                }
+            }))
+            // Header
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .flex_shrink_0()
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .justify_between()
+                            .h(px(44.0))
+                            .px(px(20.0))
+                            .child(
+                                div()
+                                    .text_size(px(13.0))
+                                    .font_weight(FontWeight::SEMIBOLD)
+                                    .text_color(theme.foreground)
+                                    .child("Settings"),
+                            )
+                            .child(
+                                div()
+                                    .flex()
+                                    .items_center()
+                                    .gap(px(8.0))
+                                    .child(
+                                        div()
+                                            .id("open-config-file")
+                                            .flex()
+                                            .items_center()
+                                            .gap(px(3.0))
+                                            .cursor_pointer()
+                                            .text_size(px(10.5))
+                                            .text_color(theme.muted_foreground.opacity(0.4))
+                                            .hover(|s| {
+                                                s.text_color(theme.muted_foreground.opacity(0.7))
+                                            })
+                                            .on_mouse_down(
+                                                MouseButton::Left,
+                                                cx.listener(|_, _, _, cx| {
+                                                    let path = Config::config_path();
+                                                    // Ensure the file exists so the editor has something to open.
+                                                    if !path.exists() {
+                                                        if let Some(parent) = path.parent() {
+                                                            let _ = std::fs::create_dir_all(parent);
+                                                        }
+                                                        let _ = std::fs::write(&path, "");
+                                                    }
+                                                    cx.open_url(&format!(
+                                                        "file://{}",
+                                                        path.display()
+                                                    ));
+                                                }),
+                                            )
+                                            .child(
+                                                svg()
+                                                    .path("phosphor/file-text.svg")
+                                                    .size(px(12.0))
+                                                    .text_color(
+                                                        theme.muted_foreground.opacity(0.4),
+                                                    ),
+                                            )
+                                            .child("config.toml"),
+                                    )
+                                    .children(self.standalone.then(|| {
+                                        Button::new("settings-apply")
+                                            .small()
+                                            .primary()
+                                            .label("Apply")
+                                            .on_click(cx.listener(|this, _, window, cx| {
+                                                this.save(window, cx);
+                                            }))
+                                    })),
+                            ),
+                    )
+                    .child(div().h(px(1.0)).bg(theme.muted.opacity(0.10))),
+            )
+            // Error banner
+            .children(self.save_error.as_ref().map(|err| {
+                div()
+                    .px_4()
+                    .py_2()
+                    .mx_4()
+                    .mt_2()
+                    .rounded_md()
+                    .bg(theme.danger)
+                    .text_color(theme.danger_foreground)
+                    .text_xs()
+                    .child(format!("Save failed: {}", err))
+            }))
+            // Body
+            .child(
+                div()
+                    .flex()
+                    .flex_1()
+                    .min_h_0()
+                    .child(sidebar)
+                    .child(content_scroll),
+            );
+
+        if self.standalone {
+            return div()
+                .id("settings-window")
+                .size_full()
+                .font_family(theme.font_family.clone())
+                .bg(theme.background)
+                .child(surface);
+        }
+
         let backdrop = div()
             .id("settings-backdrop")
             .occlude()
@@ -4344,9 +4737,8 @@ impl Render for SettingsPanel {
                 }),
             );
 
-        // Card — centered with flex centering
         let card = div()
-            .id("settings-card")
+            .id("settings-card-shell")
             .absolute()
             .inset_0()
             .flex()
@@ -4356,132 +4748,8 @@ impl Render for SettingsPanel {
             .child(
                 div()
                     .pt(vertical_reveal_offset(overlay_progress, 18.0))
-                    .px(px(0.0))
                     .opacity(overlay_progress)
-                    .child(
-                        div()
-                    .w(card_width)
-                    .h(card_height)
-                    .rounded(px(12.0))
-                    .bg(theme.title_bar)
-                    .overflow_hidden()
-                    .flex()
-                    .flex_col()
-                    .occlude()
-                    .track_focus(&self.focus_handle)
-                    .on_key_down(cx.listener(|this, event: &KeyDownEvent, window, cx| {
-                        // If recording a keybinding, capture the keystroke
-                        if this.recording_key.is_some() {
-                            this.record_keystroke(&event.keystroke, cx);
-                            return;
-                        }
-                        match event.keystroke.key.as_str() {
-                            "escape" => {
-                                this.save(window, cx);
-                            }
-                            "enter" if event.keystroke.modifiers.platform => {
-                                this.save(window, cx);
-                            }
-                            _ => {}
-                        }
-                    }))
-                    // Header
-                    .child(
-                        div()
-                            .flex()
-                            .flex_col()
-                            .flex_shrink_0()
-                            .child(
-                                div()
-                                    .flex()
-                                    .items_center()
-                                    .justify_between()
-                                    .h(px(44.0))
-                                    .px(px(20.0))
-                                    .child(
-                                        div()
-                                            .text_size(px(13.0))
-                                            .font_weight(FontWeight::SEMIBOLD)
-                                            .text_color(theme.foreground)
-                                            .child("Settings"),
-                                    )
-                                    .child(
-                                        div()
-                                            .flex()
-                                            .items_center()
-                                            .gap(px(8.0))
-                                            // Open config file link
-                                            .child(
-                                                div()
-                                                    .id("open-config-file")
-                                                    .flex()
-                                                    .items_center()
-                                                    .gap(px(3.0))
-                                                    .cursor_pointer()
-                                                    .text_size(px(10.5))
-                                                    .text_color(theme.muted_foreground.opacity(0.4))
-                                                    .hover(|s| {
-                                                        s.text_color(
-                                                            theme.muted_foreground.opacity(0.7),
-                                                        )
-                                                    })
-                                                    .on_mouse_down(
-                                                        MouseButton::Left,
-                                                        cx.listener(|_, _, _, cx| {
-                                                            let path = Config::config_path();
-                                                            // Ensure the file exists so the editor has something to open
-                                                            if !path.exists() {
-                                                                if let Some(parent) = path.parent()
-                                                                {
-                                                                    let _ = std::fs::create_dir_all(
-                                                                        parent,
-                                                                    );
-                                                                }
-                                                                let _ = std::fs::write(&path, "");
-                                                            }
-                                                            cx.open_url(&format!(
-                                                                "file://{}",
-                                                                path.display()
-                                                            ));
-                                                        }),
-                                                    )
-                                                    .child(
-                                                        svg()
-                                                            .path("phosphor/file-text.svg")
-                                                            .size(px(12.0))
-                                                            .text_color(
-                                                                theme.muted_foreground.opacity(0.4),
-                                                            ),
-                                                    )
-                                                    .child("config.toml"),
-                                            ),
-                                    ),
-                            )
-                            .child(div().h(px(1.0)).bg(theme.muted.opacity(0.10))),
-                    )
-                    // Error banner
-                    .children(self.save_error.as_ref().map(|err| {
-                        div()
-                            .px_4()
-                            .py_2()
-                            .mx_4()
-                            .mt_2()
-                            .rounded_md()
-                            .bg(theme.danger)
-                            .text_color(theme.danger_foreground)
-                            .text_xs()
-                            .child(format!("Save failed: {}", err))
-                    }))
-                    // Body
-                    .child(
-                        div()
-                            .flex()
-                            .flex_1()
-                            .min_h_0()
-                            .child(sidebar)
-                            .child(content_scroll),
-                    ),
-                    ),
+                    .child(surface),
             );
 
         div()

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -994,14 +994,7 @@ impl SettingsPanel {
             window,
             cx,
         );
-        let active_model_select = Self::make_model_select(
-            &agent.provider,
-            &pc.model,
-            pc.base_url.as_deref(),
-            &registry,
-            window,
-            cx,
-        );
+        let active_model_select = Self::make_active_model_select(config, &registry, window, cx);
 
         let model_input = cx.new(|cx| {
             let mut s = InputState::new(window, cx);
@@ -1072,21 +1065,14 @@ impl SettingsPanel {
             window,
             cx,
         );
-        let suggestion_provider = Self::effective_suggestion_provider(config);
         let suggestion_provider_select = Self::make_searchable_string_select(
             &Self::suggestion_provider_options(),
             &Self::suggestion_provider_label(agent.suggestion_model.provider.as_ref()),
             window,
             cx,
         );
-        let suggestion_model_select = Self::make_model_select(
-            &suggestion_provider,
-            &agent.suggestion_model.model,
-            Self::provider_base_url(config, &suggestion_provider),
-            &registry,
-            window,
-            cx,
-        );
+        let suggestion_model_select =
+            Self::make_suggestion_model_select(config, &registry, window, cx);
         let all_font_families = cx.text_system().all_font_names();
         let terminal_font_families =
             Self::prepare_terminal_font_families(config, all_font_families.clone());
@@ -1224,17 +1210,9 @@ impl SettingsPanel {
             |this, _, ev: &SelectEvent<SearchableVec<String>>, window, cx| {
                 if let SelectEvent::Confirm(Some(value)) = ev {
                     if let Some(provider) = Self::suggestion_provider_from_label(value) {
-                        this.config.agent.provider = provider.clone();
-                        let current_model = this
-                            .config
-                            .agent
-                            .providers
-                            .get(&provider)
-                            .and_then(|pc| pc.model.clone());
-                        this.active_model_select = Self::make_model_select(
-                            &provider,
-                            &current_model,
-                            Self::provider_base_url(&this.config, &provider),
+                        this.config.agent.provider = provider;
+                        this.active_model_select = Self::make_active_model_select(
+                            &this.config,
                             &this.registry,
                             window,
                             cx,
@@ -1246,53 +1224,18 @@ impl SettingsPanel {
         )
         .detach();
         cx.subscribe_in(
-            &active_model_select,
-            window,
-            |this, _, ev: &SelectEvent<SearchableVec<String>>, _, cx| {
-                if let SelectEvent::Confirm(Some(value)) = ev {
-                    let provider = this.config.agent.provider.clone();
-                    let mut pc = this.config.agent.providers.get_or_default(&provider);
-                    pc.model = Some(value.clone());
-                    this.config.agent.providers.set(&provider, pc);
-                    cx.notify();
-                }
-            },
-        )
-        .detach();
-        cx.subscribe_in(
             &suggestion_provider_select,
             window,
             |this, _, ev: &SelectEvent<SearchableVec<String>>, window, cx| {
                 if let SelectEvent::Confirm(Some(value)) = ev {
                     this.config.agent.suggestion_model.provider =
                         Self::suggestion_provider_from_label(value);
-                    let provider = this
-                        .config
-                        .agent
-                        .suggestion_model
-                        .provider
-                        .clone()
-                        .unwrap_or_else(|| this.config.agent.provider.clone());
-                    let selected_model = this.config.agent.suggestion_model.model.clone();
-                    this.suggestion_model_select = Self::make_model_select(
-                        &provider,
-                        &selected_model,
-                        Self::provider_base_url(&this.config, &provider),
+                    this.suggestion_model_select = Self::make_suggestion_model_select(
+                        &this.config,
                         &this.registry,
                         window,
                         cx,
                     );
-                    cx.notify();
-                }
-            },
-        )
-        .detach();
-        cx.subscribe_in(
-            &suggestion_model_select,
-            window,
-            |this, _, ev: &SelectEvent<SearchableVec<String>>, _, cx| {
-                if let SelectEvent::Confirm(Some(value)) = ev {
-                    this.config.agent.suggestion_model.model = Some(value.clone());
                     cx.notify();
                 }
             },
@@ -1478,17 +1421,8 @@ impl SettingsPanel {
                 cx,
             );
         });
-        self.active_model_select = Self::make_model_select(
-            &agent.provider,
-            &agent
-                .providers
-                .get(&agent.provider)
-                .and_then(|pc| pc.model.clone()),
-            Self::provider_base_url(&self.config, &agent.provider),
-            &self.registry,
-            window,
-            cx,
-        );
+        self.active_model_select =
+            Self::make_active_model_select(&self.config, &self.registry, window, cx);
         self.ai_purpose_select.update(cx, |select, cx| {
             select.set_selected_value(
                 &Self::ai_purpose_label(agent.purpose).to_string(),
@@ -1504,17 +1438,8 @@ impl SettingsPanel {
                 cx,
             );
         });
-        self.suggestion_model_select = Self::make_model_select(
-            &Self::effective_suggestion_provider(&self.config),
-            &agent.suggestion_model.model,
-            Self::provider_base_url(
-                &self.config,
-                &Self::effective_suggestion_provider(&self.config),
-            ),
-            &self.registry,
-            window,
-            cx,
-        );
+        self.suggestion_model_select =
+            Self::make_suggestion_model_select(&self.config, &self.registry, window, cx);
         self.auto_approve = agent.auto_approve_tools;
         self.model_select = Self::make_model_select(
             &agent.provider,
@@ -1653,7 +1578,7 @@ impl SettingsPanel {
             .and_then(|pc| pc.base_url.as_deref())
     }
 
-    fn make_model_select(
+    fn make_model_select_state(
         provider: &ProviderKind,
         current_model: &Option<String>,
         base_url: Option<&str>,
@@ -1678,6 +1603,19 @@ impl SettingsPanel {
             SelectState::new(SearchableVec::new(models), selected_index, window, cx)
                 .searchable(true)
         });
+        entity
+    }
+
+    fn make_model_select(
+        provider: &ProviderKind,
+        current_model: &Option<String>,
+        base_url: Option<&str>,
+        registry: &ModelRegistry,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Entity<SelectState<SearchableVec<String>>> {
+        let entity =
+            Self::make_model_select_state(provider, current_model, base_url, registry, window, cx);
         cx.subscribe_in(
             &entity,
             window,
@@ -1686,6 +1624,73 @@ impl SettingsPanel {
                     this.model_input.update(cx, |s, cx| {
                         s.set_value(value, window, cx);
                     });
+                    cx.notify();
+                }
+            },
+        )
+        .detach();
+        entity
+    }
+
+    fn make_active_model_select(
+        config: &Config,
+        registry: &ModelRegistry,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Entity<SelectState<SearchableVec<String>>> {
+        let provider = config.agent.provider.clone();
+        let current_model = config
+            .agent
+            .providers
+            .get(&provider)
+            .and_then(|pc| pc.model.clone());
+        let entity = Self::make_model_select_state(
+            &provider,
+            &current_model,
+            Self::provider_base_url(config, &provider),
+            registry,
+            window,
+            cx,
+        );
+        cx.subscribe_in(
+            &entity,
+            window,
+            |this, _, ev: &SelectEvent<SearchableVec<String>>, _, cx| {
+                if let SelectEvent::Confirm(Some(value)) = ev {
+                    let provider = this.config.agent.provider.clone();
+                    let mut pc = this.config.agent.providers.get_or_default(&provider);
+                    pc.model = Some(value.clone());
+                    this.config.agent.providers.set(&provider, pc);
+                    cx.notify();
+                }
+            },
+        )
+        .detach();
+        entity
+    }
+
+    fn make_suggestion_model_select(
+        config: &Config,
+        registry: &ModelRegistry,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Entity<SelectState<SearchableVec<String>>> {
+        let provider = Self::effective_suggestion_provider(config);
+        let current_model = config.agent.suggestion_model.model.clone();
+        let entity = Self::make_model_select_state(
+            &provider,
+            &current_model,
+            Self::provider_base_url(config, &provider),
+            registry,
+            window,
+            cx,
+        );
+        cx.subscribe_in(
+            &entity,
+            window,
+            |this, _, ev: &SelectEvent<SearchableVec<String>>, _, cx| {
+                if let SelectEvent::Confirm(Some(value)) = ev {
+                    this.config.agent.suggestion_model.model = Some(value.clone());
                     cx.notify();
                 }
             },
@@ -1967,6 +1972,24 @@ impl SettingsPanel {
                                     &ProviderKind::OpenAICompatible,
                                     &current_model,
                                     Some(&base_url_for_cache),
+                                    &registry,
+                                    window,
+                                    cx,
+                                );
+                            }
+                            if panel.config.agent.provider == ProviderKind::OpenAICompatible {
+                                panel.active_model_select = Self::make_active_model_select(
+                                    &panel.config,
+                                    &registry,
+                                    window,
+                                    cx,
+                                );
+                            }
+                            if Self::effective_suggestion_provider(&panel.config)
+                                == ProviderKind::OpenAICompatible
+                            {
+                                panel.suggestion_model_select = Self::make_suggestion_model_select(
+                                    &panel.config,
                                     &registry,
                                     window,
                                     cx,

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -1,6 +1,6 @@
 use con_agent::provider::{AgentPurpose, ProviderTransport};
 use con_agent::{
-    AgentConfig, OAuthDevicePrompt, ProviderConfig, ProviderKind, SuggestionModelConfig,
+    OAuthDevicePrompt, ProviderConfig, ProviderKind, SuggestionModelConfig,
     authorize_oauth_provider, oauth_token_dir,
 };
 use con_core::{
@@ -25,6 +25,7 @@ use crate::model_registry::ModelRegistry;
 use crate::motion::{MotionValue, vertical_reveal_offset};
 use std::collections::HashMap;
 use std::sync::Arc;
+use url::Url;
 
 actions!(
     settings,
@@ -95,6 +96,7 @@ pub struct SettingsPanel {
     visible: bool,
     standalone: bool,
     config: Config,
+    preview_snapshot: Option<Config>,
     registry: ModelRegistry,
     oauth_runtime: Arc<tokio::runtime::Runtime>,
     focus_handle: FocusHandle,
@@ -992,8 +994,14 @@ impl SettingsPanel {
             window,
             cx,
         );
-        let active_model_select =
-            Self::make_model_select(&agent.provider, &pc.model, &registry, window, cx);
+        let active_model_select = Self::make_model_select(
+            &agent.provider,
+            &pc.model,
+            pc.base_url.as_deref(),
+            &registry,
+            window,
+            cx,
+        );
 
         let model_input = cx.new(|cx| {
             let mut s = InputState::new(window, cx);
@@ -1001,8 +1009,14 @@ impl SettingsPanel {
             s.set_value(&pc.model.clone().unwrap_or_default(), window, cx);
             s
         });
-        let model_select =
-            Self::make_model_select(&agent.provider, &pc.model, &registry, window, cx);
+        let model_select = Self::make_model_select(
+            &agent.provider,
+            &pc.model,
+            pc.base_url.as_deref(),
+            &registry,
+            window,
+            cx,
+        );
         let endpoint_preset_select =
             Self::make_endpoint_preset_select(&agent.provider, &pc.base_url, window, cx);
         let api_key_input = cx.new(|cx| {
@@ -1068,6 +1082,7 @@ impl SettingsPanel {
         let suggestion_model_select = Self::make_model_select(
             &suggestion_provider,
             &agent.suggestion_model.model,
+            Self::provider_base_url(config, &suggestion_provider),
             &registry,
             window,
             cx,
@@ -1219,6 +1234,7 @@ impl SettingsPanel {
                         this.active_model_select = Self::make_model_select(
                             &provider,
                             &current_model,
+                            Self::provider_base_url(&this.config, &provider),
                             &this.registry,
                             window,
                             cx,
@@ -1261,6 +1277,7 @@ impl SettingsPanel {
                     this.suggestion_model_select = Self::make_model_select(
                         &provider,
                         &selected_model,
+                        Self::provider_base_url(&this.config, &provider),
                         &this.registry,
                         window,
                         cx,
@@ -1358,6 +1375,7 @@ impl SettingsPanel {
             visible: false,
             standalone: false,
             config: config.clone(),
+            preview_snapshot: None,
             registry,
             oauth_runtime,
             focus_handle: cx.focus_handle(),
@@ -1420,10 +1438,22 @@ impl SettingsPanel {
     pub fn open_standalone(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.standalone = true;
         self.visible = true;
+        self.preview_snapshot = Some(self.config.clone());
         self.overlay_motion
             .set_target(1.0, std::time::Duration::ZERO);
         self.refresh_controls_from_config(window, cx);
         cx.notify();
+    }
+
+    pub fn revert_standalone_preview(&mut self, cx: &mut Context<Self>) {
+        if !self.standalone {
+            return;
+        }
+        if let Some(snapshot) = self.preview_snapshot.take() {
+            self.config = snapshot;
+            cx.emit(AppearancePreview);
+            cx.notify();
+        }
     }
 
     fn refresh_controls_from_config(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -1454,6 +1484,7 @@ impl SettingsPanel {
                 .providers
                 .get(&agent.provider)
                 .and_then(|pc| pc.model.clone()),
+            Self::provider_base_url(&self.config, &agent.provider),
             &self.registry,
             window,
             cx,
@@ -1476,13 +1507,23 @@ impl SettingsPanel {
         self.suggestion_model_select = Self::make_model_select(
             &Self::effective_suggestion_provider(&self.config),
             &agent.suggestion_model.model,
+            Self::provider_base_url(
+                &self.config,
+                &Self::effective_suggestion_provider(&self.config),
+            ),
             &self.registry,
             window,
             cx,
         );
         self.auto_approve = agent.auto_approve_tools;
-        self.model_select =
-            Self::make_model_select(&agent.provider, &pc.model, &self.registry, window, cx);
+        self.model_select = Self::make_model_select(
+            &agent.provider,
+            &pc.model,
+            pc.base_url.as_deref(),
+            &self.registry,
+            window,
+            cx,
+        );
         self.endpoint_preset_select =
             Self::make_endpoint_preset_select(&agent.provider, &pc.base_url, window, cx);
         self.terminal_font_select.update(cx, |select, cx| {
@@ -1604,14 +1645,23 @@ impl SettingsPanel {
     }
 
     /// Build a model select entity for the given provider.
+    fn provider_base_url<'a>(config: &'a Config, provider: &ProviderKind) -> Option<&'a str> {
+        config
+            .agent
+            .providers
+            .get(provider)
+            .and_then(|pc| pc.base_url.as_deref())
+    }
+
     fn make_model_select(
         provider: &ProviderKind,
         current_model: &Option<String>,
+        base_url: Option<&str>,
         registry: &ModelRegistry,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Entity<SelectState<SearchableVec<String>>> {
-        let mut models: Vec<String> = registry.models_for(provider);
+        let mut models: Vec<String> = registry.models_for_base_url(provider, base_url);
         if let Some(model) = current_model
             .as_ref()
             .map(|model| model.trim())
@@ -1877,6 +1927,7 @@ impl SettingsPanel {
 
         let registry = self.registry.clone();
         let runtime = self.oauth_runtime.clone();
+        let base_url_for_cache = base_url.clone();
         cx.spawn_in(window, async move |this, window| {
             let result = runtime
                 .spawn(async move {
@@ -1897,7 +1948,16 @@ impl SettingsPanel {
                         }
                         Ok(models) => {
                             let count = models.len();
-                            registry.set_provider_models(ProviderKind::OpenAICompatible, models);
+                            if let Err(err) = registry.set_provider_models_for_base_url(
+                                ProviderKind::OpenAICompatible,
+                                &base_url_for_cache,
+                                models,
+                            ) {
+                                panel.provider_model_status = Some(err.to_string());
+                                panel.provider_model_status_error = true;
+                                cx.notify();
+                                return;
+                            }
                             if panel.selected_provider == ProviderKind::OpenAICompatible {
                                 let current_model =
                                     panel.model_input.read(cx).value().trim().to_string();
@@ -1906,6 +1966,7 @@ impl SettingsPanel {
                                 panel.model_select = Self::make_model_select(
                                     &ProviderKind::OpenAICompatible,
                                     &current_model,
+                                    Some(&base_url_for_cache),
                                     &registry,
                                     window,
                                     cx,
@@ -2019,6 +2080,7 @@ impl SettingsPanel {
         match self.persist_config() {
             Ok(()) => {
                 self.save_error = None;
+                self.preview_snapshot = Some(self.config.clone());
                 if !self.standalone {
                     self.visible = false;
                     self.overlay_motion
@@ -2106,8 +2168,8 @@ impl SettingsPanel {
         }
     }
 
-    pub fn agent_config(&self) -> &AgentConfig {
-        &self.config.agent
+    pub fn config(&self) -> &Config {
+        &self.config
     }
     pub fn terminal_config(&self) -> &con_core::config::TerminalConfig {
         &self.config.terminal
@@ -2115,13 +2177,6 @@ impl SettingsPanel {
     pub fn appearance_config(&self) -> &con_core::config::AppearanceConfig {
         &self.config.appearance
     }
-    pub fn keybinding_config(&self) -> &con_core::config::KeybindingConfig {
-        &self.config.keybindings
-    }
-    pub fn skills_config(&self) -> &con_core::config::SkillsConfig {
-        &self.config.skills
-    }
-
     fn persist_config(&self) -> anyhow::Result<()> {
         let path = Config::config_path();
         if let Some(parent) = path.parent() {
@@ -2183,8 +2238,14 @@ impl SettingsPanel {
         self.load_provider_inputs(&pc, window, cx);
         self.sync_provider_placeholders(&provider, window, cx);
 
-        self.model_select =
-            Self::make_model_select(&provider, &pc.model, &self.registry, window, cx);
+        self.model_select = Self::make_model_select(
+            &provider,
+            &pc.model,
+            pc.base_url.as_deref(),
+            &self.registry,
+            window,
+            cx,
+        );
         self.endpoint_preset_select =
             Self::make_endpoint_preset_select(&provider, &pc.base_url, window, cx);
         cx.notify();
@@ -3072,6 +3133,10 @@ impl SettingsPanel {
                                     cx.notify();
                                     return;
                                 }
+                                if let Some(snapshot) = &mut this.preview_snapshot {
+                                    snapshot.appearance.tabs_orientation =
+                                        this.config.appearance.tabs_orientation;
+                                }
                                 this.save_error = None;
                                 cx.emit(TabsOrientationChanged);
                                 cx.notify();
@@ -3557,7 +3622,10 @@ impl SettingsPanel {
         let api_key_input = self.api_key_input.clone();
         let base_url_input = self.base_url_input.clone();
         let max_tokens_input = self.max_tokens_input.clone();
-        let models = self.registry.models_for(&self.selected_provider);
+        let models = self.registry.models_for_base_url(
+            &self.selected_provider,
+            Self::provider_base_url(&self.config, &self.selected_provider),
+        );
         let model_select = self.model_select.clone();
         let endpoint_preset_select = self.endpoint_preset_select.clone();
         let endpoint_presets = Self::provider_endpoint_presets(&self.selected_provider);
@@ -4630,6 +4698,7 @@ impl Render for SettingsPanel {
                 match event.keystroke.key.as_str() {
                     "escape" => {
                         if this.standalone {
+                            this.revert_standalone_preview(cx);
                             window.remove_window();
                         } else {
                             this.save(window, cx);
@@ -4689,10 +4758,15 @@ impl Render for SettingsPanel {
                                                         }
                                                         let _ = std::fs::write(&path, "");
                                                     }
-                                                    cx.open_url(&format!(
-                                                        "file://{}",
-                                                        path.display()
-                                                    ));
+                                                    match Url::from_file_path(&path) {
+                                                        Ok(url) => cx.open_url(url.as_str()),
+                                                        Err(()) => {
+                                                            log::warn!(
+                                                                "settings: failed to build file URL for {}",
+                                                                path.display()
+                                                            );
+                                                        }
+                                                    }
                                                 }),
                                             )
                                             .child(

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -13,7 +13,7 @@ use con_core::{
 use futures::{FutureExt, StreamExt};
 use gpui::*;
 
-use gpui_component::button::{Button, ButtonVariants as _};
+use gpui_component::button::{Button, ButtonCustomVariant, ButtonVariants as _};
 use gpui_component::clipboard::Clipboard;
 use gpui_component::input::InputState;
 use gpui_component::select::{SearchableVec, Select, SelectEvent, SelectState};
@@ -38,6 +38,10 @@ actions!(
 
 /// Emitted when the user selects a different terminal theme for live preview.
 pub struct ThemePreview(pub String);
+
+/// Emitted for lightweight appearance changes that should be visible
+/// immediately but should not persist/rebuild the full agent config.
+pub struct AppearancePreview;
 
 #[derive(Debug, Clone, Default)]
 struct ProviderOAuthState {
@@ -1170,6 +1174,7 @@ impl SettingsPanel {
                 SliderEvent::Change(value) => {
                     this.config.appearance.terminal_opacity =
                         Self::clamp_terminal_opacity(value.end());
+                    cx.emit(AppearancePreview);
                     cx.notify();
                 }
             },
@@ -1180,6 +1185,7 @@ impl SettingsPanel {
             |this, _, event: &SliderEvent, cx| match event {
                 SliderEvent::Change(value) => {
                     this.config.appearance.ui_opacity = Self::clamp_ui_opacity(value.end());
+                    cx.emit(AppearancePreview);
                     cx.notify();
                 }
             },
@@ -1191,6 +1197,7 @@ impl SettingsPanel {
                 SliderEvent::Change(value) => {
                     this.config.appearance.background_image_opacity =
                         Self::clamp_background_image_opacity(value.end());
+                    cx.emit(AppearancePreview);
                     cx.notify();
                 }
             },
@@ -1291,6 +1298,7 @@ impl SettingsPanel {
             |this, _, ev: &SelectEvent<SearchableVec<String>>, _, cx| {
                 if let SelectEvent::Confirm(Some(value)) = ev {
                     this.config.terminal.font_family = sanitize_terminal_font_family(value);
+                    cx.emit(AppearancePreview);
                     cx.notify();
                 }
             },
@@ -1302,6 +1310,7 @@ impl SettingsPanel {
             |this, _, ev: &SelectEvent<SearchableVec<String>>, _, cx| {
                 if let SelectEvent::Confirm(Some(value)) = ev {
                     this.config.appearance.ui_font_family = value.clone();
+                    cx.emit(AppearancePreview);
                     cx.notify();
                 }
             },
@@ -1314,6 +1323,7 @@ impl SettingsPanel {
                 if let SelectEvent::Confirm(Some(value)) = ev {
                     this.config.terminal.cursor_style =
                         Self::cursor_style_from_label(value).to_string();
+                    cx.emit(AppearancePreview);
                     cx.notify();
                 }
             },
@@ -1325,6 +1335,7 @@ impl SettingsPanel {
             |this, _, ev: &SelectEvent<Vec<String>>, _, cx| {
                 if let SelectEvent::Confirm(Some(value)) = ev {
                     this.config.appearance.background_image_position = value.clone();
+                    cx.emit(AppearancePreview);
                     cx.notify();
                 }
             },
@@ -1336,6 +1347,7 @@ impl SettingsPanel {
             |this, _, ev: &SelectEvent<Vec<String>>, _, cx| {
                 if let SelectEvent::Confirm(Some(value)) = ev {
                     this.config.appearance.background_image_fit = value.clone();
+                    cx.emit(AppearancePreview);
                     cx.notify();
                 }
             },
@@ -1683,7 +1695,7 @@ impl SettingsPanel {
         });
 
         let input = self.background_image_input.clone();
-        cx.spawn_in(window, async move |_, window| {
+        cx.spawn_in(window, async move |this, window| {
             let path = paths.await.ok()?.ok()??.into_iter().next()?;
             let path_text = path.to_string_lossy().to_string();
 
@@ -1691,6 +1703,11 @@ impl SettingsPanel {
                 .update(|window, cx| {
                     _ = input.update(cx, |state, cx| {
                         state.set_value(&path_text, window, cx);
+                    });
+                    _ = this.update(cx, |panel, cx| {
+                        panel.config.appearance.background_image = Some(path_text.clone());
+                        cx.emit(AppearancePreview);
+                        cx.notify();
                     });
                 })
                 .ok()?;
@@ -2756,6 +2773,7 @@ impl SettingsPanel {
             .on_click(cx.listener(|this, checked: &bool, _, cx| {
                 this.background_image_repeat = *checked;
                 this.config.appearance.background_image_repeat = *checked;
+                cx.emit(AppearancePreview);
                 cx.notify();
             }));
         let all_themes = con_terminal::TerminalTheme::all_available();
@@ -3001,6 +3019,8 @@ impl SettingsPanel {
                                 .small()
                                 .on_click(cx.listener(|this, checked: &bool, _, cx| {
                                     this.terminal_blur = *checked;
+                                    this.config.appearance.terminal_blur = *checked;
+                                    cx.emit(AppearancePreview);
                                     cx.notify();
                                 })),
                             theme,
@@ -4428,6 +4448,7 @@ impl SettingsPanel {
 impl EventEmitter<SaveSettings> for SettingsPanel {}
 impl EventEmitter<TabsOrientationChanged> for SettingsPanel {}
 impl EventEmitter<ThemePreview> for SettingsPanel {}
+impl EventEmitter<AppearancePreview> for SettingsPanel {}
 
 impl Focusable for SettingsPanel {
     fn focus_handle(&self, _: &App) -> FocusHandle {
@@ -4574,6 +4595,11 @@ impl Render for SettingsPanel {
             .overflow_y_scroll()
             .p(content_pad)
             .child(content);
+        let apply_button_style = ButtonCustomVariant::new(cx)
+            .color(theme.primary.opacity(0.12))
+            .foreground(theme.primary)
+            .hover(theme.primary.opacity(0.18))
+            .active(theme.primary.opacity(0.24));
 
         let surface_rounding = if self.standalone { px(0.0) } else { px(12.0) };
         let surface = div()
@@ -4682,8 +4708,9 @@ impl Render for SettingsPanel {
                                     .children(self.standalone.then(|| {
                                         Button::new("settings-apply")
                                             .small()
-                                            .primary()
-                                            .label("Apply")
+                                            .custom(apply_button_style)
+                                            .icon(Icon::default().path("phosphor/check.svg"))
+                                            .label("Save Changes")
                                             .on_click(cx.listener(|this, _, window, cx| {
                                                 this.save(window, cx);
                                             }))

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -952,6 +952,20 @@ impl GhosttyView {
         };
         let keystroke = &event.keystroke;
 
+        // App-level tab selection. Let GPUI dispatch SelectTab1..9
+        // instead of forwarding Ctrl+digit to the shell.
+        if keystroke.modifiers.control
+            && !keystroke.modifiers.shift
+            && !keystroke.modifiers.alt
+            && !keystroke.modifiers.platform
+            && matches!(
+                keystroke.key.as_str(),
+                "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+            )
+        {
+            return false;
+        }
+
         // Ctrl+Shift+C / Ctrl+Shift+V → clipboard. These must run ahead
         // of the generic Ctrl-letter path below, which would otherwise
         // emit ^C / ^V to the shell.

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -6855,11 +6855,6 @@ impl ConWorkspace {
     }
 
     fn select_tab_index(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
-        if self.pane_scope_picker_open {
-            self.toggle_scope_pane_by_index(index, window, cx);
-            return;
-        }
-
         if index >= self.tabs.len() || index == self.active_tab {
             return;
         }

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -217,7 +217,7 @@ use crate::model_registry::ModelRegistry;
 use crate::motion::MotionValue;
 use crate::pane_tree::{PaneTree, SplitDirection, SplitPlacement};
 use crate::settings_panel::{
-    self, SaveSettings, SettingsPanel, TabsOrientationChanged, ThemePreview,
+    self, AppearancePreview, SaveSettings, SettingsPanel, TabsOrientationChanged, ThemePreview,
 };
 use crate::sidebar::{
     NewSession, SessionEntry, SessionSidebar, SidebarCloseOthers, SidebarCloseTab,
@@ -238,7 +238,9 @@ use crate::{
 use con_agent::{
     AgentConfig, Conversation, ProviderKind, TerminalExecRequest, TerminalExecResponse,
 };
-use con_core::config::{Config, TabsOrientation, sanitize_terminal_font_family};
+use con_core::config::{
+    AppearanceConfig, Config, TabsOrientation, TerminalConfig, sanitize_terminal_font_family,
+};
 use con_core::control::{
     AgentAskResult, ControlCommand, ControlError, ControlRequestEnvelope, ControlResult,
     SystemIdentifyResult, TabInfo,
@@ -886,6 +888,8 @@ impl ConWorkspace {
         cx.subscribe_in(&settings_panel, window, Self::on_tabs_orientation_changed)
             .detach();
         cx.subscribe_in(&settings_panel, window, Self::on_theme_preview)
+            .detach();
+        cx.subscribe_in(&settings_panel, window, Self::on_appearance_preview)
             .detach();
         // Re-render workspace when settings panel visibility changes (e.g. X close button)
         cx.observe(&settings_panel, |_, _, cx| cx.notify()).detach();
@@ -3619,49 +3623,7 @@ impl ConWorkspace {
 
         let term_config = settings.read(cx).terminal_config().clone();
         let appearance_config = settings.read(cx).appearance_config().clone();
-        self.terminal_font_family = sanitize_terminal_font_family(&term_config.font_family);
-        self.ui_font_family = appearance_config.ui_font_family.clone();
-        self.ui_font_size = appearance_config.ui_font_size;
-        self.font_size = term_config.font_size;
-        self.terminal_cursor_style = term_config.cursor_style.clone();
-        self.terminal_opacity =
-            Self::effective_terminal_opacity(appearance_config.terminal_opacity);
-        self.terminal_blur = Self::effective_terminal_blur(appearance_config.terminal_blur);
-        self.ui_opacity = Self::clamp_ui_opacity(appearance_config.ui_opacity);
-        let effective_ui_opacity = Self::effective_ui_opacity(self.ui_opacity);
-        self.background_image = appearance_config.background_image.clone();
-        self.background_image_opacity =
-            Self::clamp_background_image_opacity(appearance_config.background_image_opacity);
-        self.background_image_position = appearance_config.background_image_position.clone();
-        self.background_image_fit = appearance_config.background_image_fit.clone();
-        self.background_image_repeat = appearance_config.background_image_repeat;
-        if self.tabs_orientation != appearance_config.tabs_orientation {
-            self.tabs_orientation = appearance_config.tabs_orientation;
-            // Tab strip motion drives the top-bar height. In vertical
-            // mode the strip is always hidden — collapse the motion now
-            // so we don't pay an unrelated transition.
-            self.sync_tab_strip_motion();
-            self.save_session(cx);
-            cx.notify();
-        }
-        self.agent_panel
-            .update(cx, |panel, _cx| panel.set_ui_opacity(effective_ui_opacity));
-        self.input_bar
-            .update(cx, |bar, _cx| bar.set_ui_opacity(effective_ui_opacity));
-        self.sidebar
-            .update(cx, |s, cx| s.set_ui_opacity(effective_ui_opacity, cx));
-        self.command_palette.update(cx, |palette, _cx| {
-            palette.set_ui_opacity(effective_ui_opacity)
-        });
-
-        if let Some(new_theme) = TerminalTheme::by_name(&term_config.theme) {
-            self.apply_terminal_theme(new_theme, window, cx);
-        } else {
-            log::warn!(
-                "Skipping terminal theme sync; theme {:?} was not found",
-                term_config.theme
-            );
-        }
+        self.apply_terminal_and_ui_appearance(&term_config, &appearance_config, window, cx);
 
         // Re-apply keybindings at runtime so changes take effect immediately
         let kb = settings.read(cx).keybinding_config().clone();
@@ -3672,6 +3634,28 @@ impl ConWorkspace {
         if restore_focus {
             self.focus_terminal(window, cx);
         }
+    }
+
+    fn on_appearance_preview(
+        &mut self,
+        settings: &Entity<SettingsPanel>,
+        _event: &AppearancePreview,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.apply_appearance_preview_from_panel(settings, window, cx);
+    }
+
+    fn apply_appearance_preview_from_panel(
+        &mut self,
+        settings: &Entity<SettingsPanel>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let term_config = settings.read(cx).terminal_config().clone();
+        let appearance_config = settings.read(cx).appearance_config().clone();
+        self.apply_terminal_and_ui_appearance(&term_config, &appearance_config, window, cx);
+        cx.notify();
     }
 
     fn on_tabs_orientation_changed(
@@ -3726,6 +3710,97 @@ impl ConWorkspace {
         }
     }
 
+    fn apply_terminal_and_ui_appearance(
+        &mut self,
+        term_config: &TerminalConfig,
+        appearance_config: &AppearanceConfig,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let next_terminal_font_family = sanitize_terminal_font_family(&term_config.font_family);
+        let next_ui_font_family = appearance_config.ui_font_family.clone();
+        let next_ui_font_size = appearance_config.ui_font_size;
+        let next_font_size = term_config.font_size;
+        let next_terminal_cursor_style = term_config.cursor_style.clone();
+        let next_terminal_opacity =
+            Self::effective_terminal_opacity(appearance_config.terminal_opacity);
+        let next_terminal_blur = Self::effective_terminal_blur(appearance_config.terminal_blur);
+        let next_background_image = appearance_config.background_image.clone();
+        let next_background_image_opacity =
+            Self::clamp_background_image_opacity(appearance_config.background_image_opacity);
+        let next_background_image_position = appearance_config.background_image_position.clone();
+        let next_background_image_fit = appearance_config.background_image_fit.clone();
+        let next_background_image_repeat = appearance_config.background_image_repeat;
+
+        let font_changed = self.terminal_font_family != next_terminal_font_family
+            || (self.font_size - next_font_size).abs() > f32::EPSILON;
+        let terminal_appearance_changed = font_changed
+            || self.terminal_cursor_style != next_terminal_cursor_style
+            || (self.terminal_opacity - next_terminal_opacity).abs() > f32::EPSILON
+            || self.terminal_blur != next_terminal_blur
+            || self.background_image != next_background_image
+            || (self.background_image_opacity - next_background_image_opacity).abs() > f32::EPSILON
+            || self.background_image_position != next_background_image_position
+            || self.background_image_fit != next_background_image_fit
+            || self.background_image_repeat != next_background_image_repeat;
+        let ui_theme_changed = font_changed
+            || self.ui_font_family != next_ui_font_family
+            || (self.ui_font_size - next_ui_font_size).abs() > f32::EPSILON;
+
+        self.terminal_font_family = next_terminal_font_family;
+        self.ui_font_family = next_ui_font_family;
+        self.ui_font_size = next_ui_font_size;
+        self.font_size = next_font_size;
+        self.terminal_cursor_style = next_terminal_cursor_style;
+        self.terminal_opacity = next_terminal_opacity;
+        self.terminal_blur = next_terminal_blur;
+        self.ui_opacity = Self::clamp_ui_opacity(appearance_config.ui_opacity);
+        self.background_image = next_background_image;
+        self.background_image_opacity = next_background_image_opacity;
+        self.background_image_position = next_background_image_position;
+        self.background_image_fit = next_background_image_fit;
+        self.background_image_repeat = next_background_image_repeat;
+
+        if self.tabs_orientation != appearance_config.tabs_orientation {
+            self.tabs_orientation = appearance_config.tabs_orientation;
+            // Tab strip motion drives the top-bar height. In vertical
+            // mode the strip is always hidden, so collapse the motion now
+            // and avoid an unrelated transition.
+            self.sync_tab_strip_motion();
+            self.save_session(cx);
+            cx.notify();
+        }
+
+        let effective_ui_opacity = Self::effective_ui_opacity(self.ui_opacity);
+        self.agent_panel
+            .update(cx, |panel, _cx| panel.set_ui_opacity(effective_ui_opacity));
+        self.input_bar
+            .update(cx, |bar, _cx| bar.set_ui_opacity(effective_ui_opacity));
+        self.sidebar
+            .update(cx, |s, cx| s.set_ui_opacity(effective_ui_opacity, cx));
+        self.command_palette.update(cx, |palette, _cx| {
+            palette.set_ui_opacity(effective_ui_opacity)
+        });
+
+        if let Some(new_theme) = TerminalTheme::by_name(&term_config.theme) {
+            let theme_changed = new_theme.name != self.terminal_theme.name;
+            if theme_changed {
+                self.terminal_theme = new_theme.clone();
+            }
+            if theme_changed || terminal_appearance_changed {
+                self.sync_terminal_surface_appearance(&new_theme, window, cx);
+            }
+            if theme_changed || ui_theme_changed {
+                self.sync_gpui_theme_appearance(&new_theme, window, cx);
+            }
+        } else {
+            log::warn!(
+                "Skipping terminal theme sync; theme {:?} was not found",
+                term_config.theme
+            );
+        }
+    }
+
     /// Apply a new terminal theme to all panes and sync UI mode.
     fn apply_terminal_theme(
         &mut self,
@@ -3734,12 +3809,22 @@ impl ConWorkspace {
         cx: &mut Context<Self>,
     ) {
         self.terminal_theme = theme.clone();
-        let colors = theme_to_ghostty_colors(&theme);
+        self.sync_terminal_surface_appearance(&theme, window, cx);
+        self.sync_gpui_theme_appearance(&theme, window, cx);
+    }
+
+    fn sync_terminal_surface_appearance(
+        &self,
+        theme: &TerminalTheme,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let colors = theme_to_ghostty_colors(theme);
         // Update all terminal panes (legacy gets full theme, ghostty gets color scheme)
         for tab in &self.tabs {
             for terminal in tab.pane_tree.all_terminals() {
                 terminal.set_theme(
-                    &theme,
+                    theme,
                     &colors,
                     &self.terminal_font_family,
                     self.font_size,
@@ -3776,12 +3861,20 @@ impl ConWorkspace {
             }
         }
         #[cfg(target_os = "windows")]
-        crate::set_windows_backdrop_blur(window, self.terminal_blur);
+        crate::set_windows_backdrop_blur(_window, self.terminal_blur);
         #[cfg(target_os = "linux")]
-        crate::set_linux_window_blur(window, self.terminal_blur);
+        crate::set_linux_window_blur(_window, self.terminal_blur);
+    }
+
+    fn sync_gpui_theme_appearance(
+        &self,
+        theme: &TerminalTheme,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         // Sync GPUI UI theme colors with terminal theme
         crate::theme::sync_gpui_theme(
-            &theme,
+            theme,
             &self.terminal_font_family,
             &self.ui_font_family,
             self.ui_font_size,
@@ -5551,13 +5644,24 @@ impl ConWorkspace {
             })
             .detach();
 
-            let workspace_for_theme = workspace;
+            let workspace_for_theme = workspace.clone();
             let main_window_for_theme = main_window;
             cx.subscribe(&panel, move |_settings, event: &ThemePreview, cx| {
                 let theme_name = event.0.clone();
                 let _ = main_window_for_theme.update(cx, |_, window, cx| {
                     let _ = workspace_for_theme.update(cx, |workspace, cx| {
                         workspace.apply_theme_preview(&theme_name, window, cx);
+                    });
+                });
+            })
+            .detach();
+
+            let workspace_for_appearance = workspace.clone();
+            let main_window_for_appearance = main_window;
+            cx.subscribe(&panel, move |settings, _: &AppearancePreview, cx| {
+                let _ = main_window_for_appearance.update(cx, |_, window, cx| {
+                    let _ = workspace_for_appearance.update(cx, |workspace, cx| {
+                        workspace.apply_appearance_preview_from_panel(&settings, window, cx);
                     });
                 });
             })

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -231,9 +231,10 @@ use crate::ghostty_view::{
     GhosttyView,
 };
 use crate::{
-    ClosePane, CloseTab, CycleInputMode, FocusInput, NewTab, NextTab, PreviousTab, Quit,
-    SelectTab1, SelectTab2, SelectTab3, SelectTab4, SelectTab5, SelectTab6, SelectTab7, SelectTab8,
-    SelectTab9, SplitDown, SplitRight, ToggleAgentPanel, TogglePaneScopePicker,
+    ClosePane, CloseTab, CycleInputMode, FocusInput, NewTab, NextTab, NextWindow, PreviousTab,
+    PreviousWindow, Quit, SelectTab1, SelectTab2, SelectTab3, SelectTab4, SelectTab5, SelectTab6,
+    SelectTab7, SelectTab8, SelectTab9, SplitDown, SplitRight, ToggleAgentPanel,
+    TogglePaneScopePicker,
 };
 use con_agent::{
     AgentConfig, Conversation, ProviderKind, TerminalExecRequest, TerminalExecResponse,
@@ -6822,6 +6823,11 @@ impl ConWorkspace {
     }
 
     fn select_tab_index(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
+        if self.pane_scope_picker_open {
+            self.toggle_scope_pane_by_index(index, window, cx);
+            return;
+        }
+
         if index >= self.tabs.len() || index == self.active_tab {
             return;
         }
@@ -7871,6 +7877,38 @@ impl Render for ConWorkspace {
             .on_action(cx.listener(Self::focus_input))
             .on_action(cx.listener(Self::cycle_input_mode))
             .on_action(cx.listener(Self::toggle_pane_scope_picker))
+            .capture_key_down(cx.listener(|this, event: &KeyDownEvent, window, cx| {
+                if !this.pane_scope_picker_open {
+                    return;
+                }
+
+                let mods = &event.keystroke.modifiers;
+                let key = event.keystroke.key.as_str();
+                let local_picker_key = !mods.control && !mods.alt && !mods.shift && !mods.platform;
+
+                let mut handled = false;
+                if key == "escape" {
+                    this.close_pane_scope_picker(cx);
+                    handled = true;
+                } else if local_picker_key && key == "a" {
+                    this.set_scope_broadcast(window, cx);
+                    handled = true;
+                } else if local_picker_key && key == "f" {
+                    this.set_scope_focused(window, cx);
+                    handled = true;
+                } else if local_picker_key
+                    && let Some(digit) = key.chars().next().and_then(|c| c.to_digit(10))
+                {
+                    let pane_index = if digit == 0 { 9 } else { (digit - 1) as usize };
+                    this.toggle_scope_pane_by_index(pane_index, window, cx);
+                    handled = true;
+                }
+
+                if handled {
+                    window.prevent_default();
+                    cx.stop_propagation();
+                }
+            }))
             .on_key_down(cx.listener(|this, event: &KeyDownEvent, window, cx| {
                 // Don't handle workspace shortcuts when a modal overlay is open
                 if this.settings_panel.read(cx).is_overlay_visible()
@@ -7882,29 +7920,16 @@ impl Render for ConWorkspace {
                 let mods = &event.keystroke.modifiers;
                 let key = event.keystroke.key.as_str();
 
-                if this.pane_scope_picker_open {
-                    if key == "escape" {
-                        this.close_pane_scope_picker(cx);
-                        return;
+                #[cfg(target_os = "macos")]
+                if mods.platform && !mods.control && !mods.alt && (key == "`" || key == "~") {
+                    if mods.shift {
+                        cx.dispatch_action(&PreviousWindow);
+                    } else {
+                        cx.dispatch_action(&NextWindow);
                     }
-
-                    if mods.platform && key == "a" {
-                        this.set_scope_broadcast(window, cx);
-                        return;
-                    }
-
-                    if mods.platform && key == "f" {
-                        this.set_scope_focused(window, cx);
-                        return;
-                    }
-
-                    if mods.platform && !mods.shift {
-                        if let Some(digit) = key.chars().next().and_then(|c| c.to_digit(10)) {
-                            let pane_index = if digit == 0 { 9 } else { (digit - 1) as usize };
-                            this.toggle_scope_pane_by_index(pane_index, window, cx);
-                            return;
-                        }
-                    }
+                    window.prevent_default();
+                    cx.stop_propagation();
+                    return;
                 }
 
                 // Cmd+1..9 — jump to tab
@@ -7913,6 +7938,9 @@ impl Render for ConWorkspace {
                         let tab_index = if digit == 0 { 9 } else { (digit - 1) as usize };
                         if tab_index < this.tabs.len() {
                             this.activate_tab(tab_index, window, cx);
+                            window.prevent_default();
+                            cx.stop_propagation();
+                            return;
                         }
                     }
                 }
@@ -7921,10 +7949,15 @@ impl Render for ConWorkspace {
                 // Control-Tab / Control-Shift-Tab by default.
                 if mods.platform && mods.shift && key == "[" {
                     this.previous_tab(&PreviousTab, window, cx);
+                    window.prevent_default();
+                    cx.stop_propagation();
+                    return;
                 }
 
                 if mods.platform && mods.shift && key == "]" {
                     this.next_tab(&NextTab, window, cx);
+                    window.prevent_default();
+                    cx.stop_propagation();
                 }
             }))
             .child(top_bar)
@@ -8176,6 +8209,32 @@ impl Render for ConWorkspace {
                 };
                 let scope_frame_inset = px(4.0);
                 let scope_frame_radius = px(10.0);
+                let pane_picker_binding =
+                    crate::keycaps::first_action_keystroke(&TogglePaneScopePicker, window)
+                        .map(|stroke| {
+                            crate::keycaps::keycaps_for_stroke(&stroke, theme).into_any_element()
+                        })
+                        .unwrap_or_else(|| {
+                            crate::keycaps::keycaps_for_binding("secondary-'", theme)
+                        });
+                let local_keycap = |label: &'static str| {
+                    let wide = label.chars().count() > 1;
+                    div()
+                        .h(px(19.0))
+                        .min_w(if wide { px(32.0) } else { px(19.0) })
+                        .px(px(if wide { 6.0 } else { 0.0 }))
+                        .rounded(px(5.0))
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .bg(theme.muted.opacity(0.14))
+                        .text_size(px(10.5))
+                        .line_height(px(11.0))
+                        .font_family(theme.mono_font_family.clone())
+                        .font_weight(FontWeight::MEDIUM)
+                        .text_color(theme.foreground.opacity(0.74))
+                        .child(label)
+                };
 
                 let presets = div()
                     .flex()
@@ -8209,22 +8268,18 @@ impl Render for ConWorkspace {
                         div()
                             .flex()
                             .items_center()
-                            .gap(px(5.0))
-                            .child(crate::keycaps::keycaps_for_binding("secondary-'", theme))
+                            .gap(px(4.0))
+                            .child(pane_picker_binding)
                             .child(
                                 div()
-                                    .h(px(19.0))
-                                    .px(px(7.0))
-                                    .rounded(px(5.0))
-                                    .flex()
-                                    .items_center()
-                                    .bg(theme.muted.opacity(0.12))
-                                    .text_size(px(10.5))
+                                    .text_size(px(10.0))
                                     .font_family(theme.mono_font_family.clone())
-                                    .font_weight(FontWeight::MEDIUM)
-                                    .text_color(theme.foreground.opacity(0.66))
-                                    .child("1-9"),
-                            ),
+                                    .text_color(theme.muted_foreground.opacity(0.58))
+                                    .child("then"),
+                            )
+                            .child(local_keycap("1-9"))
+                            .child(local_keycap("A"))
+                            .child(local_keycap("F")),
                     );
 
                 let preset_segment = |id: &'static str, label: &'static str, active: bool| {

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -7891,19 +7891,20 @@ impl Render for ConWorkspace {
 
                 let mods = &event.keystroke.modifiers;
                 let key = event.keystroke.key.as_str();
-                let local_picker_key = !mods.control && !mods.alt && !mods.shift && !mods.platform;
+                let local_picker_key = !mods.control && !mods.alt && !mods.platform;
+                let unshifted_local_picker_key = local_picker_key && !mods.shift;
 
                 let mut handled = false;
                 if key == "escape" {
                     this.close_pane_scope_picker(cx);
                     handled = true;
-                } else if local_picker_key && key == "a" {
+                } else if local_picker_key && key.eq_ignore_ascii_case("a") {
                     this.set_scope_broadcast(window, cx);
                     handled = true;
-                } else if local_picker_key && key == "f" {
+                } else if local_picker_key && key.eq_ignore_ascii_case("f") {
                     this.set_scope_focused(window, cx);
                     handled = true;
-                } else if local_picker_key
+                } else if unshifted_local_picker_key
                     && let Some(digit) = key.chars().next().and_then(|c| c.to_digit(10))
                 {
                     let pane_index = if digit == 0 { 9 } else { (digit - 1) as usize };
@@ -7928,8 +7929,12 @@ impl Render for ConWorkspace {
                 let key = event.keystroke.key.as_str();
 
                 #[cfg(target_os = "macos")]
-                if mods.platform && !mods.control && !mods.alt && (key == "`" || key == "~") {
-                    if mods.shift {
+                if mods.platform
+                    && !mods.control
+                    && !mods.alt
+                    && matches!(key, "`" | "~" | ">" | "<")
+                {
+                    if mods.shift || matches!(key, "~" | "<") {
                         cx.dispatch_action(&crate::PreviousWindow);
                     } else {
                         cx.dispatch_action(&crate::NextWindow);

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -325,6 +325,7 @@ enum LocalPathCompletion {
 
 /// The main workspace: tabs + agent panel + input bar + settings overlay
 pub struct ConWorkspace {
+    config: Config,
     sidebar: Entity<SessionSidebar>,
     tabs: Vec<Tab>,
     active_tab: usize,
@@ -1207,6 +1208,7 @@ impl ConWorkspace {
         }
 
         Self {
+            config: config.clone(),
             sidebar,
             tabs,
             active_tab,
@@ -2936,6 +2938,16 @@ impl ConWorkspace {
         self.tab_agent_config(self.active_tab)
     }
 
+    fn provider_models_for_config(&self, config: &AgentConfig) -> Vec<String> {
+        self.model_registry.models_for_base_url(
+            &config.provider,
+            config
+                .providers
+                .get(&config.provider)
+                .and_then(|pc| pc.base_url.as_deref()),
+        )
+    }
+
     fn set_tab_provider_override(&mut self, tab_idx: usize, provider: ProviderKind) {
         self.tabs[tab_idx].agent_routing.provider = Some(provider);
     }
@@ -3127,6 +3139,7 @@ impl ConWorkspace {
         let provider = self.tab_agent_config(self.active_tab).provider.clone();
         self.set_tab_model_override(self.active_tab, provider.clone(), event.model.clone());
         let config = self.tab_agent_config(self.active_tab);
+        let available_models = self.provider_models_for_config(&config);
 
         self.agent_panel.update(cx, |panel, cx| {
             panel.set_session_provider_options(
@@ -3135,7 +3148,7 @@ impl ConWorkspace {
                 cx,
             );
             panel.set_model_name(event.model.clone());
-            panel.set_session_model_options(self.model_registry.models_for(&provider), window, cx);
+            panel.set_session_model_options(available_models, window, cx);
         });
 
         self.save_session(cx);
@@ -3154,7 +3167,7 @@ impl ConWorkspace {
 
         let provider = config.provider.clone();
         let model_name = AgentHarness::active_model_name_for(&config);
-        let available_models = self.model_registry.models_for(&provider);
+        let available_models = self.provider_models_for_config(&config);
 
         self.agent_panel.update(cx, |panel, cx| {
             panel.set_session_provider_options(
@@ -3567,9 +3580,11 @@ impl ConWorkspace {
         cx: &mut Context<Self>,
         restore_focus: bool,
     ) {
-        let new_config = settings.read(cx).agent_config().clone();
-        let auto_approve = new_config.auto_approve_tools;
-        self.harness.update_config(new_config);
+        let full_config = settings.read(cx).config().clone();
+        self.config = full_config.clone();
+        let new_agent_config = full_config.agent.clone();
+        let auto_approve = new_agent_config.auto_approve_tools;
+        self.harness.update_config(new_agent_config);
         self.shell_suggestion_engine = self.harness.suggestion_engine(180);
         self.shell_suggestion_engine.clear_cache();
         // Same suggestion model drives the tab summarizer; rebuild
@@ -3596,6 +3611,7 @@ impl ConWorkspace {
             self.sync_sidebar(cx);
         }
         let active_agent_config = self.active_tab_agent_config();
+        let active_agent_models = self.provider_models_for_config(&active_agent_config);
 
         // Sync auto-approve to agent panel UI
         self.agent_panel.update(cx, |panel, cx| {
@@ -3607,16 +3623,11 @@ impl ConWorkspace {
             );
             panel.set_provider_name(active_agent_config.provider.clone(), window, cx);
             panel.set_model_name(AgentHarness::active_model_name_for(&active_agent_config));
-            panel.set_session_model_options(
-                self.model_registry
-                    .models_for(&active_agent_config.provider),
-                window,
-                cx,
-            );
+            panel.set_session_model_options(active_agent_models, window, cx);
         });
 
         // Apply updated skills paths (forces rescan on next cwd check)
-        let skills_config = settings.read(cx).skills_config().clone();
+        let skills_config = full_config.skills.clone();
         self.harness.update_skills_config(skills_config);
         if self.has_active_tab() {
             if let Some(cwd) = self.active_terminal().current_dir(cx) {
@@ -3624,12 +3635,12 @@ impl ConWorkspace {
             }
         }
 
-        let term_config = settings.read(cx).terminal_config().clone();
-        let appearance_config = settings.read(cx).appearance_config().clone();
+        let term_config = full_config.terminal.clone();
+        let appearance_config = full_config.appearance.clone();
         self.apply_terminal_and_ui_appearance(&term_config, &appearance_config, window, cx);
 
         // Re-apply keybindings at runtime so changes take effect immediately
-        let kb = settings.read(cx).keybinding_config().clone();
+        let kb = full_config.keybindings.clone();
         crate::bind_app_keybindings(cx, &kb);
         #[cfg(target_os = "macos")]
         crate::global_hotkey::update_from_keybindings(&kb);
@@ -3680,6 +3691,7 @@ impl ConWorkspace {
         if self.tabs_orientation == orientation {
             return;
         }
+        self.config.appearance.tabs_orientation = orientation;
         self.tabs_orientation = orientation;
         self.sync_tab_strip_motion();
         if self.vertical_tabs_active() {
@@ -5601,7 +5613,7 @@ impl ConWorkspace {
             self.settings_window = None;
         }
 
-        let config = Config::load().unwrap_or_default();
+        let config = self.config.clone();
         let registry = self.model_registry.clone();
         let runtime = self.harness.runtime_handle();
         let workspace = cx.weak_entity();
@@ -5669,6 +5681,14 @@ impl ConWorkspace {
                 });
             })
             .detach();
+
+            let panel_for_close = panel.clone();
+            settings_window.on_window_should_close(cx, move |_window, cx| {
+                let _ = panel_for_close.update(cx, |panel, cx| {
+                    panel.revert_standalone_preview(cx);
+                });
+                true
+            });
 
             let view = cx.new(|_| SettingsWindowView {
                 panel: panel.clone(),
@@ -7206,7 +7226,7 @@ impl Render for ConWorkspace {
         let active_agent_config = self.active_tab_agent_config();
         let model_name = AgentHarness::active_model_name_for(&active_agent_config);
         let provider = active_agent_config.provider.clone();
-        let available_models = self.model_registry.models_for(&provider);
+        let available_models = self.provider_models_for_config(&active_agent_config);
         let show_inline = !self.input_bar_visible && self.agent_panel_open;
         let panel_skills: Vec<crate::input_bar::SkillEntry> = self
             .harness
@@ -7942,19 +7962,6 @@ impl Render for ConWorkspace {
                     window.prevent_default();
                     cx.stop_propagation();
                     return;
-                }
-
-                // Cmd+1..9 — jump to tab
-                if mods.platform && !mods.shift {
-                    if let Some(digit) = key.chars().next().and_then(|c| c.to_digit(10)) {
-                        let tab_index = if digit == 0 { 9 } else { (digit - 1) as usize };
-                        if tab_index < this.tabs.len() {
-                            this.activate_tab(tab_index, window, cx);
-                            window.prevent_default();
-                            cx.stop_propagation();
-                            return;
-                        }
-                    }
                 }
 
                 // Browser-style fallbacks. The configurable actions also bind

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -231,10 +231,9 @@ use crate::ghostty_view::{
     GhosttyView,
 };
 use crate::{
-    ClosePane, CloseTab, CycleInputMode, FocusInput, NewTab, NextTab, NextWindow, PreviousTab,
-    PreviousWindow, Quit, SelectTab1, SelectTab2, SelectTab3, SelectTab4, SelectTab5, SelectTab6,
-    SelectTab7, SelectTab8, SelectTab9, SplitDown, SplitRight, ToggleAgentPanel,
-    TogglePaneScopePicker,
+    ClosePane, CloseTab, CycleInputMode, FocusInput, NewTab, NextTab, PreviousTab, Quit,
+    SelectTab1, SelectTab2, SelectTab3, SelectTab4, SelectTab5, SelectTab6, SelectTab7, SelectTab8,
+    SelectTab9, SplitDown, SplitRight, ToggleAgentPanel, TogglePaneScopePicker,
 };
 use con_agent::{
     AgentConfig, Conversation, ProviderKind, TerminalExecRequest, TerminalExecResponse,
@@ -1003,8 +1002,11 @@ impl ConWorkspace {
                         let _ = handle.update(cx, |workspace, cx| {
                             workspace.prepare_window_close(cx);
                         });
+                        let should_quit = cx.windows().len() <= 1;
                         window.remove_window();
-                        cx.quit();
+                        if should_quit {
+                            cx.quit();
+                        }
                     });
                 })
                 .detach();
@@ -5899,8 +5901,12 @@ impl ConWorkspace {
 
     fn close_window_from_last_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         cx.defer_in(window, |workspace, window, cx| {
+            let should_quit = cfg!(not(target_os = "macos")) && cx.windows().len() <= 1;
             workspace.prepare_window_close(cx);
             window.remove_window();
+            if should_quit {
+                cx.quit();
+            }
         });
     }
 
@@ -6681,7 +6687,7 @@ impl ConWorkspace {
             return;
         }
 
-        self.quit(&Quit, window, cx);
+        self.close_window_from_last_tab(window, cx);
     }
 
     fn close_pane_in_tab(
@@ -6972,8 +6978,9 @@ impl ConWorkspace {
             // Last pane in this tab — close the tab.
             self.close_tab_by_index(tab_idx, window, cx);
         } else {
-            // Last pane in last tab — quit the app.
-            self.quit(&Quit, window, cx);
+            // Last pane in this window — close this workspace only.
+            // App-level quit would tear down sibling windows too.
+            self.close_window_from_last_tab(window, cx);
         }
         cx.notify();
     }
@@ -7923,9 +7930,9 @@ impl Render for ConWorkspace {
                 #[cfg(target_os = "macos")]
                 if mods.platform && !mods.control && !mods.alt && (key == "`" || key == "~") {
                     if mods.shift {
-                        cx.dispatch_action(&PreviousWindow);
+                        cx.dispatch_action(&crate::PreviousWindow);
                     } else {
-                        cx.dispatch_action(&NextWindow);
+                        cx.dispatch_action(&crate::NextWindow);
                     }
                     window.prevent_default();
                     cx.stop_propagation();

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -5921,8 +5921,8 @@ impl ConWorkspace {
 
     fn close_window_from_last_tab(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         cx.defer_in(window, |workspace, window, cx| {
-            let should_quit = cfg!(not(target_os = "macos")) && cx.windows().len() <= 1;
             workspace.prepare_window_close(cx);
+            let should_quit = cfg!(not(target_os = "macos")) && cx.windows().len() <= 1;
             window.remove_window();
             if should_quit {
                 cx.quit();
@@ -5938,6 +5938,12 @@ impl ConWorkspace {
 
         self.cancel_all_sessions();
         self.flush_session_save(cx);
+
+        if let Some(settings_window) = self.settings_window.take() {
+            let _ = settings_window.update(cx, |_, window, _| {
+                window.remove_window();
+            });
+        }
 
         for request in std::mem::take(&mut self.pending_window_control_requests) {
             match request {

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -231,8 +231,9 @@ use crate::ghostty_view::{
     GhosttyView,
 };
 use crate::{
-    ClosePane, CloseTab, CycleInputMode, FocusInput, NewTab, NextTab, PreviousTab, Quit, SplitDown,
-    SplitRight, ToggleAgentPanel, TogglePaneScopePicker,
+    ClosePane, CloseTab, CycleInputMode, FocusInput, NewTab, NextTab, PreviousTab, Quit,
+    SelectTab1, SelectTab2, SelectTab3, SelectTab4, SelectTab5, SelectTab6, SelectTab7, SelectTab8,
+    SelectTab9, SplitDown, SplitRight, ToggleAgentPanel, TogglePaneScopePicker,
 };
 use con_agent::{
     AgentConfig, Conversation, ProviderKind, TerminalExecRequest, TerminalExecResponse,
@@ -289,6 +290,16 @@ struct CommandSuggestionEntry {
     cwd: Option<String>,
 }
 
+struct SettingsWindowView {
+    panel: Entity<SettingsPanel>,
+}
+
+impl Render for SettingsWindowView {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div().size_full().child(self.panel.clone())
+    }
+}
+
 #[cfg(target_os = "macos")]
 #[repr(C)]
 struct NSOperatingSystemVersion {
@@ -332,6 +343,7 @@ pub struct ConWorkspace {
     agent_panel: Entity<AgentPanel>,
     input_bar: Entity<InputBar>,
     settings_panel: Entity<SettingsPanel>,
+    settings_window: Option<AnyWindowHandle>,
     command_palette: Entity<CommandPalette>,
     model_registry: ModelRegistry,
     harness: AgentHarness,
@@ -1208,6 +1220,7 @@ impl ConWorkspace {
             agent_panel,
             input_bar,
             settings_panel,
+            settings_window: None,
             command_palette,
             model_registry,
             harness,
@@ -3537,6 +3550,16 @@ impl ConWorkspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.apply_settings_from_panel(settings, window, cx, true);
+    }
+
+    fn apply_settings_from_panel(
+        &mut self,
+        settings: &Entity<SettingsPanel>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+        restore_focus: bool,
+    ) {
         let new_config = settings.read(cx).agent_config().clone();
         let auto_approve = new_config.auto_approve_tools;
         self.harness.update_config(new_config);
@@ -3646,8 +3669,9 @@ impl ConWorkspace {
         #[cfg(target_os = "macos")]
         crate::global_hotkey::update_from_keybindings(&kb);
 
-        // Settings panel closes on save — restore terminal focus
-        self.focus_terminal(window, cx);
+        if restore_focus {
+            self.focus_terminal(window, cx);
+        }
     }
 
     fn on_tabs_orientation_changed(
@@ -3655,6 +3679,14 @@ impl ConWorkspace {
         settings: &Entity<SettingsPanel>,
         _event: &TabsOrientationChanged,
         _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.apply_tabs_orientation_from_panel(settings, cx);
+    }
+
+    fn apply_tabs_orientation_from_panel(
+        &mut self,
+        settings: &Entity<SettingsPanel>,
         cx: &mut Context<Self>,
     ) {
         let orientation = settings.read(cx).appearance_config().tabs_orientation;
@@ -3677,7 +3709,16 @@ impl ConWorkspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Some(new_theme) = TerminalTheme::by_name(&event.0) {
+        self.apply_theme_preview(&event.0, window, cx);
+    }
+
+    fn apply_theme_preview(
+        &mut self,
+        theme_name: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(new_theme) = TerminalTheme::by_name(theme_name) {
             if new_theme.name != self.terminal_theme.name {
                 self.apply_terminal_theme(new_theme, window, cx);
                 cx.notify();
@@ -5436,7 +5477,7 @@ impl ConWorkspace {
         cx: &mut Context<Self>,
     ) {
         // Close settings if open (mutually exclusive)
-        if self.settings_panel.read(cx).is_visible() {
+        if self.settings_panel.read(cx).is_overlay_visible() {
             self.settings_panel.update(cx, |panel, cx| {
                 panel.toggle(window, cx);
             });
@@ -5451,6 +5492,93 @@ impl ConWorkspace {
         cx.notify();
     }
 
+    fn open_settings_window(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(handle) = self.settings_window {
+            if handle
+                .update(cx, |_, settings_window, _| {
+                    settings_window.activate_window();
+                })
+                .is_ok()
+            {
+                return;
+            }
+            self.settings_window = None;
+        }
+
+        let config = Config::load().unwrap_or_default();
+        let registry = self.model_registry.clone();
+        let runtime = self.harness.runtime_handle();
+        let workspace = cx.weak_entity();
+        let main_window = window.window_handle();
+        let options = WindowOptions {
+            window_bounds: Some(WindowBounds::centered(size(px(920.0), px(680.0)), cx)),
+            titlebar: Some(TitlebarOptions {
+                title: Some("Settings".into()),
+                appears_transparent: false,
+                ..Default::default()
+            }),
+            window_background: WindowBackgroundAppearance::Opaque,
+            ..Default::default()
+        };
+
+        match cx.open_window(options, move |settings_window, cx| {
+            let panel = cx.new(|cx| {
+                let mut panel =
+                    SettingsPanel::new(&config, registry.clone(), runtime, settings_window, cx);
+                panel.open_standalone(settings_window, cx);
+                panel
+            });
+
+            let workspace_for_save = workspace.clone();
+            let main_window_for_save = main_window;
+            cx.subscribe(&panel, move |settings, _: &SaveSettings, cx| {
+                let _ = main_window_for_save.update(cx, |_, window, cx| {
+                    let _ = workspace_for_save.update(cx, |workspace, cx| {
+                        workspace.apply_settings_from_panel(&settings, window, cx, false);
+                    });
+                });
+            })
+            .detach();
+
+            let workspace_for_tabs = workspace.clone();
+            let main_window_for_tabs = main_window;
+            cx.subscribe(&panel, move |settings, _: &TabsOrientationChanged, cx| {
+                let _ = main_window_for_tabs.update(cx, |_, _window, cx| {
+                    let _ = workspace_for_tabs.update(cx, |workspace, cx| {
+                        workspace.apply_tabs_orientation_from_panel(&settings, cx);
+                    });
+                });
+            })
+            .detach();
+
+            let workspace_for_theme = workspace;
+            let main_window_for_theme = main_window;
+            cx.subscribe(&panel, move |_settings, event: &ThemePreview, cx| {
+                let theme_name = event.0.clone();
+                let _ = main_window_for_theme.update(cx, |_, window, cx| {
+                    let _ = workspace_for_theme.update(cx, |workspace, cx| {
+                        workspace.apply_theme_preview(&theme_name, window, cx);
+                    });
+                });
+            })
+            .detach();
+
+            let view = cx.new(|_| SettingsWindowView {
+                panel: panel.clone(),
+            });
+            cx.new(|cx| {
+                gpui_component::Root::new(view, settings_window, cx).bg(cx.theme().background)
+            })
+        }) {
+            Ok(handle) => {
+                self.settings_window = Some(handle.into());
+            }
+            Err(err) => {
+                log::error!("Failed to open settings window: {err}");
+            }
+        }
+    }
+
     fn toggle_settings(
         &mut self,
         _: &settings_panel::ToggleSettings,
@@ -5463,18 +5591,13 @@ impl ConWorkspace {
                 palette.toggle(window, cx);
             });
         }
-        self.settings_panel.update(cx, |panel, cx| {
-            panel.toggle(window, cx);
-        });
-        // Restore terminal focus if settings just closed
-        if !self.is_modal_open(cx) {
-            self.focus_terminal(window, cx);
-        }
+        self.open_settings_window(window, cx);
         cx.notify();
     }
 
     fn is_modal_open(&self, cx: &App) -> bool {
-        self.settings_panel.read(cx).is_visible() || self.command_palette.read(cx).is_visible()
+        self.settings_panel.read(cx).is_overlay_visible()
+            || self.command_palette.read(cx).is_visible()
     }
 
     fn new_tab(&mut self, _: &NewTab, window: &mut Window, cx: &mut Context<Self>) {
@@ -6594,6 +6717,49 @@ impl ConWorkspace {
         self.activate_tab(prev, window, cx);
     }
 
+    fn select_tab_index(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
+        if index >= self.tabs.len() || index == self.active_tab {
+            return;
+        }
+        self.activate_tab(index, window, cx);
+    }
+
+    fn select_tab_1(&mut self, _: &SelectTab1, window: &mut Window, cx: &mut Context<Self>) {
+        self.select_tab_index(0, window, cx);
+    }
+
+    fn select_tab_2(&mut self, _: &SelectTab2, window: &mut Window, cx: &mut Context<Self>) {
+        self.select_tab_index(1, window, cx);
+    }
+
+    fn select_tab_3(&mut self, _: &SelectTab3, window: &mut Window, cx: &mut Context<Self>) {
+        self.select_tab_index(2, window, cx);
+    }
+
+    fn select_tab_4(&mut self, _: &SelectTab4, window: &mut Window, cx: &mut Context<Self>) {
+        self.select_tab_index(3, window, cx);
+    }
+
+    fn select_tab_5(&mut self, _: &SelectTab5, window: &mut Window, cx: &mut Context<Self>) {
+        self.select_tab_index(4, window, cx);
+    }
+
+    fn select_tab_6(&mut self, _: &SelectTab6, window: &mut Window, cx: &mut Context<Self>) {
+        self.select_tab_index(5, window, cx);
+    }
+
+    fn select_tab_7(&mut self, _: &SelectTab7, window: &mut Window, cx: &mut Context<Self>) {
+        self.select_tab_index(6, window, cx);
+    }
+
+    fn select_tab_8(&mut self, _: &SelectTab8, window: &mut Window, cx: &mut Context<Self>) {
+        self.select_tab_index(7, window, cx);
+    }
+
+    fn select_tab_9(&mut self, _: &SelectTab9, window: &mut Window, cx: &mut Context<Self>) {
+        self.select_tab_index(8, window, cx);
+    }
+
     /// Focus the active terminal (used after modal close, etc.)
     fn focus_terminal(&self, window: &mut Window, cx: &mut App) {
         self.active_terminal().focus(window, cx);
@@ -6606,7 +6772,8 @@ impl ConWorkspace {
         }
         self.focus_terminal(window, cx);
         cx.on_next_frame(window, |workspace, window, cx| {
-            if workspace.has_active_tab() && !workspace.settings_panel.read(cx).is_visible() {
+            if workspace.has_active_tab() && !workspace.settings_panel.read(cx).is_overlay_visible()
+            {
                 workspace.focus_terminal(window, cx);
                 cx.notify();
             }
@@ -7584,6 +7751,15 @@ impl Render for ConWorkspace {
             .on_action(cx.listener(Self::new_tab))
             .on_action(cx.listener(Self::next_tab))
             .on_action(cx.listener(Self::previous_tab))
+            .on_action(cx.listener(Self::select_tab_1))
+            .on_action(cx.listener(Self::select_tab_2))
+            .on_action(cx.listener(Self::select_tab_3))
+            .on_action(cx.listener(Self::select_tab_4))
+            .on_action(cx.listener(Self::select_tab_5))
+            .on_action(cx.listener(Self::select_tab_6))
+            .on_action(cx.listener(Self::select_tab_7))
+            .on_action(cx.listener(Self::select_tab_8))
+            .on_action(cx.listener(Self::select_tab_9))
             .on_action(cx.listener(Self::close_tab))
             .on_action(cx.listener(Self::close_pane))
             .on_action(cx.listener(Self::split_right))
@@ -7593,7 +7769,7 @@ impl Render for ConWorkspace {
             .on_action(cx.listener(Self::toggle_pane_scope_picker))
             .on_key_down(cx.listener(|this, event: &KeyDownEvent, window, cx| {
                 // Don't handle workspace shortcuts when a modal overlay is open
-                if this.settings_panel.read(cx).is_visible()
+                if this.settings_panel.read(cx).is_overlay_visible()
                     || this.command_palette.read(cx).is_visible()
                 {
                     return;
@@ -8149,7 +8325,7 @@ impl Render for ConWorkspace {
             root = root.child(popup);
         }
 
-        let settings_visible = self.settings_panel.read(cx).is_visible();
+        let settings_visible = self.settings_panel.read(cx).is_overlay_visible();
         if settings_visible {
             root = root.child(self.settings_panel.clone());
         }

--- a/postmortem/2026-04-30-macos-window-cycling.md
+++ b/postmortem/2026-04-30-macos-window-cycling.md
@@ -1,0 +1,19 @@
+# macOS Cmd-Backtick Window Cycling
+
+## What happened
+
+Cmd-Backtick and Cmd-Shift-Backtick were registered as GPUI actions, but they still failed when the embedded Ghostty terminal view was first responder. New workspace windows also opened centered at the exact same position, making multiple windows feel stacked instead of naturally cascading.
+
+## Root cause
+
+Window cycling is a native macOS window-management shortcut. Routing it only through GPUI is not sufficient when a native child NSView participates in key-equivalent handling before GPUI sees the event. The new-window placement issue came from Con overriding GPUI's default window placement with a fixed centered `WindowBounds`.
+
+## Fix applied
+
+Con now installs a macOS-only local AppKit key monitor for Cmd-Backtick. The monitor handles the shortcut before the terminal surface can consume it and cycles visible keyable app windows using a short-lived cycle-order snapshot, so repeated presses walk all windows instead of toggling only the top two.
+
+Workspace window bounds now cascade from the active window and wrap inside the visible display area while preserving the first-window 1200x800 default.
+
+## What we learned
+
+App-wide macOS window-management shortcuts should be handled at the native window layer when Con embeds native platform views. GPUI actions are still useful for menu display and non-native focus paths, but they cannot be the only enforcement point for native app behavior.


### PR DESCRIPTION
## Summary
- Move Settings into a standalone window with an Apply flow, while routing saves/previews back to the workspace window.
- Add direct tab selection shortcuts: Cmd/Ctrl+1 through Cmd/Ctrl+9, plus macOS Cmd+Backtick / Cmd+Shift+Backtick window cycling.
- Add OpenAI-compatible provider model discovery via the configured Base URL's /models endpoint.
- Update the changelog for the next beta.

## Validation
- cargo check -p con
- cargo check -p con --no-default-features --features con/bin-con-app
- cargo test -p con model_registry

Closes #83

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core UI/window lifecycle and cross-platform key handling, plus adds network-based model fetching and URL normalization; regressions could affect shortcuts, window management, or provider configuration UX across platforms.
> 
> **Overview**
> Adds a **standalone Settings window** with an apply/save flow, live appearance preview updates, and rollback of unsaved preview changes when the window closes; the workspace now listens to Settings events to update theme/opacity/font/etc. in real time and ensures Settings closes with the last workspace window.
> 
> Introduces **direct tab selection shortcuts** (`Cmd/Ctrl+1`…`9`) and scopes pane-scope picker keys to bare `1`…`9`/`A`/`F` while it’s open; terminal backends on macOS/Windows/Linux now stop forwarding these app-level shortcuts to the shell.
> 
> Improves **windowing behavior** by cascading new workspace window placement from the active window and implementing macOS-native window cycling (`Cmd-`` / `Cmd-Shift-``) via an AppKit key monitor plus shared menu actions.
> 
> Adds **OpenAI-compatible provider model discovery** by fetching `/models` from the configured Base URL (with URL normalization and query preservation), caching results per endpoint, and refreshing all related model pickers in Settings after fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92409d7a3629237c894a841ccc766167acd82369. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Settings now opens in a separate window with persistent open-state
  * Direct tab selection shortcuts (1–9) available on all platforms
  * macOS window cycling shortcuts using backtick combinations
  * OpenAI-compatible providers support dynamic model listing

* **Improvements**
  * Live appearance preview while editing settings
  * Refined settings save action using active theme colors
  * Fixed Shortcuts section added to keyboard settings
  * Terminal blur handling improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->