### PR TITLE
Add pane surface actions and terminal context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ con is still pre-release, so entries may group related beta work while the produ
 
 - No unreleased changes.
 
-## `v0.1.0-beta.51` - 2026-05-02
+## `v0.1.0-beta.52` - 2026-05-02
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ## `origin/main`
 
+- No unreleased changes.
+
+## `v0.1.0-beta.51` - 2026-05-02
+
 ### Added
 
 **Control Plane**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ con is still pre-release, so entries may group related beta work while the produ
 **Control Plane**
 
 - Added Command Palette entries for pane-local terminal surfaces. Users can now create the first surface as a visible split, create additional surfaces inside the focused pane, cycle between surfaces in that pane, and close the current surface without reaching for `con-cli`.
+- Added a terminal right-click context menu across macOS, Windows, and Linux. It exposes paste/copy/clear, pane split and zoom controls, pane-local surface controls, Focus Input, and Command Palette through the same action system as keybindings and the app menu.
 
 ## `v0.1.0-beta.50` - 2026-05-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ## `origin/main`
 
+### Added
+
+**Control Plane**
+
+- Added Command Palette entries for pane-local terminal surfaces. Users can now create the first surface as a visible split, create additional surfaces inside the focused pane, cycle between surfaces in that pane, and close the current surface without reaching for `con-cli`.
+
 ## `v0.1.0-beta.50` - 2026-05-01
 
 **Terminal, macOS**

--- a/crates/con-app/src/command_palette.rs
+++ b/crates/con-app/src/command_palette.rs
@@ -96,6 +96,18 @@ const PALETTE_ACTIONS: &[PaletteAction] = &[
         category: "Pane",
     },
     PaletteAction {
+        id: "split-left",
+        label: "Split Left",
+        shortcut: "",
+        category: "Pane",
+    },
+    PaletteAction {
+        id: "split-up",
+        label: "Split Up",
+        shortcut: "",
+        category: "Pane",
+    },
+    PaletteAction {
         id: "toggle-pane-zoom",
         label: "Toggle Pane Zoom",
         shortcut: TOGGLE_PANE_ZOOM_SHORTCUT,

--- a/crates/con-app/src/command_palette.rs
+++ b/crates/con-app/src/command_palette.rs
@@ -102,6 +102,42 @@ const PALETTE_ACTIONS: &[PaletteAction] = &[
         category: "Pane",
     },
     PaletteAction {
+        id: "new-surface",
+        label: "New Surface in Pane",
+        shortcut: "",
+        category: "Surface",
+    },
+    PaletteAction {
+        id: "new-surface-split-right",
+        label: "New Surface Split Right",
+        shortcut: "",
+        category: "Surface",
+    },
+    PaletteAction {
+        id: "new-surface-split-down",
+        label: "New Surface Split Down",
+        shortcut: "",
+        category: "Surface",
+    },
+    PaletteAction {
+        id: "next-surface",
+        label: "Next Surface in Pane",
+        shortcut: "",
+        category: "Surface",
+    },
+    PaletteAction {
+        id: "previous-surface",
+        label: "Previous Surface in Pane",
+        shortcut: "",
+        category: "Surface",
+    },
+    PaletteAction {
+        id: "close-surface",
+        label: "Close Current Surface",
+        shortcut: "",
+        category: "Surface",
+    },
+    PaletteAction {
         id: "toggle-input-bar",
         label: "Toggle Input Bar",
         shortcut: "ctrl-`",

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -1549,6 +1549,7 @@ impl Render for GhosttyView {
         let input_focus = focus.clone();
         let context_focus = focus.clone();
         let menu_focus = focus.clone();
+        let ui_font = cx.theme().font_family.clone();
         let entity = cx.entity().downgrade();
         let show_layout_fallback = self.show_layout_fallback();
         let layout_fallback_bg = self
@@ -1568,6 +1569,7 @@ impl Render for GhosttyView {
 
         div()
             .size_full()
+            .font_family(ui_font)
             .map(|div| {
                 if show_layout_fallback {
                     div.bg(layout_fallback_bg)

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -27,6 +27,7 @@ use con_ghostty::{
 };
 use gpui::{prelude::FluentBuilder as _, *};
 use gpui_component::ActiveTheme;
+use gpui_component::menu::ContextMenuExt;
 
 use crate::terminal_paste::{
     TerminalPastePayload, payload_from_clipboard, payload_from_external_paths,
@@ -1546,6 +1547,8 @@ impl Render for GhosttyView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let focus = self.focus_handle.clone();
         let input_focus = focus.clone();
+        let context_focus = focus.clone();
+        let menu_focus = focus.clone();
         let entity = cx.entity().downgrade();
         let show_layout_fallback = self.show_layout_fallback();
         let layout_fallback_bg = self
@@ -1639,6 +1642,15 @@ impl Render for GhosttyView {
                     cx.notify();
                 }
             }))
+            .on_mouse_down(
+                gpui::MouseButton::Right,
+                cx.listener(move |this, event: &MouseDownEvent, window, cx| {
+                    window.focus(&context_focus, cx);
+                    this.last_mouse_position = Some(event.position);
+                    cx.emit(GhosttyFocusChanged);
+                    cx.notify();
+                }),
+            )
             .on_mouse_down(
                 gpui::MouseButton::Left,
                 cx.listener(move |this, event: &MouseDownEvent, window, cx| {
@@ -1741,6 +1753,13 @@ impl Render for GhosttyView {
                 )
                 .size_full(),
             )
+            .context_menu(move |menu, window, cx| {
+                crate::terminal_context_menu::terminal_context_menu(
+                    menu.action_context(menu_focus.clone()),
+                    window,
+                    cx,
+                )
+            })
     }
 }
 

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -24,6 +24,7 @@ use futures::StreamExt;
 use futures::channel::mpsc::unbounded;
 use gpui::*;
 use gpui_component::ActiveTheme;
+use gpui_component::menu::ContextMenuExt;
 
 use crate::terminal_ime::{TerminalImeInputHandler, TerminalImeView};
 use crate::terminal_links::{self, TerminalLink};
@@ -812,6 +813,8 @@ impl Render for GhosttyView {
         let theme = cx.theme();
         let focus = self.focus_handle.clone();
         let input_focus = focus.clone();
+        let context_focus = focus.clone();
+        let menu_focus = focus.clone();
         let entity = cx.entity().downgrade();
         let input_entity = entity.clone();
         let font_size_px = effective_font_size(self.initial_font_size);
@@ -998,6 +1001,19 @@ impl Render for GhosttyView {
                 }
             }))
             .on_mouse_down(
+                MouseButton::Right,
+                cx.listener(move |this, event: &MouseDownEvent, window, cx| {
+                    window.focus(&context_focus, cx);
+                    let _ = this.ensure_session(cx);
+                    this.last_mouse_position = Some(event.position);
+                    this.mouse_down_link = None;
+                    this.suppress_link_mouse_up = false;
+                    let _ = this.update_hovered_link(&event.modifiers);
+                    cx.emit(GhosttyFocusChanged);
+                    cx.notify();
+                }),
+            )
+            .on_mouse_down(
                 MouseButton::Left,
                 cx.listener(move |this, event: &MouseDownEvent, window, cx| {
                     window.focus(&focus, cx);
@@ -1102,6 +1118,13 @@ impl Render for GhosttyView {
                         .size_full(),
                     ),
             )
+            .context_menu(move |menu, window, cx| {
+                crate::terminal_context_menu::terminal_context_menu(
+                    menu.action_context(menu_focus.clone()),
+                    window,
+                    cx,
+                )
+            })
     }
 }
 

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -927,6 +927,7 @@ impl Render for GhosttyView {
             .size_full()
             .min_w_0()
             .min_h_0()
+            .font_family(theme.font_family.clone())
             .key_context("GhosttyTerminal")
             .track_focus(&self.focus_handle)
             .id(&self.focus_handle)

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -55,6 +55,7 @@ mod motion;
 mod pane_tree;
 mod settings_panel;
 mod sidebar;
+mod terminal_context_menu;
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 mod terminal_ime;
 mod terminal_links;
@@ -102,6 +103,15 @@ actions!(
         TogglePaneZoom,
         SplitRight,
         SplitDown,
+        SplitLeft,
+        SplitUp,
+        ClearTerminal,
+        NewSurface,
+        NewSurfaceSplitRight,
+        NewSurfaceSplitDown,
+        NextSurface,
+        PreviousSurface,
+        CloseSurface,
         FocusInput,
         CycleInputMode,
         TogglePaneScopePicker,
@@ -1199,6 +1209,17 @@ fn main() {
                     MenuItem::separator(),
                     MenuItem::action("Split Right", SplitRight),
                     MenuItem::action("Split Down", SplitDown),
+                    MenuItem::action("Split Left", SplitLeft),
+                    MenuItem::action("Split Up", SplitUp),
+                    MenuItem::separator(),
+                    MenuItem::action("Clear Terminal", ClearTerminal),
+                    MenuItem::separator(),
+                    MenuItem::action("New Surface in Pane", NewSurface),
+                    MenuItem::action("New Surface Split Right", NewSurfaceSplitRight),
+                    MenuItem::action("New Surface Split Down", NewSurfaceSplitDown),
+                    MenuItem::action("Next Surface in Pane", NextSurface),
+                    MenuItem::action("Previous Surface in Pane", PreviousSurface),
+                    MenuItem::action("Close Current Surface", CloseSurface),
                 ],
                 disabled: false,
             },

--- a/crates/con-app/src/terminal_context_menu.rs
+++ b/crates/con-app/src/terminal_context_menu.rs
@@ -1,0 +1,61 @@
+use gpui::{Action, Context, Window};
+use gpui_component::menu::PopupMenu;
+
+pub(crate) fn terminal_context_menu(
+    menu: PopupMenu,
+    window: &mut Window,
+    cx: &mut Context<PopupMenu>,
+) -> PopupMenu {
+    menu.menu("Paste", Box::new(crate::Paste) as Box<dyn Action>)
+        .menu("Copy", Box::new(crate::Copy) as Box<dyn Action>)
+        .menu(
+            "Clear Terminal",
+            Box::new(crate::ClearTerminal) as Box<dyn Action>,
+        )
+        .separator()
+        .submenu("Split Pane", window, cx, |menu, _window, _cx| {
+            menu.menu("Right", Box::new(crate::SplitRight) as Box<dyn Action>)
+                .menu("Down", Box::new(crate::SplitDown) as Box<dyn Action>)
+                .menu("Left", Box::new(crate::SplitLeft) as Box<dyn Action>)
+                .menu("Up", Box::new(crate::SplitUp) as Box<dyn Action>)
+        })
+        .menu(
+            "Toggle Pane Zoom",
+            Box::new(crate::TogglePaneZoom) as Box<dyn Action>,
+        )
+        .menu("Close Pane", Box::new(crate::ClosePane) as Box<dyn Action>)
+        .separator()
+        .submenu("Surfaces", window, cx, |menu, _window, _cx| {
+            menu.menu(
+                "New in Pane",
+                Box::new(crate::NewSurface) as Box<dyn Action>,
+            )
+            .menu(
+                "New Split Right",
+                Box::new(crate::NewSurfaceSplitRight) as Box<dyn Action>,
+            )
+            .menu(
+                "New Split Down",
+                Box::new(crate::NewSurfaceSplitDown) as Box<dyn Action>,
+            )
+            .separator()
+            .menu("Next", Box::new(crate::NextSurface) as Box<dyn Action>)
+            .menu(
+                "Previous",
+                Box::new(crate::PreviousSurface) as Box<dyn Action>,
+            )
+            .menu(
+                "Close Current",
+                Box::new(crate::CloseSurface) as Box<dyn Action>,
+            )
+        })
+        .separator()
+        .menu(
+            "Focus Input",
+            Box::new(crate::FocusInput) as Box<dyn Action>,
+        )
+        .menu(
+            "Command Palette",
+            Box::new(crate::command_palette::ToggleCommandPalette) as Box<dyn Action>,
+        )
+}

--- a/crates/con-app/src/terminal_context_menu.rs
+++ b/crates/con-app/src/terminal_context_menu.rs
@@ -1,61 +1,102 @@
-use gpui::{Action, Context, Window};
-use gpui_component::menu::PopupMenu;
+use gpui::{
+    Action, AnyElement, App, Context, IntoElement as _, ParentElement as _, SharedString,
+    Styled as _, Window, div, px,
+};
+use gpui_component::ActiveTheme as _;
+use gpui_component::kbd::Kbd;
+use gpui_component::menu::{PopupMenu, PopupMenuItem};
+
+fn action_item(label: &'static str, action: Box<dyn Action>) -> PopupMenuItem {
+    let render_action = action.boxed_clone();
+    PopupMenuItem::element(move |window, cx| action_row(label, render_action.as_ref(), window, cx))
+        .action(action)
+}
+
+fn action_row(
+    label: &'static str,
+    action: &dyn Action,
+    window: &mut Window,
+    cx: &mut App,
+) -> AnyElement {
+    let theme = cx.theme();
+    let shortcut =
+        crate::keycaps::first_action_keystroke(action, window).map(|stroke| Kbd::format(&stroke));
+
+    div()
+        .flex()
+        .w_full()
+        .min_w(px(188.0))
+        .items_center()
+        .justify_between()
+        .gap(px(24.0))
+        .font_family(theme.font_family.clone())
+        .child(
+            div()
+                .min_w_0()
+                .text_size(px(13.0))
+                .line_height(px(18.0))
+                .child(SharedString::from(label)),
+        )
+        .child(
+            div()
+                .flex()
+                .min_w(px(54.0))
+                .justify_end()
+                .text_size(px(11.0))
+                .line_height(px(14.0))
+                .font_weight(gpui::FontWeight::MEDIUM)
+                .text_color(theme.muted_foreground.opacity(0.72))
+                .children(shortcut),
+        )
+        .into_any_element()
+}
 
 pub(crate) fn terminal_context_menu(
     menu: PopupMenu,
     window: &mut Window,
     cx: &mut Context<PopupMenu>,
 ) -> PopupMenu {
-    menu.menu("Paste", Box::new(crate::Paste) as Box<dyn Action>)
-        .menu("Copy", Box::new(crate::Copy) as Box<dyn Action>)
-        .menu(
+    menu.min_w(px(220.0))
+        .item(action_item("Paste", Box::new(crate::Paste)))
+        .item(action_item("Copy", Box::new(crate::Copy)))
+        .item(action_item(
             "Clear Terminal",
-            Box::new(crate::ClearTerminal) as Box<dyn Action>,
-        )
+            Box::new(crate::ClearTerminal),
+        ))
         .separator()
         .submenu("Split Pane", window, cx, |menu, _window, _cx| {
-            menu.menu("Right", Box::new(crate::SplitRight) as Box<dyn Action>)
-                .menu("Down", Box::new(crate::SplitDown) as Box<dyn Action>)
-                .menu("Left", Box::new(crate::SplitLeft) as Box<dyn Action>)
-                .menu("Up", Box::new(crate::SplitUp) as Box<dyn Action>)
+            menu.min_w(px(164.0))
+                .item(action_item("Right", Box::new(crate::SplitRight)))
+                .item(action_item("Down", Box::new(crate::SplitDown)))
+                .item(action_item("Left", Box::new(crate::SplitLeft)))
+                .item(action_item("Up", Box::new(crate::SplitUp)))
         })
-        .menu(
+        .item(action_item(
             "Toggle Pane Zoom",
-            Box::new(crate::TogglePaneZoom) as Box<dyn Action>,
-        )
-        .menu("Close Pane", Box::new(crate::ClosePane) as Box<dyn Action>)
+            Box::new(crate::TogglePaneZoom),
+        ))
+        .item(action_item("Close Pane", Box::new(crate::ClosePane)))
         .separator()
         .submenu("Surfaces", window, cx, |menu, _window, _cx| {
-            menu.menu(
-                "New in Pane",
-                Box::new(crate::NewSurface) as Box<dyn Action>,
-            )
-            .menu(
-                "New Split Right",
-                Box::new(crate::NewSurfaceSplitRight) as Box<dyn Action>,
-            )
-            .menu(
-                "New Split Down",
-                Box::new(crate::NewSurfaceSplitDown) as Box<dyn Action>,
-            )
-            .separator()
-            .menu("Next", Box::new(crate::NextSurface) as Box<dyn Action>)
-            .menu(
-                "Previous",
-                Box::new(crate::PreviousSurface) as Box<dyn Action>,
-            )
-            .menu(
-                "Close Current",
-                Box::new(crate::CloseSurface) as Box<dyn Action>,
-            )
+            menu.min_w(px(188.0))
+                .item(action_item("New in Pane", Box::new(crate::NewSurface)))
+                .item(action_item(
+                    "New Split Right",
+                    Box::new(crate::NewSurfaceSplitRight),
+                ))
+                .item(action_item(
+                    "New Split Down",
+                    Box::new(crate::NewSurfaceSplitDown),
+                ))
+                .separator()
+                .item(action_item("Next", Box::new(crate::NextSurface)))
+                .item(action_item("Previous", Box::new(crate::PreviousSurface)))
+                .item(action_item("Close Current", Box::new(crate::CloseSurface)))
         })
         .separator()
-        .menu(
-            "Focus Input",
-            Box::new(crate::FocusInput) as Box<dyn Action>,
-        )
-        .menu(
+        .item(action_item("Focus Input", Box::new(crate::FocusInput)))
+        .item(action_item(
             "Command Palette",
-            Box::new(crate::command_palette::ToggleCommandPalette) as Box<dyn Action>,
-        )
+            Box::new(crate::command_palette::ToggleCommandPalette),
+        ))
 }

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -1350,11 +1350,13 @@ impl Render for GhosttyView {
         let input_focus = focus.clone();
         let context_focus = focus.clone();
         let menu_focus = focus.clone();
+        let ui_font = cx.theme().font_family.clone();
 
         div()
             .flex()
             .flex_col()
             .size_full()
+            .font_family(ui_font)
             .min_w_0()
             .min_h_0()
             .key_context("GhosttyTerminal")

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -46,6 +46,7 @@ use futures::StreamExt;
 use futures::channel::mpsc::{UnboundedSender, unbounded};
 use gpui::*;
 use gpui_component::ActiveTheme;
+use gpui_component::menu::ContextMenuExt;
 use image::{Frame, RgbaImage};
 use smallvec::SmallVec;
 
@@ -1347,6 +1348,8 @@ impl Render for GhosttyView {
 
         let focus = self.focus_handle.clone();
         let input_focus = focus.clone();
+        let context_focus = focus.clone();
+        let menu_focus = focus.clone();
 
         div()
             .flex()
@@ -1419,6 +1422,18 @@ impl Render for GhosttyView {
                     cx.notify();
                 }
             }))
+            .on_mouse_down(
+                MouseButton::Right,
+                cx.listener(move |this, event: &MouseDownEvent, window, cx| {
+                    window.focus(&context_focus, cx);
+                    this.last_mouse_position = Some(event.position);
+                    this.mouse_down_link = None;
+                    this.suppress_link_mouse_up = false;
+                    let _ = this.update_hovered_link(&event.modifiers);
+                    cx.emit(GhosttyFocusChanged);
+                    cx.notify();
+                }),
+            )
             .on_mouse_down(
                 MouseButton::Left,
                 cx.listener(move |this, event: &MouseDownEvent, window, cx| {
@@ -1567,6 +1582,13 @@ impl Render for GhosttyView {
                             ),
                     ),
             )
+            .context_menu(move |menu, window, cx| {
+                crate::terminal_context_menu::terminal_context_menu(
+                    menu.action_context(menu_focus.clone()),
+                    window,
+                    cx,
+                )
+            })
     }
 }
 

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -246,10 +246,11 @@ use crate::ghostty_view::{
     GhosttyView,
 };
 use crate::{
-    ClosePane, CloseTab, CycleInputMode, FocusInput, NewTab, NextTab, PreviousTab, Quit,
-    SelectTab1, SelectTab2, SelectTab3, SelectTab4, SelectTab5, SelectTab6, SelectTab7, SelectTab8,
-    SelectTab9, SplitDown, SplitRight, ToggleAgentPanel, TogglePaneScopePicker, TogglePaneZoom,
-    ToggleVerticalTabs,
+    ClearTerminal, ClosePane, CloseSurface, CloseTab, CycleInputMode, FocusInput, NewSurface,
+    NewSurfaceSplitDown, NewSurfaceSplitRight, NewTab, NextSurface, NextTab, PreviousSurface,
+    PreviousTab, Quit, SelectTab1, SelectTab2, SelectTab3, SelectTab4, SelectTab5, SelectTab6,
+    SelectTab7, SelectTab8, SelectTab9, SplitDown, SplitLeft, SplitRight, SplitUp,
+    ToggleAgentPanel, TogglePaneScopePicker, TogglePaneZoom, ToggleVerticalTabs,
 };
 use con_agent::{
     AgentConfig, Conversation, ProviderKind, TerminalExecRequest, TerminalExecResponse,
@@ -4684,6 +4685,17 @@ impl ConWorkspace {
             "split-down" => {
                 self.split_pane(SplitDirection::Vertical, SplitPlacement::After, window, cx);
             }
+            "split-left" => {
+                self.split_pane(
+                    SplitDirection::Horizontal,
+                    SplitPlacement::Before,
+                    window,
+                    cx,
+                );
+            }
+            "split-up" => {
+                self.split_pane(SplitDirection::Vertical, SplitPlacement::Before, window, cx);
+            }
             "toggle-pane-zoom" => {
                 self.toggle_pane_zoom(&TogglePaneZoom, window, cx);
             }
@@ -8228,6 +8240,78 @@ impl ConWorkspace {
         }
     }
 
+    fn split_left(&mut self, _: &SplitLeft, window: &mut Window, cx: &mut Context<Self>) {
+        if self.has_active_tab() {
+            self.split_pane(
+                SplitDirection::Horizontal,
+                SplitPlacement::Before,
+                window,
+                cx,
+            );
+        }
+    }
+
+    fn split_up(&mut self, _: &SplitUp, window: &mut Window, cx: &mut Context<Self>) {
+        if self.has_active_tab() {
+            self.split_pane(SplitDirection::Vertical, SplitPlacement::Before, window, cx);
+        }
+    }
+
+    fn clear_terminal(&mut self, _: &ClearTerminal, _window: &mut Window, cx: &mut Context<Self>) {
+        if self.has_active_tab() {
+            self.active_terminal().clear_scrollback(cx);
+        }
+    }
+
+    fn new_surface(&mut self, _: &NewSurface, window: &mut Window, cx: &mut Context<Self>) {
+        self.create_surface_in_focused_pane(window, cx);
+    }
+
+    fn new_surface_split_right(
+        &mut self,
+        _: &NewSurfaceSplitRight,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.create_surface_split_from_focused_pane(
+            SplitDirection::Horizontal,
+            SplitPlacement::After,
+            window,
+            cx,
+        );
+    }
+
+    fn new_surface_split_down(
+        &mut self,
+        _: &NewSurfaceSplitDown,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.create_surface_split_from_focused_pane(
+            SplitDirection::Vertical,
+            SplitPlacement::After,
+            window,
+            cx,
+        );
+    }
+
+    fn next_surface(&mut self, _: &NextSurface, window: &mut Window, cx: &mut Context<Self>) {
+        self.cycle_surface_in_focused_pane(1, window, cx);
+    }
+
+    fn previous_surface(
+        &mut self,
+        _: &PreviousSurface,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.cycle_surface_in_focused_pane(-1, window, cx);
+    }
+
+    fn close_surface(&mut self, _: &CloseSurface, window: &mut Window, cx: &mut Context<Self>) {
+        self.close_current_surface_in_focused_pane(window, cx);
+    }
+
     fn close_pane(&mut self, _: &ClosePane, window: &mut Window, cx: &mut Context<Self>) {
         if !self.has_active_tab() {
             return;
@@ -9801,6 +9885,15 @@ impl Render for ConWorkspace {
                 .on_action(cx.listener(Self::toggle_pane_zoom))
                 .on_action(cx.listener(Self::split_right))
                 .on_action(cx.listener(Self::split_down))
+                .on_action(cx.listener(Self::split_left))
+                .on_action(cx.listener(Self::split_up))
+                .on_action(cx.listener(Self::clear_terminal))
+                .on_action(cx.listener(Self::new_surface))
+                .on_action(cx.listener(Self::new_surface_split_right))
+                .on_action(cx.listener(Self::new_surface_split_down))
+                .on_action(cx.listener(Self::next_surface))
+                .on_action(cx.listener(Self::previous_surface))
+                .on_action(cx.listener(Self::close_surface))
                 .on_action(cx.listener(Self::focus_input))
                 .on_action(cx.listener(Self::cycle_input_mode))
                 .on_action(cx.listener(Self::toggle_pane_scope_picker))

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -8037,6 +8037,7 @@ impl ConWorkspace {
                 startup_command: None,
             },
         );
+        self.sync_sidebar(cx);
         self.save_session(cx);
         cx.notify();
     }
@@ -8099,6 +8100,7 @@ impl ConWorkspace {
                 startup_command: None,
             },
         );
+        self.sync_sidebar(cx);
         self.save_session(cx);
         cx.notify();
     }
@@ -8174,6 +8176,7 @@ impl ConWorkspace {
         replacement.ensure_surface(window, cx);
         replacement.focus(window, cx);
         self.sync_active_terminal_focus_states(cx);
+        self.sync_sidebar(cx);
         self.save_session(cx);
         cx.notify();
     }

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -4687,6 +4687,34 @@ impl ConWorkspace {
             "toggle-pane-zoom" => {
                 self.toggle_pane_zoom(&TogglePaneZoom, window, cx);
             }
+            "new-surface" => {
+                self.create_surface_in_focused_pane(window, cx);
+            }
+            "new-surface-split-right" => {
+                self.create_surface_split_from_focused_pane(
+                    SplitDirection::Horizontal,
+                    SplitPlacement::After,
+                    window,
+                    cx,
+                );
+            }
+            "new-surface-split-down" => {
+                self.create_surface_split_from_focused_pane(
+                    SplitDirection::Vertical,
+                    SplitPlacement::After,
+                    window,
+                    cx,
+                );
+            }
+            "next-surface" => {
+                self.cycle_surface_in_focused_pane(1, window, cx);
+            }
+            "previous-surface" => {
+                self.cycle_surface_in_focused_pane(-1, window, cx);
+            }
+            "close-surface" => {
+                self.close_current_surface_in_focused_pane(window, cx);
+            }
             "clear-terminal" => {
                 if self.has_active_tab() {
                     self.active_terminal().clear_scrollback(cx);
@@ -7953,6 +7981,189 @@ impl ConWorkspace {
         self.harness
             .send_message(session, agent_config, content.to_string(), context);
         self.save_session(cx);
+    }
+
+    fn create_surface_in_focused_pane(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if !self.has_active_tab() {
+            return;
+        }
+
+        let tab_idx = self.active_tab;
+        let pane_id = self.tabs[tab_idx].pane_tree.focused_pane_id();
+        let cwd = self.tabs[tab_idx]
+            .pane_tree
+            .focused_terminal()
+            .current_dir(cx);
+        let terminal = self.create_terminal(cwd.as_deref(), window, cx);
+        let options = SurfaceCreateOptions::plain(None);
+        let Some(_surface_id) =
+            self.tabs[tab_idx]
+                .pane_tree
+                .create_surface_in_pane(pane_id, terminal.clone(), options)
+        else {
+            return;
+        };
+
+        #[cfg(target_os = "macos")]
+        self.mark_tab_terminal_native_layout_pending(tab_idx, cx);
+        self.notify_tab_terminal_views(tab_idx, cx);
+        terminal.ensure_surface(window, cx);
+        terminal.focus(window, cx);
+        self.sync_active_terminal_focus_states(cx);
+        self.sync_active_tab_native_view_visibility_now_or_after_layout(false, window, cx);
+        Self::schedule_terminal_bootstrap_reassert(
+            &terminal,
+            true,
+            self.window_handle,
+            self.workspace_handle.clone(),
+            cx,
+        );
+        self.record_runtime_event_for_terminal(
+            tab_idx,
+            &terminal,
+            con_agent::context::PaneRuntimeEvent::PaneCreated {
+                startup_command: None,
+            },
+        );
+        self.save_session(cx);
+        cx.notify();
+    }
+
+    fn create_surface_split_from_focused_pane(
+        &mut self,
+        direction: SplitDirection,
+        placement: SplitPlacement,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.has_active_tab() {
+            return;
+        }
+
+        let tab_idx = self.active_tab;
+        let source_pane_id = self.tabs[tab_idx].pane_tree.focused_pane_id();
+        let cwd = self.tabs[tab_idx]
+            .pane_tree
+            .focused_terminal()
+            .current_dir(cx);
+        let terminal = self.create_terminal(cwd.as_deref(), window, cx);
+        let was_zoomed = self.tabs[tab_idx].pane_tree.zoomed_pane_id().is_some();
+        let options = SurfaceCreateOptions {
+            title: None,
+            owner: Some("command-palette".to_string()),
+            close_pane_when_last: true,
+        };
+        let Some((_pane_id, _surface_id)) = self.tabs[tab_idx]
+            .pane_tree
+            .split_pane_with_surface_options(
+                source_pane_id,
+                direction,
+                placement,
+                terminal.clone(),
+                options,
+            )
+        else {
+            return;
+        };
+
+        #[cfg(target_os = "macos")]
+        self.mark_tab_terminal_native_layout_pending(tab_idx, cx);
+        self.notify_tab_terminal_views(tab_idx, cx);
+        terminal.ensure_surface(window, cx);
+        terminal.focus(window, cx);
+        self.sync_active_terminal_focus_states(cx);
+        self.sync_active_tab_native_view_visibility_now_or_after_layout(was_zoomed, window, cx);
+        Self::schedule_terminal_bootstrap_reassert(
+            &terminal,
+            true,
+            self.window_handle,
+            self.workspace_handle.clone(),
+            cx,
+        );
+        self.record_runtime_event_for_terminal(
+            tab_idx,
+            &terminal,
+            con_agent::context::PaneRuntimeEvent::PaneCreated {
+                startup_command: None,
+            },
+        );
+        self.save_session(cx);
+        cx.notify();
+    }
+
+    fn cycle_surface_in_focused_pane(
+        &mut self,
+        offset: isize,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.has_active_tab() {
+            return;
+        }
+
+        let pane_tree = &self.tabs[self.active_tab].pane_tree;
+        let pane_id = pane_tree.focused_pane_id();
+        let surfaces = pane_tree.surface_infos(Some(pane_id));
+        if surfaces.len() <= 1 {
+            return;
+        }
+
+        let active_index = surfaces
+            .iter()
+            .position(|surface| surface.is_active)
+            .unwrap_or(0);
+        let len = surfaces.len() as isize;
+        let next_index = (active_index as isize + offset).rem_euclid(len) as usize;
+        let next_surface_id = surfaces[next_index].surface_id;
+        self.focus_surface_in_active_tab(next_surface_id, window, cx);
+    }
+
+    fn close_current_surface_in_focused_pane(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.has_active_tab() {
+            return;
+        }
+
+        let tab_idx = self.active_tab;
+        let pane_id = self.tabs[tab_idx].pane_tree.focused_pane_id();
+        let surfaces = self.tabs[tab_idx].pane_tree.surface_infos(Some(pane_id));
+        if surfaces.len() <= 1
+            && !surfaces
+                .first()
+                .is_some_and(|surface| surface.close_pane_when_last && surface.owner.is_some())
+        {
+            return;
+        }
+        let Some(surface_id) = surfaces
+            .iter()
+            .find(|surface| surface.is_active)
+            .map(|surface| surface.surface_id)
+        else {
+            return;
+        };
+
+        let Some(close_outcome) = self.tabs[tab_idx].pane_tree.close_surface(surface_id, true)
+        else {
+            return;
+        };
+        let closing = close_outcome.terminal.clone();
+        closing.set_focus_state(false, cx);
+        closing.set_native_view_visible(false, cx);
+        closing.shutdown_surface(cx);
+
+        #[cfg(target_os = "macos")]
+        self.mark_tab_terminal_native_layout_pending(tab_idx, cx);
+        self.notify_tab_terminal_views(tab_idx, cx);
+        self.sync_active_tab_native_view_visibility(cx);
+        let replacement = self.tabs[tab_idx].pane_tree.focused_terminal().clone();
+        replacement.ensure_surface(window, cx);
+        replacement.focus(window, cx);
+        self.sync_active_terminal_focus_states(cx);
+        self.save_session(cx);
+        cx.notify();
     }
 
     fn split_pane(

--- a/docs/impl/pane-surfaces.md
+++ b/docs/impl/pane-surfaces.md
@@ -74,6 +74,35 @@ Surface targeting accepts:
 
 Prefer `surface_id` for follow-up automation.
 
+## Command Palette
+
+Surface control is also available from Command Palette so humans can discover
+and exercise the same pane-local model without using `con-cli`.
+
+- `New Surface in Pane`: creates a new terminal session inside the focused
+  pane and focuses it.
+- `New Surface Split Right`: creates a new right split from the focused pane,
+  with its first terminal session represented as a surface.
+- `New Surface Split Down`: creates a new down split from the focused pane,
+  with its first terminal session represented as a surface.
+- `Next Surface in Pane`: cycles forward through surfaces hosted by the
+  focused pane.
+- `Previous Surface in Pane`: cycles backward through surfaces hosted by the
+  focused pane.
+- `Close Current Surface`: closes the active surface when the focused pane has
+  more than one surface. If the surface was created as an owned palette split,
+  closing that last surface also closes the worker pane. It intentionally does
+  nothing for the last non-owned surface in a pane; ordinary pane closing
+  remains the pane-level command.
+
+These palette actions are deliberately pane-local. They do not change the
+existing `panes.*` control-plane contract, the built-in agent harness target
+model, or terminal-agent benchmark assumptions.
+
+This mirrors the interactive-subagent flow: create the first worker as a
+visible split, then add later workers as surfaces inside that worker pane so
+parallel agents do not keep shrinking the main terminal layout.
+
 ## CLI Examples
 
 First create a visible worker pane:

--- a/docs/impl/pane-surfaces.md
+++ b/docs/impl/pane-surfaces.md
@@ -74,10 +74,11 @@ Surface targeting accepts:
 
 Prefer `surface_id` for follow-up automation.
 
-## Command Palette
+## Human Entry Points
 
-Surface control is also available from Command Palette so humans can discover
-and exercise the same pane-local model without using `con-cli`.
+Surface control is also available from Command Palette and the terminal
+right-click menu so humans can discover and exercise the same pane-local model
+without using `con-cli`.
 
 - `New Surface in Pane`: creates a new terminal session inside the focused
   pane and focuses it.
@@ -98,6 +99,12 @@ and exercise the same pane-local model without using `con-cli`.
 These palette actions are deliberately pane-local. They do not change the
 existing `panes.*` control-plane contract, the built-in agent harness target
 model, or terminal-agent benchmark assumptions.
+
+The terminal context menu uses the same GPUI actions as the Command Palette and
+app menu instead of custom callbacks. That keeps right-click behavior aligned
+with keyboard and automation entry points: the menu first restores focus to the
+clicked terminal, then dispatches the selected action through the normal window
+action path.
 
 This mirrors the interactive-subagent flow: create the first worker as a
 visible split, then add later workers as surfaces inside that worker pane so


### PR DESCRIPTION
## Summary
- add Command Palette entries for the full pane-surface lifecycle: create a visible surface split right/down, add a surface inside the focused pane, cycle next/previous, and close current
- add a cross-platform terminal right-click menu that exposes paste/copy/clear, split pane, pane zoom, pane-local surfaces, Focus Input, and Command Palette through the same GPUI action system as keybindings and app menus
- mirror the interactive-subagent flow from issue #94: first worker gets a visible split; later workers become pane-local surfaces in that worker pane
- keep `panes.*`, the built-in Con agent harness, and benchmark assumptions unchanged; surface actions remain opt-in and pane-local
- document the command-palette/context-menu surface path and update the changelog

Fixes #94

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `cargo check -p con --all-targets`
- `cargo check -p con --no-default-features --features con/bin-con-app --all-targets`
- `cargo test -p con --all-targets`
- `cargo test -p con --no-default-features --features con/bin-con-app --all-targets`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core workspace/pane lifecycle and terminal view event handling across macOS/Windows/Linux; bugs could cause focus regressions or incorrect surface/pane teardown. No auth/security or external data handling changes.
> 
> **Overview**
> Adds new **pane-local surface lifecycle commands** (create surface in pane, create surface via split right/down, cycle next/previous, close current) and exposes them via the Command Palette, app menu, and new workspace action handlers.
> 
> Introduces a cross-platform **terminal right-click context menu** (paste/copy/clear, split/zoom/close pane, surface controls, focus input, command palette) and updates terminal views to restore focus on right-click before dispatching menu actions.
> 
> Also expands pane split affordances to include `SplitLeft`/`SplitUp`, and updates changelog + `docs/impl/pane-surfaces.md` to document the new human entry points and intended behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7982179be5454de99243495f76a92e84f66a8bb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->