### PR TITLE
Retry timestamped macOS codesign

### DIFF
--- a/scripts/macos/release.sh
+++ b/scripts/macos/release.sh
@@ -18,16 +18,37 @@ require_cmd shasum
 
 sign_identity_value="$(signing_identity)"
 
+run_codesign() {
+  local max_attempts=4
+  local delay=10
+  local attempt
+
+  for attempt in $(seq 1 "$max_attempts"); do
+    if codesign "$@"; then
+      return 0
+    fi
+
+    local status=$?
+    if [[ "$attempt" -ge "$max_attempts" ]]; then
+      return "$status"
+    fi
+
+    log "codesign failed with exit status $status; retrying in ${delay}s (${attempt}/${max_attempts})"
+    sleep "$delay"
+    delay=$((delay * 2))
+  done
+}
+
 sign_code() {
   local path="$1"
   log "Signing $path"
-  codesign --force --sign "$sign_identity_value" --timestamp --options runtime "$path"
+  run_codesign --force --sign "$sign_identity_value" --timestamp --options runtime "$path"
 }
 
 sign_container() {
   local path="$1"
   log "Signing $path"
-  codesign --force --sign "$sign_identity_value" --timestamp "$path"
+  run_codesign --force --sign "$sign_identity_value" --timestamp "$path"
 }
 
 sign_app_bundle() {

--- a/scripts/macos/release.sh
+++ b/scripts/macos/release.sh
@@ -24,11 +24,13 @@ run_codesign() {
   local attempt
 
   for attempt in $(seq 1 "$max_attempts"); do
+    local status=0
     if codesign "$@"; then
       return 0
+    else
+      status=$?
     fi
 
-    local status=$?
     if [[ "$attempt" -ge "$max_attempts" ]]; then
       return "$status"
     fi


### PR DESCRIPTION
## Summary
- add retry/backoff around timestamped macOS codesign calls in the release script
- covers transient Apple timestamp service failures like the arm64 release job error: `A timestamp was expected but was not found`

## Validation
- `bash -n scripts/macos/release.sh`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Enhanced macOS release process stability by improving code signing reliability and resilience. Signing operations now automatically retry up to 4 times with exponential backoff spacing between attempts before returning a final failure status. Enhanced logging provides improved visibility into the results, status, and detailed information of each individual signing operation attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to the macOS release packaging script, only altering how `codesign` is invoked (with retries) and not the signed artifacts’ contents beyond improved robustness.
> 
> **Overview**
> Improves macOS release stability by wrapping timestamped `codesign` calls in `scripts/macos/release.sh` with a `run_codesign` helper that retries up to 4 times using exponential backoff and logs each failure.
> 
> All signing entry points (`sign_code`, `sign_container`) now use this retry wrapper instead of calling `codesign` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c33b93ca184d8f7326fd763388383d8d97bab45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->