### PR TITLE
Improve Monterey embedded terminal layer sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ## `origin/main`
 
+### Fixed
+
+**Terminal, macOS**
+
+- Improved macOS Monterey fallback for the embedded Ghostty terminal. On macOS 12 and older, Con now explicitly keeps Ghostty's hosted IOSurface layer geometry synchronized with the native surface view, addressing reports where old macOS showed an opaque black terminal area but no visible output. Modern macOS keeps Ghostty's existing layer ownership unchanged. Tracks [#20](https://github.com/nowledge-co/con-terminal/issues/20).
+
 ## `v0.1.0-beta.48` - 2026-05-01
 
 ### Fixed

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -693,6 +693,55 @@ impl GhosttyView {
     }
 
     #[cfg(target_os = "macos")]
+    fn sync_native_layer_geometry(view: id, contents_scale: f32) {
+        if view.is_null() {
+            return;
+        }
+        if !Self::needs_legacy_native_layer_geometry_sync() {
+            return;
+        }
+
+        unsafe {
+            let layer: id = msg_send![view, layer];
+            if layer.is_null() {
+                return;
+            }
+
+            // Ghostty turns the surface NSView into a layer-hosting view by
+            // assigning its IOSurface CALayer directly. On older AppKit
+            // compositors (Monterey), layer-hosting views can fail to keep
+            // their hosted layer bounds in lockstep with command-driven
+            // frame mutations, leaving only our opaque backing color visible.
+            let bounds: NSRect = msg_send![view, bounds];
+            let _: () = msg_send![layer, setFrame:bounds];
+            let _: () = msg_send![layer, setBounds:bounds];
+            let _: () = msg_send![layer, setContentsScale:f64::from(contents_scale)];
+            let _: () = msg_send![layer, setNeedsDisplay];
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn needs_legacy_native_layer_geometry_sync() -> bool {
+        static NEEDS_SYNC: OnceLock<bool> = OnceLock::new();
+        *NEEDS_SYNC.get_or_init(|| unsafe {
+            #[repr(C)]
+            struct NSOperatingSystemVersion {
+                major_version: isize,
+                minor_version: isize,
+                patch_version: isize,
+            }
+
+            let process_info: id = msg_send![class!(NSProcessInfo), processInfo];
+            if process_info.is_null() {
+                return false;
+            }
+
+            let version: NSOperatingSystemVersion = msg_send![process_info, operatingSystemVersion];
+            version.major_version <= 12
+        })
+    }
+
+    #[cfg(target_os = "macos")]
     fn sync_native_backing_background(&mut self) {
         let Some(rgba) = self.native_backing_rgba() else {
             return;
@@ -715,6 +764,7 @@ impl GhosttyView {
         }
         if let Some(nsview) = self.nsview {
             Self::apply_native_backing_color(nsview, rgba);
+            Self::sync_native_layer_geometry(nsview, self.scale_factor);
         }
         if let Some(underlay_view) = self.native_underlay_view
             && let Some(underlay_rgba) = self.native_underlay_rgba()
@@ -929,6 +979,7 @@ impl GhosttyView {
                 cocoa::foundation::NSSize::new(visible_width, visible_height),
             );
             let _: () = msg_send![nsview, setFrame:surface_frame];
+            Self::sync_native_layer_geometry(nsview, self.scale_factor);
         }
     }
 

--- a/postmortem/2026-04-15-monterey-transparent-terminal.md
+++ b/postmortem/2026-04-15-monterey-transparent-terminal.md
@@ -27,6 +27,12 @@ The corrected Monterey fallback keeps two separate rules:
 
 This preserves the embedded Ghostty architecture while giving Monterey users a solid window frame without hiding the terminal itself.
 
+New feedback on beta 37 showed a third failure mode: the terminal area became an opaque black rectangle, but shell output was still not visible. That points at the embedded Ghostty layer rather than the GPUI chrome: Ghostty turns the passed surface `NSView` into a layer-hosting view by assigning its IOSurface `CALayer` directly, and older AppKit compositors can fail to keep that hosted layer's bounds synchronized when Con mutates the native frame from GPUI layout callbacks.
+
+On macOS 12 and older, Con now explicitly re-syncs the Ghostty-owned hosted layer's frame, bounds, contents scale, and display invalidation whenever the embedded surface backing or deterministic surface frame is updated. The fallback still does not make the GPUI root opaque, and it remains macOS-only. Modern macOS keeps Ghostty's existing layer ownership unchanged because forcing the hosted layer geometry there changes edge composition around the terminal surface.
+
 ## What We Learned
 
 Native transparency around embedded Metal views must be treated as an OS-version capability, not just a user preference. Just as important: for embedded native views, "make the window opaque" and "make the UI root opaque" are not interchangeable fixes. The window can safely fall back to opaque while the host UI above the embedded surface still needs transparency to avoid painting over the terminal.
+
+For embedded layer-hosting views, the host app sometimes owns geometry invariants. Passing an `NSView` to Ghostty is not enough if Con later drives that view's frame outside normal AppKit layout; on old macOS releases, the hosted CALayer must be kept in lockstep with the view bounds. On modern macOS, Ghostty's own layer geometry should be left alone unless a concrete compositor bug proves otherwise.


### PR DESCRIPTION
## Summary

- Explicitly sync Ghostty's hosted IOSurface CALayer frame, bounds, contents scale, and display invalidation after Con updates the embedded macOS surface view.
- Document the beta37 issue #20 feedback: Monterey now shows an opaque terminal rectangle but no visible shell output, suggesting the native backing is visible while Ghostty's hosted layer is not compositing correctly.
- Add an unreleased changelog entry for the macOS Monterey fallback improvement.

## Rationale

Ghostty turns the NSView we pass into a layer-hosting view by assigning its IOSurface CALayer directly. On old AppKit compositors, command-driven frame changes from GPUI layout can leave that hosted layer out of sync with the view, so Con's opaque backing color is visible but Ghostty's terminal contents are not. Keeping the hosted layer geometry in lockstep is a small macOS-only invariant that should be safe on modern macOS and may fix Monterey.

## Validation

- `cargo fmt --all --check`
- `cargo check -p con --all-targets`
- `git diff --check`

Refs #20

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches macOS-native NSView/CALayer geometry updates for the embedded terminal, which can affect rendering/layout and may have OS-version-specific side effects, but is scoped to macOS-only code paths.
> 
> **Overview**
> **Improves the macOS Monterey fallback for the embedded Ghostty terminal** by explicitly re-synchronizing Ghostty’s hosted IOSurface `CALayer` geometry (frame/bounds/contents scale + display invalidation) whenever Con updates the surface view.
> 
> This adds a new macOS-only `sync_native_layer_geometry` call after both backing-color updates and deterministic `NSView` frame updates, targeting cases where Monterey shows an opaque terminal rectangle without terminal output. Documentation is updated via an unreleased changelog entry and an expanded Monterey postmortem referencing issue `#20`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e222f3642793c399baa4b98d7e5326d4b4da033b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* **Terminal (macOS Monterey)** - Resolved an issue where the terminal display appeared as an opaque black rectangle without any visible text output on macOS Monterey systems. Display synchronization has been corrected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->