### PR TITLE
[codex] Add Windows and Linux CJK IME input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ### Added
 
+**Terminal, Windows and Linux Backends**
+
+- Added CJK IME text input for Windows and Linux terminal panes. IME commits now enter through GPUI's platform text-input path, preedit state tracks candidate positioning at the terminal cursor, and terminal-local control / alt / special key handling remains unchanged. The macOS embedded Ghostty path is unchanged.
+
 **Control Plane**
 
 - Added pane-local terminal surfaces for external orchestrators. Existing `panes.*` APIs, built-in agent tools, and benchmarks keep the active-surface pane contract, while new `tree.get` and `surfaces.*` RPC/CLI commands can create, split, wait for readiness, focus, rename, drive, read, and close terminal sessions inside a pane.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,6 +1290,7 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "tracing",
+ "unicode-width",
  "url",
  "uuid",
  "windows 0.61.3",

--- a/crates/con-app/Cargo.toml
+++ b/crates/con-app/Cargo.toml
@@ -69,6 +69,7 @@ raw-window-handle = "0.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 raw-window-handle = "0.6"
+unicode-width.workspace = true
 windows = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_System_Diagnostics_Debug",  # AddVectoredExceptionHandler
@@ -80,6 +81,9 @@ windows = { version = "0.61", features = [
 # `SmallVec<[image::Frame; 1]>` and it does not re-export either crate).
 image = { version = "0.25", default-features = false }
 smallvec = "1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+unicode-width.workspace = true
 
 [build-dependencies]
 cc = "1"

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -13,6 +13,7 @@
 //! and layout state. The Windows D3D11 path remains the model for the
 //! eventual native renderer.
 
+use std::ops::Range;
 use std::sync::Arc;
 
 use con_ghostty::{
@@ -24,6 +25,7 @@ use futures::channel::mpsc::unbounded;
 use gpui::*;
 use gpui_component::ActiveTheme;
 
+use crate::terminal_ime::{TerminalImeInputHandler, TerminalImeView};
 use crate::terminal_links::{self, TerminalLink};
 use crate::terminal_paste::{
     TerminalPastePayload, copy_selection_to_clipboard, payload_from_clipboard,
@@ -91,6 +93,8 @@ pub struct GhosttyView {
     seen_any_output: bool,
     pane_bounds: Option<Bounds<Pixels>>,
     scale_factor: f32,
+    ime_marked_text: Option<String>,
+    ime_selected_range: Option<Range<usize>>,
     last_surface_size: Option<(u32, u32, u16, u16)>,
     mouse_down_link: Option<TerminalLink>,
     suppress_link_mouse_up: bool,
@@ -164,6 +168,8 @@ impl GhosttyView {
             seen_any_output: false,
             pane_bounds: None,
             scale_factor: 1.0,
+            ime_marked_text: None,
+            ime_selected_range: None,
             last_surface_size: None,
             mouse_down_link: None,
             suppress_link_mouse_up: false,
@@ -230,6 +236,8 @@ impl GhosttyView {
         self.row_cache_style = None;
         self.row_cache_shape = None;
         self.seen_any_output = false;
+        self.ime_marked_text = None;
+        self.ime_selected_range = None;
         self.last_surface_size = None;
         self.mouse_down_link = None;
         self.suppress_link_mouse_up = false;
@@ -571,6 +579,15 @@ impl GhosttyView {
             return true;
         }
 
+        if event.prefer_character_input
+            && keystroke
+                .key_char
+                .as_deref()
+                .is_some_and(|text| !text.is_empty())
+        {
+            return false;
+        }
+
         if keystroke.modifiers.control
             && !keystroke.modifiers.alt
             && !keystroke.modifiers.shift
@@ -602,16 +619,46 @@ impl GhosttyView {
             .as_deref()
             .filter(|text| !text.is_empty())
         {
+            if !keystroke.modifiers.control
+                && !keystroke.modifiers.alt
+                && !keystroke.modifiers.platform
+            {
+                return false;
+            }
             terminal.send_text(text);
             return true;
         }
 
         if keystroke.key.len() == 1 {
+            if !keystroke.modifiers.control
+                && !keystroke.modifiers.alt
+                && !keystroke.modifiers.platform
+            {
+                return false;
+            }
             terminal.send_text(&keystroke.key);
             return true;
         }
 
         false
+    }
+
+    fn ime_cursor_bounds(&self) -> Option<Bounds<Pixels>> {
+        let bounds = self.pane_bounds?;
+        let snapshot = self.snapshot.as_ref()?;
+        let font_size_px = effective_font_size(self.initial_font_size);
+        let cell_width = (font_size_px * DEFAULT_CELL_WIDTH_RATIO).round().max(7.0);
+        let cell_height = (font_size_px * DEFAULT_CELL_HEIGHT_RATIO).round().max(14.0);
+        let col = snapshot.cursor.col.min(snapshot.cols.saturating_sub(1)) as f32;
+        let row = snapshot.cursor.row.min(snapshot.rows.saturating_sub(1)) as f32;
+
+        Some(Bounds::new(
+            point(
+                bounds.origin.x + px(TERMINAL_PADDING_X_PX + col * cell_width),
+                bounds.origin.y + px(TERMINAL_PADDING_Y_PX + row * cell_height),
+            ),
+            size(px(cell_width.max(1.0)), px(cell_height.max(1.0))),
+        ))
     }
 
     fn sync_row_cache(
@@ -723,11 +770,50 @@ impl Focusable for GhosttyView {
     }
 }
 
+type LinuxTerminalInputHandler = TerminalImeInputHandler<GhosttyView>;
+
+impl TerminalImeView for GhosttyView {
+    fn ime_marked_text(&self) -> Option<&str> {
+        self.ime_marked_text.as_deref()
+    }
+
+    fn ime_selected_range(&self) -> Option<Range<usize>> {
+        self.ime_selected_range.clone()
+    }
+
+    fn set_ime_state(&mut self, marked_text: Option<String>, selected_range: Option<Range<usize>>) {
+        self.ime_marked_text = marked_text;
+        self.ime_selected_range = selected_range;
+    }
+
+    fn clear_ime_state(&mut self) {
+        self.ime_marked_text = None;
+        self.ime_selected_range = None;
+    }
+
+    fn send_ime_text(&mut self, text: &str, cx: &mut Context<Self>) {
+        let _ = self.ensure_session(cx);
+        if let Some(terminal) = &self.terminal {
+            terminal.send_text(text);
+        }
+    }
+
+    fn prepare_ime_marked_text(&mut self, cx: &mut Context<Self>) {
+        let _ = self.ensure_session(cx);
+    }
+
+    fn ime_cursor_bounds(&self) -> Option<Bounds<Pixels>> {
+        GhosttyView::ime_cursor_bounds(self)
+    }
+}
+
 impl Render for GhosttyView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
         let focus = self.focus_handle.clone();
+        let input_focus = focus.clone();
         let entity = cx.entity().downgrade();
+        let input_entity = entity.clone();
         let font_size_px = effective_font_size(self.initial_font_size);
         let line_height_px = (font_size_px * 1.45).round();
         let cell_width_px = (font_size_px * DEFAULT_CELL_WIDTH_RATIO).round().max(7.0);
@@ -978,6 +1064,7 @@ impl Render for GhosttyView {
             )
             .child(
                 div()
+                    .relative()
                     .flex()
                     .flex_col()
                     .size_full()
@@ -999,7 +1086,21 @@ impl Render for GhosttyView {
                             });
                         }
                     })
-                    .child(terminal_layer),
+                    .child(terminal_layer)
+                    .child(
+                        canvas(
+                            |_, _, _| {},
+                            move |_, _, window, cx| {
+                                window.handle_input(
+                                    &input_focus,
+                                    LinuxTerminalInputHandler::new(input_entity.clone()),
+                                    cx,
+                                );
+                            },
+                        )
+                        .absolute()
+                        .size_full(),
+                    ),
             )
     }
 }

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -55,6 +55,8 @@ mod motion;
 mod pane_tree;
 mod settings_panel;
 mod sidebar;
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+mod terminal_ime;
 mod terminal_links;
 mod terminal_pane;
 mod terminal_paste;

--- a/crates/con-app/src/terminal_ime.rs
+++ b/crates/con-app/src/terminal_ime.rs
@@ -1,0 +1,171 @@
+use std::ops::Range;
+
+use gpui::*;
+use unicode_width::UnicodeWidthStr;
+
+pub(crate) trait TerminalImeView: Sized + 'static {
+    fn ime_marked_text(&self) -> Option<&str>;
+    fn ime_selected_range(&self) -> Option<Range<usize>>;
+    fn set_ime_state(&mut self, marked_text: Option<String>, selected_range: Option<Range<usize>>);
+    fn clear_ime_state(&mut self);
+    fn send_ime_text(&mut self, text: &str, cx: &mut Context<Self>);
+    fn prepare_ime_marked_text(&mut self, _cx: &mut Context<Self>) {}
+    fn ime_cursor_bounds(&self) -> Option<Bounds<Pixels>>;
+}
+
+pub(crate) struct TerminalImeInputHandler<V> {
+    view: WeakEntity<V>,
+}
+
+impl<V> TerminalImeInputHandler<V> {
+    pub(crate) fn new(view: WeakEntity<V>) -> Self {
+        Self { view }
+    }
+}
+
+fn selected_range_for_text(
+    selected_range: Option<Range<usize>>,
+    text: &str,
+) -> Option<Range<usize>> {
+    if text.is_empty() {
+        return None;
+    }
+
+    let text_len = text.encode_utf16().count();
+    let range = selected_range.unwrap_or(text_len..text_len);
+    let start = range.start.min(text_len);
+    let end = range.end.min(text_len);
+    Some(start.min(end)..start.max(end))
+}
+
+fn prefix_cell_width(text: &str, utf16_index: usize) -> usize {
+    let mut consumed_utf16 = 0;
+    for (byte_index, ch) in text.char_indices() {
+        let next_utf16 = consumed_utf16 + ch.len_utf16();
+        if next_utf16 > utf16_index {
+            return UnicodeWidthStr::width(&text[..byte_index]);
+        }
+        consumed_utf16 = next_utf16;
+    }
+
+    UnicodeWidthStr::width(text)
+}
+
+impl<V: TerminalImeView> InputHandler for TerminalImeInputHandler<V> {
+    fn selected_text_range(
+        &mut self,
+        _ignore_disabled_input: bool,
+        _window: &mut Window,
+        cx: &mut App,
+    ) -> Option<UTF16Selection> {
+        let range = self
+            .view
+            .read_with(cx, |view, _| view.ime_selected_range())
+            .ok()
+            .flatten()
+            .unwrap_or(0..0);
+        Some(UTF16Selection {
+            range,
+            reversed: false,
+        })
+    }
+
+    fn marked_text_range(&mut self, _window: &mut Window, cx: &mut App) -> Option<Range<usize>> {
+        self.view
+            .read_with(cx, |view, _| {
+                view.ime_marked_text()
+                    .map(|text| 0..text.encode_utf16().count())
+            })
+            .ok()
+            .flatten()
+    }
+
+    fn text_for_range(
+        &mut self,
+        _range_utf16: Range<usize>,
+        adjusted_range: &mut Option<Range<usize>>,
+        _window: &mut Window,
+        _cx: &mut App,
+    ) -> Option<String> {
+        *adjusted_range = Some(0..0);
+        Some(String::new())
+    }
+
+    fn replace_text_in_range(
+        &mut self,
+        _replacement_range: Option<Range<usize>>,
+        text: &str,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        let _ = self.view.update(cx, |view, cx| {
+            view.clear_ime_state();
+            if !text.is_empty() {
+                view.send_ime_text(text, cx);
+                cx.notify();
+            }
+        });
+        window.invalidate_character_coordinates();
+    }
+
+    fn replace_and_mark_text_in_range(
+        &mut self,
+        _range_utf16: Option<Range<usize>>,
+        new_text: &str,
+        new_selected_range: Option<Range<usize>>,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        let _ = self.view.update(cx, |view, cx| {
+            view.prepare_ime_marked_text(cx);
+            view.set_ime_state(
+                (!new_text.is_empty()).then(|| new_text.to_string()),
+                selected_range_for_text(new_selected_range, new_text),
+            );
+            cx.notify();
+        });
+        window.invalidate_character_coordinates();
+    }
+
+    fn unmark_text(&mut self, window: &mut Window, cx: &mut App) {
+        let _ = self.view.update(cx, |view, cx| {
+            view.clear_ime_state();
+            cx.notify();
+        });
+        window.invalidate_character_coordinates();
+    }
+
+    fn bounds_for_range(
+        &mut self,
+        range_utf16: Range<usize>,
+        _window: &mut Window,
+        cx: &mut App,
+    ) -> Option<Bounds<Pixels>> {
+        self.view
+            .read_with(cx, |view, _| {
+                let mut bounds = view.ime_cursor_bounds()?;
+                let cell_width = bounds.size.width;
+                let cell_offset = view
+                    .ime_marked_text()
+                    .map(|text| prefix_cell_width(text, range_utf16.start))
+                    .unwrap_or(range_utf16.start);
+                bounds.origin.x += cell_width * cell_offset as f32;
+                Some(bounds)
+            })
+            .ok()
+            .flatten()
+    }
+
+    fn character_index_for_point(
+        &mut self,
+        _point: Point<Pixels>,
+        _window: &mut Window,
+        _cx: &mut App,
+    ) -> Option<usize> {
+        Some(0)
+    }
+
+    fn prefers_ime_for_printable_keys(&mut self, _window: &mut Window, _cx: &mut App) -> bool {
+        true
+    }
+}

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -36,6 +36,7 @@
 //!    stalling GPUI's thread.
 //! 4. Drop releases the `RenderSession` and ends the child shell.
 
+use std::ops::Range;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
@@ -48,6 +49,7 @@ use gpui_component::ActiveTheme;
 use image::{Frame, RgbaImage};
 use smallvec::SmallVec;
 
+use crate::terminal_ime::{TerminalImeInputHandler, TerminalImeView};
 use crate::terminal_links::{self, TerminalLink};
 use crate::terminal_paste::{
     TerminalPastePayload, copy_selection_to_clipboard, payload_from_clipboard,
@@ -113,6 +115,8 @@ pub struct GhosttyView {
     /// Pane bounds in logical window pixels, captured during prepaint.
     pane_bounds: Option<Bounds<Pixels>>,
     scale_factor: f32,
+    ime_marked_text: Option<String>,
+    ime_selected_range: Option<Range<usize>>,
     /// Last physical-pixel size we sent to `session.resize`. Avoids
     /// resize churn when the logical bounds round to the same physical
     /// size frame-to-frame.
@@ -205,6 +209,8 @@ impl GhosttyView {
             process_exit_emitted: false,
             pane_bounds: None,
             scale_factor: 1.0,
+            ime_marked_text: None,
+            ime_selected_range: None,
             last_physical_size: None,
             last_scale_factor: 0.0,
             cached_image: None,
@@ -266,6 +272,8 @@ impl GhosttyView {
         self.cached_frame_size = None;
         self.scrollbar_cache = None;
         self.scrollbar_drag = None;
+        self.ime_marked_text = None;
+        self.ime_selected_range = None;
         self.mouse_down_link = None;
         self.suppress_link_mouse_up = false;
         self.hovered_link = None;
@@ -1019,6 +1027,15 @@ impl GhosttyView {
             return true;
         }
 
+        if event.prefer_character_input
+            && keystroke
+                .key_char
+                .as_deref()
+                .is_some_and(|text| !text.is_empty())
+        {
+            return false;
+        }
+
         // Ctrl + ascii letter → control char (Ctrl-C = 0x03 etc.)
         if keystroke.modifiers.control
             && !keystroke.modifiers.alt
@@ -1059,16 +1076,55 @@ impl GhosttyView {
 
         if let Some(ch) = keystroke.key_char.as_deref() {
             if !ch.is_empty() {
+                if !keystroke.modifiers.control
+                    && !keystroke.modifiers.alt
+                    && !keystroke.modifiers.platform
+                {
+                    return false;
+                }
                 terminal.send_text(ch);
                 return true;
             }
         }
         if keystroke.key.len() == 1 {
+            if !keystroke.modifiers.control
+                && !keystroke.modifiers.alt
+                && !keystroke.modifiers.platform
+            {
+                return false;
+            }
             terminal.send_text(&keystroke.key);
             return true;
         }
 
         false
+    }
+
+    fn ime_cursor_bounds(&self) -> Option<Bounds<Pixels>> {
+        let bounds = self.pane_bounds?;
+        let terminal = self.terminal.as_ref()?;
+        let inner = terminal.inner();
+        let guard = inner.lock();
+        let session = guard.as_ref()?;
+        let snapshot = session.vt().snapshot();
+        let metrics = session.metrics();
+        if metrics.cell_width_px == 0 || metrics.cell_height_px == 0 {
+            return None;
+        }
+
+        let scale = self.scale_factor.max(f32::EPSILON);
+        let cell_width = metrics.cell_width_px as f32 / scale;
+        let cell_height = metrics.cell_height_px as f32 / scale;
+        let col = snapshot.cursor.col.min(snapshot.cols.saturating_sub(1)) as f32;
+        let row = snapshot.cursor.row.min(snapshot.rows.saturating_sub(1)) as f32;
+
+        Some(Bounds::new(
+            point(
+                bounds.origin.x + px(col * cell_width),
+                bounds.origin.y + px(row * cell_height),
+            ),
+            size(px(cell_width.max(1.0)), px(cell_height.max(1.0))),
+        ))
     }
 
     fn placeholder_background(&self) -> Option<Hsla> {
@@ -1233,6 +1289,38 @@ impl Focusable for GhosttyView {
     }
 }
 
+type WindowsTerminalInputHandler = TerminalImeInputHandler<GhosttyView>;
+
+impl TerminalImeView for GhosttyView {
+    fn ime_marked_text(&self) -> Option<&str> {
+        self.ime_marked_text.as_deref()
+    }
+
+    fn ime_selected_range(&self) -> Option<Range<usize>> {
+        self.ime_selected_range.clone()
+    }
+
+    fn set_ime_state(&mut self, marked_text: Option<String>, selected_range: Option<Range<usize>>) {
+        self.ime_marked_text = marked_text;
+        self.ime_selected_range = selected_range;
+    }
+
+    fn clear_ime_state(&mut self) {
+        self.ime_marked_text = None;
+        self.ime_selected_range = None;
+    }
+
+    fn send_ime_text(&mut self, text: &str, _cx: &mut Context<Self>) {
+        if let Some(terminal) = &self.terminal {
+            terminal.send_text(text);
+        }
+    }
+
+    fn ime_cursor_bounds(&self) -> Option<Bounds<Pixels>> {
+        GhosttyView::ime_cursor_bounds(self)
+    }
+}
+
 impl Render for GhosttyView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         match self.sync_render(window) {
@@ -1248,6 +1336,7 @@ impl Render for GhosttyView {
         let background =
             placeholder_background.unwrap_or_else(|| cx.theme().background.opacity(0.0));
         let entity = cx.entity().downgrade();
+        let input_entity = entity.clone();
         let mut terminal_children = self.image_children();
         if let Some(overlay) = self.render_link_cursor_overlay() {
             terminal_children.push(overlay);
@@ -1257,6 +1346,7 @@ impl Render for GhosttyView {
         }
 
         let focus = self.focus_handle.clone();
+        let input_focus = focus.clone();
 
         div()
             .flex()
@@ -1460,7 +1550,21 @@ impl Render for GhosttyView {
                             .relative()
                             .size_full()
                             .overflow_hidden()
-                            .children(terminal_children),
+                            .children(terminal_children)
+                            .child(
+                                canvas(
+                                    |_, _, _| {},
+                                    move |_, _, window, cx| {
+                                        window.handle_input(
+                                            &input_focus,
+                                            WindowsTerminalInputHandler::new(input_entity.clone()),
+                                            cx,
+                                        );
+                                    },
+                                )
+                                .absolute()
+                                .size_full(),
+                            ),
                     ),
             )
     }

--- a/docs/impl/linux-port.md
+++ b/docs/impl/linux-port.md
@@ -268,7 +268,7 @@ can ship.
 | 2c | Architecture decision | pick Linux backend lane | one recommended implementation path, no split-brain plan | ✅ landed |
 | 3 | Linux backend scaffold | `con-ghostty/src/linux/` plus `con-app/src/linux_view.rs` (or equivalent) with real lifecycle types | Linux no longer routes through the generic stub path conceptually | ✅ landed |
 | 4 | First real terminal surface | PTY spawn, resize, exit, `libghostty-vt` state, GPUI-owned pane paint, real product chrome (no native WM titlebar), embedded mono font, transparent + rounded window with compositor-gated blur | VT-backed Linux pane compiles and displays live shell state with SGR colors / bold / italic / underline / strikethrough / inverse, cursor block, theme palette synced from settings, IoskeleyMono shaping, client-side titlebar with min/max/close caption cluster, transparent ARGB window with rounded corners and per-pane / per-surface opacity, real KWin Wayland blur where available, fast paint pipeline (16 ms keystroke-echo round-trip), no placeholder flash on alt-screen TUIs | ✅ landed (preview) |
-| 5 | Input + selection + glyph-atlas grid renderer | keyboard, mouse, clipboard, bracketed paste, DECCKM, selection, plus the long-term GPUI-owned glyph-atlas grid renderer matching the D3D11/DirectWrite path Windows uses | vim/tmux/fzf/less usable on Linux at full speed | 🚧 in progress (DECCKM, bracketed paste, and terminal-local Tab / Shift+Tab capture are wired; mouse reporting, selection, and the glyph-atlas renderer remain) |
+| 5 | Input + selection + glyph-atlas grid renderer | keyboard, mouse, clipboard, bracketed paste, DECCKM, CJK IME text/preedit input, selection, plus the long-term GPUI-owned glyph-atlas grid renderer matching the D3D11/DirectWrite path Windows uses | vim/tmux/fzf/less usable on Linux at full speed | 🚧 in progress (DECCKM, bracketed paste, CJK IME text/preedit input, and terminal-local Tab / Shift+Tab capture are wired; mouse reporting, selection, desktop IME validation matrix, and the glyph-atlas renderer remain) |
 | 6 | Packaging | one-line installer, tarball release, desktop entry, icon integration, appcast / notify-only updater, plus native artifact strategy (`.deb`, AppImage, Flatpak, etc.) | tarball installer exists; native package format decision remains | 🚧 partially landed |
 
 ## Immediate next work
@@ -290,12 +290,12 @@ With phase 4 landed (preview), the remaining Linux tasks are:
    workloads and large command-start redraws).
 2. Finish Linux input correctness: mouse reporting (button + wheel),
    selection (mouse drag → SGR 1006 / X10 reports + clipboard
-   integration), and scrollback gestures. DECCKM and bracketed
-   paste are already wired through `libghostty-vt` mode tracking
-   and exercised by the existing keystroke encoder; Tab / Shift+Tab
-   now use a terminal-local key context so shell completion and reverse
-   focus traversal are not intercepted by GPUI's app-level focus
-   navigation.
+   integration), scrollback gestures, and a real desktop/IME validation
+   matrix across Wayland and X11. DECCKM, bracketed paste, and CJK
+   IME commit/preedit input are already wired through `libghostty-vt`
+   mode tracking plus GPUI's text-input path; Tab / Shift+Tab now use
+   a terminal-local key context so shell completion and reverse focus
+   traversal are not intercepted by GPUI's app-level focus navigation.
 3. Validate on hardware-accelerated native Linux desktops (Wayland
    on KDE Plasma to confirm `org_kde_kwin_blur`; Wayland on
    GNOME / sway and X11 on each major WM to confirm the

--- a/docs/impl/windows-port.md
+++ b/docs/impl/windows-port.md
@@ -339,7 +339,7 @@ phase keeps the macOS build green.
 | 3c | Input + selection | Beta-baseline input, selection, scrollback, clipboard, and ConPTY launch behavior are landed; details below. | Beta-baseline terminal interactivity is landed. Remaining polish belongs in Phase 4 hardening. ✅ largely landed |
 | 3d | (Parallel, upstream) | `WindowsWindow::attach_external_swap_chain_handle(bounds, HANDLE)` PR to `zed-industries/zed`. When merged, swap the current offscreen readback/image bridge to a composition swap chain that GPUI can place directly in its DComp tree. | No con-side merge blocker; still upstream-facing work. This is the remaining structural performance cleanup. — |
 | 3e | renderer perf tuning | The current pipeline draws into an offscreen D3D11 texture, reads back BGRA bytes (`RenderSession::render_frame`), wraps them as `ImageSource::Render(Arc<RenderImage>)`, and lets GPUI re-upload them into its DComp tree. The GPU→CPU readback per dirty frame plus the CPU→GPU re-upload adds structural overhead versus Windows Terminal's direct-DComp present path. Landed mitigations: (1) ✅ wake GPUI from the ConPTY reader thread so freshly arrived shell output paints on the next prepaint instead of waiting for user input; (2) ✅ move steady-state terminal image generation into the main render path so freshly rendered images can appear in the current frame rather than always one frame later; (3) ✅ skip default-background blank-cell instances that are already covered by the render-target clear; (4) ✅ avoid a full-frame zero-fill before D3D readback; (5) ✅ only stable-sort the instance stream when a frame actually contains overflowing wide glyphs; (6) ✅ keep low-latency presents armed until the triggering input actually advances the VT generation, so shell echo/prompt redraws do not miss the fresh-frame path; (7) ✅ treat the staging ring as a mailbox so maximize/fullscreen backlog never blocks GPUI's thread trying to rescue stale readbacks; (8) ✅ snapshot Ghostty's actual render-state rows/cols during asynchronous resize catch-up and include snapshot geometry in the renderer invalidation key so resize catch-up frames are not skipped as "unchanged"; (9) ✅ keep the fresh-frame preference armed across a short interactive typing/paste burst so repeated echoed generations do not periodically fall back to stale-frame presents mid-burst; (10) ✅ stop forcing speculative GPUI repaints on handled key input before ConPTY echo has advanced the VT, so steady typing rides the real output wake path instead of paying for an extra unchanged prepaint; (11) ✅ preserve successive output wakes from the ConPTY reader instead of draining them into one repaint request, so bursty commands like `ls` can advance across multiple prepaints rather than visibly batching intermediate output; (12) ✅ when a fresher VT snapshot has already been submitted, stop presenting an older completed readback ahead of it, so PTY-driven redraws use true mailbox semantics instead of sliding through stale intermediate frames; (13) ✅ compute exact changed VT rows even when libghostty-vt reports full dirty, and use D3D `CopySubresourceRegion` to read back only those pixel rows for small updates while keeping full-readback fallbacks for resize/selection/theme changes; (14) ✅ replace dirty rows inside a CPU-side BGRA backing frame before publishing one GPUI image, so partial D3D readbacks keep replacement semantics even with translucent terminal backgrounds; (15) ✅ keep command-start output latency-critical for long enough to cover delayed shell output; (16) ✅ control shell/profile as a benchmark variable by honoring Windows Terminal's `defaultProfile` where possible. Runtime instrumentation behind `CON_GHOSTTY_PROFILE` now logs the full chain: `conpty_read` for chunk cadence, `vt_snapshot` for shared render-state + clone cost, `win_renderer` for drain/draw/submit/readback timing, partial-readback row counts, and ring state, `win_render_frame` for session-level timing, and `win_sync_render` for GPUI image-wrap/upload timing. Use `CON_LOG_FILE=con-profile.log` to capture these logs without shell redirection; idle unchanged frames are filtered by default to keep the app usable during profiling, and `CON_GHOSTTY_PROFILE_VERBOSE=1` enables every-frame traces. Postmortem: `postmortem/2026-04-26-windows-command-render-latency.md`. Long-term plan: once Phase 3d lands, present the swap chain directly via `attach_external_swap_chain_handle` and drop the readback entirely; profile with PIX / GPUView / ETW to verify Enter→glyph latency parity with WT. | Wins in `crates/con-app/src/windows_view.rs` (output wake handling + same-frame image swap + CPU-backed row replacement + image-wrap timing), `crates/con-ghostty/src/windows/conpty.rs` (chunk cadence timing + spawn-handle marker + Windows Terminal default-profile shell resolution), `crates/con-ghostty/src/windows/host_view.rs` (VT-generation-aware low-latency presents + frame instrumentation), `crates/con-ghostty/src/vt.rs` (render-state geometry snapshot + exact dirty-row derivation + shared snapshot instrumentation), and `crates/con-ghostty/src/windows/render/mod.rs` (instance/readback hot path + partial-row staging copies + per-stage timing + true mailbox presentation policy). ✅ substantially improved; direct swap-chain composition remains the long-term cleanup |
-| 4 | Hardening | Multi-pane, splits, IME, focus, resize, copy/paste, drag/drop, OSC 133 shell integration, ligatures | Beta-quality polish and correctness backlog. — |
+| 4 | Hardening | Multi-pane, splits, IME edge-case validation, focus, resize, copy/paste, drag/drop, OSC 133 shell integration, ligatures | Beta-quality polish and correctness backlog. — |
 | 5 | Distribution | Installer/signing strategy (MSI/MSIX/winget/`cargo dist`), code signing, update verification / hardening, `con-app.exe` rename via feature-gated twin `[[bin]]` | ZIP + PowerShell installer + in-place beta update flow exist; release-trust hardening remains. — |
 
 Phase 3c details now covered by the beta baseline:
@@ -348,6 +348,11 @@ Phase 3c details now covered by the beta baseline:
 - Wheel and touchpad input scroll libghostty-vt viewport state when mouse tracking is inactive. Alternate-screen mode-1007 wheel gestures translate into cursor keys with the same fractional row accumulator used by primary scrollback.
 - The Windows pane has a visible GPUI scrollback scrollbar backed by cached libghostty-vt scrollbar state, so render no longer polls the expensive scrollbar query on every paint.
 - OSC 52 and ordinary clipboard operations are wired through the Win32 clipboard.
+- CJK IME commit/preedit input is wired through GPUI's platform
+  `InputHandler`. The terminal still owns control, alt/meta, and
+  special-key encoding, while printable text and IME commits enter the
+  PTY as text. Composition ranges report cursor-relative bounds so
+  candidate windows anchor to the terminal cursor.
 - ConPTY child launch passes the pseudo-console with `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE`, avoids inheriting con's unrelated stdout/stderr handles, starts from a valid absolute cwd when provided, then falls back to the user's home directory and finally `%TEMP%`.
 - Profiling uses `CON_LOG_FILE` instead of shell redirection so the child shell never sees redirected log handles.
 
@@ -421,14 +426,14 @@ ConPTY spawns the Windows Terminal default profile shell when its
 settings are readable, libghostty-vt parses the VT
 stream, and the D3D11/DirectWrite atlas renderer draws the grid at
 native refresh rate — IoskeleyMono ASCII, box-drawing, Powerline
-separators, CJK/wide fallback glyphs, and the Nerd-Font icon set
+separators, CJK/wide fallback glyphs, CJK IME text input, and the Nerd-Font icon set
 (folder, git, status, …) all render correctly, cursor lands on the
 right column, Tab / Shift+Tab reach shells and TUIs, wheel gestures
 respect the platform scroll intent, and normal-shell scrollback is
 reachable through both the mouse wheel and the visible scrollbar.
 Resize works. Window close kills the shell. The remaining Windows work
-is now direct-composition presentation, IME input / resize / advanced
-selection polish, and distribution hardening rather than basic
+is now direct-composition presentation, IME edge-case validation /
+resize / advanced selection polish, and distribution hardening rather than basic
 input/selection bring-up.
 
 Caveats:
@@ -459,9 +464,10 @@ remaining decisions are narrower:
 2. **Shell integration scope.** Decide whether OSC 133 / OSC 7 and
    related shell-integration features belong in the shared VT layer or in
    per-platform shell adapters.
-3. **Windows hardening.** Finish IME coverage, drag-to-scroll selection
-   polish, column selection, extreme resize behavior, ligatures, and
-   remaining multi-monitor/GPU edge cases.
+3. **Windows hardening.** Broaden IME/dead-key/international-keyboard
+   validation, drag-to-scroll selection polish, column selection,
+   extreme resize behavior, ligatures, and remaining multi-monitor/GPU
+   edge cases.
 4. **Distribution.** Choose the installer/signing path (MSIX/MSI/cargo
    dist/winget), code-sign the binary, and harden the existing beta
    in-place update flow with artifact signature verification.

--- a/postmortem/2026-05-01-windows-linux-cjk-ime.md
+++ b/postmortem/2026-05-01-windows-linux-cjk-ime.md
@@ -1,0 +1,24 @@
+# Windows and Linux CJK IME input
+
+## What happened
+
+Windows and Linux terminal panes accepted raw key events and clipboard paste, but CJK IME commits did not reach the PTY reliably. Plain keyboard input was translated directly in `windows_view.rs` and `linux_view.rs`, while GPUI's platform IME plumbing had no focused terminal `InputHandler` registered for those panes.
+
+## Root cause
+
+The macOS terminal path already registers an input handler around the embedded Ghostty view. The Windows and Linux preview terminal views did not. GPUI already receives Windows IMM32 composition events, X11 XIM commits/preedit, and Wayland text-input-v3 commits/preedit, but without an active `InputHandler` it cannot deliver committed text or ask for a cursor rectangle for candidate placement.
+
+## Fix applied
+
+Added non-macOS terminal input handlers that:
+
+- keep IME marked text and selected-range state for composition tracking;
+- send committed text to the focused terminal PTY;
+- report cursor-relative bounds so candidate windows anchor at the terminal cursor;
+- route plain printable input through the platform text-input path while preserving terminal handling for control, alt/meta, and special keys.
+
+The macOS `ghostty_view.rs` path was left unchanged.
+
+## What we learned
+
+The non-macOS terminal views need to participate in GPUI text input even though they still own terminal-specific key encoding. Printable text and IME commits should enter through `InputHandler`; terminal-only key semantics should stay in the keydown encoder. Composition is not just a commit event: the marked-text caret range must also be tracked so Windows and Linux IMEs can place candidate UI at the right terminal cell during preedit.


### PR DESCRIPTION
## Summary

Adds CJK IME support for the Windows and Linux terminal panes without changing the existing macOS Ghostty view path.

- Registers focused GPUI `InputHandler`s for Windows and Linux terminal views so platform IME commits/preedit can reach the PTY.
- Tracks marked text plus the IME-selected preedit range, and reports cursor-relative bounds so candidate windows anchor at the terminal cursor.
- Uses display-cell width, not raw UTF-16 length, when offsetting candidate bounds through CJK/wide preedit text.
- Extracts the shared non-macOS IME `InputHandler` state machine so Windows and Linux stay in sync while keeping platform-specific session/cursor behavior local to each view.
- Clears IME composition state during terminal surface shutdown so stale preedit ranges cannot leak into a restarted session.
- Routes plain printable input through the platform text-input path while preserving terminal handling for control, alt/meta, and special keys.
- Updates the changelog, Windows/Linux implementation docs, and the postmortem so the remaining backlog is validation/hardening rather than basic IME bring-up.

## Root Cause

The non-macOS terminal views translated raw keydown events directly, but did not register a focused text input handler. GPUI already receives Windows IMM32, X11 XIM, and Wayland text-input-v3 events, but had no terminal handler to deliver committed text to or to query candidate-window coordinates from.

## Validation

- User smoke-tested the Windows CJK IME path successfully.
- `cargo fmt`
- `cargo check -p con`
- `cargo check -p con --no-default-features --features bin-con-app`
- `git diff --check`

Cross-target checks were attempted but are blocked by this macOS host toolchain before reaching the changed platform view code:

- Windows MSVC target: missing MSVC/Windows SDK tooling and headers (`lib.exe`, `windows.h`, standard C headers) while building native C dependencies such as `psm`, `ring`, and `aws-lc-sys`.
- Linux GNU target: missing `x86_64-linux-gnu-gcc` while building native C dependencies such as `ring` and `aws-lc-sys`.

References #89, #18, #34.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new GPUI `InputHandler`-based text input plumbing to the Windows/Linux terminal views and changes key event routing, which can regress keyboard behavior or IME composition/candidate positioning if edge cases are missed.
> 
> **Overview**
> Adds CJK IME commit/preedit support to **Windows and Linux terminal panes** by registering a focused GPUI `InputHandler` over the terminal views and tracking marked-text + selection ranges so candidate windows can anchor to the terminal cursor.
> 
> Introduces a shared `terminal_ime` module (and `unicode-width` dependency) to translate UTF-16 composition ranges into display-cell offsets, clears IME state on surface shutdown, and adjusts key handling so printable characters prefer the platform text-input path while ctrl/alt/special-key encoding remains terminal-local. Documentation/changelog/postmortem are updated to reflect the new IME support and remaining validation work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5665d3a24982ee70e58d9ba5e53476303b93dee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->