### PR TITLE
Add pane-local terminal surfaces for interactive subagents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ con is still pre-release, so entries may group related beta work while the produ
 
 - Added pane-local terminal surfaces for external orchestrators. Existing `panes.*` APIs, built-in agent tools, and benchmarks keep the active-surface pane contract, while new `tree.get` and `surfaces.*` RPC/CLI commands can create, split, wait for readiness, focus, rename, drive, read, and close terminal sessions inside a pane.
 
+### Fixed
+
+**Control Plane**
+
+- Hardened pane-local surface lifecycle behavior so owned ephemeral worker panes can close when their final surface closes, inactive surfaces keep correct pane membership, replacement surfaces are materialized before focus moves to them, and `surfaces.wait_ready` only reports `ready` once the terminal is live with shell integration.
+
 ## `v0.1.0-beta.46` - 2026-04-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ## `origin/main`
 
+### Added
+
+**Control Plane**
+
+- Added pane-local terminal surfaces for external orchestrators. Existing `panes.*` APIs, built-in agent tools, and benchmarks keep the active-surface pane contract, while new `tree.get` and `surfaces.*` RPC/CLI commands can create, split, wait for readiness, focus, rename, drive, read, and close terminal sessions inside a pane.
+
 ## `v0.1.0-beta.46` - 2026-04-30
 
 ### Added

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -312,12 +312,15 @@ impl PaneTree {
     }
 
     pub fn focus_surface(&mut self, surface_id: SurfaceId) -> bool {
-        if let Some(pane_id) = Self::activate_surface(&mut self.root, surface_id) {
-            if self.zoomed_pane_id.is_some_and(|zoomed| zoomed != pane_id) {
+        if let Some((pane_id, surface_changed)) = Self::activate_surface(&mut self.root, surface_id)
+        {
+            let focus_changed = self.focused_pane_id != pane_id;
+            let zoom_changed = self.zoomed_pane_id.is_some_and(|zoomed| zoomed != pane_id);
+            if zoom_changed {
                 self.zoomed_pane_id = None;
             }
             self.focused_pane_id = pane_id;
-            true
+            surface_changed || focus_changed || zoom_changed
         } else {
             false
         }
@@ -799,7 +802,7 @@ impl PaneTree {
         }
     }
 
-    fn activate_surface(node: &mut PaneNode, surface_id: SurfaceId) -> Option<PaneId> {
+    fn activate_surface(node: &mut PaneNode, surface_id: SurfaceId) -> Option<(PaneId, bool)> {
         match node {
             PaneNode::Leaf {
                 id,
@@ -807,8 +810,9 @@ impl PaneTree {
                 active_surface_id,
             } => {
                 if surfaces.iter().any(|surface| surface.id == surface_id) {
+                    let changed = *active_surface_id != surface_id;
                     *active_surface_id = surface_id;
-                    Some(*id)
+                    Some((*id, changed))
                 } else {
                     None
                 }

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -301,6 +301,9 @@ impl PaneTree {
         surface.close_pane_when_last = options.close_pane_when_last;
 
         if Self::push_surface(&mut self.root, pane_id, surface) {
+            if self.zoomed_pane_id.is_some_and(|zoomed| zoomed != pane_id) {
+                self.zoomed_pane_id = None;
+            }
             self.focused_pane_id = pane_id;
             Some(surface_id)
         } else {
@@ -310,6 +313,9 @@ impl PaneTree {
 
     pub fn focus_surface(&mut self, surface_id: SurfaceId) -> bool {
         if let Some(pane_id) = Self::activate_surface(&mut self.root, surface_id) {
+            if self.zoomed_pane_id.is_some_and(|zoomed| zoomed != pane_id) {
+                self.zoomed_pane_id = None;
+            }
             self.focused_pane_id = pane_id;
             true
         } else {

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -411,6 +411,12 @@ impl PaneTree {
         result
     }
 
+    pub fn surface_terminals(&self) -> Vec<(PaneId, bool, TerminalPane)> {
+        let mut result = Vec::new();
+        Self::collect_surface_terminals(&self.root, &mut result);
+        result
+    }
+
     pub fn surface_infos(&self, target_pane_id: Option<PaneId>) -> Vec<PaneSurfaceInfo> {
         let mut result = Vec::new();
         let mut pane_index = 0;
@@ -1216,6 +1222,28 @@ impl PaneTree {
             PaneNode::Split { first, second, .. } => {
                 Self::collect_pane_terminals(first, result);
                 Self::collect_pane_terminals(second, result);
+            }
+        }
+    }
+
+    fn collect_surface_terminals(node: &PaneNode, result: &mut Vec<(PaneId, bool, TerminalPane)>) {
+        match node {
+            PaneNode::Leaf {
+                id,
+                surfaces,
+                active_surface_id,
+            } => {
+                result.extend(surfaces.iter().map(|surface| {
+                    (
+                        *id,
+                        surface.id == *active_surface_id,
+                        surface.terminal.clone(),
+                    )
+                }));
+            }
+            PaneNode::Split { first, second, .. } => {
+                Self::collect_surface_terminals(first, result);
+                Self::collect_surface_terminals(second, result);
             }
         }
     }

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -17,17 +17,80 @@ pub enum SplitPlacement {
     After,
 }
 
-/// Unique identifier for a leaf pane
-type PaneId = usize;
+/// Unique identifier for a leaf pane.
+///
+/// Pane IDs remain the public, stable split-layout target used by the
+/// built-in agent and the existing `panes.*` control API.
+pub type PaneId = usize;
+
+/// Unique identifier for a terminal surface hosted inside a pane.
+///
+/// A pane can hold multiple surfaces, but only its active surface participates
+/// in pane-level agent context. This lets external orchestrators create
+/// pane-local tabs without changing the benchmarked pane contract.
+pub type SurfaceId = usize;
 
 /// Unique identifier for a split node
 pub type SplitId = usize;
 
-/// A node in the pane tree — either a single terminal or a split
+#[derive(Clone)]
+struct PaneSurface {
+    id: SurfaceId,
+    terminal: TerminalPane,
+    title: Option<String>,
+    owner: Option<String>,
+    close_pane_when_last: bool,
+}
+
+impl PaneSurface {
+    fn new(id: SurfaceId, terminal: TerminalPane) -> Self {
+        Self {
+            id,
+            terminal,
+            title: None,
+            owner: None,
+            close_pane_when_last: false,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct PaneSurfaceInfo {
+    pub pane_id: PaneId,
+    pub pane_index: usize,
+    pub surface_id: SurfaceId,
+    pub surface_index: usize,
+    pub is_active: bool,
+    pub is_focused_pane: bool,
+    pub title: Option<String>,
+    pub owner: Option<String>,
+    pub close_pane_when_last: bool,
+    pub terminal: TerminalPane,
+}
+
+#[derive(Debug, Clone)]
+pub struct SurfaceCreateOptions {
+    pub title: Option<String>,
+    pub owner: Option<String>,
+    pub close_pane_when_last: bool,
+}
+
+impl SurfaceCreateOptions {
+    pub fn plain(title: Option<String>) -> Self {
+        Self {
+            title,
+            owner: None,
+            close_pane_when_last: false,
+        }
+    }
+}
+
+/// A node in the pane tree — either a pane slot or a split.
 enum PaneNode {
     Leaf {
         id: PaneId,
-        terminal: TerminalPane,
+        surfaces: Vec<PaneSurface>,
+        active_surface_id: SurfaceId,
     },
     Split {
         split_id: SplitId,
@@ -55,6 +118,7 @@ pub struct PaneTree {
     focused_pane_id: PaneId,
     zoomed_pane_id: Option<PaneId>,
     next_id: PaneId,
+    next_surface_id: SurfaceId,
     next_split_id: SplitId,
     /// Active divider drag, if any
     pub dragging: Option<DragState>,
@@ -63,10 +127,15 @@ pub struct PaneTree {
 impl PaneTree {
     pub fn new(terminal: TerminalPane) -> Self {
         Self {
-            root: PaneNode::Leaf { id: 0, terminal },
+            root: PaneNode::Leaf {
+                id: 0,
+                surfaces: vec![PaneSurface::new(0, terminal)],
+                active_surface_id: 0,
+            },
             focused_pane_id: 0,
             zoomed_pane_id: None,
             next_id: 1,
+            next_surface_id: 1,
             next_split_id: 0,
             dragging: None,
         }
@@ -81,6 +150,7 @@ impl PaneTree {
         let mut next_split_id = 0;
         Self::normalize_split_ids(&mut root, &mut next_split_id);
         let next_id = Self::max_pane_id(&root).saturating_add(1);
+        let next_surface_id = Self::max_surface_id(&root).saturating_add(1);
         let requested_focus = focused_pane_id.unwrap_or_else(|| Self::first_pane_id(&root));
         let focused_pane_id = if Self::find_terminal(&root, requested_focus).is_some() {
             requested_focus
@@ -93,6 +163,7 @@ impl PaneTree {
             focused_pane_id,
             zoomed_pane_id: None,
             next_id,
+            next_surface_id,
             next_split_id,
             dragging: None,
         }
@@ -115,6 +186,13 @@ impl PaneTree {
         result
     }
 
+    /// Get every terminal surface in the tree, including inactive pane-local tabs.
+    pub fn all_surface_terminals(&self) -> Vec<&TerminalPane> {
+        let mut result = Vec::new();
+        Self::collect_all_surface_terminals(&self.root, &mut result);
+        result
+    }
+
     /// Split the focused pane
     pub fn split(&mut self, direction: SplitDirection, new_terminal: TerminalPane) {
         self.split_with_placement(direction, SplitPlacement::After, new_terminal);
@@ -128,6 +206,8 @@ impl PaneTree {
     ) {
         let new_id = self.next_id;
         self.next_id += 1;
+        let new_surface_id = self.next_surface_id;
+        self.next_surface_id += 1;
         let new_split_id = self.next_split_id;
         self.next_split_id += 1;
         Self::split_node(
@@ -136,8 +216,10 @@ impl PaneTree {
             direction,
             placement,
             new_id,
+            new_surface_id,
             new_terminal,
             new_split_id,
+            SurfaceCreateOptions::plain(None),
         );
         self.focused_pane_id = new_id;
         self.zoomed_pane_id = None;
@@ -152,6 +234,8 @@ impl PaneTree {
     ) {
         let new_id = self.next_id;
         self.next_id += 1;
+        let new_surface_id = self.next_surface_id;
+        self.next_surface_id += 1;
         let new_split_id = self.next_split_id;
         self.next_split_id += 1;
         if Self::split_node(
@@ -160,12 +244,96 @@ impl PaneTree {
             direction,
             placement,
             new_id,
+            new_surface_id,
             new_terminal,
             new_split_id,
+            SurfaceCreateOptions::plain(None),
         ) {
             self.focused_pane_id = new_id;
             self.zoomed_pane_id = None;
         }
+    }
+
+    pub fn split_pane_with_surface_options(
+        &mut self,
+        target_pane_id: PaneId,
+        direction: SplitDirection,
+        placement: SplitPlacement,
+        new_terminal: TerminalPane,
+        options: SurfaceCreateOptions,
+    ) -> Option<(PaneId, SurfaceId)> {
+        let new_id = self.next_id;
+        self.next_id += 1;
+        let new_surface_id = self.next_surface_id;
+        self.next_surface_id += 1;
+        let new_split_id = self.next_split_id;
+        self.next_split_id += 1;
+        if Self::split_node(
+            &mut self.root,
+            target_pane_id,
+            direction,
+            placement,
+            new_id,
+            new_surface_id,
+            new_terminal,
+            new_split_id,
+            options,
+        ) {
+            self.focused_pane_id = new_id;
+            self.zoomed_pane_id = None;
+            Some((new_id, new_surface_id))
+        } else {
+            None
+        }
+    }
+
+    pub fn create_surface_in_pane(
+        &mut self,
+        pane_id: PaneId,
+        terminal: TerminalPane,
+        options: SurfaceCreateOptions,
+    ) -> Option<SurfaceId> {
+        let surface_id = self.next_surface_id;
+        self.next_surface_id += 1;
+        let mut surface = PaneSurface::new(surface_id, terminal);
+        surface.title = options.title;
+        surface.owner = options.owner;
+        surface.close_pane_when_last = options.close_pane_when_last;
+
+        if Self::push_surface(&mut self.root, pane_id, surface) {
+            self.focused_pane_id = pane_id;
+            Some(surface_id)
+        } else {
+            None
+        }
+    }
+
+    pub fn focus_surface(&mut self, surface_id: SurfaceId) -> bool {
+        if let Some(pane_id) = Self::activate_surface(&mut self.root, surface_id) {
+            self.focused_pane_id = pane_id;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn rename_surface(&mut self, surface_id: SurfaceId, title: Option<String>) -> bool {
+        Self::rename_surface_node(&mut self.root, surface_id, title)
+    }
+
+    pub fn close_surface(&mut self, surface_id: SurfaceId) -> Option<(PaneId, TerminalPane)> {
+        let removed = Self::remove_surface(&mut self.root, surface_id)?;
+        if self.pane_count() <= 1
+            || self
+                .zoomed_pane_id
+                .is_some_and(|zoomed_id| Self::find_terminal(&self.root, zoomed_id).is_none())
+        {
+            self.zoomed_pane_id = None;
+        }
+        if Self::find_terminal(&self.root, self.focused_pane_id).is_none() {
+            self.focused_pane_id = Self::first_pane_id(&self.root);
+        }
+        Some(removed)
     }
 
     /// Close the focused pane, returning true if the tree still has panes
@@ -183,7 +351,8 @@ impl PaneTree {
             &mut self.root,
             PaneNode::Leaf {
                 id: 0,
-                terminal: placeholder_terminal,
+                surfaces: vec![PaneSurface::new(0, placeholder_terminal)],
+                active_surface_id: 0,
             },
         );
         self.root = Self::remove_leaf(old_root, pane_id);
@@ -234,6 +403,23 @@ impl PaneTree {
         let mut result = Vec::new();
         Self::collect_pane_terminals(&self.root, &mut result);
         result
+    }
+
+    pub fn surface_infos(&self, target_pane_id: Option<PaneId>) -> Vec<PaneSurfaceInfo> {
+        let mut result = Vec::new();
+        let mut pane_index = 0;
+        Self::collect_surface_infos(
+            &self.root,
+            target_pane_id,
+            self.focused_pane_id,
+            &mut pane_index,
+            &mut result,
+        );
+        result
+    }
+
+    pub fn active_surface_id_for_pane(&self, pane_id: PaneId) -> Option<SurfaceId> {
+        Self::find_active_surface_id(&self.root, pane_id)
     }
 
     pub fn focused_pane_id(&self) -> PaneId {
@@ -320,13 +506,22 @@ impl PaneTree {
     }
 
     /// Render the pane tree as a GPUI element.
-    pub fn render(&self, begin_drag_cb: impl Fn(SplitId, f32) + 'static, cx: &App) -> AnyElement {
+    pub fn render(
+        &self,
+        begin_drag_cb: impl Fn(SplitId, f32) + 'static,
+        focus_surface_cb: impl Fn(SurfaceId, &mut Window, &mut App) + 'static,
+        cx: &App,
+    ) -> AnyElement {
+        let focus_surface_cb = std::sync::Arc::new(focus_surface_cb);
         if let Some(zoomed_id) = self.zoomed_pane_id {
-            if let Some(terminal) = Self::find_terminal(&self.root, zoomed_id) {
-                return div()
-                    .size_full()
-                    .child(terminal.render_child())
-                    .into_any_element();
+            if let Some(zoomed) = Self::render_zoomed_leaf(
+                &self.root,
+                zoomed_id,
+                self.focused_pane_id,
+                focus_surface_cb.clone(),
+                cx,
+            ) {
+                return zoomed;
             }
         }
 
@@ -335,6 +530,7 @@ impl PaneTree {
             self.focused_pane_id,
             self.pane_count() > 1,
             std::sync::Arc::new(begin_drag_cb),
+            focus_surface_cb,
             cx,
         )
     }
@@ -343,7 +539,13 @@ impl PaneTree {
 
     fn find_terminal(node: &PaneNode, target_id: PaneId) -> Option<&TerminalPane> {
         match node {
-            PaneNode::Leaf { id, terminal } if *id == target_id => Some(terminal),
+            PaneNode::Leaf {
+                id,
+                surfaces,
+                active_surface_id,
+            } if *id == target_id => {
+                Self::active_surface(surfaces, *active_surface_id).map(|surface| &surface.terminal)
+            }
             PaneNode::Leaf { .. } => None,
             PaneNode::Split { first, second, .. } => Self::find_terminal(first, target_id)
                 .or_else(|| Self::find_terminal(second, target_id)),
@@ -352,7 +554,15 @@ impl PaneTree {
 
     fn first_terminal(node: &PaneNode) -> &TerminalPane {
         match node {
-            PaneNode::Leaf { terminal, .. } => terminal,
+            PaneNode::Leaf {
+                surfaces,
+                active_surface_id,
+                ..
+            } => {
+                &Self::active_surface(surfaces, *active_surface_id)
+                    .unwrap_or_else(|| surfaces.first().expect("pane leaf must have a surface"))
+                    .terminal
+            }
             PaneNode::Split { first, .. } => Self::first_terminal(first),
         }
     }
@@ -367,10 +577,30 @@ impl PaneTree {
 
     fn collect_terminals<'a>(node: &'a PaneNode, result: &mut Vec<&'a TerminalPane>) {
         match node {
-            PaneNode::Leaf { terminal, .. } => result.push(terminal),
+            PaneNode::Leaf {
+                surfaces,
+                active_surface_id,
+                ..
+            } => {
+                if let Some(surface) = Self::active_surface(surfaces, *active_surface_id) {
+                    result.push(&surface.terminal);
+                }
+            }
             PaneNode::Split { first, second, .. } => {
                 Self::collect_terminals(first, result);
                 Self::collect_terminals(second, result);
+            }
+        }
+    }
+
+    fn collect_all_surface_terminals<'a>(node: &'a PaneNode, result: &mut Vec<&'a TerminalPane>) {
+        match node {
+            PaneNode::Leaf { surfaces, .. } => {
+                result.extend(surfaces.iter().map(|surface| &surface.terminal));
+            }
+            PaneNode::Split { first, second, .. } => {
+                Self::collect_all_surface_terminals(first, result);
+                Self::collect_all_surface_terminals(second, result);
             }
         }
     }
@@ -389,6 +619,17 @@ impl PaneTree {
             PaneNode::Leaf { id, .. } => *id,
             PaneNode::Split { first, second, .. } => {
                 Self::max_pane_id(first).max(Self::max_pane_id(second))
+            }
+        }
+    }
+
+    fn max_surface_id(node: &PaneNode) -> SurfaceId {
+        match node {
+            PaneNode::Leaf { surfaces, .. } => {
+                surfaces.iter().map(|surface| surface.id).max().unwrap_or(0)
+            }
+            PaneNode::Split { first, second, .. } => {
+                Self::max_surface_id(first).max(Self::max_surface_id(second))
             }
         }
     }
@@ -462,21 +703,29 @@ impl PaneTree {
         direction: SplitDirection,
         placement: SplitPlacement,
         new_id: PaneId,
+        new_surface_id: SurfaceId,
         new_terminal: TerminalPane,
         new_split_id: SplitId,
+        options: SurfaceCreateOptions,
     ) -> bool {
         match node {
             PaneNode::Leaf { id, .. } if *id == target_id => {
+                let mut surface = PaneSurface::new(new_surface_id, new_terminal.clone());
+                surface.title = options.title;
+                surface.owner = options.owner;
+                surface.close_pane_when_last = options.close_pane_when_last;
                 let old_node = std::mem::replace(
                     node,
                     PaneNode::Leaf {
                         id: new_id,
-                        terminal: new_terminal.clone(),
+                        surfaces: vec![surface.clone()],
+                        active_surface_id: new_surface_id,
                     },
                 );
                 let new_leaf = PaneNode::Leaf {
                     id: new_id,
-                    terminal: new_terminal,
+                    surfaces: vec![surface],
+                    active_surface_id: new_surface_id,
                 };
                 let (first, second) = match placement {
                     SplitPlacement::Before => (Box::new(new_leaf), Box::new(old_node)),
@@ -498,19 +747,115 @@ impl PaneTree {
                     direction,
                     placement,
                     new_id,
+                    new_surface_id,
                     new_terminal.clone(),
                     new_split_id,
+                    options.clone(),
                 ) || Self::split_node(
                     second,
                     target_id,
                     direction,
                     placement,
                     new_id,
+                    new_surface_id,
                     new_terminal,
                     new_split_id,
+                    options,
                 )
             }
             _ => false,
+        }
+    }
+
+    fn push_surface(node: &mut PaneNode, pane_id: PaneId, surface: PaneSurface) -> bool {
+        match node {
+            PaneNode::Leaf {
+                id,
+                surfaces,
+                active_surface_id,
+            } if *id == pane_id => {
+                let surface_id = surface.id;
+                surfaces.push(surface);
+                *active_surface_id = surface_id;
+                true
+            }
+            PaneNode::Leaf { .. } => false,
+            PaneNode::Split { first, second, .. } => {
+                Self::push_surface(first, pane_id, surface.clone())
+                    || Self::push_surface(second, pane_id, surface)
+            }
+        }
+    }
+
+    fn activate_surface(node: &mut PaneNode, surface_id: SurfaceId) -> Option<PaneId> {
+        match node {
+            PaneNode::Leaf {
+                id,
+                surfaces,
+                active_surface_id,
+            } => {
+                if surfaces.iter().any(|surface| surface.id == surface_id) {
+                    *active_surface_id = surface_id;
+                    Some(*id)
+                } else {
+                    None
+                }
+            }
+            PaneNode::Split { first, second, .. } => Self::activate_surface(first, surface_id)
+                .or_else(|| Self::activate_surface(second, surface_id)),
+        }
+    }
+
+    fn rename_surface_node(
+        node: &mut PaneNode,
+        surface_id: SurfaceId,
+        title: Option<String>,
+    ) -> bool {
+        match node {
+            PaneNode::Leaf { surfaces, .. } => {
+                if let Some(surface) = surfaces.iter_mut().find(|surface| surface.id == surface_id)
+                {
+                    surface.title = title;
+                    true
+                } else {
+                    false
+                }
+            }
+            PaneNode::Split { first, second, .. } => {
+                Self::rename_surface_node(first, surface_id, title.clone())
+                    || Self::rename_surface_node(second, surface_id, title)
+            }
+        }
+    }
+
+    fn remove_surface(
+        node: &mut PaneNode,
+        surface_id: SurfaceId,
+    ) -> Option<(PaneId, TerminalPane)> {
+        match node {
+            PaneNode::Leaf {
+                id,
+                surfaces,
+                active_surface_id,
+            } => {
+                if surfaces.len() <= 1 {
+                    return None;
+                }
+                let index = surfaces
+                    .iter()
+                    .position(|surface| surface.id == surface_id)?;
+                let removed = surfaces.remove(index);
+                if *active_surface_id == surface_id {
+                    *active_surface_id = surfaces
+                        .get(index.saturating_sub(1))
+                        .or_else(|| surfaces.first())
+                        .map(|surface| surface.id)
+                        .expect("pane leaf must retain a surface");
+                }
+                Some((*id, removed.terminal))
+            }
+            PaneNode::Split { first, second, .. } => Self::remove_surface(first, surface_id)
+                .or_else(|| Self::remove_surface(second, surface_id)),
         }
     }
 
@@ -547,15 +892,24 @@ impl PaneTree {
         focused_id: PaneId,
         has_splits: bool,
         begin_drag_cb: std::sync::Arc<dyn Fn(SplitId, f32) + 'static>,
+        focus_surface_cb: std::sync::Arc<dyn Fn(SurfaceId, &mut Window, &mut App) + 'static>,
         cx: &App,
     ) -> AnyElement {
         let theme = cx.theme();
 
         match node {
-            PaneNode::Leaf { terminal, .. } => div()
-                .size_full()
-                .child(terminal.render_child())
-                .into_any_element(),
+            PaneNode::Leaf {
+                id,
+                surfaces,
+                active_surface_id,
+            } => Self::render_leaf(
+                *id,
+                surfaces,
+                *active_surface_id,
+                focused_id,
+                focus_surface_cb,
+                cx,
+            ),
             PaneNode::Split {
                 split_id,
                 direction,
@@ -570,9 +924,19 @@ impl PaneTree {
                 let cb_first = begin_drag_cb.clone();
                 let cb_second = begin_drag_cb.clone();
                 let cb_divider = begin_drag_cb.clone();
+                let focus_cb_first = focus_surface_cb.clone();
+                let focus_cb_second = focus_surface_cb.clone();
 
-                let first_el = Self::render_node(first, focused_id, has_splits, cb_first, cx);
-                let second_el = Self::render_node(second, focused_id, has_splits, cb_second, cx);
+                let first_el =
+                    Self::render_node(first, focused_id, has_splits, cb_first, focus_cb_first, cx);
+                let second_el = Self::render_node(
+                    second,
+                    focused_id,
+                    has_splits,
+                    cb_second,
+                    focus_cb_second,
+                    cx,
+                );
 
                 let divider_id = ElementId::Name(format!("divider-{}", sid).into());
                 let divider = match dir {
@@ -657,10 +1021,135 @@ impl PaneTree {
         }
     }
 
+    fn render_zoomed_leaf(
+        node: &PaneNode,
+        target_id: PaneId,
+        focused_id: PaneId,
+        focus_surface_cb: std::sync::Arc<dyn Fn(SurfaceId, &mut Window, &mut App) + 'static>,
+        cx: &App,
+    ) -> Option<AnyElement> {
+        match node {
+            PaneNode::Leaf {
+                id,
+                surfaces,
+                active_surface_id,
+            } if *id == target_id => Some(Self::render_leaf(
+                *id,
+                surfaces,
+                *active_surface_id,
+                focused_id,
+                focus_surface_cb,
+                cx,
+            )),
+            PaneNode::Leaf { .. } => None,
+            PaneNode::Split { first, second, .. } => {
+                Self::render_zoomed_leaf(first, target_id, focused_id, focus_surface_cb.clone(), cx)
+                    .or_else(|| {
+                        Self::render_zoomed_leaf(
+                            second,
+                            target_id,
+                            focused_id,
+                            focus_surface_cb,
+                            cx,
+                        )
+                    })
+            }
+        }
+    }
+
+    fn render_leaf(
+        pane_id: PaneId,
+        surfaces: &[PaneSurface],
+        active_surface_id: SurfaceId,
+        focused_id: PaneId,
+        focus_surface_cb: std::sync::Arc<dyn Fn(SurfaceId, &mut Window, &mut App) + 'static>,
+        cx: &App,
+    ) -> AnyElement {
+        let theme = cx.theme();
+        let active = Self::active_surface(surfaces, active_surface_id)
+            .unwrap_or_else(|| surfaces.first().expect("pane leaf must have a surface"));
+        let terminal = active.terminal.render_child();
+        if surfaces.len() <= 1 {
+            return div().size_full().child(terminal).into_any_element();
+        }
+
+        let mut strip = div()
+            .flex()
+            .items_center()
+            .gap(px(3.0))
+            .h(px(24.0))
+            .w_full()
+            .px(px(6.0))
+            .bg(theme
+                .background
+                .opacity(if pane_id == focused_id { 0.20 } else { 0.12 }))
+            .overflow_hidden();
+
+        for (index, surface) in surfaces.iter().enumerate() {
+            let is_active = surface.id == active_surface_id;
+            let title = surface
+                .title
+                .clone()
+                .or_else(|| surface.terminal.title(cx))
+                .unwrap_or_else(|| format!("Surface {}", index + 1));
+            let color = if is_active {
+                theme.foreground.opacity(0.86)
+            } else {
+                theme.foreground.opacity(0.46)
+            };
+            let bg = if is_active {
+                theme.foreground.opacity(0.075)
+            } else {
+                theme.transparent
+            };
+            let sid = surface.id;
+            let focus_cb = focus_surface_cb.clone();
+            strip = strip.child(
+                div()
+                    .id(ElementId::Name(format!("surface-tab-{sid}").into()))
+                    .flex()
+                    .items_center()
+                    .h(px(18.0))
+                    .max_w(px(180.0))
+                    .min_w(px(0.0))
+                    .px(px(6.0))
+                    .rounded(px(5.0))
+                    .bg(bg)
+                    .cursor_pointer()
+                    .hover(|s| s.bg(theme.foreground.opacity(0.10)))
+                    .on_mouse_down(MouseButton::Left, move |_event, window, cx| {
+                        focus_cb(sid, window, cx);
+                    })
+                    .child(
+                        div()
+                            .truncate()
+                            .text_xs()
+                            .line_height(px(13.0))
+                            .text_color(color)
+                            .child(title),
+                    ),
+            );
+        }
+
+        div()
+            .flex()
+            .flex_col()
+            .size_full()
+            .child(strip)
+            .child(div().flex_1().min_h_0().overflow_hidden().child(terminal))
+            .into_any_element()
+    }
+
     fn find_focused_pane(node: &PaneNode, window: &Window, cx: &App) -> Option<PaneId> {
         match node {
-            PaneNode::Leaf { id, terminal } => {
-                if terminal.is_focused(window, cx) {
+            PaneNode::Leaf {
+                id,
+                surfaces,
+                active_surface_id,
+            } => {
+                if let Some(surface) = Self::active_surface(surfaces, *active_surface_id)
+                    && surface.terminal.is_focused(window, cx)
+                {
                     Some(*id)
                 } else {
                     None
@@ -673,7 +1162,15 @@ impl PaneTree {
 
     fn check_terminal_pane_id(node: &PaneNode, entity_id: EntityId, pane_id: PaneId) -> bool {
         match node {
-            PaneNode::Leaf { id, terminal } => *id == pane_id && terminal.entity_id() == entity_id,
+            PaneNode::Leaf {
+                id,
+                surfaces,
+                active_surface_id,
+            } => {
+                *id == pane_id
+                    && Self::active_surface(surfaces, *active_surface_id)
+                        .is_some_and(|surface| surface.terminal.entity_id() == entity_id)
+            }
             PaneNode::Split { first, second, .. } => {
                 Self::check_terminal_pane_id(first, entity_id, pane_id)
                     || Self::check_terminal_pane_id(second, entity_id, pane_id)
@@ -683,8 +1180,11 @@ impl PaneTree {
 
     fn find_pane_id_by_entity_id(node: &PaneNode, entity_id: EntityId) -> Option<PaneId> {
         match node {
-            PaneNode::Leaf { id, terminal } => {
-                if terminal.entity_id() == entity_id {
+            PaneNode::Leaf { id, surfaces, .. } => {
+                if surfaces
+                    .iter()
+                    .any(|surface| surface.terminal.entity_id() == entity_id)
+                {
                     Some(*id)
                 } else {
                     None
@@ -699,8 +1199,14 @@ impl PaneTree {
 
     fn collect_pane_terminals(node: &PaneNode, result: &mut Vec<(PaneId, TerminalPane)>) {
         match node {
-            PaneNode::Leaf { id, terminal } => {
-                result.push((*id, terminal.clone()));
+            PaneNode::Leaf {
+                id,
+                surfaces,
+                active_surface_id,
+            } => {
+                if let Some(surface) = Self::active_surface(surfaces, *active_surface_id) {
+                    result.push((*id, surface.terminal.clone()));
+                }
             }
             PaneNode::Split { first, second, .. } => {
                 Self::collect_pane_terminals(first, result);
@@ -709,11 +1215,90 @@ impl PaneTree {
         }
     }
 
+    fn collect_surface_infos(
+        node: &PaneNode,
+        target_pane_id: Option<PaneId>,
+        focused_pane_id: PaneId,
+        pane_index: &mut usize,
+        result: &mut Vec<PaneSurfaceInfo>,
+    ) {
+        match node {
+            PaneNode::Leaf {
+                id,
+                surfaces,
+                active_surface_id,
+            } => {
+                *pane_index += 1;
+                if target_pane_id.is_some_and(|target| target != *id) {
+                    return;
+                }
+                result.extend(surfaces.iter().enumerate().map(|(surface_index, surface)| {
+                    PaneSurfaceInfo {
+                        pane_id: *id,
+                        pane_index: *pane_index,
+                        surface_id: surface.id,
+                        surface_index: surface_index + 1,
+                        is_active: surface.id == *active_surface_id,
+                        is_focused_pane: *id == focused_pane_id,
+                        title: surface.title.clone(),
+                        owner: surface.owner.clone(),
+                        close_pane_when_last: surface.close_pane_when_last,
+                        terminal: surface.terminal.clone(),
+                    }
+                }));
+            }
+            PaneNode::Split { first, second, .. } => {
+                Self::collect_surface_infos(
+                    first,
+                    target_pane_id,
+                    focused_pane_id,
+                    pane_index,
+                    result,
+                );
+                Self::collect_surface_infos(
+                    second,
+                    target_pane_id,
+                    focused_pane_id,
+                    pane_index,
+                    result,
+                );
+            }
+        }
+    }
+
+    fn find_active_surface_id(node: &PaneNode, pane_id: PaneId) -> Option<SurfaceId> {
+        match node {
+            PaneNode::Leaf {
+                id,
+                active_surface_id,
+                ..
+            } if *id == pane_id => Some(*active_surface_id),
+            PaneNode::Leaf { .. } => None,
+            PaneNode::Split { first, second, .. } => Self::find_active_surface_id(first, pane_id)
+                .or_else(|| Self::find_active_surface_id(second, pane_id)),
+        }
+    }
+
+    fn active_surface(
+        surfaces: &[PaneSurface],
+        active_surface_id: SurfaceId,
+    ) -> Option<&PaneSurface> {
+        surfaces
+            .iter()
+            .find(|surface| surface.id == active_surface_id)
+            .or_else(|| surfaces.first())
+    }
+
     fn node_to_state(node: &PaneNode, cx: &App) -> PaneLayoutState {
         match node {
-            PaneNode::Leaf { id, terminal } => PaneLayoutState::Leaf {
+            PaneNode::Leaf {
+                id,
+                surfaces,
+                active_surface_id,
+            } => PaneLayoutState::Leaf {
                 pane_id: *id,
-                cwd: terminal.current_dir(cx),
+                cwd: Self::active_surface(surfaces, *active_surface_id)
+                    .and_then(|surface| surface.terminal.current_dir(cx)),
             },
             PaneNode::Split {
                 direction,
@@ -740,7 +1325,8 @@ impl PaneTree {
         match state {
             PaneLayoutState::Leaf { pane_id, cwd } => PaneNode::Leaf {
                 id: *pane_id,
-                terminal: make_terminal(cwd.as_deref()),
+                surfaces: vec![PaneSurface::new(*pane_id, make_terminal(cwd.as_deref()))],
+                active_surface_id: *pane_id,
             },
             PaneLayoutState::Split {
                 direction,

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -85,6 +85,20 @@ impl SurfaceCreateOptions {
     }
 }
 
+pub struct SurfaceCloseOutcome {
+    pub pane_id: PaneId,
+    pub terminal: TerminalPane,
+    pub closed_pane: bool,
+}
+
+struct SurfaceCloseCandidate {
+    pane_id: PaneId,
+    terminal: TerminalPane,
+    is_last_surface: bool,
+    owner: Option<String>,
+    close_pane_when_last: bool,
+}
+
 /// A node in the pane tree — either a pane slot or a split.
 enum PaneNode {
     Leaf {
@@ -331,8 +345,33 @@ impl PaneTree {
         Self::rename_surface_node(&mut self.root, surface_id, title)
     }
 
-    pub fn close_surface(&mut self, surface_id: SurfaceId) -> Option<(PaneId, TerminalPane)> {
-        let removed = Self::remove_surface(&mut self.root, surface_id)?;
+    pub fn close_surface(
+        &mut self,
+        surface_id: SurfaceId,
+        close_empty_owned_pane: bool,
+    ) -> Option<SurfaceCloseOutcome> {
+        let candidate = Self::surface_close_candidate(&self.root, surface_id)?;
+        let outcome = if candidate.is_last_surface {
+            let can_close_pane = close_empty_owned_pane
+                && candidate.owner.is_some()
+                && candidate.close_pane_when_last
+                && self.pane_count() > 1;
+            if !can_close_pane || !self.close_pane(candidate.pane_id) {
+                return None;
+            }
+            SurfaceCloseOutcome {
+                pane_id: candidate.pane_id,
+                terminal: candidate.terminal,
+                closed_pane: true,
+            }
+        } else {
+            let removed = Self::remove_surface(&mut self.root, surface_id)?;
+            SurfaceCloseOutcome {
+                pane_id: removed.0,
+                terminal: removed.1,
+                closed_pane: false,
+            }
+        };
         if self.pane_count() <= 1
             || self
                 .zoomed_pane_id
@@ -343,7 +382,7 @@ impl PaneTree {
         if Self::find_terminal(&self.root, self.focused_pane_id).is_none() {
             self.focused_pane_id = Self::first_pane_id(&self.root);
         }
-        Some(removed)
+        Some(outcome)
     }
 
     /// Close the focused pane, returning true if the tree still has panes
@@ -876,6 +915,28 @@ impl PaneTree {
         }
     }
 
+    fn surface_close_candidate(
+        node: &PaneNode,
+        surface_id: SurfaceId,
+    ) -> Option<SurfaceCloseCandidate> {
+        match node {
+            PaneNode::Leaf { id, surfaces, .. } => {
+                let surface = surfaces.iter().find(|surface| surface.id == surface_id)?;
+                Some(SurfaceCloseCandidate {
+                    pane_id: *id,
+                    terminal: surface.terminal.clone(),
+                    is_last_surface: surfaces.len() <= 1,
+                    owner: surface.owner.clone(),
+                    close_pane_when_last: surface.close_pane_when_last,
+                })
+            }
+            PaneNode::Split { first, second, .. } => {
+                Self::surface_close_candidate(first, surface_id)
+                    .or_else(|| Self::surface_close_candidate(second, surface_id))
+            }
+        }
+    }
+
     #[allow(dead_code)]
     fn remove_leaf(node: PaneNode, target_id: PaneId) -> PaneNode {
         match node {
@@ -1091,6 +1152,7 @@ impl PaneTree {
         }
 
         let mut strip = div()
+            .id(("surface-tab-strip", pane_id))
             .flex()
             .items_center()
             .gap(px(3.0))
@@ -1100,7 +1162,7 @@ impl PaneTree {
             .bg(theme
                 .background
                 .opacity(if pane_id == focused_id { 0.20 } else { 0.12 }))
-            .overflow_hidden();
+            .overflow_x_scroll();
 
         for (index, surface) in surfaces.iter().enumerate() {
             let is_active = surface.id == active_surface_id;
@@ -1128,7 +1190,7 @@ impl PaneTree {
                     .items_center()
                     .h(px(18.0))
                     .max_w(px(180.0))
-                    .min_w(px(0.0))
+                    .flex_shrink_0()
                     .px(px(6.0))
                     .bg(bg)
                     .cursor_pointer()
@@ -1178,14 +1240,11 @@ impl PaneTree {
 
     fn check_terminal_pane_id(node: &PaneNode, entity_id: EntityId, pane_id: PaneId) -> bool {
         match node {
-            PaneNode::Leaf {
-                id,
-                surfaces,
-                active_surface_id,
-            } => {
+            PaneNode::Leaf { id, surfaces, .. } => {
                 *id == pane_id
-                    && Self::active_surface(surfaces, *active_surface_id)
-                        .is_some_and(|surface| surface.terminal.entity_id() == entity_id)
+                    && surfaces
+                        .iter()
+                        .any(|surface| surface.terminal.entity_id() == entity_id)
             }
             PaneNode::Split { first, second, .. } => {
                 Self::check_terminal_pane_id(first, entity_id, pane_id)

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -1119,7 +1119,6 @@ impl PaneTree {
                     .max_w(px(180.0))
                     .min_w(px(0.0))
                     .px(px(6.0))
-                    .rounded(px(5.0))
                     .bg(bg)
                     .cursor_pointer()
                     .hover(|s| s.bg(theme.foreground.opacity(0.10)))

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -146,7 +146,8 @@ impl PaneTree {
         focused_pane_id: Option<PaneId>,
         make_terminal: &mut impl FnMut(Option<&str>) -> TerminalPane,
     ) -> Self {
-        let mut root = Self::node_from_state(layout, make_terminal);
+        let mut restored_surface_id = 0;
+        let mut root = Self::node_from_state(layout, make_terminal, &mut restored_surface_id);
         let mut next_split_id = 0;
         Self::normalize_split_ids(&mut root, &mut next_split_id);
         let next_id = Self::max_pane_id(&root).saturating_add(1);
@@ -1358,13 +1359,18 @@ impl PaneTree {
     fn node_from_state(
         state: &PaneLayoutState,
         make_terminal: &mut impl FnMut(Option<&str>) -> TerminalPane,
+        next_surface_id: &mut SurfaceId,
     ) -> PaneNode {
         match state {
-            PaneLayoutState::Leaf { pane_id, cwd } => PaneNode::Leaf {
-                id: *pane_id,
-                surfaces: vec![PaneSurface::new(*pane_id, make_terminal(cwd.as_deref()))],
-                active_surface_id: *pane_id,
-            },
+            PaneLayoutState::Leaf { pane_id, cwd } => {
+                let surface_id = *next_surface_id;
+                *next_surface_id = (*next_surface_id).saturating_add(1);
+                PaneNode::Leaf {
+                    id: *pane_id,
+                    surfaces: vec![PaneSurface::new(surface_id, make_terminal(cwd.as_deref()))],
+                    active_surface_id: surface_id,
+                }
+            }
             PaneLayoutState::Split {
                 direction,
                 ratio,
@@ -1376,8 +1382,12 @@ impl PaneTree {
                     PaneSplitDirection::Horizontal => SplitDirection::Horizontal,
                     PaneSplitDirection::Vertical => SplitDirection::Vertical,
                 },
-                first: Box::new(Self::node_from_state(first, make_terminal)),
-                second: Box::new(Self::node_from_state(second, make_terminal)),
+                first: Box::new(Self::node_from_state(first, make_terminal, next_surface_id)),
+                second: Box::new(Self::node_from_state(
+                    second,
+                    make_terminal,
+                    next_surface_id,
+                )),
                 ratio: ratio.clamp(0.05, 0.95),
             },
         }

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -2710,6 +2710,10 @@ impl ConWorkspace {
         }
     }
 
+    fn tab_index_for_summary_id(&self, tab_id: u64) -> Option<usize> {
+        self.tabs.iter().position(|tab| tab.summary_id == tab_id)
+    }
+
     fn pane_selector_from_target(target: con_core::PaneTarget) -> con_agent::tools::PaneSelector {
         con_agent::tools::PaneSelector::new(target.pane_index, target.pane_id)
     }
@@ -3403,20 +3407,32 @@ impl ConWorkspace {
                 timeout_secs,
             } => match self.resolve_control_tab_index(tab_index) {
                 Ok(tab_idx) => {
+                    let requested_tab_index = tab_idx + 1;
+                    let tab_id = self.tabs[tab_idx].summary_id;
+                    let surface_id = match self.resolve_surface_target_for_tab(tab_idx, target) {
+                        Ok(resolved) => resolved.surface_id,
+                        Err(err) => {
+                            Self::send_control_result(response_tx, Err(err));
+                            return;
+                        }
+                    };
                     let timeout = Duration::from_secs(timeout_secs.unwrap_or(10).clamp(1, 300));
                     let started = std::time::Instant::now();
                     cx.spawn(async move |this, cx| {
                         loop {
                             let result = this.update(cx, |workspace, cx| {
-                                if tab_idx >= workspace.tabs.len() {
+                                let Some(current_tab_idx) =
+                                    workspace.tab_index_for_summary_id(tab_id)
+                                else {
                                     return Some(Err(ControlError::invalid_params(format!(
                                         "Tab {} is no longer available.",
-                                        tab_idx + 1
+                                        requested_tab_index
                                     ))));
-                                }
-                                let resolved = match workspace
-                                    .resolve_surface_target_for_tab(tab_idx, target)
-                                {
+                                };
+                                let resolved = match workspace.resolve_surface_target_for_tab(
+                                    current_tab_idx,
+                                    con_core::SurfaceTarget::new(None, None, Some(surface_id)),
+                                ) {
                                     Ok(resolved) => resolved,
                                     Err(err) => return Some(Err(err)),
                                 };
@@ -3425,8 +3441,12 @@ impl ConWorkspace {
                                 let timed_out = started.elapsed() >= timeout;
                                 if is_ready || timed_out {
                                     let status = if is_ready { "ready" } else { "timeout" };
-                                    Some(Ok(workspace
-                                        .surface_wait_ready_result(tab_idx, &resolved, status, cx)))
+                                    Some(Ok(workspace.surface_wait_ready_result(
+                                        current_tab_idx,
+                                        &resolved,
+                                        status,
+                                        cx,
+                                    )))
                                 } else {
                                     None
                                 }

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -1359,7 +1359,7 @@ impl ConWorkspace {
         }
 
         let pane_tree = &self.tabs[self.active_tab].pane_tree;
-        let pane_terminals = pane_tree.pane_terminals();
+        let surface_terminals = pane_tree.surface_terminals();
         let focused_id = pane_tree.focused_pane_id();
         let (mode, is_broadcast, is_focused, selected_ids) = {
             let input_bar = self.input_bar.read(cx);
@@ -1370,9 +1370,9 @@ impl ConWorkspace {
                 input_bar.scope_selected_ids(),
             )
         };
-        let all_ids = pane_terminals
+        let all_ids = surface_terminals
             .iter()
-            .map(|(pane_id, _)| *pane_id)
+            .map(|(pane_id, _, _)| *pane_id)
             .collect::<HashSet<_>>();
 
         let target_ids: HashSet<usize> = if mode == InputMode::Agent || is_focused {
@@ -1391,8 +1391,8 @@ impl ConWorkspace {
             }
         };
 
-        for (pane_id, terminal) in pane_terminals {
-            terminal.set_focus_state(target_ids.contains(&pane_id), cx);
+        for (pane_id, is_active_surface, terminal) in surface_terminals {
+            terminal.set_focus_state(is_active_surface && target_ids.contains(&pane_id), cx);
         }
     }
 
@@ -2015,6 +2015,9 @@ impl ConWorkspace {
                         .find(|surface| surface.surface_id == resolved.surface_id)
                         .cloned();
                     let surface_count = surfaces.len();
+                    let closing_was_focused = current
+                        .as_ref()
+                        .is_some_and(|surface| surface.is_active && surface.is_focused_pane);
                     if surface_count > 1 {
                         let Some((_pane_id, closing)) = self.tabs[tab_idx]
                             .pane_tree
@@ -2029,10 +2032,17 @@ impl ConWorkspace {
                             );
                             continue;
                         };
+                        closing.set_focus_state(false, cx);
                         closing.set_native_view_visible(false, cx);
                         closing.shutdown_surface(cx);
                         if tab_idx == self.active_tab {
                             self.sync_active_tab_native_view_visibility(cx);
+                            if closing_was_focused {
+                                let replacement =
+                                    self.tabs[tab_idx].pane_tree.focused_terminal().clone();
+                                replacement.ensure_surface(window, cx);
+                                replacement.focus(window, cx);
+                            }
                             self.sync_active_terminal_focus_states(cx);
                         }
                         self.save_session(cx);

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -215,7 +215,7 @@ use crate::input_bar::{
 };
 use crate::model_registry::ModelRegistry;
 use crate::motion::MotionValue;
-use crate::pane_tree::{PaneTree, SplitDirection, SplitPlacement};
+use crate::pane_tree::{PaneTree, SplitDirection, SplitPlacement, SurfaceCreateOptions};
 use crate::settings_panel::{
     self, AppearancePreview, SaveSettings, SettingsPanel, TabsOrientationChanged, ThemePreview,
 };
@@ -382,6 +382,8 @@ pub struct ConWorkspace {
     pending_create_pane_requests: Vec<PendingCreatePane>,
     /// Pending window-aware control requests such as tab lifecycle mutations.
     pending_window_control_requests: Vec<PendingWindowControlRequest>,
+    /// Pending surface-control requests that need a window context to allocate a terminal view.
+    pending_surface_control_requests: Vec<PendingSurfaceControlRequest>,
     /// Control-plane requests from the external `con-cli` socket bridge.
     control_request_rx: crossbeam_channel::Receiver<ControlRequestEnvelope>,
     /// Keeps the Unix socket alive for this workspace instance.
@@ -424,6 +426,15 @@ struct ResolvedPaneTarget {
     pane_id: usize,
 }
 
+#[derive(Clone)]
+struct ResolvedSurfaceTarget {
+    terminal: TerminalPane,
+    pane_index: usize,
+    pane_id: usize,
+    surface_index: usize,
+    surface_id: usize,
+}
+
 /// A deferred create-pane request waiting for a window-aware context.
 struct PendingCreatePane {
     command: Option<String>,
@@ -438,6 +449,34 @@ enum PendingWindowControlRequest {
     },
     TabsClose {
         tab_idx: usize,
+        response_tx: oneshot::Sender<ControlResult>,
+    },
+}
+
+enum PendingSurfaceControlRequest {
+    Create {
+        tab_idx: usize,
+        pane: con_core::PaneTarget,
+        title: Option<String>,
+        command: Option<String>,
+        owner: Option<String>,
+        close_pane_when_last: bool,
+        response_tx: oneshot::Sender<ControlResult>,
+    },
+    Split {
+        tab_idx: usize,
+        source: con_core::SurfaceTarget,
+        location: con_agent::tools::PaneCreateLocation,
+        title: Option<String>,
+        command: Option<String>,
+        owner: Option<String>,
+        close_pane_when_last: bool,
+        response_tx: oneshot::Sender<ControlResult>,
+    },
+    Close {
+        tab_idx: usize,
+        target: con_core::SurfaceTarget,
+        close_empty_owned_pane: bool,
         response_tx: oneshot::Sender<ControlResult>,
     },
 }
@@ -1149,7 +1188,7 @@ impl ConWorkspace {
         // Hide non-active tabs' ghostty NSViews so only the active tab is visible
         for (i, tab) in tabs.iter().enumerate() {
             if i != active_tab {
-                for terminal in tab.pane_tree.all_terminals() {
+                for terminal in tab.pane_tree.all_surface_terminals() {
                     terminal.set_native_view_visible(false, cx);
                 }
             }
@@ -1254,6 +1293,7 @@ impl ConWorkspace {
             last_window_resize_increment_millipoints: None,
             pending_create_pane_requests: Vec::new(),
             pending_window_control_requests: Vec::new(),
+            pending_surface_control_requests: Vec::new(),
             control_request_rx,
             control_socket,
             pending_control_agent_requests: HashMap::new(),
@@ -1362,9 +1402,12 @@ impl ConWorkspace {
         };
         let zoomed_pane_id = tab.pane_tree.zoomed_pane_id();
 
-        for (pane_id, terminal) in tab.pane_tree.pane_terminals() {
-            let pane_visible = visible && zoomed_pane_id.is_none_or(|zoomed| zoomed == pane_id);
-            terminal.set_native_view_visible(pane_visible, cx);
+        for surface in tab.pane_tree.surface_infos(None) {
+            let pane_visible =
+                visible && zoomed_pane_id.is_none_or(|zoomed| zoomed == surface.pane_id);
+            surface
+                .terminal
+                .set_native_view_visible(pane_visible && surface.is_active, cx);
         }
     }
 
@@ -1383,9 +1426,9 @@ impl ConWorkspace {
             return;
         };
 
-        for (pane_id, terminal) in tab.pane_tree.pane_terminals() {
-            if pane_id != zoomed_pane_id {
-                terminal.set_native_view_visible(false, cx);
+        for surface in tab.pane_tree.surface_infos(None) {
+            if surface.pane_id != zoomed_pane_id || !surface.is_active {
+                surface.terminal.set_native_view_visible(false, cx);
             }
         }
     }
@@ -1489,7 +1532,7 @@ impl ConWorkspace {
         let mut drain_count = 0usize;
 
         for tab in &self.tabs {
-            for terminal in tab.pane_tree.all_terminals() {
+            for terminal in tab.pane_tree.all_surface_terminals() {
                 terminal_count += 1;
                 changed |= terminal.pump_surface_deferred_work(cx);
             }
@@ -1513,7 +1556,7 @@ impl ConWorkspace {
         self.last_ghostty_wake_generation = generation;
         for (tab_index, tab) in self.tabs.iter().enumerate() {
             let sync_native_scroll = tab_index == self.active_tab;
-            for terminal in tab.pane_tree.all_terminals() {
+            for terminal in tab.pane_tree.all_surface_terminals() {
                 drain_count += 1;
                 changed |= terminal.drain_surface_state_with_native_scroll(sync_native_scroll, cx);
             }
@@ -1635,6 +1678,7 @@ impl ConWorkspace {
                     let _ = workspace.update(cx, |workspace, cx| {
                         workspace.flush_pending_window_control_requests(window, cx);
                         workspace.flush_pending_create_pane_requests(window, cx);
+                        workspace.flush_pending_surface_control_requests(window, cx);
                     });
                 }
             });
@@ -1773,6 +1817,315 @@ impl ConWorkspace {
         }
 
         cx.notify();
+        window.refresh();
+    }
+
+    fn flush_pending_surface_control_requests(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let pending = std::mem::take(&mut self.pending_surface_control_requests);
+        if pending.is_empty() {
+            return;
+        }
+
+        for request in pending {
+            match request {
+                PendingSurfaceControlRequest::Create {
+                    tab_idx,
+                    pane,
+                    title,
+                    command,
+                    owner,
+                    close_pane_when_last,
+                    response_tx,
+                } => {
+                    if tab_idx >= self.tabs.len() {
+                        Self::send_control_result(
+                            response_tx,
+                            Err(ControlError::invalid_params(format!(
+                                "Tab {} is no longer available.",
+                                tab_idx + 1
+                            ))),
+                        );
+                        continue;
+                    }
+                    let resolved = match self
+                        .resolve_pane_target_for_tab(tab_idx, Self::pane_selector_from_target(pane))
+                    {
+                        Ok(resolved) => resolved,
+                        Err(err) => {
+                            Self::send_control_result(
+                                response_tx,
+                                Err(ControlError::invalid_params(err)),
+                            );
+                            continue;
+                        }
+                    };
+                    let cwd = resolved.pane.current_dir(cx);
+                    let terminal = self.create_terminal(cwd.as_deref(), window, cx);
+                    let options = SurfaceCreateOptions {
+                        title,
+                        owner,
+                        close_pane_when_last,
+                    };
+                    let Some(surface_id) = self.tabs[tab_idx].pane_tree.create_surface_in_pane(
+                        resolved.pane_id,
+                        terminal.clone(),
+                        options,
+                    ) else {
+                        Self::send_control_result(
+                            response_tx,
+                            Err(ControlError::invalid_params(format!(
+                                "Pane id {} is no longer available in tab {}.",
+                                resolved.pane_id,
+                                tab_idx + 1
+                            ))),
+                        );
+                        continue;
+                    };
+                    if tab_idx == self.active_tab {
+                        #[cfg(target_os = "macos")]
+                        self.mark_tab_terminal_native_layout_pending(tab_idx, cx);
+                        self.notify_tab_terminal_views(tab_idx, cx);
+                        self.sync_active_tab_native_view_visibility_now_or_after_layout(
+                            false, window, cx,
+                        );
+                    }
+                    self.finish_created_surface(
+                        tab_idx,
+                        resolved.pane_id,
+                        surface_id,
+                        terminal,
+                        command,
+                        false,
+                        response_tx,
+                        window,
+                        cx,
+                    );
+                }
+                PendingSurfaceControlRequest::Split {
+                    tab_idx,
+                    source,
+                    location,
+                    title,
+                    command,
+                    owner,
+                    close_pane_when_last,
+                    response_tx,
+                } => {
+                    if tab_idx >= self.tabs.len() {
+                        Self::send_control_result(
+                            response_tx,
+                            Err(ControlError::invalid_params(format!(
+                                "Tab {} is no longer available.",
+                                tab_idx + 1
+                            ))),
+                        );
+                        continue;
+                    }
+                    let resolved = match self.resolve_surface_target_for_tab(tab_idx, source) {
+                        Ok(resolved) => resolved,
+                        Err(err) => {
+                            Self::send_control_result(response_tx, Err(err));
+                            continue;
+                        }
+                    };
+                    let cwd = resolved.terminal.current_dir(cx);
+                    let terminal = self.create_terminal(cwd.as_deref(), window, cx);
+                    let direction = match location {
+                        con_agent::tools::PaneCreateLocation::Right => SplitDirection::Horizontal,
+                        con_agent::tools::PaneCreateLocation::Down => SplitDirection::Vertical,
+                    };
+                    let was_zoomed = self.tabs[tab_idx].pane_tree.zoomed_pane_id().is_some();
+                    let options = SurfaceCreateOptions {
+                        title,
+                        owner: Some(owner.unwrap_or_else(|| "con-cli".to_string())),
+                        close_pane_when_last,
+                    };
+                    let Some((pane_id, surface_id)) = self.tabs[tab_idx]
+                        .pane_tree
+                        .split_pane_with_surface_options(
+                            resolved.pane_id,
+                            direction,
+                            SplitPlacement::After,
+                            terminal.clone(),
+                            options,
+                        )
+                    else {
+                        Self::send_control_result(
+                            response_tx,
+                            Err(ControlError::invalid_params(format!(
+                                "{} is no longer available in tab {}.",
+                                source.describe(),
+                                tab_idx + 1
+                            ))),
+                        );
+                        continue;
+                    };
+                    if tab_idx == self.active_tab {
+                        #[cfg(target_os = "macos")]
+                        self.mark_tab_terminal_native_layout_pending(tab_idx, cx);
+                        self.notify_tab_terminal_views(tab_idx, cx);
+                        self.sync_active_tab_native_view_visibility_now_or_after_layout(
+                            was_zoomed, window, cx,
+                        );
+                    }
+                    self.finish_created_surface(
+                        tab_idx,
+                        pane_id,
+                        surface_id,
+                        terminal,
+                        command,
+                        true,
+                        response_tx,
+                        window,
+                        cx,
+                    );
+                }
+                PendingSurfaceControlRequest::Close {
+                    tab_idx,
+                    target,
+                    close_empty_owned_pane,
+                    response_tx,
+                } => {
+                    if tab_idx >= self.tabs.len() {
+                        Self::send_control_result(
+                            response_tx,
+                            Err(ControlError::invalid_params(format!(
+                                "Tab {} is no longer available.",
+                                tab_idx + 1
+                            ))),
+                        );
+                        continue;
+                    }
+                    let resolved = match self.resolve_surface_target_for_tab(tab_idx, target) {
+                        Ok(resolved) => resolved,
+                        Err(err) => {
+                            Self::send_control_result(response_tx, Err(err));
+                            continue;
+                        }
+                    };
+                    let surfaces = self.tabs[tab_idx]
+                        .pane_tree
+                        .surface_infos(Some(resolved.pane_id));
+                    let current = surfaces
+                        .iter()
+                        .find(|surface| surface.surface_id == resolved.surface_id)
+                        .cloned();
+                    let surface_count = surfaces.len();
+                    if surface_count > 1 {
+                        let Some((_pane_id, closing)) = self.tabs[tab_idx]
+                            .pane_tree
+                            .close_surface(resolved.surface_id)
+                        else {
+                            Self::send_control_result(
+                                response_tx,
+                                Err(ControlError::invalid_params(format!(
+                                    "Surface id {} could not be closed.",
+                                    resolved.surface_id
+                                ))),
+                            );
+                            continue;
+                        };
+                        closing.set_native_view_visible(false, cx);
+                        closing.shutdown_surface(cx);
+                        if tab_idx == self.active_tab {
+                            self.sync_active_tab_native_view_visibility(cx);
+                            self.sync_active_terminal_focus_states(cx);
+                        }
+                        self.save_session(cx);
+                        Self::send_control_result(
+                            response_tx,
+                            Ok(json!({
+                                "status": "closed",
+                                "closed_pane": false,
+                                "tab_index": tab_idx + 1,
+                                "pane_id": resolved.pane_id,
+                                "surface_id": resolved.surface_id,
+                            })),
+                        );
+                    } else {
+                        let owned_empty_close = current.as_ref().is_some_and(|surface| {
+                            surface.owner.is_some() && surface.close_pane_when_last
+                        });
+                        if close_empty_owned_pane
+                            && owned_empty_close
+                            && self.tabs[tab_idx].pane_tree.pane_count() > 1
+                        {
+                            let closed =
+                                self.close_pane_in_tab(tab_idx, resolved.pane_id, window, cx);
+                            Self::send_control_result(
+                                response_tx,
+                                Ok(json!({
+                                    "status": if closed { "closed" } else { "unchanged" },
+                                    "closed_pane": closed,
+                                    "tab_index": tab_idx + 1,
+                                    "pane_id": resolved.pane_id,
+                                    "surface_id": resolved.surface_id,
+                                })),
+                            );
+                        } else {
+                            Self::send_control_result(
+                                response_tx,
+                                Err(ControlError::invalid_params(
+                                    "Refusing to close the last surface in a pane unless it is an owned ephemeral pane and close_empty_owned_pane=true.",
+                                )),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        cx.notify();
+        window.refresh();
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn finish_created_surface(
+        &mut self,
+        tab_idx: usize,
+        pane_id: usize,
+        surface_id: usize,
+        terminal: TerminalPane,
+        command: Option<String>,
+        created_pane: bool,
+        response_tx: oneshot::Sender<ControlResult>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let tab_is_active = tab_idx == self.active_tab;
+        if tab_is_active {
+            terminal.focus(window, cx);
+            self.sync_active_terminal_focus_states(cx);
+            self.sync_active_tab_native_view_visibility(cx);
+        } else {
+            terminal.set_focus_state(false, cx);
+            terminal.set_native_view_visible(false, cx);
+        }
+        Self::schedule_terminal_bootstrap_reassert(
+            &terminal,
+            tab_is_active,
+            self.window_handle,
+            self.workspace_handle.clone(),
+            cx,
+        );
+        if let Some(cmd) = &command {
+            terminal.write(format!("{cmd}\n").as_bytes(), cx);
+        }
+        self.record_runtime_event_for_terminal(
+            tab_idx,
+            &terminal,
+            con_agent::context::PaneRuntimeEvent::PaneCreated {
+                startup_command: command.clone(),
+            },
+        );
+        let result =
+            self.surface_created_result(tab_idx, pane_id, surface_id, created_pane, &terminal, cx);
+        Self::send_control_result(response_tx, Ok(result));
+        self.save_session(cx);
     }
 
     fn reconcile_runtime_trackers_for_tab(&self, tab_idx: usize) {
@@ -1956,6 +2309,191 @@ impl ConWorkspace {
                 pane_index: focused_pane_index,
                 pane_id: focused_pane_id,
             }),
+        }
+    }
+
+    fn resolve_surface_target_for_tab(
+        &self,
+        tab_idx: usize,
+        target: con_core::SurfaceTarget,
+    ) -> Result<ResolvedSurfaceTarget, ControlError> {
+        let pane_tree = &self.tabs[tab_idx].pane_tree;
+        let surfaces = pane_tree.surface_infos(None);
+        if let Some(surface_id) = target.surface_id {
+            let surface = surfaces
+                .into_iter()
+                .find(|surface| surface.surface_id == surface_id)
+                .ok_or_else(|| {
+                    ControlError::invalid_params(format!(
+                        "Surface id {} is no longer available in tab {}.",
+                        surface_id,
+                        tab_idx + 1
+                    ))
+                })?;
+            if let Some(pane_id) = target.pane_id
+                && pane_id != surface.pane_id
+            {
+                return Err(ControlError::invalid_params(format!(
+                    "Surface id {} belongs to pane id {}, not pane id {}.",
+                    surface_id, surface.pane_id, pane_id
+                )));
+            }
+            if let Some(pane_index) = target.pane_index
+                && pane_index != surface.pane_index
+            {
+                return Err(ControlError::invalid_params(format!(
+                    "Surface id {} belongs to pane {}, not pane {}.",
+                    surface_id, surface.pane_index, pane_index
+                )));
+            }
+            return Ok(ResolvedSurfaceTarget {
+                terminal: surface.terminal,
+                pane_index: surface.pane_index,
+                pane_id: surface.pane_id,
+                surface_index: surface.surface_index,
+                surface_id,
+            });
+        }
+
+        let resolved_pane = self
+            .resolve_pane_target_for_tab(
+                tab_idx,
+                Self::pane_selector_from_target(target.pane_target()),
+            )
+            .map_err(ControlError::invalid_params)?;
+        let surface_id = pane_tree
+            .active_surface_id_for_pane(resolved_pane.pane_id)
+            .ok_or_else(|| {
+                ControlError::invalid_params(format!(
+                    "Pane id {} has no active surface in tab {}.",
+                    resolved_pane.pane_id,
+                    tab_idx + 1
+                ))
+            })?;
+        let surface = pane_tree
+            .surface_infos(Some(resolved_pane.pane_id))
+            .into_iter()
+            .find(|surface| surface.surface_id == surface_id)
+            .ok_or_else(|| {
+                ControlError::invalid_params(format!(
+                    "Surface id {} is no longer available in tab {}.",
+                    surface_id,
+                    tab_idx + 1
+                ))
+            })?;
+        Ok(ResolvedSurfaceTarget {
+            terminal: surface.terminal,
+            pane_index: surface.pane_index,
+            pane_id: surface.pane_id,
+            surface_index: surface.surface_index,
+            surface_id,
+        })
+    }
+
+    fn surface_created_result(
+        &self,
+        tab_idx: usize,
+        pane_id: usize,
+        surface_id: usize,
+        created_pane: bool,
+        terminal: &TerminalPane,
+        cx: &App,
+    ) -> serde_json::Value {
+        let pane_tree = &self.tabs[tab_idx].pane_tree;
+        let pane_index = pane_tree
+            .pane_terminals()
+            .into_iter()
+            .enumerate()
+            .find_map(|(index, (candidate, _))| (candidate == pane_id).then_some(index + 1))
+            .unwrap_or(1);
+        let surface_index = pane_tree
+            .surface_infos(Some(pane_id))
+            .into_iter()
+            .find_map(|surface| (surface.surface_id == surface_id).then_some(surface.surface_index))
+            .unwrap_or(1);
+        json!({
+            "tab_index": tab_idx + 1,
+            "created_pane": created_pane,
+            "pane_index": pane_index,
+            "pane_id": pane_id,
+            "pane_ref": format!("pane:{pane_index}"),
+            "surface_index": surface_index,
+            "surface_id": surface_id,
+            "surface_ref": format!("surface:{surface_index}"),
+            "surface_ready": terminal.surface_ready(cx),
+            "is_alive": terminal.is_alive(cx),
+            "has_shell_integration": terminal.has_shell_integration(cx),
+        })
+    }
+
+    fn surface_wait_ready_result(
+        &self,
+        tab_idx: usize,
+        resolved: &ResolvedSurfaceTarget,
+        status: &str,
+        cx: &App,
+    ) -> serde_json::Value {
+        json!({
+            "status": status,
+            "tab_index": tab_idx + 1,
+            "pane_index": resolved.pane_index,
+            "pane_id": resolved.pane_id,
+            "surface_index": resolved.surface_index,
+            "surface_id": resolved.surface_id,
+            "surface_ready": resolved.terminal.surface_ready(cx),
+            "is_alive": resolved.terminal.is_alive(cx),
+            "has_shell_integration": resolved.terminal.has_shell_integration(cx),
+            "is_busy": resolved.terminal.is_busy(cx),
+        })
+    }
+
+    fn surface_info_value(
+        &self,
+        tab_idx: usize,
+        surface: crate::pane_tree::PaneSurfaceInfo,
+        cx: &App,
+    ) -> serde_json::Value {
+        let title = surface
+            .title
+            .clone()
+            .or_else(|| surface.terminal.title(cx))
+            .unwrap_or_else(|| format!("Surface {}", surface.surface_index));
+        let (cols, rows) = surface.terminal.grid_size(cx);
+        json!({
+            "tab_index": tab_idx + 1,
+            "pane_index": surface.pane_index,
+            "pane_id": surface.pane_id,
+            "pane_ref": format!("pane:{}", surface.pane_index),
+            "surface_index": surface.surface_index,
+            "surface_id": surface.surface_id,
+            "surface_ref": format!("surface:{}", surface.surface_index),
+            "title": title,
+            "cwd": surface.terminal.current_dir(cx),
+            "is_active": surface.is_active,
+            "is_focused_pane": surface.is_focused_pane,
+            "surface_ready": surface.terminal.surface_ready(cx),
+            "is_alive": surface.terminal.is_alive(cx),
+            "has_shell_integration": surface.terminal.has_shell_integration(cx),
+            "is_busy": surface.terminal.is_busy(cx),
+            "rows": rows,
+            "cols": cols,
+            "owner": surface.owner,
+            "close_pane_when_last": surface.close_pane_when_last,
+        })
+    }
+
+    fn surface_key_bytes(key: &str) -> Result<Vec<u8>, ControlError> {
+        match key.trim().to_ascii_lowercase().as_str() {
+            "escape" | "esc" => Ok(vec![0x1b]),
+            "enter" | "return" => Ok(b"\n".to_vec()),
+            "tab" => Ok(b"\t".to_vec()),
+            "backspace" => Ok(vec![0x7f]),
+            "ctrl-c" | "control-c" | "c-c" => Ok(vec![0x03]),
+            "ctrl-d" | "control-d" | "c-d" => Ok(vec![0x04]),
+            other if other.len() == 1 => Ok(other.as_bytes().to_vec()),
+            _ => Err(ControlError::invalid_params(format!(
+                "Unsupported surface key `{key}`. Supported keys: escape, enter, tab, backspace, ctrl-c, ctrl-d."
+            ))),
         }
     }
 
@@ -2560,6 +3098,362 @@ impl ConWorkspace {
                     Err(err) => Self::send_control_result(response_tx, Err(err)),
                 }
             }
+            ControlCommand::TreeGet { tab_index } => {
+                match self.resolve_control_tab_index(tab_index) {
+                    Ok(tab_idx) => {
+                        let tabs = self
+                        .tabs
+                        .iter()
+                        .enumerate()
+                        .filter(|(idx, _)| tab_index.is_none() || *idx == tab_idx)
+                        .map(|(idx, tab)| {
+                            let panes = tab
+                                .pane_tree
+                                .pane_terminals()
+                                .into_iter()
+                                .enumerate()
+                                .map(|(pane_index, (pane_id, terminal))| {
+                                    let surfaces = tab
+                                        .pane_tree
+                                        .surface_infos(Some(pane_id))
+                                        .into_iter()
+                                        .map(|surface| self.surface_info_value(idx, surface, cx))
+                                        .collect::<Vec<_>>();
+                                    json!({
+                                        "pane_index": pane_index + 1,
+                                        "pane_id": pane_id,
+                                        "pane_ref": format!("pane:{}", pane_index + 1),
+                                        "title": terminal.title(cx).unwrap_or_else(|| format!("Pane {}", pane_index + 1)),
+                                        "is_focused": pane_id == tab.pane_tree.focused_pane_id(),
+                                        "active_surface_id": tab.pane_tree.active_surface_id_for_pane(pane_id),
+                                        "surfaces": surfaces,
+                                    })
+                                })
+                                .collect::<Vec<_>>();
+                            json!({
+                                "tab_index": idx + 1,
+                                "is_active": idx == self.active_tab,
+                                "title": tab.title,
+                                "focused_pane_id": tab.pane_tree.focused_pane_id(),
+                                "panes": panes,
+                            })
+                        })
+                        .collect::<Vec<_>>();
+                        Self::send_control_result(
+                            response_tx,
+                            Ok(json!({
+                                "active_tab_index": self.active_tab + 1,
+                                "tabs": tabs,
+                            })),
+                        );
+                    }
+                    Err(err) => Self::send_control_result(response_tx, Err(err)),
+                }
+            }
+            ControlCommand::SurfacesList { tab_index, pane } => {
+                match self.resolve_control_tab_index(tab_index) {
+                    Ok(tab_idx) => {
+                        let target_pane_id = if pane.pane_index.is_some() || pane.pane_id.is_some()
+                        {
+                            match self.resolve_pane_target_for_tab(
+                                tab_idx,
+                                Self::pane_selector_from_target(pane),
+                            ) {
+                                Ok(resolved) => Some(resolved.pane_id),
+                                Err(err) => {
+                                    Self::send_control_result(
+                                        response_tx,
+                                        Err(ControlError::invalid_params(err)),
+                                    );
+                                    return;
+                                }
+                            }
+                        } else {
+                            None
+                        };
+                        let surfaces = self.tabs[tab_idx]
+                            .pane_tree
+                            .surface_infos(target_pane_id)
+                            .into_iter()
+                            .map(|surface| self.surface_info_value(tab_idx, surface, cx))
+                            .collect::<Vec<_>>();
+                        Self::send_control_result(
+                            response_tx,
+                            Ok(json!({
+                                "tab_index": tab_idx + 1,
+                                "surfaces": surfaces,
+                            })),
+                        );
+                    }
+                    Err(err) => Self::send_control_result(response_tx, Err(err)),
+                }
+            }
+            ControlCommand::SurfacesCreate {
+                tab_index,
+                pane,
+                title,
+                command,
+                owner,
+                close_pane_when_last,
+            } => match self.resolve_control_tab_index(tab_index) {
+                Ok(tab_idx) => {
+                    self.pending_surface_control_requests.push(
+                        PendingSurfaceControlRequest::Create {
+                            tab_idx,
+                            pane,
+                            title,
+                            command,
+                            owner,
+                            close_pane_when_last,
+                            response_tx,
+                        },
+                    );
+                    self.schedule_pending_create_pane_flush(cx);
+                }
+                Err(err) => Self::send_control_result(response_tx, Err(err)),
+            },
+            ControlCommand::SurfacesSplit {
+                tab_index,
+                source,
+                location,
+                title,
+                command,
+                owner,
+                close_pane_when_last,
+            } => match self.resolve_control_tab_index(tab_index) {
+                Ok(tab_idx) => {
+                    self.pending_surface_control_requests.push(
+                        PendingSurfaceControlRequest::Split {
+                            tab_idx,
+                            source,
+                            location,
+                            title,
+                            command,
+                            owner,
+                            close_pane_when_last,
+                            response_tx,
+                        },
+                    );
+                    self.schedule_pending_create_pane_flush(cx);
+                }
+                Err(err) => Self::send_control_result(response_tx, Err(err)),
+            },
+            ControlCommand::SurfacesFocus { tab_index, target } => {
+                match self.resolve_control_tab_index(tab_index) {
+                    Ok(tab_idx) => match self.resolve_surface_target_for_tab(tab_idx, target) {
+                        Ok(resolved) => {
+                            let focused = self.tabs[tab_idx]
+                                .pane_tree
+                                .focus_surface(resolved.surface_id);
+                            if tab_idx == self.active_tab {
+                                self.sync_active_tab_native_view_visibility(cx);
+                                self.sync_active_terminal_focus_states(cx);
+                            }
+                            Self::send_control_result(
+                                response_tx,
+                                Ok(json!({
+                                    "status": if focused { "focused" } else { "unchanged" },
+                                    "tab_index": tab_idx + 1,
+                                    "pane_index": resolved.pane_index,
+                                    "pane_id": resolved.pane_id,
+                                    "surface_index": resolved.surface_index,
+                                    "surface_id": resolved.surface_id,
+                                })),
+                            );
+                        }
+                        Err(err) => Self::send_control_result(response_tx, Err(err)),
+                    },
+                    Err(err) => Self::send_control_result(response_tx, Err(err)),
+                }
+            }
+            ControlCommand::SurfacesRename {
+                tab_index,
+                target,
+                title,
+            } => match self.resolve_control_tab_index(tab_index) {
+                Ok(tab_idx) => match self.resolve_surface_target_for_tab(tab_idx, target) {
+                    Ok(resolved) => {
+                        self.tabs[tab_idx]
+                            .pane_tree
+                            .rename_surface(resolved.surface_id, Some(title.clone()));
+                        self.sync_sidebar(cx);
+                        Self::send_control_result(
+                            response_tx,
+                            Ok(json!({
+                                "status": "renamed",
+                                "tab_index": tab_idx + 1,
+                                "pane_id": resolved.pane_id,
+                                "surface_id": resolved.surface_id,
+                                "title": title,
+                            })),
+                        );
+                        cx.notify();
+                    }
+                    Err(err) => Self::send_control_result(response_tx, Err(err)),
+                },
+                Err(err) => Self::send_control_result(response_tx, Err(err)),
+            },
+            ControlCommand::SurfacesClose {
+                tab_index,
+                target,
+                close_empty_owned_pane,
+            } => match self.resolve_control_tab_index(tab_index) {
+                Ok(tab_idx) => {
+                    self.pending_surface_control_requests.push(
+                        PendingSurfaceControlRequest::Close {
+                            tab_idx,
+                            target,
+                            close_empty_owned_pane,
+                            response_tx,
+                        },
+                    );
+                    self.schedule_pending_create_pane_flush(cx);
+                }
+                Err(err) => Self::send_control_result(response_tx, Err(err)),
+            },
+            ControlCommand::SurfacesRead {
+                tab_index,
+                target,
+                lines,
+            } => match self.resolve_control_tab_index(tab_index) {
+                Ok(tab_idx) => match self.resolve_surface_target_for_tab(tab_idx, target) {
+                    Ok(resolved) => Self::send_control_result(
+                        response_tx,
+                        Ok(json!({
+                            "tab_index": tab_idx + 1,
+                            "pane_id": resolved.pane_id,
+                            "surface_id": resolved.surface_id,
+                            "content": resolved.terminal.recent_lines(lines, cx).join("\n"),
+                        })),
+                    ),
+                    Err(err) => Self::send_control_result(response_tx, Err(err)),
+                },
+                Err(err) => Self::send_control_result(response_tx, Err(err)),
+            },
+            ControlCommand::SurfacesSendText {
+                tab_index,
+                target,
+                text,
+            } => match self.resolve_control_tab_index(tab_index) {
+                Ok(tab_idx) => match self.resolve_surface_target_for_tab(tab_idx, target) {
+                    Ok(resolved) => {
+                        resolved.terminal.write(text.as_bytes(), cx);
+                        self.record_runtime_event_for_terminal(
+                            tab_idx,
+                            &resolved.terminal,
+                            con_agent::context::PaneRuntimeEvent::RawInput {
+                                keys: text,
+                                input_generation: resolved.terminal.input_generation(cx),
+                            },
+                        );
+                        Self::send_control_result(
+                            response_tx,
+                            Ok(json!({
+                                "status": "sent",
+                                "tab_index": tab_idx + 1,
+                                "pane_id": resolved.pane_id,
+                                "surface_id": resolved.surface_id,
+                            })),
+                        );
+                    }
+                    Err(err) => Self::send_control_result(response_tx, Err(err)),
+                },
+                Err(err) => Self::send_control_result(response_tx, Err(err)),
+            },
+            ControlCommand::SurfacesSendKey {
+                tab_index,
+                target,
+                key,
+            } => match self.resolve_control_tab_index(tab_index) {
+                Ok(tab_idx) => match self.resolve_surface_target_for_tab(tab_idx, target) {
+                    Ok(resolved) => match Self::surface_key_bytes(&key) {
+                        Ok(bytes) => {
+                            resolved.terminal.write(&bytes, cx);
+                            self.record_runtime_event_for_terminal(
+                                tab_idx,
+                                &resolved.terminal,
+                                con_agent::context::PaneRuntimeEvent::RawInput {
+                                    keys: key,
+                                    input_generation: resolved.terminal.input_generation(cx),
+                                },
+                            );
+                            Self::send_control_result(
+                                response_tx,
+                                Ok(json!({
+                                    "status": "sent",
+                                    "tab_index": tab_idx + 1,
+                                    "pane_id": resolved.pane_id,
+                                    "surface_id": resolved.surface_id,
+                                })),
+                            );
+                        }
+                        Err(err) => Self::send_control_result(response_tx, Err(err)),
+                    },
+                    Err(err) => Self::send_control_result(response_tx, Err(err)),
+                },
+                Err(err) => Self::send_control_result(response_tx, Err(err)),
+            },
+            ControlCommand::SurfacesWaitReady {
+                tab_index,
+                target,
+                timeout_secs,
+            } => match self.resolve_control_tab_index(tab_index) {
+                Ok(tab_idx) => {
+                    let timeout = Duration::from_secs(timeout_secs.unwrap_or(10).clamp(1, 300));
+                    let started = std::time::Instant::now();
+                    cx.spawn(async move |this, cx| {
+                        loop {
+                            let result = this.update(cx, |workspace, cx| {
+                                if tab_idx >= workspace.tabs.len() {
+                                    return Some(Err(ControlError::invalid_params(format!(
+                                        "Tab {} is no longer available.",
+                                        tab_idx + 1
+                                    ))));
+                                }
+                                let resolved = match workspace
+                                    .resolve_surface_target_for_tab(tab_idx, target)
+                                {
+                                    Ok(resolved) => resolved,
+                                    Err(err) => return Some(Err(err)),
+                                };
+                                let is_ready = resolved.terminal.surface_ready(cx)
+                                    && resolved.terminal.is_alive(cx);
+                                let timed_out = started.elapsed() >= timeout;
+                                if is_ready || timed_out {
+                                    let status = if is_ready { "ready" } else { "timeout" };
+                                    Some(Ok(workspace
+                                        .surface_wait_ready_result(tab_idx, &resolved, status, cx)))
+                                } else {
+                                    None
+                                }
+                            });
+
+                            match result {
+                                Ok(Some(result)) => {
+                                    Self::send_control_result(response_tx, result);
+                                    return;
+                                }
+                                Ok(None) => {}
+                                Err(err) => {
+                                    Self::send_control_result(
+                                        response_tx,
+                                        Err(ControlError::internal(format!(
+                                            "Failed to wait for surface readiness: {err}"
+                                        ))),
+                                    );
+                                    return;
+                                }
+                            }
+
+                            cx.background_executor()
+                                .timer(Duration::from_millis(50))
+                                .await;
+                        }
+                    })
+                    .detach();
+                }
+                Err(err) => Self::send_control_result(response_tx, Err(err)),
+            },
             ControlCommand::TmuxInspect { tab_index, target } => {
                 match self.resolve_control_tab_index(tab_index) {
                     Ok(tab_idx) => self.spawn_control_pane_query(
@@ -3972,7 +4866,7 @@ impl ConWorkspace {
         let colors = theme_to_ghostty_colors(theme);
         // Update all terminal panes (legacy gets full theme, ghostty gets color scheme)
         for tab in &self.tabs {
-            for terminal in tab.pane_tree.all_terminals() {
+            for terminal in tab.pane_tree.all_surface_terminals() {
                 terminal.set_theme(
                     theme,
                     &colors,
@@ -4006,7 +4900,7 @@ impl ConWorkspace {
             log::error!("Failed to update Ghostty appearance: {}", e);
         }
         for tab in &self.tabs {
-            for terminal in tab.pane_tree.all_terminals() {
+            for terminal in tab.pane_tree.all_surface_terminals() {
                 terminal.sync_window_background_blur(cx);
             }
         }
@@ -4501,7 +5395,6 @@ impl ConWorkspace {
     ) {
         use con_agent::{PaneInfo, PaneQuery, PaneResponse};
 
-        log::info!("[workspace] handle_pane_request entered");
         let pane_tree = &self.tabs[tab_idx].pane_tree;
         let focused_pid = pane_tree.focused_pane_id();
         let all_terminals = pane_tree.all_terminals();
@@ -5617,7 +6510,7 @@ impl ConWorkspace {
         // Hide views and unfocus first, then clear the tabs vector so GhosttyTerminal
         // Drop runs (calling ghostty_surface_free) before cx.quit() exits the process.
         for tab in &self.tabs {
-            for t in tab.pane_tree.all_terminals() {
+            for t in tab.pane_tree.all_surface_terminals() {
                 t.set_focus_state(false, cx);
                 t.set_native_view_visible(false, cx);
             }
@@ -5894,7 +6787,7 @@ impl ConWorkspace {
             .update(cx, |panel, cx| panel.swap_state(incoming, cx));
         self.tabs[old_active].panel_state = outgoing;
 
-        for t in self.tabs[old_active].pane_tree.all_terminals() {
+        for t in self.tabs[old_active].pane_tree.all_surface_terminals() {
             t.set_focus_state(false, cx);
         }
         for terminal in self.tabs[self.active_tab].pane_tree.all_terminals() {
@@ -5903,7 +6796,7 @@ impl ConWorkspace {
         self.sync_active_tab_native_view_visibility(cx);
         let old_terminals: Vec<TerminalPane> = self.tabs[old_active]
             .pane_tree
-            .all_terminals()
+            .all_surface_terminals()
             .into_iter()
             .cloned()
             .collect();
@@ -5953,14 +6846,20 @@ impl ConWorkspace {
         // If the active tab has multiple panes, close the focused pane first.
         // Only close the entire tab when it's down to a single pane.
         if self.tabs[self.active_tab].pane_tree.pane_count() > 1 {
-            let (closing, surviving_terminals, new_focus) = {
+            let (closing_terminals, surviving_terminals, new_focus) = {
                 let tab = &mut self.tabs[self.active_tab];
-                let closing = tab.pane_tree.focused_terminal().clone();
+                let pane_id = tab.pane_tree.focused_pane_id();
+                let closing_terminals = tab
+                    .pane_tree
+                    .surface_infos(Some(pane_id))
+                    .into_iter()
+                    .map(|surface| surface.terminal)
+                    .collect::<Vec<_>>();
                 tab.pane_tree.close_focused();
                 let surviving_terminals: Vec<TerminalPane> =
                     tab.pane_tree.all_terminals().into_iter().cloned().collect();
                 let new_focus = tab.pane_tree.focused_terminal().clone();
-                (closing, surviving_terminals, new_focus)
+                (closing_terminals, surviving_terminals, new_focus)
             };
             #[cfg(target_os = "macos")]
             self.mark_active_tab_terminal_native_layout_pending(cx);
@@ -5974,7 +6873,9 @@ impl ConWorkspace {
             new_focus.focus(window, cx);
             self.sync_active_terminal_focus_states(cx);
             cx.on_next_frame(window, move |_workspace, _window, cx| {
-                closing.shutdown_surface(cx);
+                for terminal in &closing_terminals {
+                    terminal.shutdown_surface(cx);
+                }
                 for terminal in &surviving_terminals {
                     terminal.notify(cx);
                 }
@@ -5996,7 +6897,7 @@ impl ConWorkspace {
         }
         let closing_terminals: Vec<TerminalPane> = self.tabs[index]
             .pane_tree
-            .all_terminals()
+            .all_surface_terminals()
             .into_iter()
             .cloned()
             .collect();
@@ -6007,6 +6908,7 @@ impl ConWorkspace {
         }
         let was_active = index == self.active_tab;
         self.reindex_pending_control_agent_requests_after_tab_close(index);
+        self.reindex_pending_surface_control_requests_after_tab_close(index);
         let removed = self.tabs.remove(index);
         // Drop the closed tab's cached AI summary so a future tab
         // assigned the same summary_id (which won't happen, since
@@ -6110,11 +7012,25 @@ impl ConWorkspace {
             );
         }
 
+        for request in std::mem::take(&mut self.pending_surface_control_requests) {
+            let response_tx = match request {
+                PendingSurfaceControlRequest::Create { response_tx, .. }
+                | PendingSurfaceControlRequest::Split { response_tx, .. }
+                | PendingSurfaceControlRequest::Close { response_tx, .. } => response_tx,
+            };
+            Self::send_control_result(
+                response_tx,
+                Err(ControlError::internal(
+                    "window closed while a surface control request was pending".to_string(),
+                )),
+            );
+        }
+
         for tab in &self.tabs {
             let conv = tab.session.conversation();
             let _ = conv.lock().save();
 
-            for terminal in tab.pane_tree.all_terminals() {
+            for terminal in tab.pane_tree.all_surface_terminals() {
                 terminal.shutdown_surface(cx);
             }
         }
@@ -6142,6 +7058,110 @@ impl ConWorkspace {
             shifted.insert(next_idx, pending);
         }
         self.pending_control_agent_requests = shifted;
+    }
+
+    fn reindex_pending_surface_control_requests_after_tab_close(&mut self, closed_tab_idx: usize) {
+        let mut shifted = Vec::new();
+        for request in std::mem::take(&mut self.pending_surface_control_requests) {
+            match request {
+                PendingSurfaceControlRequest::Create {
+                    tab_idx,
+                    pane,
+                    title,
+                    command,
+                    owner,
+                    close_pane_when_last,
+                    response_tx,
+                } => {
+                    if tab_idx == closed_tab_idx {
+                        Self::send_control_result(
+                            response_tx,
+                            Err(ControlError::internal(format!(
+                                "Tab {} was closed while surfaces.create was pending",
+                                closed_tab_idx + 1
+                            ))),
+                        );
+                        continue;
+                    }
+                    shifted.push(PendingSurfaceControlRequest::Create {
+                        tab_idx: if tab_idx > closed_tab_idx {
+                            tab_idx - 1
+                        } else {
+                            tab_idx
+                        },
+                        pane,
+                        title,
+                        command,
+                        owner,
+                        close_pane_when_last,
+                        response_tx,
+                    });
+                }
+                PendingSurfaceControlRequest::Split {
+                    tab_idx,
+                    source,
+                    location,
+                    title,
+                    command,
+                    owner,
+                    close_pane_when_last,
+                    response_tx,
+                } => {
+                    if tab_idx == closed_tab_idx {
+                        Self::send_control_result(
+                            response_tx,
+                            Err(ControlError::internal(format!(
+                                "Tab {} was closed while surfaces.split was pending",
+                                closed_tab_idx + 1
+                            ))),
+                        );
+                        continue;
+                    }
+                    shifted.push(PendingSurfaceControlRequest::Split {
+                        tab_idx: if tab_idx > closed_tab_idx {
+                            tab_idx - 1
+                        } else {
+                            tab_idx
+                        },
+                        source,
+                        location,
+                        title,
+                        command,
+                        owner,
+                        close_pane_when_last,
+                        response_tx,
+                    });
+                }
+                PendingSurfaceControlRequest::Close {
+                    tab_idx,
+                    target,
+                    close_empty_owned_pane,
+                    response_tx,
+                } => {
+                    if tab_idx == closed_tab_idx {
+                        Self::send_control_result(
+                            response_tx,
+                            Err(ControlError::internal(format!(
+                                "Tab {} was closed while surfaces.close was pending",
+                                closed_tab_idx + 1
+                            ))),
+                        );
+                        continue;
+                    }
+                    shifted.push(PendingSurfaceControlRequest::Close {
+                        tab_idx: if tab_idx > closed_tab_idx {
+                            tab_idx - 1
+                        } else {
+                            tab_idx
+                        },
+                        target,
+                        close_empty_owned_pane,
+                        response_tx,
+                    });
+                }
+            }
+        }
+        self.pending_surface_control_requests = shifted;
     }
 
     fn record_shell_command(
@@ -6898,13 +7918,13 @@ impl ConWorkspace {
         let mut sync_visibility_after_close = false;
         {
             let pane_tree = &mut self.tabs[tab_idx].pane_tree;
-            let closing = pane_tree
-                .pane_terminals()
+            let closing_terminals = pane_tree
+                .surface_infos(Some(pane_id))
                 .into_iter()
-                .find(|(candidate_pane_id, _)| *candidate_pane_id == pane_id)
-                .map(|(_, terminal)| terminal);
+                .map(|surface| surface.terminal)
+                .collect::<Vec<_>>();
 
-            if closing.is_none() || !pane_tree.close_pane(pane_id) {
+            if closing_terminals.is_empty() || !pane_tree.close_pane(pane_id) {
                 return false;
             }
 
@@ -6919,16 +7939,16 @@ impl ConWorkspace {
                 sync_visibility_after_close = true;
             }
 
-            if let Some(closing) = closing {
-                cx.on_next_frame(window, move |_workspace, _window, cx| {
-                    closing.shutdown_surface(cx);
-                    if tab_is_visible {
-                        for terminal in &surviving_terminals {
-                            terminal.notify(cx);
-                        }
+            cx.on_next_frame(window, move |_workspace, _window, cx| {
+                for terminal in &closing_terminals {
+                    terminal.shutdown_surface(cx);
+                }
+                if tab_is_visible {
+                    for terminal in &surviving_terminals {
+                        terminal.notify(cx);
                     }
-                });
-            }
+                }
+            });
 
             if tab_idx == self.active_tab {
                 focus_after_close = Some(pane_tree.focused_terminal().clone());
@@ -6975,12 +7995,12 @@ impl ConWorkspace {
             terminal.ensure_surface(window, cx);
         }
         self.sync_tab_native_view_visibility(index, true, cx);
-        for terminal in self.tabs[old_active].pane_tree.all_terminals() {
+        for terminal in self.tabs[old_active].pane_tree.all_surface_terminals() {
             terminal.set_focus_state(false, cx);
         }
         let old_terminals: Vec<TerminalPane> = self.tabs[old_active]
             .pane_tree
-            .all_terminals()
+            .all_surface_terminals()
             .into_iter()
             .cloned()
             .collect();
@@ -7078,6 +8098,33 @@ impl ConWorkspace {
         self.sync_active_terminal_focus_states(cx);
     }
 
+    fn focus_surface_in_active_tab(
+        &mut self,
+        surface_id: usize,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.has_active_tab() {
+            return;
+        }
+        let changed = self.tabs[self.active_tab]
+            .pane_tree
+            .focus_surface(surface_id);
+        if !changed {
+            return;
+        }
+        let terminal = self.tabs[self.active_tab]
+            .pane_tree
+            .focused_terminal()
+            .clone();
+        terminal.ensure_surface(window, cx);
+        self.sync_active_tab_native_view_visibility(cx);
+        terminal.focus(window, cx);
+        self.sync_active_terminal_focus_states(cx);
+        self.save_session(cx);
+        cx.notify();
+    }
+
     fn restore_terminal_focus_after_modal(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if !self.has_active_tab() {
             return;
@@ -7109,7 +8156,7 @@ impl ConWorkspace {
         } else {
             // Hide all tabs' views for modal z-order
             for tab in &self.tabs {
-                for terminal in tab.pane_tree.all_terminals() {
+                for terminal in tab.pane_tree.all_surface_terminals() {
                     terminal.set_native_view_visible(false, cx);
                 }
             }
@@ -7142,31 +8189,55 @@ impl ConWorkspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        // Find which tab contains the dead pane (may not be the active tab).
+        // Find which tab contains the dead terminal surface (may not be the active tab).
         let entity_id = entity.entity_id();
         let tab_idx = self
             .tabs
             .iter()
             .position(|tab| tab.pane_tree.pane_id_for_entity(entity_id).is_some());
         let Some(tab_idx) = tab_idx else { return };
-        if let Some(terminal) = self.tabs[tab_idx]
+
+        let surface = self.tabs[tab_idx]
             .pane_tree
-            .all_terminals()
+            .surface_infos(None)
             .into_iter()
-            .find(|terminal| terminal.entity_id() == entity_id)
-        {
-            self.record_runtime_event_for_terminal(
-                tab_idx,
-                &terminal,
-                con_agent::context::PaneRuntimeEvent::ProcessExited,
-            );
+            .find(|surface| surface.terminal.entity_id() == entity_id);
+        let Some(surface) = surface else { return };
+        self.record_runtime_event_for_terminal(
+            tab_idx,
+            &surface.terminal,
+            con_agent::context::PaneRuntimeEvent::ProcessExited,
+        );
+
+        let pane_surface_count = self.tabs[tab_idx]
+            .pane_tree
+            .surface_infos(Some(surface.pane_id))
+            .len();
+        if pane_surface_count > 1 {
+            let should_focus_replacement =
+                tab_idx == self.active_tab && surface.is_active && surface.is_focused_pane;
+            if let Some((_pane_id, terminal)) = self.tabs[tab_idx]
+                .pane_tree
+                .close_surface(surface.surface_id)
+            {
+                terminal.set_native_view_visible(false, cx);
+                terminal.shutdown_surface(cx);
+            }
+            if tab_idx == self.active_tab {
+                self.sync_active_tab_native_view_visibility(cx);
+                if should_focus_replacement {
+                    let replacement = self.tabs[tab_idx].pane_tree.focused_terminal().clone();
+                    replacement.focus(window, cx);
+                }
+                self.sync_active_terminal_focus_states(cx);
+            }
+            self.save_session(cx);
+            cx.notify();
+            return;
         }
 
         if self.tabs[tab_idx].pane_tree.pane_count() > 1 {
-            let Some(pane_id) = self.tabs[tab_idx].pane_tree.pane_id_for_entity(entity_id) else {
-                return;
-            };
-            let _ = self.close_pane_in_tab(tab_idx, pane_id, window, cx);
+            let _ = self.close_pane_in_tab(tab_idx, surface.pane_id, window, cx);
         } else if self.tabs.len() > 1 {
             // Last pane in this tab — close the tab.
             self.close_tab_by_index(tab_idx, window, cx);
@@ -7233,10 +8304,11 @@ impl ConWorkspace {
 
         let origin_terminal = self.tabs[tab_idx]
             .pane_tree
-            .all_terminals()
+            .surface_infos(Some(origin_pane_id))
             .into_iter()
-            .find(|terminal| terminal.entity_id() == entity_id)
-            .cloned();
+            .find_map(|surface| {
+                (surface.terminal.entity_id() == entity_id).then_some(surface.terminal)
+            });
         let cwd = origin_terminal
             .as_ref()
             .and_then(|terminal| terminal.current_dir(cx));
@@ -7479,9 +8551,17 @@ impl Render for ConWorkspace {
                     *guard = Some((split_id, start_pos));
                 }
             };
+            let workspace = cx.weak_entity();
+            let focus_surface_cb = move |surface_id: usize, window: &mut Window, cx: &mut App| {
+                if let Some(workspace) = workspace.upgrade() {
+                    workspace.update(cx, |workspace, cx| {
+                        workspace.focus_surface_in_active_tab(surface_id, window, cx);
+                    });
+                }
+            };
             self.tabs[self.active_tab]
                 .pane_tree
-                .render(begin_drag_cb, cx)
+                .render(begin_drag_cb, focus_surface_cb, cx)
         };
 
         let mut terminal_area = div()

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -7180,104 +7180,39 @@ impl ConWorkspace {
 
     fn reindex_pending_surface_control_requests_after_tab_close(&mut self, closed_tab_idx: usize) {
         let mut shifted = Vec::new();
-        for request in std::mem::take(&mut self.pending_surface_control_requests) {
-            match request {
-                PendingSurfaceControlRequest::Create {
-                    tab_idx,
-                    pane,
-                    title,
-                    command,
-                    owner,
-                    close_pane_when_last,
-                    response_tx,
-                } => {
-                    if tab_idx == closed_tab_idx {
-                        Self::send_control_result(
-                            response_tx,
-                            Err(ControlError::internal(format!(
-                                "Tab {} was closed while surfaces.create was pending",
-                                closed_tab_idx + 1
-                            ))),
-                        );
-                        continue;
+        for mut request in std::mem::take(&mut self.pending_surface_control_requests) {
+            let tab_idx = match &mut request {
+                PendingSurfaceControlRequest::Create { tab_idx, .. }
+                | PendingSurfaceControlRequest::Split { tab_idx, .. }
+                | PendingSurfaceControlRequest::Close { tab_idx, .. } => tab_idx,
+            };
+
+            if *tab_idx == closed_tab_idx {
+                let (method, response_tx) = match request {
+                    PendingSurfaceControlRequest::Create { response_tx, .. } => {
+                        ("surfaces.create", response_tx)
                     }
-                    shifted.push(PendingSurfaceControlRequest::Create {
-                        tab_idx: if tab_idx > closed_tab_idx {
-                            tab_idx - 1
-                        } else {
-                            tab_idx
-                        },
-                        pane,
-                        title,
-                        command,
-                        owner,
-                        close_pane_when_last,
-                        response_tx,
-                    });
-                }
-                PendingSurfaceControlRequest::Split {
-                    tab_idx,
-                    source,
-                    location,
-                    title,
-                    command,
-                    owner,
-                    close_pane_when_last,
-                    response_tx,
-                } => {
-                    if tab_idx == closed_tab_idx {
-                        Self::send_control_result(
-                            response_tx,
-                            Err(ControlError::internal(format!(
-                                "Tab {} was closed while surfaces.split was pending",
-                                closed_tab_idx + 1
-                            ))),
-                        );
-                        continue;
+                    PendingSurfaceControlRequest::Split { response_tx, .. } => {
+                        ("surfaces.split", response_tx)
                     }
-                    shifted.push(PendingSurfaceControlRequest::Split {
-                        tab_idx: if tab_idx > closed_tab_idx {
-                            tab_idx - 1
-                        } else {
-                            tab_idx
-                        },
-                        source,
-                        location,
-                        title,
-                        command,
-                        owner,
-                        close_pane_when_last,
-                        response_tx,
-                    });
-                }
-                PendingSurfaceControlRequest::Close {
-                    tab_idx,
-                    target,
-                    close_empty_owned_pane,
-                    response_tx,
-                } => {
-                    if tab_idx == closed_tab_idx {
-                        Self::send_control_result(
-                            response_tx,
-                            Err(ControlError::internal(format!(
-                                "Tab {} was closed while surfaces.close was pending",
-                                closed_tab_idx + 1
-                            ))),
-                        );
-                        continue;
+                    PendingSurfaceControlRequest::Close { response_tx, .. } => {
+                        ("surfaces.close", response_tx)
                     }
-                    shifted.push(PendingSurfaceControlRequest::Close {
-                        tab_idx: if tab_idx > closed_tab_idx {
-                            tab_idx - 1
-                        } else {
-                            tab_idx
-                        },
-                        target,
-                        close_empty_owned_pane,
-                        response_tx,
-                    });
-                }
+                };
+                Self::send_control_result(
+                    response_tx,
+                    Err(ControlError::internal(format!(
+                        "Tab {} was closed while {method} was pending",
+                        closed_tab_idx + 1
+                    ))),
+                );
+                continue;
             }
+
+            if *tab_idx > closed_tab_idx {
+                *tab_idx -= 1;
+            }
+            shifted.push(request);
         }
         self.pending_surface_control_requests = shifted;
     }

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -1643,12 +1643,36 @@ impl ConWorkspace {
                             return false;
                         };
                         workspace.update(cx, |_workspace, cx| {
+                            let terminal_entity_id = terminal.entity_id();
+                            let terminal_still_owned = _workspace.tabs.iter().any(|tab| {
+                                tab.pane_tree
+                                    .all_surface_terminals()
+                                    .iter()
+                                    .any(|candidate| candidate.entity_id() == terminal_entity_id)
+                            });
+                            if !terminal_still_owned {
+                                terminal.set_focus_state(false, cx);
+                                return true;
+                            }
+
                             terminal.ensure_surface(window, cx);
                             terminal.notify(cx);
                             _workspace.sync_active_tab_native_view_visibility(cx);
                             if should_focus {
-                                _workspace.sync_active_terminal_focus_states(cx);
-                                terminal.focus(window, cx);
+                                let still_active_terminal = _workspace
+                                    .tabs
+                                    .get(_workspace.active_tab)
+                                    .is_some_and(|tab| {
+                                        tab.pane_tree.all_terminals().iter().any(|candidate| {
+                                            candidate.entity_id() == terminal_entity_id
+                                        })
+                                    });
+                                if still_active_terminal {
+                                    _workspace.sync_active_terminal_focus_states(cx);
+                                    terminal.focus(window, cx);
+                                } else {
+                                    terminal.set_focus_state(false, cx);
+                                }
                             } else {
                                 terminal.set_focus_state(false, cx);
                             }
@@ -1685,6 +1709,36 @@ impl ConWorkspace {
             if let Err(err) = result {
                 log::warn!(
                     "[control] failed to flush deferred pane creation in a window-aware context: {err}"
+                );
+            }
+        });
+    }
+
+    fn schedule_active_terminal_focus(&self, cx: &mut Context<Self>) {
+        let window_handle = self.window_handle;
+        let workspace_handle = self.workspace_handle.clone();
+        cx.defer(move |cx| {
+            let result = window_handle.update(cx, |_root, window, cx| {
+                if let Some(workspace) = workspace_handle.upgrade() {
+                    let _ = workspace.update(cx, |workspace, cx| {
+                        if !workspace.has_active_tab() {
+                            return;
+                        }
+                        let terminal = workspace.tabs[workspace.active_tab]
+                            .pane_tree
+                            .focused_terminal()
+                            .clone();
+                        terminal.ensure_surface(window, cx);
+                        workspace.sync_active_tab_native_view_visibility(cx);
+                        terminal.focus(window, cx);
+                        workspace.sync_active_terminal_focus_states(cx);
+                        cx.notify();
+                    });
+                }
+            });
+            if let Err(err) = result {
+                log::warn!(
+                    "[control] failed to focus active terminal in a window-aware context: {err}"
                 );
             }
         });
@@ -3263,6 +3317,7 @@ impl ConWorkspace {
                             if tab_idx == self.active_tab {
                                 self.sync_active_tab_native_view_visibility(cx);
                                 self.sync_active_terminal_focus_states(cx);
+                                self.schedule_active_terminal_focus(cx);
                             }
                             self.save_session(cx);
                             cx.notify();
@@ -4464,6 +4519,36 @@ impl ConWorkspace {
             }
         }
         self.pending_control_agent_requests = remapped_pending;
+
+        for pending in &mut self.pending_create_pane_requests {
+            if let Some(summary_id) = old_order.get(pending.tab_idx)
+                && let Some(&new_idx) = new_positions.get(summary_id)
+            {
+                pending.tab_idx = new_idx;
+            }
+        }
+
+        for pending in &mut self.pending_window_control_requests {
+            if let PendingWindowControlRequest::TabsClose { tab_idx, .. } = pending
+                && let Some(summary_id) = old_order.get(*tab_idx)
+                && let Some(&new_idx) = new_positions.get(summary_id)
+            {
+                *tab_idx = new_idx;
+            }
+        }
+
+        for pending in &mut self.pending_surface_control_requests {
+            let tab_idx = match pending {
+                PendingSurfaceControlRequest::Create { tab_idx, .. }
+                | PendingSurfaceControlRequest::Split { tab_idx, .. }
+                | PendingSurfaceControlRequest::Close { tab_idx, .. } => tab_idx,
+            };
+            if let Some(summary_id) = old_order.get(*tab_idx)
+                && let Some(&new_idx) = new_positions.get(summary_id)
+            {
+                *tab_idx = new_idx;
+            }
+        }
 
         // Re-locate the active tab by stable summary_id rather than
         // index arithmetic (which had its own off-by-one in the

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -3251,6 +3251,7 @@ impl ConWorkspace {
                                 self.sync_active_terminal_focus_states(cx);
                             }
                             self.save_session(cx);
+                            cx.notify();
                             Self::send_control_result(
                                 response_tx,
                                 Ok(json!({

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -3311,20 +3311,31 @@ impl ConWorkspace {
                 match self.resolve_control_tab_index(tab_index) {
                     Ok(tab_idx) => match self.resolve_surface_target_for_tab(tab_idx, target) {
                         Ok(resolved) => {
-                            let focused = self.tabs[tab_idx]
-                                .pane_tree
-                                .focus_surface(resolved.surface_id);
-                            if tab_idx == self.active_tab {
+                            let surface_id = resolved.surface_id;
+                            let changed = self.tabs[tab_idx].pane_tree.focus_surface(surface_id);
+                            let resolved = match self.resolve_surface_target_for_tab(
+                                tab_idx,
+                                con_core::SurfaceTarget::new(None, None, Some(surface_id)),
+                            ) {
+                                Ok(resolved) => resolved,
+                                Err(err) => {
+                                    Self::send_control_result(response_tx, Err(err));
+                                    return;
+                                }
+                            };
+                            if changed && tab_idx == self.active_tab {
                                 self.sync_active_tab_native_view_visibility(cx);
                                 self.sync_active_terminal_focus_states(cx);
                                 self.schedule_active_terminal_focus(cx);
                             }
-                            self.save_session(cx);
-                            cx.notify();
+                            if changed {
+                                self.save_session(cx);
+                                cx.notify();
+                            }
                             Self::send_control_result(
                                 response_tx,
                                 Ok(json!({
-                                    "status": if focused { "focused" } else { "unchanged" },
+                                    "status": if changed { "focused" } else { "unchanged" },
                                     "tab_index": tab_idx + 1,
                                     "pane_index": resolved.pane_index,
                                     "pane_id": resolved.pane_id,

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -3250,6 +3250,7 @@ impl ConWorkspace {
                                 self.sync_active_tab_native_view_visibility(cx);
                                 self.sync_active_terminal_focus_states(cx);
                             }
+                            self.save_session(cx);
                             Self::send_control_result(
                                 response_tx,
                                 Ok(json!({
@@ -3278,6 +3279,7 @@ impl ConWorkspace {
                             .pane_tree
                             .rename_surface(resolved.surface_id, Some(title.clone()));
                         self.sync_sidebar(cx);
+                        self.save_session(cx);
                         Self::send_control_result(
                             response_tx,
                             Ok(json!({

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -2068,77 +2068,63 @@ impl ConWorkspace {
                         .iter()
                         .find(|surface| surface.surface_id == resolved.surface_id)
                         .cloned();
-                    let surface_count = surfaces.len();
                     let closing_was_focused = current
                         .as_ref()
                         .is_some_and(|surface| surface.is_active && surface.is_focused_pane);
-                    if surface_count > 1 {
-                        let Some((_pane_id, closing)) = self.tabs[tab_idx]
-                            .pane_tree
-                            .close_surface(resolved.surface_id)
-                        else {
-                            Self::send_control_result(
-                                response_tx,
-                                Err(ControlError::invalid_params(format!(
-                                    "Surface id {} could not be closed.",
-                                    resolved.surface_id
-                                ))),
-                            );
-                            continue;
-                        };
-                        closing.set_focus_state(false, cx);
-                        closing.set_native_view_visible(false, cx);
-                        closing.shutdown_surface(cx);
-                        if tab_idx == self.active_tab {
-                            self.sync_active_tab_native_view_visibility(cx);
-                            if closing_was_focused {
-                                let replacement =
-                                    self.tabs[tab_idx].pane_tree.focused_terminal().clone();
-                                replacement.ensure_surface(window, cx);
-                                replacement.focus(window, cx);
-                            }
-                            self.sync_active_terminal_focus_states(cx);
-                        }
-                        self.save_session(cx);
+                    let Some(close_outcome) = self.tabs[tab_idx]
+                        .pane_tree
+                        .close_surface(resolved.surface_id, close_empty_owned_pane)
+                    else {
                         Self::send_control_result(
                             response_tx,
-                            Ok(json!({
-                                "status": "closed",
-                                "closed_pane": false,
-                                "tab_index": tab_idx + 1,
-                                "pane_id": resolved.pane_id,
-                                "surface_id": resolved.surface_id,
-                            })),
+                            Err(ControlError::invalid_params(
+                                "Refusing to close the last surface in a pane unless it is an owned ephemeral pane and close_empty_owned_pane=true.",
+                            )),
                         );
-                    } else {
-                        let owned_empty_close = current.as_ref().is_some_and(|surface| {
-                            surface.owner.is_some() && surface.close_pane_when_last
-                        });
-                        if close_empty_owned_pane
-                            && owned_empty_close
-                            && self.tabs[tab_idx].pane_tree.pane_count() > 1
-                        {
-                            let closed =
-                                self.close_pane_in_tab(tab_idx, resolved.pane_id, window, cx);
-                            Self::send_control_result(
-                                response_tx,
-                                Ok(json!({
-                                    "status": if closed { "closed" } else { "unchanged" },
-                                    "closed_pane": closed,
-                                    "tab_index": tab_idx + 1,
-                                    "pane_id": resolved.pane_id,
-                                    "surface_id": resolved.surface_id,
-                                })),
-                            );
-                        } else {
-                            Self::send_control_result(
-                                response_tx,
-                                Err(ControlError::invalid_params(
-                                    "Refusing to close the last surface in a pane unless it is an owned ephemeral pane and close_empty_owned_pane=true.",
-                                )),
-                            );
+                        continue;
+                    };
+                    let closing = close_outcome.terminal.clone();
+                    closing.set_focus_state(false, cx);
+                    closing.set_native_view_visible(false, cx);
+                    closing.shutdown_surface(cx);
+                    if tab_idx == self.active_tab {
+                        if close_outcome.closed_pane {
+                            #[cfg(target_os = "macos")]
+                            self.mark_active_tab_terminal_native_layout_pending(cx);
+                            for terminal in self.tabs[tab_idx]
+                                .pane_tree
+                                .all_terminals()
+                                .into_iter()
+                                .cloned()
+                                .collect::<Vec<_>>()
+                            {
+                                terminal.ensure_surface(window, cx);
+                                terminal.notify(cx);
+                            }
                         }
+                        self.sync_active_tab_native_view_visibility(cx);
+                        if closing_was_focused || close_outcome.closed_pane {
+                            let replacement =
+                                self.tabs[tab_idx].pane_tree.focused_terminal().clone();
+                            replacement.ensure_surface(window, cx);
+                            replacement.focus(window, cx);
+                        }
+                        self.sync_active_terminal_focus_states(cx);
                     }
+                    if close_outcome.closed_pane {
+                        self.reconcile_runtime_trackers_for_tab(tab_idx);
+                    }
+                    self.save_session(cx);
+                    Self::send_control_result(
+                        response_tx,
+                        Ok(json!({
+                            "status": "closed",
+                            "closed_pane": close_outcome.closed_pane,
+                            "tab_index": tab_idx + 1,
+                            "pane_id": close_outcome.pane_id,
+                            "surface_id": resolved.surface_id,
+                        })),
+                    );
                 }
             }
         }
@@ -3323,12 +3309,13 @@ impl ConWorkspace {
                                     return;
                                 }
                             };
-                            if changed && tab_idx == self.active_tab {
-                                self.sync_active_tab_native_view_visibility(cx);
-                                self.sync_active_terminal_focus_states(cx);
-                                self.schedule_active_terminal_focus(cx);
-                            }
                             if changed {
+                                if tab_idx == self.active_tab {
+                                    self.sync_active_tab_native_view_visibility(cx);
+                                    self.sync_active_terminal_focus_states(cx);
+                                    self.schedule_active_terminal_focus(cx);
+                                }
+                                self.sync_sidebar(cx);
                                 self.save_session(cx);
                                 cx.notify();
                             }
@@ -3513,7 +3500,8 @@ impl ConWorkspace {
                                     Err(err) => return Some(Err(err)),
                                 };
                                 let is_ready = resolved.terminal.surface_ready(cx)
-                                    && resolved.terminal.is_alive(cx);
+                                    && resolved.terminal.is_alive(cx)
+                                    && resolved.terminal.has_shell_integration(cx);
                                 let timed_out = started.elapsed() >= timeout;
                                 if is_ready || timed_out {
                                     let status = if is_ready { "ready" } else { "timeout" };
@@ -8249,6 +8237,7 @@ impl ConWorkspace {
             .clone();
         terminal.ensure_surface(window, cx);
         self.sync_active_tab_native_view_visibility(cx);
+        self.sync_sidebar(cx);
         terminal.focus(window, cx);
         self.sync_active_terminal_focus_states(cx);
         self.save_session(cx);
@@ -8346,10 +8335,11 @@ impl ConWorkspace {
         if pane_surface_count > 1 {
             let should_focus_replacement =
                 tab_idx == self.active_tab && surface.is_active && surface.is_focused_pane;
-            if let Some((_pane_id, terminal)) = self.tabs[tab_idx]
+            if let Some(outcome) = self.tabs[tab_idx]
                 .pane_tree
-                .close_surface(surface.surface_id)
+                .close_surface(surface.surface_id, false)
             {
+                let terminal = outcome.terminal;
                 terminal.set_native_view_visible(false, cx);
                 terminal.shutdown_surface(cx);
             }
@@ -8357,6 +8347,7 @@ impl ConWorkspace {
                 self.sync_active_tab_native_view_visibility(cx);
                 if should_focus_replacement {
                     let replacement = self.tabs[tab_idx].pane_tree.focused_terminal().clone();
+                    replacement.ensure_surface(window, cx);
                     replacement.focus(window, cx);
                 }
                 self.sync_active_terminal_focus_states(cx);

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -2483,14 +2483,15 @@ impl ConWorkspace {
     }
 
     fn surface_key_bytes(key: &str) -> Result<Vec<u8>, ControlError> {
-        match key.trim().to_ascii_lowercase().as_str() {
+        let key = key.trim();
+        match key.to_ascii_lowercase().as_str() {
             "escape" | "esc" => Ok(vec![0x1b]),
             "enter" | "return" => Ok(b"\n".to_vec()),
             "tab" => Ok(b"\t".to_vec()),
             "backspace" => Ok(vec![0x7f]),
             "ctrl-c" | "control-c" | "c-c" => Ok(vec![0x03]),
             "ctrl-d" | "control-d" | "c-d" => Ok(vec![0x04]),
-            other if other.len() == 1 => Ok(other.as_bytes().to_vec()),
+            _ if key.chars().count() == 1 => Ok(key.as_bytes().to_vec()),
             _ => Err(ControlError::invalid_params(format!(
                 "Unsupported surface key `{key}`. Supported keys: escape, enter, tab, backspace, ctrl-c, ctrl-d."
             ))),
@@ -10092,4 +10093,24 @@ fn longest_common_prefix<'a>(values: impl IntoIterator<Item = &'a str>) -> Strin
         }
     }
     prefix
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ConWorkspace;
+
+    #[test]
+    fn surface_key_bytes_preserves_literal_character_case() {
+        assert_eq!(ConWorkspace::surface_key_bytes("A").unwrap(), b"A");
+        assert_eq!(ConWorkspace::surface_key_bytes("z").unwrap(), b"z");
+    }
+
+    #[test]
+    fn surface_key_bytes_matches_named_keys_case_insensitively() {
+        assert_eq!(ConWorkspace::surface_key_bytes("ENTER").unwrap(), b"\n");
+        assert_eq!(
+            ConWorkspace::surface_key_bytes("Ctrl-C").unwrap(),
+            vec![0x03]
+        );
+    }
 }

--- a/crates/con-cli/src/main.rs
+++ b/crates/con-cli/src/main.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result, bail};
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use con_agent::{PaneCreateLocation, TmuxExecLocation};
 use con_core::{
-    ControlCommand, JSON_RPC_VERSION, JsonRpcRequest, JsonRpcResponse, PaneTarget,
+    ControlCommand, JSON_RPC_VERSION, JsonRpcRequest, JsonRpcResponse, PaneTarget, SurfaceTarget,
     control_socket_path,
 };
 use serde_json::{Value, json};
@@ -33,6 +33,11 @@ enum Command {
         #[command(subcommand)]
         command: PanesCommand,
     },
+    Tree(TabArgs),
+    Surfaces {
+        #[command(subcommand)]
+        command: SurfacesCommand,
+    },
     Tmux {
         #[command(subcommand)]
         command: TmuxCommand,
@@ -59,6 +64,20 @@ enum PanesCommand {
     Create(PaneCreateArgs),
     Wait(PaneWaitArgs),
     ProbeShell(PaneTargetArgs),
+}
+
+#[derive(Subcommand)]
+enum SurfacesCommand {
+    List(PaneTargetArgs),
+    Create(SurfaceCreateArgs),
+    Split(SurfaceSplitArgs),
+    Focus(SurfaceTargetArgs),
+    Rename(SurfaceRenameArgs),
+    Close(SurfaceCloseArgs),
+    Read(SurfaceReadArgs),
+    SendText(SurfaceSendTextArgs),
+    SendKey(SurfaceSendKeyArgs),
+    WaitReady(SurfaceWaitReadyArgs),
 }
 
 #[derive(Subcommand)]
@@ -96,6 +115,28 @@ impl PaneTargetArgs {
     fn target(&self) -> PaneTarget {
         PaneTarget::new(self.pane_index, self.pane_id)
     }
+}
+
+#[derive(Args, Clone, Default)]
+struct SurfaceTargetArgs {
+    #[command(flatten)]
+    pane: PaneTargetArgs,
+    #[arg(long, value_name = "ID")]
+    surface_id: Option<usize>,
+}
+
+impl SurfaceTargetArgs {
+    fn target(&self) -> SurfaceTarget {
+        SurfaceTarget::new(self.pane.pane_index, self.pane.pane_id, self.surface_id)
+    }
+}
+
+#[derive(Args, Clone)]
+struct SurfaceWaitReadyArgs {
+    #[command(flatten)]
+    target: SurfaceTargetArgs,
+    #[arg(long)]
+    timeout: Option<u64>,
 }
 
 #[derive(Args, Clone)]
@@ -155,6 +196,76 @@ struct PaneWaitArgs {
     timeout: Option<u64>,
     #[arg(long)]
     pattern: Option<String>,
+}
+
+#[derive(Args, Clone)]
+struct SurfaceCreateArgs {
+    #[command(flatten)]
+    pane: PaneTargetArgs,
+    #[arg(long)]
+    title: Option<String>,
+    #[arg(long)]
+    command: Option<String>,
+    #[arg(long)]
+    owner: Option<String>,
+    #[arg(long)]
+    close_pane_when_last: bool,
+}
+
+#[derive(Args, Clone)]
+struct SurfaceSplitArgs {
+    #[command(flatten)]
+    source: SurfaceTargetArgs,
+    #[arg(long, value_enum, default_value_t = PaneCreateLocationArg::Right)]
+    location: PaneCreateLocationArg,
+    #[arg(long)]
+    title: Option<String>,
+    #[arg(long)]
+    command: Option<String>,
+    #[arg(long)]
+    owner: Option<String>,
+    #[arg(long = "keep-pane-when-last", action = clap::ArgAction::SetFalse, default_value_t = true)]
+    close_pane_when_last: bool,
+}
+
+#[derive(Args, Clone)]
+struct SurfaceRenameArgs {
+    #[command(flatten)]
+    target: SurfaceTargetArgs,
+    #[arg(required = true)]
+    title: String,
+}
+
+#[derive(Args, Clone)]
+struct SurfaceCloseArgs {
+    #[command(flatten)]
+    target: SurfaceTargetArgs,
+    #[arg(long)]
+    close_empty_owned_pane: bool,
+}
+
+#[derive(Args, Clone)]
+struct SurfaceReadArgs {
+    #[command(flatten)]
+    target: SurfaceTargetArgs,
+    #[arg(long, default_value_t = 80)]
+    lines: usize,
+}
+
+#[derive(Args, Clone)]
+struct SurfaceSendTextArgs {
+    #[command(flatten)]
+    target: SurfaceTargetArgs,
+    #[arg(required = true, trailing_var_arg = true)]
+    text: Vec<String>,
+}
+
+#[derive(Args, Clone)]
+struct SurfaceSendKeyArgs {
+    #[command(flatten)]
+    target: SurfaceTargetArgs,
+    #[arg(required = true)]
+    key: String,
 }
 
 #[derive(Args, Clone)]
@@ -335,6 +446,132 @@ fn main() -> Result<()> {
                     },
                 )?;
                 print_result(&result, cli.json, render_pretty_json)?;
+            }
+        },
+        Command::Tree(args) => {
+            let result = send_command(
+                &socket_path,
+                ControlCommand::TreeGet {
+                    tab_index: args.tab,
+                },
+            )?;
+            print_result(&result, cli.json, render_tree)?;
+        }
+        Command::Surfaces { command } => match command {
+            SurfacesCommand::List(args) => {
+                let result = send_command(
+                    &socket_path,
+                    ControlCommand::SurfacesList {
+                        tab_index: args.tab.tab,
+                        pane: args.target(),
+                    },
+                )?;
+                print_result(&result, cli.json, render_surfaces_list)?;
+            }
+            SurfacesCommand::Create(args) => {
+                let result = send_command(
+                    &socket_path,
+                    ControlCommand::SurfacesCreate {
+                        tab_index: args.pane.tab.tab,
+                        pane: args.pane.target(),
+                        title: args.title,
+                        command: args.command,
+                        owner: args.owner,
+                        close_pane_when_last: args.close_pane_when_last,
+                    },
+                )?;
+                print_result(&result, cli.json, render_surface_created)?;
+            }
+            SurfacesCommand::Split(args) => {
+                let result = send_command(
+                    &socket_path,
+                    ControlCommand::SurfacesSplit {
+                        tab_index: args.source.pane.tab.tab,
+                        source: args.source.target(),
+                        location: args.location.into(),
+                        title: args.title,
+                        command: args.command,
+                        owner: args.owner,
+                        close_pane_when_last: args.close_pane_when_last,
+                    },
+                )?;
+                print_result(&result, cli.json, render_surface_created)?;
+            }
+            SurfacesCommand::Focus(args) => {
+                let result = send_command(
+                    &socket_path,
+                    ControlCommand::SurfacesFocus {
+                        tab_index: args.pane.tab.tab,
+                        target: args.target(),
+                    },
+                )?;
+                print_result(&result, cli.json, render_status_only)?;
+            }
+            SurfacesCommand::Rename(args) => {
+                let result = send_command(
+                    &socket_path,
+                    ControlCommand::SurfacesRename {
+                        tab_index: args.target.pane.tab.tab,
+                        target: args.target.target(),
+                        title: args.title,
+                    },
+                )?;
+                print_result(&result, cli.json, render_status_only)?;
+            }
+            SurfacesCommand::Close(args) => {
+                let result = send_command(
+                    &socket_path,
+                    ControlCommand::SurfacesClose {
+                        tab_index: args.target.pane.tab.tab,
+                        target: args.target.target(),
+                        close_empty_owned_pane: args.close_empty_owned_pane,
+                    },
+                )?;
+                print_result(&result, cli.json, render_status_only)?;
+            }
+            SurfacesCommand::Read(args) => {
+                let result = send_command(
+                    &socket_path,
+                    ControlCommand::SurfacesRead {
+                        tab_index: args.target.pane.tab.tab,
+                        target: args.target.target(),
+                        lines: args.lines,
+                    },
+                )?;
+                print_result(&result, cli.json, render_content_only)?;
+            }
+            SurfacesCommand::SendText(args) => {
+                let result = send_command(
+                    &socket_path,
+                    ControlCommand::SurfacesSendText {
+                        tab_index: args.target.pane.tab.tab,
+                        target: args.target.target(),
+                        text: join_words(args.text),
+                    },
+                )?;
+                print_result(&result, cli.json, render_status_only)?;
+            }
+            SurfacesCommand::SendKey(args) => {
+                let result = send_command(
+                    &socket_path,
+                    ControlCommand::SurfacesSendKey {
+                        tab_index: args.target.pane.tab.tab,
+                        target: args.target.target(),
+                        key: args.key,
+                    },
+                )?;
+                print_result(&result, cli.json, render_status_only)?;
+            }
+            SurfacesCommand::WaitReady(args) => {
+                let result = send_command(
+                    &socket_path,
+                    ControlCommand::SurfacesWaitReady {
+                        tab_index: args.target.pane.tab.tab,
+                        target: args.target.target(),
+                        timeout_secs: args.timeout,
+                    },
+                )?;
+                print_result(&result, cli.json, render_surface_wait)?;
             }
         },
         Command::Tmux { command } => match command {
@@ -679,6 +916,77 @@ fn render_panes_list(value: &Value) -> Result<()> {
     Ok(())
 }
 
+fn render_tree(value: &Value) -> Result<()> {
+    let tabs = value
+        .get("tabs")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("missing tabs array"))?;
+    for tab in tabs {
+        let marker = if tab["is_active"].as_bool().unwrap_or(false) {
+            "*"
+        } else {
+            " "
+        };
+        let tab_index = tab["tab_index"].as_u64().unwrap_or(0);
+        let title = tab["title"].as_str().unwrap_or("Untitled");
+        println!("{marker} tab {tab_index}  {title}");
+        let panes = tab
+            .get("panes")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        for pane in panes {
+            let pane_marker = if pane["is_focused"].as_bool().unwrap_or(false) {
+                "*"
+            } else {
+                " "
+            };
+            let pane_index = pane["pane_index"].as_u64().unwrap_or(0);
+            let pane_id = pane["pane_id"].as_u64().unwrap_or(0);
+            let active_surface_id = pane["active_surface_id"].as_u64().unwrap_or(0);
+            println!(
+                "  {pane_marker} pane {pane_index:<3} id={pane_id:<3} active_surface={active_surface_id}"
+            );
+            if let Some(surfaces) = pane.get("surfaces").and_then(Value::as_array) {
+                render_surface_rows(surfaces, "      ");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn render_surfaces_list(value: &Value) -> Result<()> {
+    let surfaces = value
+        .get("surfaces")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("missing surfaces array"))?;
+    render_surface_rows(surfaces, "");
+    Ok(())
+}
+
+fn render_surface_rows(surfaces: &[Value], prefix: &str) {
+    for surface in surfaces {
+        let marker = if surface["is_active"].as_bool().unwrap_or(false) {
+            "*"
+        } else {
+            " "
+        };
+        let pane_index = surface["pane_index"].as_u64().unwrap_or(0);
+        let pane_id = surface["pane_id"].as_u64().unwrap_or(0);
+        let surface_index = surface["surface_index"].as_u64().unwrap_or(0);
+        let surface_id = surface["surface_id"].as_u64().unwrap_or(0);
+        let title = surface["title"].as_str().unwrap_or("Surface");
+        let cwd = surface["cwd"].as_str().unwrap_or("");
+        let owner = surface["owner"].as_str().unwrap_or("");
+        println!(
+            "{prefix}{marker} surface {surface_index:<3} id={surface_id:<3} pane={pane_index} pane_id={pane_id} owner={owner} cwd={cwd}"
+        );
+        if !title.is_empty() {
+            println!("{prefix}    title: {title}");
+        }
+    }
+}
+
 fn render_content_only(value: &Value) -> Result<()> {
     print!("{}", value["content"].as_str().unwrap_or(""));
     Ok(())
@@ -715,6 +1023,24 @@ fn render_create_result(value: &Value) -> Result<()> {
     Ok(())
 }
 
+fn render_surface_created(value: &Value) -> Result<()> {
+    let created_pane = value["created_pane"].as_bool().unwrap_or(false);
+    let noun = if created_pane {
+        "Created pane surface"
+    } else {
+        "Created surface"
+    };
+    println!(
+        "{noun} {} (id {}) in pane {} (id {}) on tab {}",
+        value["surface_index"].as_u64().unwrap_or(0),
+        value["surface_id"].as_u64().unwrap_or(0),
+        value["pane_index"].as_u64().unwrap_or(0),
+        value["pane_id"].as_u64().unwrap_or(0),
+        value["tab_index"].as_u64().unwrap_or(0)
+    );
+    Ok(())
+}
+
 fn render_wait_result(value: &Value) -> Result<()> {
     let status = value["status"].as_str().unwrap_or("unknown");
     println!("status: {status}");
@@ -723,6 +1049,20 @@ fn render_wait_result(value: &Value) -> Result<()> {
         println!();
         print!("{output}");
     }
+    Ok(())
+}
+
+fn render_surface_wait(value: &Value) -> Result<()> {
+    println!(
+        "surface {} in pane {}: status={} ready={} alive={} shell={} busy={}",
+        value["surface_id"].as_u64().unwrap_or(0),
+        value["pane_id"].as_u64().unwrap_or(0),
+        value["status"].as_str().unwrap_or("unknown"),
+        value["surface_ready"].as_bool().unwrap_or(false),
+        value["is_alive"].as_bool().unwrap_or(false),
+        value["has_shell_integration"].as_bool().unwrap_or(false),
+        value["is_busy"].as_bool().unwrap_or(false)
+    );
     Ok(())
 }
 

--- a/crates/con-core/src/control.rs
+++ b/crates/con-core/src/control.rs
@@ -53,6 +53,42 @@ impl PaneTarget {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct SurfaceTarget {
+    pub pane_index: Option<usize>,
+    pub pane_id: Option<usize>,
+    pub surface_id: Option<usize>,
+}
+
+impl SurfaceTarget {
+    pub const fn new(
+        pane_index: Option<usize>,
+        pane_id: Option<usize>,
+        surface_id: Option<usize>,
+    ) -> Self {
+        Self {
+            pane_index,
+            pane_id,
+            surface_id,
+        }
+    }
+
+    pub fn pane_target(self) -> PaneTarget {
+        PaneTarget::new(self.pane_index, self.pane_id)
+    }
+
+    pub fn describe(self) -> String {
+        match (self.surface_id, self.pane_index, self.pane_id) {
+            (Some(surface_id), _, _) => format!("surface id {surface_id}"),
+            (None, Some(index), Some(id)) => format!("active surface in pane {index} (id {id})"),
+            (None, Some(index), None) => format!("active surface in pane {index}"),
+            (None, None, Some(id)) => format!("active surface in pane id {id}"),
+            (None, None, None) => "active surface in focused pane".to_string(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct ControlMethodInfo {
     pub method: &'static str,
@@ -95,6 +131,41 @@ const CONTROL_METHODS: &[(&str, &str)] = &[
     (
         "panes.probe_shell",
         "Run a read-only shell probe against a proven shell prompt.",
+    ),
+    (
+        "tree.get",
+        "Return the tab, pane, and pane-local surface tree.",
+    ),
+    (
+        "surfaces.list",
+        "List pane-local terminal surfaces without changing pane semantics.",
+    ),
+    (
+        "surfaces.create",
+        "Create a terminal surface inside an existing pane.",
+    ),
+    (
+        "surfaces.split",
+        "Create a split pane with an initial terminal surface.",
+    ),
+    ("surfaces.focus", "Focus a pane-local terminal surface."),
+    ("surfaces.rename", "Rename a pane-local terminal surface."),
+    ("surfaces.close", "Close a pane-local terminal surface."),
+    (
+        "surfaces.read",
+        "Read recent content from a terminal surface.",
+    ),
+    (
+        "surfaces.send_text",
+        "Send text bytes to a terminal surface.",
+    ),
+    (
+        "surfaces.send_key",
+        "Send a named key to a terminal surface.",
+    ),
+    (
+        "surfaces.wait_ready",
+        "Wait for a terminal surface to become ready and return readiness metadata.",
     ),
     ("tmux.inspect", "Inspect tmux control state for a pane."),
     (
@@ -195,6 +266,64 @@ pub enum ControlCommand {
         tab_index: Option<usize>,
         target: PaneTarget,
     },
+    TreeGet {
+        tab_index: Option<usize>,
+    },
+    SurfacesList {
+        tab_index: Option<usize>,
+        pane: PaneTarget,
+    },
+    SurfacesCreate {
+        tab_index: Option<usize>,
+        pane: PaneTarget,
+        title: Option<String>,
+        command: Option<String>,
+        owner: Option<String>,
+        close_pane_when_last: bool,
+    },
+    SurfacesSplit {
+        tab_index: Option<usize>,
+        source: SurfaceTarget,
+        location: PaneCreateLocation,
+        title: Option<String>,
+        command: Option<String>,
+        owner: Option<String>,
+        close_pane_when_last: bool,
+    },
+    SurfacesFocus {
+        tab_index: Option<usize>,
+        target: SurfaceTarget,
+    },
+    SurfacesRename {
+        tab_index: Option<usize>,
+        target: SurfaceTarget,
+        title: String,
+    },
+    SurfacesClose {
+        tab_index: Option<usize>,
+        target: SurfaceTarget,
+        close_empty_owned_pane: bool,
+    },
+    SurfacesRead {
+        tab_index: Option<usize>,
+        target: SurfaceTarget,
+        lines: usize,
+    },
+    SurfacesSendText {
+        tab_index: Option<usize>,
+        target: SurfaceTarget,
+        text: String,
+    },
+    SurfacesSendKey {
+        tab_index: Option<usize>,
+        target: SurfaceTarget,
+        key: String,
+    },
+    SurfacesWaitReady {
+        tab_index: Option<usize>,
+        target: SurfaceTarget,
+        timeout_secs: Option<u64>,
+    },
     TmuxInspect {
         tab_index: Option<usize>,
         target: PaneTarget,
@@ -253,6 +382,17 @@ impl ControlCommand {
             Self::PanesCreate { .. } => "panes.create",
             Self::PanesWait { .. } => "panes.wait",
             Self::PanesProbeShell { .. } => "panes.probe_shell",
+            Self::TreeGet { .. } => "tree.get",
+            Self::SurfacesList { .. } => "surfaces.list",
+            Self::SurfacesCreate { .. } => "surfaces.create",
+            Self::SurfacesSplit { .. } => "surfaces.split",
+            Self::SurfacesFocus { .. } => "surfaces.focus",
+            Self::SurfacesRename { .. } => "surfaces.rename",
+            Self::SurfacesClose { .. } => "surfaces.close",
+            Self::SurfacesRead { .. } => "surfaces.read",
+            Self::SurfacesSendText { .. } => "surfaces.send_text",
+            Self::SurfacesSendKey { .. } => "surfaces.send_key",
+            Self::SurfacesWaitReady { .. } => "surfaces.wait_ready",
             Self::TmuxInspect { .. } => "tmux.inspect",
             Self::TmuxList { .. } => "tmux.list",
             Self::TmuxCapture { .. } => "tmux.capture",
@@ -327,6 +467,119 @@ impl ControlCommand {
                 "tab_index": tab_index,
                 "pane_index": target.pane_index,
                 "pane_id": target.pane_id,
+            }),
+            Self::TreeGet { tab_index } => json!({ "tab_index": tab_index }),
+            Self::SurfacesList { tab_index, pane } => json!({
+                "tab_index": tab_index,
+                "pane_index": pane.pane_index,
+                "pane_id": pane.pane_id,
+            }),
+            Self::SurfacesCreate {
+                tab_index,
+                pane,
+                title,
+                command,
+                owner,
+                close_pane_when_last,
+            } => json!({
+                "tab_index": tab_index,
+                "pane_index": pane.pane_index,
+                "pane_id": pane.pane_id,
+                "title": title,
+                "command": command,
+                "owner": owner,
+                "close_pane_when_last": close_pane_when_last,
+            }),
+            Self::SurfacesSplit {
+                tab_index,
+                source,
+                location,
+                title,
+                command,
+                owner,
+                close_pane_when_last,
+            } => json!({
+                "tab_index": tab_index,
+                "pane_index": source.pane_index,
+                "pane_id": source.pane_id,
+                "surface_id": source.surface_id,
+                "location": location,
+                "title": title,
+                "command": command,
+                "owner": owner,
+                "close_pane_when_last": close_pane_when_last,
+            }),
+            Self::SurfacesFocus { tab_index, target } => json!({
+                "tab_index": tab_index,
+                "pane_index": target.pane_index,
+                "pane_id": target.pane_id,
+                "surface_id": target.surface_id,
+            }),
+            Self::SurfacesWaitReady {
+                tab_index,
+                target,
+                timeout_secs,
+            } => json!({
+                "tab_index": tab_index,
+                "pane_index": target.pane_index,
+                "pane_id": target.pane_id,
+                "surface_id": target.surface_id,
+                "timeout_secs": timeout_secs,
+            }),
+            Self::SurfacesRename {
+                tab_index,
+                target,
+                title,
+            } => json!({
+                "tab_index": tab_index,
+                "pane_index": target.pane_index,
+                "pane_id": target.pane_id,
+                "surface_id": target.surface_id,
+                "title": title,
+            }),
+            Self::SurfacesClose {
+                tab_index,
+                target,
+                close_empty_owned_pane,
+            } => json!({
+                "tab_index": tab_index,
+                "pane_index": target.pane_index,
+                "pane_id": target.pane_id,
+                "surface_id": target.surface_id,
+                "close_empty_owned_pane": close_empty_owned_pane,
+            }),
+            Self::SurfacesRead {
+                tab_index,
+                target,
+                lines,
+            } => json!({
+                "tab_index": tab_index,
+                "pane_index": target.pane_index,
+                "pane_id": target.pane_id,
+                "surface_id": target.surface_id,
+                "lines": lines,
+            }),
+            Self::SurfacesSendText {
+                tab_index,
+                target,
+                text,
+            } => json!({
+                "tab_index": tab_index,
+                "pane_index": target.pane_index,
+                "pane_id": target.pane_id,
+                "surface_id": target.surface_id,
+                "text": text,
+            }),
+            Self::SurfacesSendKey {
+                tab_index,
+                target,
+                key,
+            } => json!({
+                "tab_index": tab_index,
+                "pane_index": target.pane_index,
+                "pane_id": target.pane_id,
+                "surface_id": target.surface_id,
+                "key": key,
             }),
             Self::TmuxCapture {
                 tab_index,
@@ -455,6 +708,97 @@ impl ControlCommand {
                 Ok(Self::PanesProbeShell {
                     tab_index: params.tab_index,
                     target: params.target(),
+                })
+            }
+            "tree.get" => {
+                let params: TabScopedParams = decode_params(params)?;
+                Ok(Self::TreeGet {
+                    tab_index: params.tab_index,
+                })
+            }
+            "surfaces.list" => {
+                let params: PaneTargetParams = decode_params(params)?;
+                Ok(Self::SurfacesList {
+                    tab_index: params.tab_index,
+                    pane: params.target(),
+                })
+            }
+            "surfaces.create" => {
+                let params: SurfaceCreateParams = decode_params(params)?;
+                Ok(Self::SurfacesCreate {
+                    tab_index: params.tab_index,
+                    pane: params.pane_target(),
+                    title: params.title,
+                    command: params.command,
+                    owner: params.owner,
+                    close_pane_when_last: params.close_pane_when_last,
+                })
+            }
+            "surfaces.split" => {
+                let params: SurfaceSplitParams = decode_params(params)?;
+                Ok(Self::SurfacesSplit {
+                    tab_index: params.tab_index,
+                    source: params.surface_target(),
+                    location: params.location,
+                    title: params.title,
+                    command: params.command,
+                    owner: params.owner,
+                    close_pane_when_last: params.close_pane_when_last,
+                })
+            }
+            "surfaces.focus" => {
+                let params: SurfaceTargetParams = decode_params(params)?;
+                Ok(Self::SurfacesFocus {
+                    tab_index: params.tab_index,
+                    target: params.target(),
+                })
+            }
+            "surfaces.rename" => {
+                let params: SurfaceRenameParams = decode_params(params)?;
+                Ok(Self::SurfacesRename {
+                    tab_index: params.tab_index,
+                    target: params.target(),
+                    title: params.title,
+                })
+            }
+            "surfaces.close" => {
+                let params: SurfaceCloseParams = decode_params(params)?;
+                Ok(Self::SurfacesClose {
+                    tab_index: params.tab_index,
+                    target: params.target(),
+                    close_empty_owned_pane: params.close_empty_owned_pane,
+                })
+            }
+            "surfaces.read" => {
+                let params: SurfaceReadParams = decode_params(params)?;
+                Ok(Self::SurfacesRead {
+                    tab_index: params.tab_index,
+                    target: params.target(),
+                    lines: params.lines,
+                })
+            }
+            "surfaces.send_text" => {
+                let params: SurfaceSendTextParams = decode_params(params)?;
+                Ok(Self::SurfacesSendText {
+                    tab_index: params.tab_index,
+                    target: params.target(),
+                    text: params.text,
+                })
+            }
+            "surfaces.send_key" => {
+                let params: SurfaceSendKeyParams = decode_params(params)?;
+                Ok(Self::SurfacesSendKey {
+                    tab_index: params.tab_index,
+                    target: params.target(),
+                    key: params.key,
+                })
+            }
+            "surfaces.wait_ready" => {
+                let params: SurfaceWaitReadyParams = decode_params(params)?;
+                Ok(Self::SurfacesWaitReady {
+                    tab_index: params.tab_index,
+                    target: params.target(),
+                    timeout_secs: params.timeout_secs,
                 })
             }
             "tmux.inspect" => {
@@ -934,6 +1278,184 @@ impl PaneTargetParams {
     }
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+struct SurfaceTargetParams {
+    tab_index: Option<usize>,
+    pane_index: Option<usize>,
+    pane_id: Option<usize>,
+    surface_id: Option<usize>,
+}
+
+impl SurfaceTargetParams {
+    fn target(&self) -> SurfaceTarget {
+        SurfaceTarget::new(self.pane_index, self.pane_id, self.surface_id)
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+struct SurfaceWaitReadyParams {
+    tab_index: Option<usize>,
+    pane_index: Option<usize>,
+    pane_id: Option<usize>,
+    surface_id: Option<usize>,
+    timeout_secs: Option<u64>,
+}
+
+impl SurfaceWaitReadyParams {
+    fn target(&self) -> SurfaceTarget {
+        SurfaceTarget::new(self.pane_index, self.pane_id, self.surface_id)
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+struct SurfaceCreateParams {
+    tab_index: Option<usize>,
+    pane_index: Option<usize>,
+    pane_id: Option<usize>,
+    title: Option<String>,
+    command: Option<String>,
+    owner: Option<String>,
+    close_pane_when_last: bool,
+}
+
+impl SurfaceCreateParams {
+    fn pane_target(&self) -> PaneTarget {
+        PaneTarget::new(self.pane_index, self.pane_id)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+struct SurfaceSplitParams {
+    tab_index: Option<usize>,
+    pane_index: Option<usize>,
+    pane_id: Option<usize>,
+    surface_id: Option<usize>,
+    location: PaneCreateLocation,
+    title: Option<String>,
+    command: Option<String>,
+    owner: Option<String>,
+    close_pane_when_last: bool,
+}
+
+impl Default for SurfaceSplitParams {
+    fn default() -> Self {
+        Self {
+            tab_index: None,
+            pane_index: None,
+            pane_id: None,
+            surface_id: None,
+            location: PaneCreateLocation::Right,
+            title: None,
+            command: None,
+            owner: None,
+            close_pane_when_last: true,
+        }
+    }
+}
+
+impl SurfaceSplitParams {
+    fn surface_target(&self) -> SurfaceTarget {
+        SurfaceTarget::new(self.pane_index, self.pane_id, self.surface_id)
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+struct SurfaceRenameParams {
+    tab_index: Option<usize>,
+    pane_index: Option<usize>,
+    pane_id: Option<usize>,
+    surface_id: Option<usize>,
+    title: String,
+}
+
+impl SurfaceRenameParams {
+    fn target(&self) -> SurfaceTarget {
+        SurfaceTarget::new(self.pane_index, self.pane_id, self.surface_id)
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+struct SurfaceCloseParams {
+    tab_index: Option<usize>,
+    pane_index: Option<usize>,
+    pane_id: Option<usize>,
+    surface_id: Option<usize>,
+    close_empty_owned_pane: bool,
+}
+
+impl SurfaceCloseParams {
+    fn target(&self) -> SurfaceTarget {
+        SurfaceTarget::new(self.pane_index, self.pane_id, self.surface_id)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+struct SurfaceReadParams {
+    tab_index: Option<usize>,
+    pane_index: Option<usize>,
+    pane_id: Option<usize>,
+    surface_id: Option<usize>,
+    #[serde(default = "default_read_lines")]
+    lines: usize,
+}
+
+impl Default for SurfaceReadParams {
+    fn default() -> Self {
+        Self {
+            tab_index: None,
+            pane_index: None,
+            pane_id: None,
+            surface_id: None,
+            lines: default_read_lines(),
+        }
+    }
+}
+
+impl SurfaceReadParams {
+    fn target(&self) -> SurfaceTarget {
+        SurfaceTarget::new(self.pane_index, self.pane_id, self.surface_id)
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+struct SurfaceSendTextParams {
+    tab_index: Option<usize>,
+    pane_index: Option<usize>,
+    pane_id: Option<usize>,
+    surface_id: Option<usize>,
+    text: String,
+}
+
+impl SurfaceSendTextParams {
+    fn target(&self) -> SurfaceTarget {
+        SurfaceTarget::new(self.pane_index, self.pane_id, self.surface_id)
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+struct SurfaceSendKeyParams {
+    tab_index: Option<usize>,
+    pane_index: Option<usize>,
+    pane_id: Option<usize>,
+    surface_id: Option<usize>,
+    key: String,
+}
+
+impl SurfaceSendKeyParams {
+    fn target(&self) -> SurfaceTarget {
+        SurfaceTarget::new(self.pane_index, self.pane_id, self.surface_id)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 struct PaneReadParams {
@@ -1149,6 +1671,84 @@ mod tests {
                 assert_eq!(tab_index, Some(2));
                 assert_eq!(target.pane_id, Some(7));
                 assert_eq!(command, "cargo test");
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn surface_command_round_trips_from_rpc() {
+        let command = ControlCommand::SurfacesSplit {
+            tab_index: Some(3),
+            source: SurfaceTarget::new(None, Some(9), Some(12)),
+            location: PaneCreateLocation::Down,
+            title: Some("worker".to_string()),
+            command: Some("codex".to_string()),
+            owner: Some("subagent".to_string()),
+            close_pane_when_last: true,
+        };
+
+        let parsed = ControlCommand::from_rpc(command.method_name(), command.params_json())
+            .expect("round-trip parse");
+
+        match parsed {
+            ControlCommand::SurfacesSplit {
+                tab_index,
+                source,
+                location,
+                title,
+                command,
+                owner,
+                close_pane_when_last,
+            } => {
+                assert_eq!(tab_index, Some(3));
+                assert_eq!(source.pane_id, Some(9));
+                assert_eq!(source.surface_id, Some(12));
+                assert_eq!(location, PaneCreateLocation::Down);
+                assert_eq!(title.as_deref(), Some("worker"));
+                assert_eq!(command.as_deref(), Some("codex"));
+                assert_eq!(owner.as_deref(), Some("subagent"));
+                assert!(close_pane_when_last);
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn surface_split_defaults_to_ephemeral_pane_close() {
+        let parsed = ControlCommand::from_rpc("surfaces.split", json!({}))
+            .expect("default surface split parse");
+
+        match parsed {
+            ControlCommand::SurfacesSplit {
+                close_pane_when_last,
+                ..
+            } => assert!(close_pane_when_last),
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn surface_wait_ready_accepts_timeout() {
+        let parsed = ControlCommand::from_rpc(
+            "surfaces.wait_ready",
+            json!({
+                "tab_index": 2,
+                "surface_id": 7,
+                "timeout_secs": 15,
+            }),
+        )
+        .expect("surface wait-ready parse");
+
+        match parsed {
+            ControlCommand::SurfacesWaitReady {
+                tab_index,
+                target,
+                timeout_secs,
+            } => {
+                assert_eq!(tab_index, Some(2));
+                assert_eq!(target.surface_id, Some(7));
+                assert_eq!(timeout_secs, Some(15));
             }
             other => panic!("unexpected command: {other:?}"),
         }

--- a/crates/con-core/src/lib.rs
+++ b/crates/con-core/src/lib.rs
@@ -10,7 +10,7 @@ pub use config::Config;
 pub use control::{
     AgentAskResult, ControlCommand, ControlError, ControlMethodInfo, ControlRequestEnvelope,
     ControlResult, ControlSocketHandle, DEFAULT_SOCKET_PATH, JSON_RPC_VERSION, JsonRpcRequest,
-    JsonRpcResponse, PaneTarget, SystemIdentifyResult, TabInfo, control_methods,
+    JsonRpcResponse, PaneTarget, SurfaceTarget, SystemIdentifyResult, TabInfo, control_methods,
     control_socket_path, spawn_control_socket_server,
 };
 pub use harness::{AgentHarness, AgentSession};

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ This folder collects research notes, implementation notes, and design handoff do
 - `impl/macos-release.md` — packaging, signing, notarization, and updater flow
 - `impl/terminal-agent-benchmark.md` — benchmark architecture and evaluation policy
 - `impl/terminal-rendering.md` — rendering pipeline
+- `impl/pane-surfaces.md` — pane-local terminal surface design and control API
 - `impl/socket-api.md` — automation and control API
 - `impl/build-system.md` — build and dependency notes
 

--- a/docs/impl/con-cli-e2e.md
+++ b/docs/impl/con-cli-e2e.md
@@ -119,7 +119,8 @@ For follow-up shell control, wait until the pane reports:
   sessions. Existing pane and agent benchmarks should stay on `panes.*`.
 - Use `surface_id` for surface follow-up targeting.
 - After `surfaces create` or `surfaces split`, call
-  `surfaces wait-ready --surface-id <id> --timeout 10` before sending input.
+  `surfaces wait-ready --surface-id <id> --timeout 10` before sending input that
+  assumes an initialized shell.
 - Keep assertions concrete and machine-checkable
 - Record the exact tab index you used
 - Capture both the command result and a follow-up `panes list` snapshot when reporting regressions

--- a/docs/impl/con-cli-e2e.md
+++ b/docs/impl/con-cli-e2e.md
@@ -41,6 +41,7 @@ Prefer `--json` for automation:
 con-cli --json identify
 con-cli --json tabs list
 con-cli --json panes list
+con-cli --json tree
 ```
 
 Before driving a pane, confirm it actually exposes the capability you need.
@@ -114,6 +115,11 @@ For follow-up shell control, wait until the pane reports:
 ## 6. Automation guidance
 
 - Use `pane_id` for follow-up targeting, not `pane_index`
+- Use `surfaces.*` only when the test is explicitly about pane-local terminal
+  sessions. Existing pane and agent benchmarks should stay on `panes.*`.
+- Use `surface_id` for surface follow-up targeting.
+- After `surfaces create` or `surfaces split`, call
+  `surfaces wait-ready --surface-id <id> --timeout 10` before sending input.
 - Keep assertions concrete and machine-checkable
 - Record the exact tab index you used
 - Capture both the command result and a follow-up `panes list` snapshot when reporting regressions

--- a/docs/impl/pane-surfaces.md
+++ b/docs/impl/pane-surfaces.md
@@ -62,7 +62,8 @@ The JSON-RPC methods are:
 - `surfaces.send_key`: sends a small named key set (`escape`, `enter`, `tab`,
   `backspace`, `ctrl-c`, `ctrl-d`) to a surface.
 - `surfaces.wait_ready`: waits until the surface has a live terminal session
-  or the timeout expires, then returns readiness and shell-integration metadata.
+  with shell integration or the timeout expires, then returns readiness
+  metadata.
 
 Surface targeting accepts:
 

--- a/docs/impl/pane-surfaces.md
+++ b/docs/impl/pane-surfaces.md
@@ -1,0 +1,147 @@
+# Pane Surfaces
+
+## Summary
+
+Con's public pane model now has two layers:
+
+- **Pane**: a visible split rectangle in a tab.
+- **Surface**: a live terminal session hosted by a pane.
+
+Every pane always has one active surface. A pane may also host additional
+inactive surfaces, which behave like pane-local terminal tabs. The existing
+pane APIs, built-in agent tools, and terminal-agent benchmarks continue to see
+only the active surface of each pane.
+
+This is an additive control-plane feature for external orchestrators that need
+interactive subagent patterns without creating unbounded visible splits.
+
+## Why This Exists
+
+Interactive subagent tools often want this lifecycle:
+
+1. First worker gets a visible split, usually to the right of the caller.
+2. Later workers join that same worker pane as tabs.
+3. The orchestrator can read, send keys, focus, rename, and close those tabs.
+4. When the last owned worker tab exits, the worker pane can be closed.
+
+cmux calls the inner unit a `surface`, so Con uses the same word for the
+control-plane concept. In product terms, a surface is simply a terminal session
+inside a pane.
+
+This is distinct from the lower-level Ghostty/native rendering surface used by
+the terminal backend. In this document, "surface" always means the
+control-plane terminal session inside a pane.
+
+## Compatibility Contract
+
+The compatibility rule is strict:
+
+- `panes.*` targets panes and operates on the active surface only.
+- The built-in agent prompt/tool set keeps the existing pane model.
+- Existing benchmark fixtures should keep using `panes.*` unless a test is
+  explicitly about pane-local surfaces.
+- Surface APIs are opt-in under `surfaces.*`.
+
+This prevents a new abstraction from changing the behavior of Con's benchmarked
+agent harness or the user-facing pane picker.
+
+## Control API
+
+The JSON-RPC methods are:
+
+- `tree.get`: returns tabs, panes, and pane-local surfaces.
+- `surfaces.list`: lists surfaces in a tab, optionally scoped to one pane.
+- `surfaces.create`: creates a new surface inside an existing pane.
+- `surfaces.split`: creates a split pane with an initial surface.
+- `surfaces.focus`: activates a surface in its pane.
+- `surfaces.rename`: updates the surface title shown in the pane-local strip.
+- `surfaces.close`: closes a surface; it refuses to close the last surface in a
+  pane unless the caller opts into closing an owned ephemeral pane.
+- `surfaces.read`: reads recent terminal content from a surface.
+- `surfaces.send_text`: writes literal text bytes to a surface.
+- `surfaces.send_key`: sends a small named key set (`escape`, `enter`, `tab`,
+  `backspace`, `ctrl-c`, `ctrl-d`) to a surface.
+- `surfaces.wait_ready`: waits until the surface has a live terminal session
+  or the timeout expires, then returns readiness and shell-integration metadata.
+
+Surface targeting accepts:
+
+- `surface_id`: stable within the tab for the lifetime of the surface.
+- `pane_id`: stable within the tab for the lifetime of the pane.
+- `pane_index`: current visible pane position, useful for humans but not ideal
+  for follow-up automation.
+
+Prefer `surface_id` for follow-up automation.
+
+## CLI Examples
+
+First create a visible worker pane:
+
+```bash
+con-cli --json surfaces split \
+  --tab 1 \
+  --pane-id 0 \
+  --location right \
+  --title worker-1 \
+  --owner pi-interactive-subagents \
+  --command "codex"
+```
+
+Then create more worker sessions inside the same pane:
+
+```bash
+con-cli --json surfaces create \
+  --tab 1 \
+  --pane-id <worker_pane_id> \
+  --title worker-2 \
+  --owner pi-interactive-subagents \
+  --command "codex"
+```
+
+Wait for the worker before driving it:
+
+```bash
+con-cli --json surfaces wait-ready --surface-id <surface_id> --timeout 10
+```
+
+Drive a worker:
+
+```bash
+con-cli --json surfaces send-text --surface-id <surface_id> "explain this repo"
+con-cli --json surfaces send-key --surface-id <surface_id> enter
+con-cli --json surfaces read --surface-id <surface_id> --lines 120
+```
+
+Close a worker surface:
+
+```bash
+con-cli --json surfaces close --surface-id <surface_id>
+```
+
+Close the last surface and its owned worker pane:
+
+```bash
+con-cli --json surfaces close \
+  --surface-id <surface_id> \
+  --close-empty-owned-pane
+```
+
+`surfaces split` marks its initial pane as closeable by default. Use
+`--keep-pane-when-last` when the pane should survive after its last surface
+closes.
+
+## Lifecycle Rules
+
+- Only active surfaces are visible.
+- Hidden surfaces keep running and continue receiving terminal output.
+- Tab, pane, window, and app close paths tear down every surface, not just the
+  active surface.
+- If a non-last surface exits, Con removes only that surface.
+- If the last surface in a pane exits, Con follows the existing pane close
+  escalation: close pane, then close tab, then close the workspace window.
+
+## Current Limit
+
+Session restore persists the split layout and active surface cwd, matching the
+existing terminal-session restore behavior. It does not yet restore multiple
+live pane-local surfaces because terminal processes themselves are not restored.

--- a/docs/impl/socket-api.md
+++ b/docs/impl/socket-api.md
@@ -76,6 +76,20 @@ JSON-RPC 2.0 over a Unix domain socket, one JSON request per line and one JSON r
 - `panes.wait`
 - `panes.probe_shell`
 
+### Tree / Surfaces
+
+- `tree.get`
+- `surfaces.list`
+- `surfaces.create`
+- `surfaces.split`
+- `surfaces.focus`
+- `surfaces.rename`
+- `surfaces.close`
+- `surfaces.read`
+- `surfaces.send_text`
+- `surfaces.send_key`
+- `surfaces.wait_ready`
+
 ### tmux
 
 - `tmux.inspect`
@@ -107,6 +121,17 @@ con-cli panes send-keys --tab 1 --pane-id 3 $'\u0003'
 con-cli panes create --tab 1 --location right --command "htop"
 con-cli panes wait --tab 1 --pane-id 3 --timeout 20
 
+con-cli tree --tab 1
+con-cli surfaces list --tab 1
+con-cli surfaces split --tab 1 --pane-id 3 --location right --title worker-1 --owner subagent --command "codex"
+con-cli surfaces create --tab 1 --pane-id 4 --title worker-2 --owner subagent --command "codex"
+con-cli surfaces wait-ready --tab 1 --surface-id 7 --timeout 10
+con-cli surfaces focus --tab 1 --surface-id 7
+con-cli surfaces send-text --surface-id 7 "explain this repo"
+con-cli surfaces send-key --surface-id 7 enter
+con-cli surfaces read --surface-id 7 --lines 120
+con-cli surfaces close --surface-id 7 --close-empty-owned-pane
+
 con-cli tmux list --tab 1 --pane-id 3
 con-cli tmux capture --tab 1 --pane-id 3 --target %17 --lines 80
 con-cli tmux run --tab 1 --pane-id 3 --location new-window -- cargo test
@@ -130,6 +155,18 @@ For automation, every command also supports `--json`.
 - `pane_index` is the current visible position in the split layout
 - `pane_id` is the stable identity for the life of that pane inside the tab
 - follow-up automation should prefer `pane_id`
+
+### Surfaces are opt-in pane-local sessions
+
+- a pane is a visible split rectangle
+- a surface is a live terminal session inside a pane
+- every pane has one active surface
+- `panes.*` continues to operate only on the active surface
+- `surfaces.*` exposes additional pane-local tabs without changing pane
+  semantics for the built-in agent or existing benchmarks
+- follow-up surface automation should prefer `surface_id`
+
+See `docs/impl/pane-surfaces.md` for the full compatibility contract.
 
 ### Pane actions reuse existing guards
 
@@ -168,6 +205,8 @@ The render loop stays authoritative, but the socket never blocks on it directly.
 - no auth modes beyond local socket file permissions yet
 - `agent.ask` assumes one automation request at a time per tab
 - the socket surface only exposes capabilities that already exist in con's runtime and agent layers; it does not yet add a new app-native Codex/OpenCode attachment
+- pane-local surfaces are live-session control primitives; session restore
+  persists the active pane layout as before, not every hidden live surface
 
 Those are acceptable limits for phase one. The important part is that the control transport now exists and is wired to real product semantics instead of placeholder CLI text.
 

--- a/docs/impl/terminal-agent-benchmark.md
+++ b/docs/impl/terminal-agent-benchmark.md
@@ -35,6 +35,12 @@ Current focus:
 
 These are hard product invariants. If they fail, higher-level SSH/tmux evaluation is not meaningful.
 
+Pane-local terminal surfaces are intentionally outside the default strict
+benchmark path. The benchmark's existing pane model maps to one active surface
+per pane so the built-in agent's tool contract stays stable. Add `surfaces.*`
+coverage only in scenarios that explicitly test external-orchestrator behavior,
+such as interactive subagent panes.
+
 ### 2. Operator suites
 
 This layer executes real multi-turn benchmark prompts through `con-cli agent ask`.

--- a/skills/con-cli-e2e/SKILL.md
+++ b/skills/con-cli-e2e/SKILL.md
@@ -18,12 +18,18 @@ Default workflow:
 3. Wait for `/tmp/con.sock`.
 4. Use `con-cli --json identify`, `tabs list`, and `panes list` before acting.
 5. Only use `panes exec` on panes that expose `exec_visible_shell`.
-6. Use `agent ask` to verify the real in-tab built-in agent session.
+6. Use `tree` / `surfaces list` only for pane-local surface validation.
+7. After `surfaces create` or `surfaces split`, use `surfaces wait-ready --surface-id <id> --timeout 10` before sending input.
+8. Use `agent ask` to verify the real in-tab built-in agent session.
 
 Rules:
 
 - Prefer `--json` for every command in automated evaluation.
 - Prefer `pane_id` over `pane_index` for follow-up actions.
+- Prefer `surface_id` for follow-up actions only when testing the explicit
+  `surfaces.*` API.
+- Keep existing pane and agent benchmarks on `panes.*`; surfaces are additive
+  and must not change the built-in agent's pane model.
 - After visible execution, confirm the pane still reports `shell_prompt` and keeps `exec_visible_shell`.
 - If `agent ask` fails, check provider config/env before blaming the socket layer.
 

--- a/skills/con-cli-e2e/SKILL.md
+++ b/skills/con-cli-e2e/SKILL.md
@@ -19,7 +19,7 @@ Default workflow:
 4. Use `con-cli --json identify`, `tabs list`, and `panes list` before acting.
 5. Only use `panes exec` on panes that expose `exec_visible_shell`.
 6. Use `tree` / `surfaces list` only for pane-local surface validation.
-7. After `surfaces create` or `surfaces split`, use `surfaces wait-ready --surface-id <id> --timeout 10` before sending input.
+7. After `surfaces create` or `surfaces split`, use `surfaces wait-ready --surface-id <id> --timeout 10` before sending input that assumes an initialized shell.
 8. Use `agent ask` to verify the real in-tab built-in agent session.
 
 Rules:

--- a/skills/terminal-agent-benchmark/SKILL.md
+++ b/skills/terminal-agent-benchmark/SKILL.md
@@ -40,6 +40,9 @@ Primary references:
 ## Rules
 
 - Prefer `pane_id` over `pane_index` when following up on benchmark findings.
+- Keep benchmark control on the existing `panes.*` API unless the benchmark
+  explicitly targets pane-local surfaces. Surface support is additive and should
+  not change the built-in agent's pane/tool contract.
 - Do not treat playbook observations as strict pass/fail evidence unless the behavior is actually deterministic.
 - If a scenario depends on host setup, say so explicitly.
 - Keep operator playbooks safe-by-default. Prefer read-only checks first, and treat destructive or privileged steps as explicit branches.


### PR DESCRIPTION
Closes #94

## Summary
- Add pane-local terminal surfaces: a pane remains the visible split rectangle, while each surface is a live terminal session inside that pane.
- Add `tree.get` and `surfaces.*` JSON-RPC / `con-cli` commands to create, split, wait for readiness, focus, rename, drive, read, and close surfaces.
- Preserve the existing `panes.*` contract for the built-in agent, pane picker, and terminal-agent benchmarks: they continue to see only the active surface of each pane.
- Document the API and e2e workflow in `docs/impl/pane-surfaces.md`, socket API docs, benchmark notes, and the local e2e skill.

## Design Notes
Jay's issue describes the cmux/pi-interactive-subagents workflow: create the first worker visibly, attach later workers as pane-local tabs, steer them interactively, then close the owned worker pane when done. This PR implements that as an additive surface layer instead of changing pane semantics.

A `surface` here is the control-plane terminal session inside a pane. It is intentionally separate from the lower-level Ghostty/native rendering surface. Existing pane APIs remain stable so current agent harness behavior and benchmarks are not disturbed.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p con-core`
- `cargo check --workspace --all-targets`
- Real app e2e on an isolated socket/session:
  - `identify`, `panes list`, `tree`
  - `surfaces split` -> `surfaces wait-ready --timeout 10` -> `surfaces read` matched `SURFACE_SPLIT_READY`
  - `surfaces create` -> `surfaces wait-ready --timeout 10` -> `surfaces read` matched `SURFACE_CREATE_READY`
  - `surfaces send-text` + `surfaces send-key enter` matched `SURFACE_SEND_OK`
  - `surfaces close` for both a nested surface and an owned ephemeral pane
  - legacy `panes create` + `panes wait` still works


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new control-plane abstraction (pane-local terminal surfaces) and threads it through pane tree rendering, focus/visibility, lifecycle, and JSON-RPC/CLI handling; bugs could affect terminal focus, view visibility, and cleanup when closing panes/tabs/surfaces.
> 
> **Overview**
> Adds *pane-local terminal surfaces* so each pane can host multiple terminal sessions (tabs) while keeping the existing `panes.*` contract operating on only the active surface.
> 
> Extends the control plane with `tree.get` plus `surfaces.*` RPC/CLI commands to list/create/split/focus/rename/read/send input/wait for readiness/close surfaces, including rules to optionally close an owned ephemeral pane when its last surface exits.
> 
> Updates UI/runtime wiring to track surface IDs, render an in-pane surface tab strip, and harden focus/native-view visibility and teardown paths so inactive surfaces stay hidden but live, and closing/exit events clean up the right surface(s) without breaking pane/tab lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c21dca410cfc0b8711ed2e8c16d4b296cd882e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pane-local terminal surface support, enabling creation, splitting, focusing, renaming, and closing of multiple independent terminal sessions within a pane.
  * Added new `tree.get` and `surfaces.*` commands for external control plane integration to manage pane-local surfaces with readiness synchronization.

* **Documentation**
  * Added comprehensive surface control API documentation and implementation guides.
  * Updated automation and testing guidance with surface-targeting best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->