### PR TITLE
Fix Windows TUI frame freeze by always draining staging textures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## `v0.1.0-beta.65` - 2026-05-07
+
+### Fixed
+
+**Windows**
+
+- Fixed continuously updating TUIs such as Codex, `top`, `watch`, and `btop`
+  freezing until the next click or key press. The Windows renderer now drains
+  completed staging frames under sustained output, caps fallback presentation at
+  the display cadence, and schedules the final catch-up frame when output stops.
+  _(PR [#116](https://github.com/nowledge-co/con-terminal/pull/116) by [@wey-gu](https://github.com/wey-gu))_
+
 ## `v0.1.0-beta.64` - 2026-05-07
 
 ### Added

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -164,7 +164,7 @@ pub struct GhosttyView {
 
 enum SyncRenderResult {
     Unchanged,
-    Rendered,
+    Rendered { needs_followup_prepaint: bool },
     Pending,
 }
 
@@ -328,7 +328,7 @@ impl GhosttyView {
         }
 
         match self.sync_render(window) {
-            SyncRenderResult::Pending | SyncRenderResult::Rendered => cx.notify(),
+            SyncRenderResult::Pending | SyncRenderResult::Rendered { .. } => cx.notify(),
             SyncRenderResult::Unchanged if bounds_changed => cx.notify(),
             SyncRenderResult::Unchanged => {}
         }
@@ -505,7 +505,10 @@ impl GhosttyView {
         let render_started = perf_trace_enabled().then(Instant::now);
         let outcome = match session.render_frame() {
             Ok(RenderOutcome::Unchanged) => SyncRenderResult::Unchanged,
-            Ok(RenderOutcome::Rendered(frame)) => {
+            Ok(RenderOutcome::Rendered {
+                frame,
+                needs_followup_prepaint,
+            }) => {
                 let render_frame_ms = render_started
                     .map(|started| started.elapsed().as_secs_f64() * 1000.0)
                     .unwrap_or(0.0);
@@ -527,7 +530,11 @@ impl GhosttyView {
                             started.elapsed().as_secs_f64() * 1000.0,
                         );
                     }
-                    SyncRenderResult::Rendered
+                    SyncRenderResult::Rendered {
+                        needs_followup_prepaint,
+                    }
+                } else if needs_followup_prepaint {
+                    SyncRenderResult::Pending
                 } else {
                     SyncRenderResult::Unchanged
                 }
@@ -1397,7 +1404,13 @@ impl Render for GhosttyView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         match self.sync_render(window) {
             SyncRenderResult::Pending => cx.notify(),
-            SyncRenderResult::Rendered | SyncRenderResult::Unchanged => {}
+            SyncRenderResult::Rendered {
+                needs_followup_prepaint: true,
+            } => cx.notify(),
+            SyncRenderResult::Rendered {
+                needs_followup_prepaint: false,
+            }
+            | SyncRenderResult::Unchanged => {}
         }
 
         let placeholder_background = if self.cached_image.is_none() {

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -241,7 +241,7 @@ impl RenderSession {
         if let Some(started) = prof_started {
             let total_ms = started.elapsed().as_secs_f64() * 1000.0;
             let outcome_name = match &outcome {
-                RenderOutcome::Rendered(_) => "rendered",
+                RenderOutcome::Rendered { .. } => "rendered",
                 RenderOutcome::Pending => "pending",
                 RenderOutcome::Unchanged => "unchanged",
             };

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -390,17 +390,27 @@ impl Renderer {
 
         let in_flight_before_submit = ring.in_flight_count();
 
-        // A completed readback is only useful when we have no fresher VT
-        // snapshot to submit. If `needs_draw` is true, mapping the older
-        // slot just burns UI-thread time and cannot be presented because
-        // it would regress the pane to stale pixels. If no new draw is
-        // needed but more than one slot is still in flight, discard the
-        // oldest cache entry first so command bursts present the newest
-        // completed frame instead of replaying intermediate snapshots.
-        if !needs_draw && in_flight_before_submit > 1 {
+        // A completed readback from an earlier submit is the freshest
+        // pixels we can currently put on screen. If `needs_draw` is
+        // false, draining is the only way to advance the displayed
+        // image at all. If `needs_draw` is true, the just-submitted
+        // copy is even fresher but isn't ready yet — and refusing to
+        // drain the older slot here strands the on-screen image on
+        // whatever frame was last presented. With continuous-output
+        // TUIs (codex spinner / streaming, watch, top, btop), every
+        // prepaint sees a new VT generation, so `needs_draw` stays
+        // true forever and the screen freezes until a click flips
+        // `prefer_latest=true`. Drain in both cases; the non-blocking
+        // `try_drain` is cheap, and presenting one-frame-old pixels is
+        // strictly better than freezing.
+        //
+        // When more than one slot is still in flight, drop the oldest
+        // first so command bursts present the newest completed frame
+        // instead of replaying intermediate snapshots.
+        if in_flight_before_submit > 1 {
             ring.discard_oldest_in_flight();
         }
-        let drain_target = (!needs_draw).then(|| ring.oldest_in_flight()).flatten();
+        let drain_target = ring.oldest_in_flight();
 
         let drain_started = perf_trace_enabled().then(Instant::now);
         let drained: Option<Readback> = if let Some(idx) = drain_target {
@@ -508,14 +518,41 @@ impl Renderer {
         }
 
         if needs_draw {
-            // Mailbox semantics: once we've submitted a fresher frame
-            // for the current VT snapshot, do not regress to an older
-            // already-drained readback just because it happens to be
-            // ready first. Returning that stale frame is what makes
-            // bursty command output (`ls`, `dir`, `clear`) feel like a
-            // slideshow of historical snapshots. Keep the previous
-            // on-screen image and let the next prepaint pick up the
-            // freshest completed frame instead.
+            // Continuous-output fallback: if a prior submit's readback
+            // is ready right now, present it instead of stalling on
+            // `Pending`. Without this, TUIs that never let the VT
+            // quiesce (codex, watch, top) leave `needs_draw=true` on
+            // every prepaint, the just-submitted copy never gets a
+            // chance to drain, and the on-screen image freezes until
+            // a click flips `prefer_latest=true` (issue #114). The
+            // freshly submitted frame is still in flight and will be
+            // picked up by the next prepaint, so we lag the VT by at
+            // most one frame instead of indefinitely.
+            if let Some(readback) = drained {
+                let outcome = RenderOutcome::Rendered(self.frame_from_readback(readback));
+                log_render_profile(
+                    prof_started,
+                    snapshot,
+                    prefer_latest,
+                    needs_draw,
+                    in_flight_before_submit,
+                    drain_target,
+                    true,
+                    backlog,
+                    submitted,
+                    draw_ms,
+                    submit_ms,
+                    drain_ms,
+                    block_drain_ms,
+                    "rendered",
+                    "drained_during_submit",
+                );
+                return Ok(outcome);
+            }
+
+            // No prior readback ready yet — wait for the just-submitted
+            // copy. The next prepaint (driven by the `Pending`
+            // `cx.notify()` in `GhosttyView::render`) will pick it up.
             let outcome = RenderOutcome::Pending;
             log_render_profile(
                 prof_started,

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -404,10 +404,13 @@ impl Renderer {
         // `try_drain` is cheap, and presenting one-frame-old pixels is
         // strictly better than freezing.
         //
-        // When more than one slot is still in flight, drop the oldest
-        // first so command bursts present the newest completed frame
-        // instead of replaying intermediate snapshots.
-        if in_flight_before_submit > 1 {
+        // Discarding the oldest in-flight slot stays gated on
+        // `!needs_draw`. Under `needs_draw` the oldest slot is the
+        // most likely to be GPU-ready, and discarding it would force
+        // the drain onto the newer (less likely ready) slot — on
+        // GPUs where copies take more than one prepaint that re-
+        // creates the freeze this fix is meant to remove.
+        if !needs_draw && in_flight_before_submit > 1 {
             ring.discard_oldest_in_flight();
         }
         let drain_target = ring.oldest_in_flight();
@@ -528,7 +531,16 @@ impl Renderer {
             // freshly submitted frame is still in flight and will be
             // picked up by the next prepaint, so we lag the VT by at
             // most one frame instead of indefinitely.
-            if let Some(readback) = drained {
+            //
+            // Skip this shortcut when `prefer_latest` is set. The
+            // user is waiting on a specific fresh frame (mouse/key
+            // input, paste echo, low-latency generation target), and
+            // the `block_drain` branch above already tried to deliver
+            // it; if it didn't fire (backlog or replaced slot),
+            // returning a stale readback would prematurely satisfy
+            // `host_view`'s low-latency target tracking and clear
+            // the target generation without ever presenting it.
+            if !prefer_latest && let Some(readback) = drained {
                 let outcome = RenderOutcome::Rendered(self.frame_from_readback(readback));
                 log_render_profile(
                     prof_started,

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -352,27 +352,72 @@ impl Renderer {
         Ok(())
     }
 
-    /// Render one frame and return a BGRA byte buffer sized to the
-    /// current render target.
+    /// Render one frame and return BGRA bytes (full or row-patched)
+    /// for the caller to publish through GPUI.
     ///
-    /// `prefer_latest` is set by the view/session for user-driven
-    /// interactions (typing, paste, mouse actions). In that mode we
-    /// prefer the freshly submitted slot over any older already-drained
-    /// frame so the caller paints the newest state now, but only while
-    /// the staging ring is otherwise clear. Once the GPU is already
-    /// behind (for example after a fullscreen resize), unread staging
-    /// slots are treated as disposable and we stay non-blocking.
+    /// # State machine
     ///
-    /// Non-interactive work like resize/fullscreen keeps the old
-    /// non-blocking behavior: if the ring has nothing older to drain,
-    /// we return `Pending` and let the next prepaint pick up the fresh
-    /// slot once the GPU copy has finished.
+    /// Inputs read each call:
+    /// * `snapshot.generation`, `selection`, viewport geometry —
+    ///   combined into a fingerprint that decides `needs_draw`.
+    /// * Staging ring's `oldest_in_flight()` — the GPU copy queued by
+    ///   a prior call that may now have completed.
+    /// * `prefer_latest` — set by `host_view` when the user is
+    ///   actively waiting on a specific frame (mouse / key / paste /
+    ///   `low_latency_generation_target`).
     ///
-    /// The ring behaves like a mailbox, not a must-deliver queue:
-    /// unread readback slots are only cached copies of older terminal
-    /// frames, and the VT snapshot remains the source of truth. When we
-    /// run out of clean slots we reclaim the oldest unread one instead
-    /// of blocking the UI thread to preserve stale pixels.
+    /// Outputs:
+    /// * `Rendered(frame)` — fresh BGRA bytes; caller publishes.
+    ///   Stamps `last_presented_at` so `presentation_due` reflects the
+    ///   actual on-screen update cadence.
+    /// * `Pending` — GPU work was submitted (or is still in flight)
+    ///   but no frame is presentable on this call. Caller must
+    ///   schedule another prepaint (`cx.notify()`).
+    /// * `Unchanged` — nothing to draw and nothing in flight; caller
+    ///   keeps the previous image.
+    ///
+    /// Decisions, in priority order:
+    ///
+    /// 1. **User-driven fast path.** When `prefer_latest && needs_draw`
+    ///    and `can_block_for_latest` is satisfied, `block_drain` waits
+    ///    for the freshly submitted slot and returns `Rendered` with
+    ///    the freshest possible bytes. This is what makes key echo,
+    ///    paste, and `low_latency_generation_target` deterministic.
+    ///
+    /// 2. **Continuous-output fallback.** When `needs_draw` is true
+    ///    but the user is not waiting on a target, present the prior
+    ///    submit's already-completed readback (gated on
+    ///    `presentation_due`). Without this, TUIs that never let the
+    ///    VT quiesce (codex spinner, watch, top, btop) leave
+    ///    `needs_draw=true` on every prepaint, the just-submitted
+    ///    copy never gets a chance to drain, and the on-screen image
+    ///    freezes until a click flips `prefer_latest=true` (issue
+    ///    #114). Capping the fallback at `MIN_FALLBACK_PRESENT_INTERVAL`
+    ///    preserves the established mailbox snap-to-final behavior
+    ///    for short bursts (`ls`, `dir`, `clear`) — they finish under
+    ///    one cap interval, so the fallback never fires for them.
+    ///
+    /// 3. **Quiet-VT catch-up.** When `!needs_draw` and a prior
+    ///    submit's readback is ready, present it. This is the path
+    ///    that lands the final frame after a burst.
+    ///
+    /// 4. **Pure pending.** When something is still in flight and
+    ///    nothing else is presentable, return `Pending` so the caller
+    ///    schedules another prepaint.
+    ///
+    /// 5. **Idle.** Nothing to do.
+    ///
+    /// # Mailbox semantics
+    ///
+    /// The ring is a mailbox at the *submit* level: when both slots
+    /// are in flight, a fresh submit reuses the oldest, evicting its
+    /// pending readback. The drain side prefers the oldest in-flight
+    /// slot because it is the most likely to be GPU-ready (it has
+    /// had the longest time to complete). The discard step that
+    /// drops the oldest in-flight readback before draining only runs
+    /// when `!needs_draw`; under continuous output the oldest slot
+    /// is the only ready one, and discarding it would force the
+    /// drain onto the in-flight newer slot and re-create the freeze.
     pub fn render(
         &self,
         snapshot: &ScreenSnapshot,

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -169,7 +169,15 @@ pub enum RenderOutcome {
     /// No change since the previous call — reuse the prior image.
     Unchanged,
     /// Fresh BGRA bytes, ready to hand to GPUI as an `ImageSource`.
-    Rendered(FrameBgra),
+    Rendered {
+        frame: FrameBgra,
+        /// A newer copy was submitted while this frame was drained from
+        /// an older staging slot. The caller should publish this frame
+        /// now, then schedule one more prepaint so the fresher in-flight
+        /// copy can be drained even if VT output stops immediately after
+        /// the fallback present.
+        needs_followup_prepaint: bool,
+    },
     /// GPU work was submitted but the staging ring has nothing older
     /// ready to drain without waiting. Caller should keep the previous
     /// image and schedule another prepaint unless this frame was marked
@@ -367,9 +375,10 @@ impl Renderer {
     ///   `low_latency_generation_target`).
     ///
     /// Outputs:
-    /// * `Rendered(frame)` — fresh BGRA bytes; caller publishes.
-    ///   Stamps `last_presented_at` so `presentation_due` reflects the
-    ///   actual on-screen update cadence.
+    /// * `Rendered { frame, needs_followup_prepaint }` — fresh BGRA
+    ///   bytes; caller publishes. The follow-up flag is set only when
+    ///   an older drained slot was presented while a fresher submitted
+    ///   copy remains in flight.
     /// * `Pending` — GPU work was submitted (or is still in flight)
     ///   but no frame is presentable on this call. Caller must
     ///   schedule another prepaint (`cx.notify()`).
@@ -565,7 +574,10 @@ impl Renderer {
                 readback.map(|readback| self.frame_from_readback(readback))
             }
         {
-            let outcome = RenderOutcome::Rendered(frame);
+            let outcome = RenderOutcome::Rendered {
+                frame,
+                needs_followup_prepaint: false,
+            };
             self.mark_presented();
             log_render_profile(
                 prof_started,
@@ -624,7 +636,10 @@ impl Renderer {
                 && self.presentation_due()
                 && let Some(readback) = drained
             {
-                let outcome = RenderOutcome::Rendered(self.frame_from_readback(readback));
+                let outcome = RenderOutcome::Rendered {
+                    frame: self.frame_from_readback(readback),
+                    needs_followup_prepaint: submitted.is_some(),
+                };
                 self.mark_presented();
                 log_render_profile(
                     prof_started,
@@ -671,7 +686,10 @@ impl Renderer {
         }
 
         if let Some(readback) = drained {
-            let outcome = RenderOutcome::Rendered(self.frame_from_readback(readback));
+            let outcome = RenderOutcome::Rendered {
+                frame: self.frame_from_readback(readback),
+                needs_followup_prepaint: false,
+            };
             self.mark_presented();
             log_render_profile(
                 prof_started,

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -28,7 +28,7 @@ mod font_loader;
 mod pipeline;
 
 use std::sync::Mutex;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use windows::Win32::Graphics::Direct3D::{
@@ -125,10 +125,30 @@ pub struct Renderer {
     /// show before the shell has printed anything.
     last_generation: Mutex<u64>,
     selection: Mutex<Option<Selection>>,
+    /// Wall-clock time of the last `Rendered` outcome. Drives the
+    /// `MIN_FALLBACK_PRESENT_INTERVAL` cap that decouples presentation
+    /// rate from the VT update rate, so continuous-output TUIs (issue
+    /// #114) don't churn one full-frame image-handoff per prepaint.
+    /// `None` until the first frame is presented.
+    last_presented_at: Mutex<Option<Instant>>,
 
     width_px: u32,
     height_px: u32,
 }
+
+/// Minimum wall-clock spacing between two `Rendered` outcomes from the
+/// continuous-output fallback path. Set to one 60 Hz vsync interval —
+/// presenting faster than this is wasted work because GPUI only paints
+/// once per refresh, and each present pays a full-frame Map + memcpy
+/// + `bgra_frame_to_image` + sprite-atlas upload.
+///
+/// Short bursts (`ls`, `dir`, `clear`) finish well under one interval,
+/// so the fallback never fires for them and the established mailbox
+/// "snap to final" behavior is preserved exactly. Sustained TUIs
+/// (codex, watch, top) hit the cap and update at 60 Hz instead of
+/// freezing. User-driven paths (mouse / key / paste / generation
+/// target) bypass the cap via the `block_drain` branch.
+const MIN_FALLBACK_PRESENT_INTERVAL: Duration = Duration::from_millis(16);
 
 /// Freshly rendered BGRA patch. Coordinates and sizes are physical pixels.
 pub struct FramePatchBgra {
@@ -246,6 +266,7 @@ impl Renderer {
             has_full_frame: Mutex::new(false),
             last_generation: Mutex::new(u64::MAX),
             selection: Mutex::new(None),
+            last_presented_at: Mutex::new(None),
             width_px: width,
             height_px: height,
         })
@@ -500,6 +521,7 @@ impl Renderer {
             }
         {
             let outcome = RenderOutcome::Rendered(frame);
+            self.mark_presented();
             log_render_profile(
                 prof_started,
                 snapshot,
@@ -522,26 +544,43 @@ impl Renderer {
 
         if needs_draw {
             // Continuous-output fallback: if a prior submit's readback
-            // is ready right now, present it instead of stalling on
-            // `Pending`. Without this, TUIs that never let the VT
-            // quiesce (codex, watch, top) leave `needs_draw=true` on
-            // every prepaint, the just-submitted copy never gets a
-            // chance to drain, and the on-screen image freezes until
-            // a click flips `prefer_latest=true` (issue #114). The
-            // freshly submitted frame is still in flight and will be
-            // picked up by the next prepaint, so we lag the VT by at
-            // most one frame instead of indefinitely.
+            // is ready right now AND we haven't presented within the
+            // last `MIN_FALLBACK_PRESENT_INTERVAL`, present it instead
+            // of stalling on `Pending`. Without this, TUIs that never
+            // let the VT quiesce (codex, watch, top) leave
+            // `needs_draw=true` on every prepaint, the just-submitted
+            // copy never gets a chance to drain, and the on-screen
+            // image freezes until a click flips `prefer_latest=true`
+            // (issue #114). The freshly submitted frame is still in
+            // flight and will be picked up by the next prepaint, so
+            // we lag the VT by at most one frame instead of
+            // indefinitely.
             //
-            // Skip this shortcut when `prefer_latest` is set. The
-            // user is waiting on a specific fresh frame (mouse/key
-            // input, paste echo, low-latency generation target), and
-            // the `block_drain` branch above already tried to deliver
-            // it; if it didn't fire (backlog or replaced slot),
-            // returning a stale readback would prematurely satisfy
-            // `host_view`'s low-latency target tracking and clear
-            // the target generation without ever presenting it.
-            if !prefer_latest && let Some(readback) = drained {
+            // Two gates keep this from regressing the perf work in
+            // postmortem 2026-04-26-windows-command-render-latency:
+            //
+            // - `!prefer_latest`: the user is waiting on a specific
+            //   fresh frame (mouse/key input, paste echo, low-latency
+            //   generation target). The `block_drain` branch above
+            //   already tried; if it didn't fire (backlog or replaced
+            //   slot), returning a stale readback would prematurely
+            //   satisfy `host_view`'s low-latency target tracking and
+            //   clear the target generation without ever presenting
+            //   the targeted frame.
+            //
+            // - `presentation_due()`: caps presentation rate to one
+            //   60 Hz vsync. Short bursts (`ls`, `dir`, `clear`)
+            //   finish under one interval, so the fallback never
+            //   fires for them and the established mailbox snap-to-
+            //   final behavior is preserved exactly. Sustained TUIs
+            //   hit the cap and update at 60 Hz with bounded image-
+            //   handoff cost.
+            if !prefer_latest
+                && self.presentation_due()
+                && let Some(readback) = drained
+            {
                 let outcome = RenderOutcome::Rendered(self.frame_from_readback(readback));
+                self.mark_presented();
                 log_render_profile(
                     prof_started,
                     snapshot,
@@ -588,6 +627,7 @@ impl Renderer {
 
         if let Some(readback) = drained {
             let outcome = RenderOutcome::Rendered(self.frame_from_readback(readback));
+            self.mark_presented();
             log_render_profile(
                 prof_started,
                 snapshot,
@@ -693,6 +733,33 @@ impl Renderer {
         } else {
             regions
         }
+    }
+
+    /// Returns true when the continuous-output fallback in `render`
+    /// is allowed to publish a fresh image. Always true on the very
+    /// first frame (no prior present) and otherwise gated on
+    /// `MIN_FALLBACK_PRESENT_INTERVAL` since the last `Rendered`
+    /// outcome.
+    fn presentation_due(&self) -> bool {
+        let last = self
+            .last_presented_at
+            .lock()
+            .expect("last_presented_at mutex poisoned in presentation_due()");
+        match *last {
+            None => true,
+            Some(t) => t.elapsed() >= MIN_FALLBACK_PRESENT_INTERVAL,
+        }
+    }
+
+    /// Stamp the wall-clock time of a fresh present. Called from every
+    /// `Rendered` exit point in `render` so `presentation_due` reflects
+    /// the true on-screen update cadence — including user-driven
+    /// `block_drain` presents — rather than just fallback presents.
+    fn mark_presented(&self) {
+        *self
+            .last_presented_at
+            .lock()
+            .expect("last_presented_at mutex poisoned in mark_presented()") = Some(Instant::now());
     }
 
     fn frame_from_readback(&self, mut readback: Readback) -> FrameBgra {

--- a/postmortem/2026-05-03-windows-codex-frame-freeze.md
+++ b/postmortem/2026-05-03-windows-codex-frame-freeze.md
@@ -61,7 +61,12 @@ out of one rule rather than two competing modes.
    `prefer_latest` is false AND `presentation_due()` returns true,
    return `RenderOutcome::Rendered(...)` from that prior readback
    instead of `Pending`.
-3. Every `Rendered` exit point stamps `last_presented_at = Some(now)`.
+3. Mark that fallback `Rendered` outcome as needing a follow-up
+   prepaint. The older frame should paint immediately, but the fresh
+   copy is still in flight; if VT output stops right after the fallback,
+   the caller still needs one more prepaint to drain and present the
+   final frame.
+4. Every `Rendered` exit point stamps `last_presented_at = Some(now)`.
    `presentation_due()` is gated on `MIN_FALLBACK_PRESENT_INTERVAL`
    (one 60 Hz vsync = 16 ms).
 
@@ -96,7 +101,9 @@ Effect:
 
 - Continuous-output TUIs (codex, top, watch, btop): screen updates
   at 60 Hz with bounded image-handoff cost — no freeze, no churn
-  beyond what GPUI would composite anyway.
+  beyond what GPUI would composite anyway. When a stream stops just
+  after a fallback frame, the explicit follow-up prepaint drains the
+  final submitted copy instead of leaving the pane one frame stale.
 - Burst commands (`ls`, `dir`, `clear`): unchanged from the
   04-26 mailbox tuning — snap-to-final, no slideshow.
 - User-driven echo / paste / click: unchanged — `block_drain`

--- a/postmortem/2026-05-03-windows-codex-frame-freeze.md
+++ b/postmortem/2026-05-03-windows-codex-frame-freeze.md
@@ -1,0 +1,86 @@
+# Windows codex frame freeze (2026-05-03)
+
+## What happened
+
+Issue #114: on Windows, codex's TUI output stopped refreshing on screen
+unless the user pressed Enter or clicked the terminal. The reporter also
+noticed that codex's input cursor visually "jumped" several rows when
+they clicked — the catch-up frame painted the cursor at its true row
+while the screen had been frozen showing a much older row.
+
+The same pattern reproduces with any TUI that never lets the VT
+quiesce: `watch`, `top`, `btop`, streaming output, spinners.
+
+## Root cause
+
+The Windows renderer (`crates/con-ghostty/src/windows/render/mod.rs`)
+uses a two-slot D3D11 staging-texture ring with mailbox semantics:
+draws are queued, copies of the render target are submitted into a
+staging slot, and the next prepaint maps the slot to read the BGRA
+bytes back into a GPUI image.
+
+`Renderer::render` only chose a `drain_target` when `needs_draw` was
+false:
+
+```rust
+let drain_target = (!needs_draw).then(|| ring.oldest_in_flight()).flatten();
+```
+
+The intent was a "newest-frame-wins" mailbox: if a fresher VT snapshot
+exists, don't waste UI-thread time mapping an older slot whose pixels
+are about to be superseded. After submitting the fresh copy the path
+returned `Pending` and relied on the next prepaint to drain it.
+
+That works when the VT eventually quiets down. With a continuously
+streaming TUI it doesn't:
+
+1. PTY chunk arrives, wake fires, prepaint runs.
+2. `snapshot.generation` is new → `needs_draw = true`.
+3. We submit a fresh copy, skip drain, return `Pending`, `cx.notify()`.
+4. Before the next prepaint, the GPU finishes the copy AND another PTY
+   chunk arrives. New generation again.
+5. Goto 2 — forever. The just-submitted copy never gets mapped.
+
+Result: `cached_image` was frozen at whatever frame happened to land
+when output began. A user click flipped `prefer_latest = true`, which
+took the `block_drain` branch, blocked until the latest copy was ready,
+and presented it — making the screen "jump" forward in one step,
+including the cursor row.
+
+## Fix
+
+`crates/con-ghostty/src/windows/render/mod.rs::Renderer::render`:
+
+- Always compute `drain_target = ring.oldest_in_flight()` regardless of
+  `needs_draw`. Try-draining the older slot is non-blocking and cheap.
+- After submitting the fresh copy, if `drained` is `Some`, return
+  `RenderOutcome::Rendered(...)` from that prior readback instead of
+  `Pending`.
+
+Effect: with continuous output the screen now lags the live VT by at
+most one frame per prepaint instead of freezing indefinitely. The
+just-submitted copy is still in flight and will be picked up by the
+next prepaint, so the pipeline depth is unchanged.
+
+The original "no slideshow during burst" intent (`ls`, `dir`, `clear`)
+is largely preserved because such bursts are short — at most one or
+two intermediate frames are presented before the burst ends and the
+quiet-VT path returns the freshest frame as before.
+
+macOS and Linux are unaffected: this code is gated by
+`#[cfg(target_os = "windows")]` and the macOS path uses the embedded
+libghostty NSView with its own Metal compositor.
+
+## What we learned
+
+- Mailbox semantics need a forward-progress invariant. "Skip draining
+  an older slot when a fresher one exists" only terminates if the
+  fresher slot eventually drains; under a busy producer it never does.
+- For interactive UIs, presenting a one-frame-old image is strictly
+  better than freezing on the assumption that "the next frame will be
+  fresher." Falling back to drain-on-submit gives us that floor without
+  giving up the newest-wins preference for quiet-VT cases.
+- Bug reports framed as "needs a click to refresh" almost always point
+  at a redraw scheduler that's gated on input events; on Windows here
+  the gate was the `prefer_latest` block_drain path, not the
+  `cx.notify()` plumbing.

--- a/postmortem/2026-05-03-windows-codex-frame-freeze.md
+++ b/postmortem/2026-05-03-windows-codex-frame-freeze.md
@@ -49,38 +49,66 @@ including the cursor row.
 
 ## Fix
 
+The elegant move is to **decouple presentation rate from VT update
+rate**, so mailbox-for-bursts and forward-progress-for-streaming fall
+out of one rule rather than two competing modes.
+
 `crates/con-ghostty/src/windows/render/mod.rs::Renderer::render`:
 
-- Always compute `drain_target = ring.oldest_in_flight()` regardless of
-  `needs_draw`. Try-draining the older slot is non-blocking and cheap.
-- After submitting the fresh copy, if `drained` is `Some` *and*
-  `prefer_latest` is false, return `RenderOutcome::Rendered(...)` from
-  that prior readback instead of `Pending`.
+1. Always compute `drain_target = ring.oldest_in_flight()` regardless
+   of `needs_draw`. Try-draining is non-blocking and cheap.
+2. After submitting the fresh copy, if `drained` is `Some` AND
+   `prefer_latest` is false AND `presentation_due()` returns true,
+   return `RenderOutcome::Rendered(...)` from that prior readback
+   instead of `Pending`.
+3. Every `Rendered` exit point stamps `last_presented_at = Some(now)`.
+   `presentation_due()` is gated on `MIN_FALLBACK_PRESENT_INTERVAL`
+   (one 60 Hz vsync = 16 ms).
 
-Two important guards keep the original behavior intact in cases the
-naive ungate would break:
+Three guards keep the established perf wins from the 2026-04-26
+postmortem (`windows-command-render-latency.md`) intact:
 
-- `discard_oldest_in_flight()` stays gated on `!needs_draw`. Under
+- **`discard_oldest_in_flight()` stays gated on `!needs_draw`.** Under
   `needs_draw=true` the oldest slot is the most likely to be GPU-
   ready; discarding it would force the drain onto the newer (still
   in-flight) slot. On GPUs where copies take more than one prepaint
   cycle, that loop reproduces the very freeze this fix is meant to
-  remove (cursor / Bugbot review on PR #116).
-- The drained-during-submit shortcut is gated on `!prefer_latest`.
+  remove (Bugbot review on PR #116).
+- **The drained-during-submit shortcut is gated on `!prefer_latest`.**
   With `prefer_latest` set, the user is waiting on a specific fresh
-  frame — a mouse/key event, paste echo, or a `low_latency_generation_target`
-  set by `host_view` — and the `block_drain` branch above already
-  tried to deliver it. Returning a stale readback would prematurely
-  satisfy `host_view`'s "non-Pending → clear target" rule and drop
-  the generation target before the user-targeted frame is ever
-  presented (CodeRabbit review on PR #116).
+  frame — a mouse/key event, paste echo, or a
+  `low_latency_generation_target` set by `host_view` — and the
+  `block_drain` branch above already tried to deliver it. Returning a
+  stale readback would prematurely satisfy `host_view`'s "non-Pending
+  → clear target" rule and drop the generation target before the
+  user-targeted frame is ever presented (CodeRabbit review on PR
+  #116).
+- **The shortcut is gated on `presentation_due()`.** Short bursts
+  (`ls`, `dir`, `clear`) finish under one cap interval, so the
+  fallback never fires for them and the established mailbox snap-to-
+  final behavior is preserved exactly. Sustained TUIs hit the cap
+  and update at 60 Hz, which is the GPUI/vsync ceiling — presenting
+  faster is wasted work because GPUI only paints once per refresh,
+  and each present pays a full-frame Map + memcpy +
+  `bgra_frame_to_image` + sprite-atlas upload.
 
-Effect: with continuous output the screen now lags the live VT by at
-most one frame per prepaint instead of freezing indefinitely. The
-just-submitted copy is still in flight and will be picked up by the
-next prepaint, so the pipeline depth is unchanged. User-driven
-interactive frames keep their fast-path through `block_drain` and
-their generation-target handshake intact.
+Effect:
+
+- Continuous-output TUIs (codex, top, watch, btop): screen updates
+  at 60 Hz with bounded image-handoff cost — no freeze, no churn
+  beyond what GPUI would composite anyway.
+- Burst commands (`ls`, `dir`, `clear`): unchanged from the
+  04-26 mailbox tuning — snap-to-final, no slideshow.
+- User-driven echo / paste / click: unchanged — `block_drain`
+  fast path still wins and generation-target handshake stays
+  honest.
+- Resize drag: capped at 60 Hz feedback (was unbounded before the
+  cap), reducing image churn during interactive resize.
+
+The wider long-term answer remains direct swap-chain composition into
+GPUI's DirectComposition tree (called out in the 2026-04-26 PM); this
+fix is the right tactical bridge inside the existing staging-ring
+architecture and will be retired together with that swap-chain work.
 
 The original "no slideshow during burst" intent (`ls`, `dir`, `clear`)
 is largely preserved because such bursts are short — at most one or

--- a/postmortem/2026-05-03-windows-codex-frame-freeze.md
+++ b/postmortem/2026-05-03-windows-codex-frame-freeze.md
@@ -53,14 +53,34 @@ including the cursor row.
 
 - Always compute `drain_target = ring.oldest_in_flight()` regardless of
   `needs_draw`. Try-draining the older slot is non-blocking and cheap.
-- After submitting the fresh copy, if `drained` is `Some`, return
-  `RenderOutcome::Rendered(...)` from that prior readback instead of
-  `Pending`.
+- After submitting the fresh copy, if `drained` is `Some` *and*
+  `prefer_latest` is false, return `RenderOutcome::Rendered(...)` from
+  that prior readback instead of `Pending`.
+
+Two important guards keep the original behavior intact in cases the
+naive ungate would break:
+
+- `discard_oldest_in_flight()` stays gated on `!needs_draw`. Under
+  `needs_draw=true` the oldest slot is the most likely to be GPU-
+  ready; discarding it would force the drain onto the newer (still
+  in-flight) slot. On GPUs where copies take more than one prepaint
+  cycle, that loop reproduces the very freeze this fix is meant to
+  remove (cursor / Bugbot review on PR #116).
+- The drained-during-submit shortcut is gated on `!prefer_latest`.
+  With `prefer_latest` set, the user is waiting on a specific fresh
+  frame — a mouse/key event, paste echo, or a `low_latency_generation_target`
+  set by `host_view` — and the `block_drain` branch above already
+  tried to deliver it. Returning a stale readback would prematurely
+  satisfy `host_view`'s "non-Pending → clear target" rule and drop
+  the generation target before the user-targeted frame is ever
+  presented (CodeRabbit review on PR #116).
 
 Effect: with continuous output the screen now lags the live VT by at
 most one frame per prepaint instead of freezing indefinitely. The
 just-submitted copy is still in flight and will be picked up by the
-next prepaint, so the pipeline depth is unchanged.
+next prepaint, so the pipeline depth is unchanged. User-driven
+interactive frames keep their fast-path through `block_drain` and
+their generation-target handshake intact.
 
 The original "no slideshow during burst" intent (`ls`, `dir`, `clear`)
 is largely preserved because such bursts are short — at most one or

--- a/postmortem/2026-05-03-windows-codex-frame-freeze.md
+++ b/postmortem/2026-05-03-windows-codex-frame-freeze.md
@@ -110,25 +110,45 @@ GPUI's DirectComposition tree (called out in the 2026-04-26 PM); this
 fix is the right tactical bridge inside the existing staging-ring
 architecture and will be retired together with that swap-chain work.
 
-The original "no slideshow during burst" intent (`ls`, `dir`, `clear`)
-is largely preserved because such bursts are short — at most one or
-two intermediate frames are presented before the burst ends and the
-quiet-VT path returns the freshest frame as before.
+## How the fallback composes with `host_view`'s burst arming
+
+Every input event in `host_view.rs` arms `low_latency_burst_until` for
+`LOW_LATENCY_BURST_WINDOW = 750 ms`. While that window is active,
+`burst_low_latency_active()` returns true, so `prefer_latest` is true,
+so the fallback's `!prefer_latest` gate keeps it suppressed — the
+`block_drain` fast path owns the entire post-input window.
+
+The fallback only takes over once 750 ms have elapsed since the last
+input. That is exactly the regime issue #114 covered: codex / top /
+watch streaming with no further user activity. The two systems split
+the timeline cleanly, with no overlap and no shared state to
+synchronise.
 
 macOS and Linux are unaffected: this code is gated by
 `#[cfg(target_os = "windows")]` and the macOS path uses the embedded
-libghostty NSView with its own Metal compositor.
+libghostty NSView with its own Metal compositor. Linux's preview
+renderer paints rows directly through GPUI `StyledText` and has no
+staging ring, so the freeze condition cannot arise there in the
+current architecture.
 
 ## What we learned
 
-- Mailbox semantics need a forward-progress invariant. "Skip draining
-  an older slot when a fresher one exists" only terminates if the
-  fresher slot eventually drains; under a busy producer it never does.
-- For interactive UIs, presenting a one-frame-old image is strictly
-  better than freezing on the assumption that "the next frame will be
-  fresher." Falling back to drain-on-submit gives us that floor without
-  giving up the newest-wins preference for quiet-VT cases.
-- Bug reports framed as "needs a click to refresh" almost always point
-  at a redraw scheduler that's gated on input events; on Windows here
-  the gate was the `prefer_latest` block_drain path, not the
-  `cx.notify()` plumbing.
+- The original mailbox conflated two distinct concerns under one
+  rule: "newest-wins" (correct) and "wait for the next prepaint to
+  drain" (broken under continuous load). Decoupling presentation
+  *rate* from VT update *rate* separates them cleanly — one rule,
+  capped at the GPUI/vsync ceiling, covers both bursts and
+  streaming.
+- Mailbox semantics need a forward-progress invariant. "Skip
+  draining an older slot when a fresher one exists" only terminates
+  if the fresher slot eventually drains; under a busy producer it
+  never does. The cap-paced fallback is what guarantees forward
+  progress without sacrificing newest-wins for quiet-VT cases.
+- The most expensive thing in this pipeline is the full-frame
+  CPU↔GPU↔GPUI handoff, not the GPU draw. The cap exists because
+  presenting faster than vsync would do that handoff for a frame
+  the compositor will never paint.
+- Bug reports framed as "needs a click to refresh" almost always
+  point at a redraw scheduler gated on input events; on Windows
+  here the gate was the `prefer_latest` `block_drain` path, not
+  the `cx.notify()` plumbing.


### PR DESCRIPTION
## Summary

Fixes issue #114 where continuously updating TUIs on Windows could stop refreshing until the user clicked the terminal or pressed a key.

The root cause was a staging-ring mailbox invariant bug: `Renderer::render` only drained completed readbacks when `needs_draw` became false. Apps such as Codex, `top`, `watch`, and `btop` can keep producing VT generations every prepaint, so `needs_draw` stayed true forever and the already-completed staging texture was never mapped.

## Changes

- Always choose the oldest in-flight staging slot as the non-blocking drain target, even while a fresher VT snapshot is being submitted.
- Keep `discard_oldest_in_flight()` gated on `!needs_draw`; under continuous output the oldest slot is the one most likely to be ready, and discarding it can recreate the freeze on slower GPUs.
- Add a continuous-output fallback that presents a drained prior frame when no user-driven low-latency target is active, capped at one 60 Hz interval to preserve mailbox snap-to-final behavior for short bursts.
- Carry `needs_followup_prepaint` on fallback `Rendered` outcomes so the view schedules one more prepaint to drain the fresher just-submitted frame if output stops immediately afterward.
- Documented the Windows renderer state machine and added a postmortem for the freeze.
- Added the beta 65 changelog entry.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `RUSTFLAGS='-D warnings' cargo check -p con`
- `RUSTFLAGS='-D warnings' cargo check -p con --no-default-features --features con/bin-con-app`
- `RUSTFLAGS='-D warnings' cargo check -p con-ghostty --target x86_64-pc-windows-msvc`
- `cargo test -p con-core -p con-cli -p con-agent -p con-terminal`
- `cargo test --workspace`

Note: a full `cargo check -p con --target x86_64-pc-windows-msvc` cannot complete from this macOS machine because the MSVC C toolchain and Windows SDK headers are not installed locally (`lib.exe`, `windows.h`, C std headers). The narrower `con-ghostty` Windows-target check passed and typechecked the changed renderer code; GitHub Actions remains the authority for the full Windows app build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Windows render/presentation scheduling in the D3D11 staging-ring pipeline; mistakes could impact frame cadence, latency, or CPU/GPU load, but scope is limited to the Windows backend.
> 
> **Overview**
> Fixes a Windows-only freeze where continuously updating TUIs could stop repainting until user input by changing the staging-texture mailbox drain/present behavior.
> 
> The Windows renderer now **always attempts to drain the oldest in-flight staging slot**, adds a **rate-capped fallback present (~60Hz)** during sustained output (when no low-latency user-driven target is active), and returns a `needs_followup_prepaint` flag so the view schedules an extra prepaint to catch up to the freshest submitted frame when output stops.
> 
> Also updates plumbing to the new `RenderOutcome::Rendered { frame, needs_followup_prepaint }` shape, adds a `v0.1.0-beta.65` changelog entry, and includes a postmortem documenting the issue and fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b1f96690a6255802900f7cce8e925ec6f035189. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->