### PR TITLE
Bundle con-cli with release installs

### DIFF
--- a/.github/workflows/ci-portable.yml
+++ b/.github/workflows/ci-portable.yml
@@ -18,19 +18,23 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/ci-portable.yml"
+      - ".github/workflows/release-*.yml"
       - ".cargo/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - "assets/**"
       - "crates/**"
+      - "scripts/**"
   pull_request:
     paths:
       - ".github/workflows/ci-portable.yml"
+      - ".github/workflows/release-*.yml"
       - ".cargo/**"
       - "Cargo.toml"
       - "Cargo.lock"
       - "assets/**"
       - "crates/**"
+      - "scripts/**"
 
 env:
   CARGO_TERM_COLOR: always
@@ -78,6 +82,20 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: C:\src\repo
+      - name: PowerShell installer parse check
+        shell: pwsh
+        run: |
+          $errors = $null
+          $tokens = $null
+          [System.Management.Automation.Language.Parser]::ParseFile(
+            "scripts/install.ps1",
+            [ref]$tokens,
+            [ref]$errors
+          ) | Out-Null
+          if ($errors.Count -gt 0) {
+            $errors | Format-List | Out-String | Write-Host
+            throw "PowerShell parse errors in scripts/install.ps1"
+          }
       - name: cargo check — portable crates
         run: cargo check -p con-core -p con-cli -p con-agent -p con-terminal -p con-ghostty
       - name: cargo check — UI binary (stub terminal backend)
@@ -94,6 +112,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Release script syntax checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash -n scripts/install.sh
+          bash -n scripts/linux/release.sh
+          bash -n scripts/release/verify-artifacts.sh
+          bash -n scripts/release/verify-release-gate.sh
+          for script in scripts/macos/*.sh scripts/sparkle/*.sh; do
+            bash -n "$script"
+          done
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install Zig 0.15.2

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -161,6 +161,8 @@ jobs:
 
       - uses: actions/checkout@v5
         if: steps.gate.outputs.ready == 'true'
+        with:
+          ref: ${{ steps.ctx.outputs.sha }}
 
       - name: Checkout gh-pages for release gate
         if: steps.gate.outputs.ready == 'true'

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -174,6 +174,27 @@ jobs:
             "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" \
             gh-pages
 
+      - name: Sync public installer scripts
+        if: steps.gate.outputs.ready == 'true'
+        run: |
+          set -euo pipefail
+
+          cp scripts/install.sh gh-pages/install.sh
+          cp scripts/install.ps1 gh-pages/install.ps1
+
+          cd gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add install.sh install.ps1
+          if git diff --cached --quiet; then
+            echo "Installer scripts are already current."
+            exit 0
+          fi
+
+          git commit -m "Sync installer scripts for ${{ steps.ctx.outputs.tag }}"
+          git pull --rebase origin gh-pages
+          git push origin gh-pages
+
       - name: Verify release payload before promotion
         if: steps.gate.outputs.ready == 'true'
         env:

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -29,10 +29,11 @@ name: Finalize release
 # behave as if the tag does not exist yet, which is the correct
 # answer while assets are still uploading.
 #
-# This workflow watches the three release workflows and flips the
-# draft to public via `gh release edit --draft=false` only after all
-# three have a `success` workflow_run for the same `head_sha`. If
-# one platform fails, the draft stays a draft (intentional — better
+# This workflow watches the three release workflows, verifies the
+# release assets/appcasts/installers still agree on the same tag,
+# and only then flips the draft to public via
+# `gh release edit --draft=false`. If one platform or the final
+# release gate fails, the draft stays a draft (intentional — better
 # to block than to ship an incomplete release; the maintainer can
 # either re-run the failing job or flip the draft manually via the
 # UI once the situation is understood).
@@ -157,6 +158,28 @@ jobs:
             echo "ready=false" >>"$GITHUB_OUTPUT"
             echo "Not all platforms have succeeded yet; waiting for the next sibling's completion."
           fi
+
+      - uses: actions/checkout@v5
+        if: steps.gate.outputs.ready == 'true'
+
+      - name: Checkout gh-pages for release gate
+        if: steps.gate.outputs.ready == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          git clone --single-branch --branch gh-pages \
+            "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" \
+            gh-pages
+
+      - name: Verify release payload before promotion
+        if: steps.gate.outputs.ready == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          ./scripts/release/verify-release-gate.sh "${{ steps.ctx.outputs.tag }}" gh-pages
 
       - name: Promote draft to public release
         if: steps.gate.outputs.ready == 'true'

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -248,6 +248,7 @@ jobs:
 
       - name: Check Sparkle signing key
         id: sparkle
+        if: steps.meta.outputs.channel != 'dev'
         shell: bash
         env:
           SPARKLE_SIGNING_KEY: ${{ secrets.SPARKLE_SIGNING_KEY }}
@@ -260,19 +261,19 @@ jobs:
           fi
 
       - name: Download Sparkle tools
-        if: steps.sparkle.outputs.available == 'true'
+        if: steps.meta.outputs.channel != 'dev' && steps.sparkle.outputs.available == 'true'
         shell: bash
         run: ./scripts/sparkle/download.sh
 
       - name: Download Linux release artifact
-        if: steps.sparkle.outputs.available == 'true'
+        if: steps.meta.outputs.channel != 'dev' && steps.sparkle.outputs.available == 'true'
         uses: actions/download-artifact@v5
         with:
           name: linux-x86_64
           path: release-artifacts
 
       - name: Checkout gh-pages
-        if: steps.sparkle.outputs.available == 'true'
+        if: steps.meta.outputs.channel != 'dev' && steps.sparkle.outputs.available == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -299,7 +300,7 @@ jobs:
           }
 
       - name: Sign tarball and update Linux appcast
-        if: steps.sparkle.outputs.available == 'true'
+        if: steps.meta.outputs.channel != 'dev' && steps.sparkle.outputs.available == 'true'
         shell: bash
         env:
           SPARKLE_SIGNING_KEY: ${{ secrets.SPARKLE_SIGNING_KEY }}
@@ -358,7 +359,7 @@ jobs:
           echo "Updated appcast: ${channel}-linux-x86_64.xml (build $build_number)"
 
       - name: Push appcast to gh-pages
-        if: steps.sparkle.outputs.available == 'true'
+        if: steps.meta.outputs.channel != 'dev' && steps.sparkle.outputs.available == 'true'
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -106,13 +106,12 @@ jobs:
         id: package
         shell: bash
         # scripts/linux/release.sh:
-        #   - cargo build -p con --release with the channel + version
+        #   - cargo build -p con -p con-cli --release with the channel + version
         #     baked in via CON_RELEASE_CHANNEL / CON_RELEASE_VERSION
         #     (option_env! in con-core::release_channel reads them so
         #     the notify-only updater knows which appcast to poll),
-        #   - strip --strip-debug the ~300 MB debug-laden binary down
-        #     to ~80 MB,
-        #   - stage the binary + LICENSE + README.md + a .desktop
+        #   - strip --strip-debug the debug-laden binaries,
+        #   - stage con + con-cli + LICENSE + README.md + a .desktop
         #     entry + a 256x256 icon into a versioned dir,
         #   - tar -czf the staging dir into
         #     dist/con-<version>-linux-x86_64.tar.gz,

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -121,6 +121,9 @@ jobs:
           CON_RELEASE_VERSION: ${{ steps.meta.outputs.version }}
         run: |
           ./scripts/linux/release.sh
+          ./scripts/release/verify-artifacts.sh linux \
+            "dist/con-${{ steps.meta.outputs.version }}-linux-x86_64.tar.gz" \
+            "dist/SHA256SUMS-linux.txt"
           echo "tarball=dist/con-${{ steps.meta.outputs.version }}-linux-x86_64.tar.gz" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifacts

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -197,7 +197,7 @@ jobs:
             echo "Uploading: $file"
             gh release upload "$tag" "$file" --clobber
           done < <(find release-artifacts -type f \
-            \( -name '*.zip' -o -name '*.dmg' -o -name 'SHA256SUMS.txt' \) \
+            \( -name '*.zip' -o -name '*.dmg' -o -name 'SHA256SUMS-macos-*.txt' \) \
             -print0)
 
   update-appcast:

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -36,6 +36,8 @@ jobs:
           channel="stable"
           if [[ "$version" == *"-beta."* ]]; then
             channel="beta"
+          elif [[ "$version" == *"-dev."* ]]; then
+            channel="dev"
           fi
           echo "version=$version" >>"$GITHUB_OUTPUT"
           echo "channel=$channel" >>"$GITHUB_OUTPUT"
@@ -217,6 +219,8 @@ jobs:
           channel="stable"
           if [[ "$version" == *"-beta."* ]]; then
             channel="beta"
+          elif [[ "$version" == *"-dev."* ]]; then
+            channel="dev"
           fi
           marketing="${version%%[-+]*}"
           echo "version=$version" >>"$GITHUB_OUTPUT"
@@ -225,6 +229,7 @@ jobs:
 
       - name: Check Sparkle signing key
         id: sparkle
+        if: steps.meta.outputs.channel != 'dev'
         shell: bash
         env:
           SPARKLE_SIGNING_KEY: ${{ secrets.SPARKLE_SIGNING_KEY }}
@@ -237,18 +242,18 @@ jobs:
           fi
 
       - name: Download Sparkle tools
-        if: steps.sparkle.outputs.available == 'true'
+        if: steps.meta.outputs.channel != 'dev' && steps.sparkle.outputs.available == 'true'
         shell: bash
         run: ./scripts/sparkle/download.sh
 
       - name: Download release artifacts
-        if: steps.sparkle.outputs.available == 'true'
+        if: steps.meta.outputs.channel != 'dev' && steps.sparkle.outputs.available == 'true'
         uses: actions/download-artifact@v5
         with:
           path: release-artifacts
 
       - name: Checkout gh-pages
-        if: steps.sparkle.outputs.available == 'true'
+        if: steps.meta.outputs.channel != 'dev' && steps.sparkle.outputs.available == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -270,7 +275,7 @@ jobs:
           }
 
       - name: Sign artifacts and update appcasts
-        if: steps.sparkle.outputs.available == 'true'
+        if: steps.meta.outputs.channel != 'dev' && steps.sparkle.outputs.available == 'true'
         shell: bash
         env:
           SPARKLE_SIGNING_KEY: ${{ secrets.SPARKLE_SIGNING_KEY }}
@@ -328,7 +333,7 @@ jobs:
           done
 
       - name: Push appcast to gh-pages
-        if: steps.sparkle.outputs.available == 'true'
+        if: steps.meta.outputs.channel != 'dev' && steps.sparkle.outputs.available == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -362,16 +367,20 @@ jobs:
           channel="stable"
           if [[ "$version" == *"-beta."* ]]; then
             channel="beta"
+          elif [[ "$version" == *"-dev."* ]]; then
+            channel="dev"
           fi
           echo "version=$version" >>"$GITHUB_OUTPUT"
           echo "channel=$channel" >>"$GITHUB_OUTPUT"
 
       - name: Download release artifacts
+        if: steps.meta.outputs.channel != 'dev'
         uses: actions/download-artifact@v5
         with:
           path: release-artifacts
 
       - name: Update cask formula
+        if: steps.meta.outputs.channel != 'dev'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -99,6 +99,25 @@ jobs:
           APPLE_NOTARY_API_KEY_BASE64: ${{ secrets.APPLE_NOTARY_API_KEY_BASE64 }}
         run: ./scripts/macos/release.sh
 
+      - name: Verify release artifact contract
+        shell: bash
+        env:
+          CON_CHANNEL: ${{ steps.meta.outputs.channel }}
+          CON_APP_VERSION: ${{ steps.meta.outputs.version }}
+          CON_BUILD_NUMBER: ${{ github.run_number }}
+          CON_ARCH: ${{ matrix.arch }}
+          CON_RUST_TARGET: ${{ matrix.rust_target }}
+          CON_SPARKLE_PUBLIC_ED_KEY: ${{ secrets.SPARKLE_PUBLIC_ED_KEY }}
+        run: |
+          set -euo pipefail
+          source ./scripts/macos/common.sh
+          setup_release_env
+          ./scripts/release/verify-artifacts.sh macos \
+            "$CON_APP_BUNDLE_PATH" \
+            "$CON_APP_ZIP_PATH" \
+            "$CON_DMG_PATH" \
+            "$CON_CHECKSUM_PATH"
+
       - name: Upload notarized artifacts
         uses: actions/upload-artifact@v5
         with:

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -430,6 +430,7 @@ jobs:
             depends_on macos: ">= :catalina"
 
             app "${app_name}.app"
+            binary "#{appdir}/${app_name}.app/Contents/MacOS/con-cli", target: "con-cli"
 
             zap trash: [
               "~/.config/con",

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -140,6 +140,11 @@ jobs:
         run: |
           cargo wbuild -p con --release
 
+      - name: Build con-cli
+        shell: pwsh
+        run: |
+          cargo build -p con-cli --release
+
       - name: Diagnose build failure
         if: failure() && steps.build.conclusion == 'failure'
         shell: pwsh
@@ -246,6 +251,7 @@ jobs:
           $StagingDir = "dist\con-$Version-windows-x86_64"
           New-Item -ItemType Directory -Force -Path $StagingDir | Out-Null
           Copy-Item "target\release\con-app.exe" "$StagingDir\con-app.exe"
+          Copy-Item "target\release\con-cli.exe" "$StagingDir\con-cli.exe"
           if (Test-Path "README.md")  { Copy-Item "README.md"  $StagingDir }
           if (Test-Path "LICENSE")    { Copy-Item "LICENSE"    $StagingDir }
           if (Test-Path "LICENSE.md") { Copy-Item "LICENSE.md" $StagingDir }

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -142,6 +142,9 @@ jobs:
 
       - name: Build con-cli
         shell: pwsh
+        env:
+          CON_RELEASE_CHANNEL: ${{ steps.meta.outputs.channel }}
+          CON_RELEASE_VERSION: ${{ steps.meta.outputs.version }}
         run: |
           cargo build -p con-cli --release
 

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -141,6 +141,7 @@ jobs:
           cargo wbuild -p con --release
 
       - name: Build con-cli
+        id: build_cli
         shell: pwsh
         env:
           CON_RELEASE_CHANNEL: ${{ steps.meta.outputs.channel }}
@@ -149,7 +150,7 @@ jobs:
           cargo build -p con-cli --release
 
       - name: Diagnose build failure
-        if: failure() && steps.build.conclusion == 'failure'
+        if: failure() && (steps.build.conclusion == 'failure' || steps.build_cli.conclusion == 'failure')
         shell: pwsh
         # Zig reports `FileNotFound` for any CreateProcess failure,
         # including `STATUS_DLL_NOT_FOUND` and other loader errors. That

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -265,6 +265,34 @@ jobs:
           "zip=$Zip"                          | Out-File $env:GITHUB_OUTPUT -Append
           "sha256=dist\SHA256SUMS-windows.txt" | Out-File $env:GITHUB_OUTPUT -Append
 
+      - name: Verify release artifact contract
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $Zip = "${{ steps.package.outputs.zip }}"
+          $Sha = "${{ steps.package.outputs.sha256 }}"
+          if (-not (Test-Path $Zip)) { throw "missing ZIP: $Zip" }
+          if (-not (Test-Path $Sha)) { throw "missing checksum: $Sha" }
+
+          $Expected = (Select-String -Path $Sha -Pattern ([regex]::Escape((Split-Path -Leaf $Zip))) |
+              Select-Object -First 1).Line -split '\s+' | Select-Object -First 1
+          if (-not $Expected) { throw "checksum file does not reference $(Split-Path -Leaf $Zip)" }
+          $Actual = (Get-FileHash -Algorithm SHA256 $Zip).Hash.ToLower()
+          if ($Actual -ne $Expected.ToLower()) {
+              throw "checksum mismatch for $Zip (expected $Expected, got $Actual)"
+          }
+
+          $Extract = Join-Path $env:RUNNER_TEMP "con-release-verify-$([System.Guid]::NewGuid())"
+          New-Item -ItemType Directory -Force -Path $Extract | Out-Null
+          Expand-Archive -Path $Zip -DestinationPath $Extract -Force
+
+          $App = Join-Path $Extract 'con-app.exe'
+          $Cli = Join-Path $Extract 'con-cli.exe'
+          if (-not (Test-Path $App)) { throw 'con-app.exe missing from Windows ZIP' }
+          if (-not (Test-Path $Cli)) { throw 'con-cli.exe missing from Windows ZIP' }
+          & $Cli --help | Out-Null
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v5
         with:

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -389,6 +389,8 @@ jobs:
           channel="stable"
           if [[ "$version" == *"-beta."* ]]; then
             channel="beta"
+          elif [[ "$version" == *"-dev."* ]]; then
+            channel="dev"
           fi
           marketing="${version%%[-+]*}"
           echo "version=$version"     >>"$GITHUB_OUTPUT"
@@ -397,6 +399,7 @@ jobs:
 
       - name: Check Sparkle signing key
         id: sparkle
+        if: steps.meta.outputs.channel != 'dev'
         shell: bash
         env:
           SPARKLE_SIGNING_KEY: ${{ secrets.SPARKLE_SIGNING_KEY }}
@@ -409,19 +412,19 @@ jobs:
           fi
 
       - name: Download Sparkle tools
-        if: steps.sparkle.outputs.available == 'true'
+        if: steps.meta.outputs.channel != 'dev' && steps.sparkle.outputs.available == 'true'
         shell: bash
         run: ./scripts/sparkle/download.sh
 
       - name: Download Windows release artifact
-        if: steps.sparkle.outputs.available == 'true'
+        if: steps.meta.outputs.channel != 'dev' && steps.sparkle.outputs.available == 'true'
         uses: actions/download-artifact@v5
         with:
           name: windows-x86_64
           path: release-artifacts
 
       - name: Checkout gh-pages
-        if: steps.sparkle.outputs.available == 'true'
+        if: steps.meta.outputs.channel != 'dev' && steps.sparkle.outputs.available == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -441,7 +444,7 @@ jobs:
           }
 
       - name: Sign ZIP and update Windows appcast
-        if: steps.sparkle.outputs.available == 'true'
+        if: steps.meta.outputs.channel != 'dev' && steps.sparkle.outputs.available == 'true'
         shell: bash
         env:
           SPARKLE_SIGNING_KEY: ${{ secrets.SPARKLE_SIGNING_KEY }}
@@ -503,7 +506,7 @@ jobs:
           echo "Updated appcast: ${channel}-windows-x86_64.xml (build $build_number)"
 
       - name: Push appcast to gh-pages
-        if: steps.sparkle.outputs.available == 'true'
+        if: steps.meta.outputs.channel != 'dev' && steps.sparkle.outputs.available == 'true'
         shell: bash
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ con is still pre-release, so entries may group related beta work while the produ
   user-managed binaries.
 - Added release verification for the macOS app bundle so a signed/notarized
   build cannot ship without the control-plane CLI.
+- Added blocking release gates for installer/update safety. macOS and Linux
+  release jobs now verify artifact layout before upload; Windows verifies the
+  ZIP contains both `con-app.exe` and `con-cli.exe`; the finalizer refuses to
+  publish a draft unless all expected assets, appcasts, and gh-pages installer
+  scripts are present and point at the same tag.
 - Documented that `con-cli` is part of the normal install path for surface
   orchestrators such as `pi-interactive-subagents`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ con is still pre-release, so entries may group related beta work while the produ
   dev app names/bundle ids, never embed/update stable/beta appcasts, and never
   update Homebrew casks while the final gate still validates their artifact
   shape.
+- Made the release finalizer sync hosted installer scripts from the tagged
+  commit before promotion, so dev smoke tags can test the real `install.sh` /
+  `install.ps1` path without moving beta/stable appcasts or Homebrew casks.
 - Documented that `con-cli` is part of the normal install path for surface
   orchestrators such as `pi-interactive-subagents`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ con is still pre-release, so entries may group related beta work while the produ
   ZIP contains both `con-app.exe` and `con-cli.exe`; the finalizer refuses to
   publish a draft unless all expected assets, appcasts, and gh-pages installer
   scripts are present and point at the same tag.
+- Tightened those release gates after review: appcasts are now parsed as XML,
+  each macOS architecture publishes its own checksum asset, the finalizer runs
+  from the tagged revision, and the macOS CLI shim ignores transient DMG/test
+  app bundles.
 - Documented that `con-cli` is part of the normal install path for surface
   orchestrators such as `pi-interactive-subagents`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,9 @@ con is still pre-release, so entries may group related beta work while the produ
   from the tagged revision, and the macOS CLI shim ignores transient DMG/test
   app bundles.
 - Hardened internal `v*-dev.*` release behavior so dev smoke tags are scoped to
-  dev app names/bundle ids and never update stable/beta appcasts or Homebrew
-  casks while the final gate still validates their artifact shape.
+  dev app names/bundle ids, never embed/update stable/beta appcasts, and never
+  update Homebrew casks while the final gate still validates their artifact
+  shape.
 - Documented that `con-cli` is part of the normal install path for surface
   orchestrators such as `pi-interactive-subagents`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ con is still pre-release, so entries may group related beta work while the produ
   app bundle and exposes it through Homebrew/script installs; Linux tarballs
   install both `con` and `con-cli`; Windows ZIP/script installs include
   `con-app.exe` and `con-cli.exe`.
+- Added a conservative macOS launch-time self-heal for `~/.local/bin/con-cli`
+  so manual-DMG installs and Sparkle-updated app bundles converge to the same
+  CLI availability as installer/Homebrew installs without overwriting
+  user-managed binaries.
 - Added release verification for the macOS app bundle so a signed/notarized
   build cannot ship without the control-plane CLI.
 - Documented that `con-cli` is part of the normal install path for surface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## `v0.1.0-beta.58` - 2026-05-03
+
+### Added
+
+**Distribution**
+
+- Bundled `con-cli` with every release artifact. macOS now ships it inside the
+  app bundle and exposes it through Homebrew/script installs; Linux tarballs
+  install both `con` and `con-cli`; Windows ZIP/script installs include
+  `con-app.exe` and `con-cli.exe`.
+- Added release verification for the macOS app bundle so a signed/notarized
+  build cannot ship without the control-plane CLI.
+- Documented that `con-cli` is part of the normal install path for surface
+  orchestrators such as `pi-interactive-subagents`.
+
 ## `v0.1.0-beta.57` - 2026-05-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ con is still pre-release, so entries may group related beta work while the produ
   each macOS architecture publishes its own checksum asset, the finalizer runs
   from the tagged revision, and the macOS CLI shim ignores transient DMG/test
   app bundles.
+- Hardened internal `v*-dev.*` release behavior so dev smoke tags are scoped to
+  dev app names/bundle ids and never update stable/beta appcasts or Homebrew
+  casks while the final gate still validates their artifact shape.
 - Documented that `con-cli` is part of the normal install path for surface
   orchestrators such as `pi-interactive-subagents`.
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -122,6 +122,12 @@ missing. The Homebrew cask and Unix installer expose that bundled
 `con-cli` on PATH so orchestrators such as `pi-interactive-subagents`
 do not need a separate source checkout.
 
+Release CI also has a final promotion gate. Platform jobs verify the
+artifact shape before upload, and `release-finalize.yml` keeps the
+GitHub Release drafted unless all expected assets, appcasts, and
+gh-pages installer scripts are present for the same tag. A broken
+artifact should fail private, not become `/releases/latest`.
+
 For a Linux release tarball (un-signed; mirrors the Windows
 preview's distribution shape), use:
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -128,8 +128,8 @@ GitHub Release drafted unless all expected assets, appcasts, and
 gh-pages installer scripts are present for the same tag. A broken
 artifact should fail private, not become `/releases/latest`. Internal
 `v*-dev.*` smoke tags are prereleases, never update public
-stable/beta appcasts or Homebrew casks, and are only gated on artifact
-and installer-script shape.
+stable/beta appcasts or Homebrew casks, do not embed a Sparkle feed URL,
+and are only gated on artifact and installer-script shape.
 
 For a Linux release tarball (un-signed; mirrors the Windows
 preview's distribution shape), use:

--- a/HACKING.md
+++ b/HACKING.md
@@ -126,7 +126,10 @@ Release CI also has a final promotion gate. Platform jobs verify the
 artifact shape before upload, and `release-finalize.yml` keeps the
 GitHub Release drafted unless all expected assets, appcasts, and
 gh-pages installer scripts are present for the same tag. A broken
-artifact should fail private, not become `/releases/latest`.
+artifact should fail private, not become `/releases/latest`. Internal
+`v*-dev.*` smoke tags are prereleases, never update public
+stable/beta appcasts or Homebrew casks, and are only gated on artifact
+and installer-script shape.
 
 For a Linux release tarball (un-signed; mirrors the Windows
 preview's distribution shape), use:

--- a/HACKING.md
+++ b/HACKING.md
@@ -105,7 +105,9 @@ cargo wtest -p con-core -p con-cli -p con-agent -p con-terminal   # Windows (por
 
 ```bash
 cargo build --release -p con                  # macOS / Linux
+cargo build --release -p con-cli              # control-plane CLI
 cargo wbuild -p con --release                 # Windows → target\release\con-app.exe
+cargo build --release -p con-cli              # Windows → target\release\con-cli.exe
 ```
 
 For signed macOS release artifacts, use:
@@ -113,6 +115,12 @@ For signed macOS release artifacts, use:
 ```bash
 ./scripts/macos/release.sh
 ```
+
+The macOS app bundle contains both `Contents/MacOS/con` and
+`Contents/MacOS/con-cli`; the release verifier fails if the CLI is
+missing. The Homebrew cask and Unix installer expose that bundled
+`con-cli` on PATH so orchestrators such as `pi-interactive-subagents`
+do not need a separate source checkout.
 
 For a Linux release tarball (un-signed; mirrors the Windows
 preview's distribution shape), use:

--- a/README.md
+++ b/README.md
@@ -82,13 +82,17 @@ Quick controls:
 brew install --cask nowledge-co/tap/con-beta
 ```
 
+This installs the app and exposes `con-cli` on your PATH for automation.
+
 **macOS**
 
 ```sh
 curl -fsSL https://con-releases.nowledge.co/install.sh | sh
 ```
 
-Or download the DMG directly from [Releases](https://github.com/nowledge-co/con-terminal/releases).
+This installs the app into `/Applications` and links `con-cli` into
+`~/.local/bin`. Or download the DMG directly from
+[Releases](https://github.com/nowledge-co/con-terminal/releases).
 
 **Linux** (preview)
 
@@ -96,7 +100,9 @@ Or download the DMG directly from [Releases](https://github.com/nowledge-co/con-
 curl -fsSL https://con-releases.nowledge.co/install.sh | sh
 ```
 
-Or download `con-<version>-linux-x86_64.tar.gz` from the latest [Release](https://github.com/nowledge-co/con-terminal/releases).
+This installs both `con` and `con-cli` into `~/.local/bin`. Or download
+`con-<version>-linux-x86_64.tar.gz` from the latest
+[Release](https://github.com/nowledge-co/con-terminal/releases).
 
 **Windows**
 
@@ -104,7 +110,9 @@ Or download `con-<version>-linux-x86_64.tar.gz` from the latest [Release](https:
 irm https://con-releases.nowledge.co/install.ps1 | iex
 ```
 
-Or download `con-windows-x86_64.zip` from the latest [Release](https://github.com/nowledge-co/con-terminal/releases).
+This installs `con-app.exe` and `con-cli.exe` into the same PATH directory.
+Or download `con-windows-x86_64.zip` from the latest
+[Release](https://github.com/nowledge-co/con-terminal/releases).
 
 To build from source, see `HACKING.md`.
 

--- a/crates/con-app/src/cli_shim.rs
+++ b/crates/con-app/src/cli_shim.rs
@@ -121,7 +121,7 @@ fn is_con_app_cli_target(target: &Path) -> bool {
             .and_then(Path::parent)
             .and_then(Path::file_name)
             .and_then(|name| name.to_str()),
-        Some("con.app" | "con Beta.app")
+        Some("con.app" | "con Beta.app" | "con Dev.app")
     )
 }
 
@@ -169,6 +169,9 @@ mod tests {
         assert!(is_con_app_cli_target(Path::new(
             "/Applications/con Beta.app/Contents/MacOS/con-cli"
         )));
+        assert!(is_con_app_cli_target(Path::new(
+            "/Applications/con Dev.app/Contents/MacOS/con-cli"
+        )));
         assert!(!is_con_app_cli_target(Path::new(
             "/opt/homebrew/bin/con-cli"
         )));
@@ -184,6 +187,9 @@ mod tests {
     fn only_installed_con_app_cli_symlinks_are_managed() {
         assert!(is_installed_con_app_cli_target(Path::new(
             "/Applications/con Beta.app/Contents/MacOS/con-cli"
+        )));
+        assert!(is_installed_con_app_cli_target(Path::new(
+            "/Applications/con Dev.app/Contents/MacOS/con-cli"
         )));
         assert!(!is_installed_con_app_cli_target(Path::new(
             "/Volumes/con Beta/con Beta.app/Contents/MacOS/con-cli"

--- a/crates/con-app/src/cli_shim.rs
+++ b/crates/con-app/src/cli_shim.rs
@@ -94,8 +94,28 @@ fn is_app_bundle_macos_dir(path: &Path) -> bool {
 }
 
 fn is_con_app_cli_target(target: &Path) -> bool {
-    target.file_name().and_then(|name| name.to_str()) == Some("con-cli")
-        && target.parent().is_some_and(is_app_bundle_macos_dir)
+    if target.file_name().and_then(|name| name.to_str()) != Some("con-cli") {
+        return false;
+    }
+
+    let Some(macos_dir) = target.parent() else {
+        return false;
+    };
+    if !is_app_bundle_macos_dir(macos_dir) {
+        return false;
+    }
+
+    // Keep ownership intentionally narrow. Sparkle/manual installs should
+    // repair stale links to Con's own app bundles, but we must not replace a
+    // user-managed symlink to another app that happens to ship `con-cli`.
+    matches!(
+        macos_dir
+            .parent()
+            .and_then(Path::parent)
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str()),
+        Some("con.app" | "con Beta.app")
+    )
 }
 
 #[cfg(target_family = "unix")]
@@ -125,6 +145,9 @@ mod tests {
         )));
         assert!(!is_con_app_cli_target(Path::new(
             "/Applications/Other.app/Contents/MacOS/other-cli"
+        )));
+        assert!(!is_con_app_cli_target(Path::new(
+            "/Applications/Other.app/Contents/MacOS/con-cli"
         )));
     }
 }

--- a/crates/con-app/src/cli_shim.rs
+++ b/crates/con-app/src/cli_shim.rs
@@ -23,6 +23,13 @@ fn ensure_cli_shim_inner() -> Result<(), String> {
     if !cli.is_file() {
         return Ok(());
     }
+    if !is_installed_con_app_cli_target(&cli) {
+        log::info!(
+            "con-cli shim: not linking from transient app bundle at {}",
+            cli.display()
+        );
+        return Ok(());
+    }
 
     let Some(home) = dirs::home_dir() else {
         return Ok(());
@@ -37,7 +44,7 @@ fn ensure_cli_shim_inner() -> Result<(), String> {
             if target == cli {
                 return Ok(());
             }
-            if !is_con_app_cli_target(&target) {
+            if !is_installed_con_app_cli_target(&target) {
                 log::info!(
                     "con-cli shim: preserving user-managed symlink at {} -> {}",
                     link.display(),
@@ -118,6 +125,28 @@ fn is_con_app_cli_target(target: &Path) -> bool {
     )
 }
 
+fn is_installed_con_app_cli_target(target: &Path) -> bool {
+    if !is_con_app_cli_target(target) {
+        return false;
+    }
+
+    let Some(app_bundle) = target
+        .parent()
+        .and_then(Path::parent)
+        .and_then(Path::parent)
+    else {
+        return false;
+    };
+
+    // Only app bundles in normal install locations are considered managed.
+    // A mounted DMG or copied test bundle with the same app name must not steal
+    // ~/.local/bin/con-cli away from the installed app.
+    app_bundle.starts_with("/Applications")
+        || dirs::home_dir()
+            .map(|home| app_bundle.starts_with(home.join("Applications")))
+            .unwrap_or(false)
+}
+
 #[cfg(target_family = "unix")]
 fn symlink_file(src: &Path, dst: &Path) -> std::io::Result<()> {
     unix_fs::symlink(src, dst)
@@ -148,6 +177,19 @@ mod tests {
         )));
         assert!(!is_con_app_cli_target(Path::new(
             "/Applications/Other.app/Contents/MacOS/con-cli"
+        )));
+    }
+
+    #[test]
+    fn only_installed_con_app_cli_symlinks_are_managed() {
+        assert!(is_installed_con_app_cli_target(Path::new(
+            "/Applications/con Beta.app/Contents/MacOS/con-cli"
+        )));
+        assert!(!is_installed_con_app_cli_target(Path::new(
+            "/Volumes/con Beta/con Beta.app/Contents/MacOS/con-cli"
+        )));
+        assert!(!is_installed_con_app_cli_target(Path::new(
+            "/tmp/con Beta.app/Contents/MacOS/con-cli"
         )));
     }
 }

--- a/crates/con-app/src/cli_shim.rs
+++ b/crates/con-app/src/cli_shim.rs
@@ -1,0 +1,130 @@
+use std::path::Path;
+
+#[cfg(target_family = "unix")]
+use std::os::unix::fs as unix_fs;
+
+pub fn ensure_cli_shim() {
+    if let Err(err) = ensure_cli_shim_inner() {
+        log::warn!("con-cli shim: {err}");
+    }
+}
+
+fn ensure_cli_shim_inner() -> Result<(), String> {
+    let exe = std::env::current_exe()
+        .map_err(|err| format!("could not resolve current executable: {err}"))?;
+    let Some(macos_dir) = exe.parent() else {
+        return Ok(());
+    };
+    if !is_app_bundle_macos_dir(macos_dir) {
+        return Ok(());
+    }
+
+    let cli = macos_dir.join("con-cli");
+    if !cli.is_file() {
+        return Ok(());
+    }
+
+    let Some(home) = dirs::home_dir() else {
+        return Ok(());
+    };
+    let bin_dir = home.join(".local/bin");
+    let link = bin_dir.join("con-cli");
+
+    match std::fs::symlink_metadata(&link) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            let target = std::fs::read_link(&link)
+                .map_err(|err| format!("could not inspect {}: {err}", link.display()))?;
+            if target == cli {
+                return Ok(());
+            }
+            if !is_con_app_cli_target(&target) {
+                log::info!(
+                    "con-cli shim: preserving user-managed symlink at {} -> {}",
+                    link.display(),
+                    target.display()
+                );
+                return Ok(());
+            }
+            std::fs::remove_file(&link)
+                .map_err(|err| format!("could not replace {}: {err}", link.display()))?;
+        }
+        Ok(_) => {
+            log::info!(
+                "con-cli shim: preserving user-managed file at {}",
+                link.display()
+            );
+            return Ok(());
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+        Err(err) => {
+            return Err(format!("could not inspect {}: {err}", link.display()));
+        }
+    }
+
+    std::fs::create_dir_all(&bin_dir)
+        .map_err(|err| format!("could not create {}: {err}", bin_dir.display()))?;
+    symlink_file(&cli, &link).map_err(|err| {
+        format!(
+            "could not link {} -> {}: {err}",
+            link.display(),
+            cli.display()
+        )
+    })?;
+    log::info!(
+        "con-cli shim: linked {} -> {}",
+        link.display(),
+        cli.display()
+    );
+    Ok(())
+}
+
+fn is_app_bundle_macos_dir(path: &Path) -> bool {
+    path.file_name().and_then(|name| name.to_str()) == Some("MacOS")
+        && path
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str())
+            == Some("Contents")
+        && path
+            .parent()
+            .and_then(Path::parent)
+            .and_then(Path::extension)
+            .and_then(|ext| ext.to_str())
+            == Some("app")
+}
+
+fn is_con_app_cli_target(target: &Path) -> bool {
+    target.file_name().and_then(|name| name.to_str()) == Some("con-cli")
+        && target.parent().is_some_and(is_app_bundle_macos_dir)
+}
+
+#[cfg(target_family = "unix")]
+fn symlink_file(src: &Path, dst: &Path) -> std::io::Result<()> {
+    unix_fs::symlink(src, dst)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn app_bundle_macos_dir_is_recognized() {
+        assert!(is_app_bundle_macos_dir(Path::new(
+            "/Applications/con Beta.app/Contents/MacOS"
+        )));
+        assert!(!is_app_bundle_macos_dir(Path::new("/tmp/target/release")));
+    }
+
+    #[test]
+    fn only_con_app_cli_symlinks_are_managed() {
+        assert!(is_con_app_cli_target(Path::new(
+            "/Applications/con Beta.app/Contents/MacOS/con-cli"
+        )));
+        assert!(!is_con_app_cli_target(Path::new(
+            "/opt/homebrew/bin/con-cli"
+        )));
+        assert!(!is_con_app_cli_target(Path::new(
+            "/Applications/Other.app/Contents/MacOS/other-cli"
+        )));
+    }
+}

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -14,6 +14,8 @@
 mod agent_panel;
 mod assets;
 mod chat_markdown;
+#[cfg(target_os = "macos")]
+mod cli_shim;
 mod command_palette;
 #[cfg(target_os = "macos")]
 mod global_hotkey;
@@ -1383,6 +1385,8 @@ fn main() {
     if let Some(path) = log_file_path.as_ref() {
         log::info!("logging to {}", path.display());
     }
+    #[cfg(target_os = "macos")]
+    cli_shim::ensure_cli_shim();
     apply_linux_platform_override();
 
     let config = con_core::Config::load().unwrap_or_default();

--- a/docs/impl/macos-release.md
+++ b/docs/impl/macos-release.md
@@ -143,9 +143,10 @@ git push origin v0.2.0-dev.1
 
 The workflow maps `*-beta.*` tags to the beta channel and `*-dev.*` tags to an
 internal dev channel. Dev releases are marked as GitHub prereleases and do not
-update public appcasts or Homebrew casks. Beta tags are not marked as
-prereleases while Con is still in the all-beta era, so fresh installs resolve
-to the newest public beta after the finalizer promotes the draft.
+embed or update public appcasts, and do not update Homebrew casks. Beta tags
+are not marked as prereleases while Con is still in the all-beta era, so fresh
+installs resolve to the newest public beta after the finalizer promotes the
+draft.
 
 ## Reusing Existing Apple Credentials
 

--- a/docs/impl/macos-release.md
+++ b/docs/impl/macos-release.md
@@ -134,7 +134,18 @@ git tag v0.2.0-beta.1
 git push origin v0.2.0-beta.1
 ```
 
-The workflow maps `*-beta.*` tags to the beta channel and marks the GitHub Release as a prerelease.
+Dev smoke release:
+
+```bash
+git tag v0.2.0-dev.1
+git push origin v0.2.0-dev.1
+```
+
+The workflow maps `*-beta.*` tags to the beta channel and `*-dev.*` tags to an
+internal dev channel. Dev releases are marked as GitHub prereleases and do not
+update public appcasts or Homebrew casks. Beta tags are not marked as
+prereleases while Con is still in the all-beta era, so fresh installs resolve
+to the newest public beta after the finalizer promotes the draft.
 
 ## Reusing Existing Apple Credentials
 
@@ -285,6 +296,8 @@ Release safety is enforced in two layers:
    expected GitHub Release assets exist, stable/beta appcasts point at the
    same tag's artifacts, and the gh-pages installer scripts expose `con-cli`
    / `con-cli.exe`.
+   Dev tags skip appcast/Homebrew publication entirely and are only checked for
+   artifact and installer-script shape.
 
 This means a failed or incomplete platform build can upload nothing more than
 a private draft. Fresh installs keep resolving the previous public release, and
@@ -294,7 +307,7 @@ older clients keep polling the previous valid appcast entry.
 
 `con-core/src/release_channel.rs` provides a cross-platform `ReleaseChannel` enum:
 
-- `Dev` — local builds, never polls for updates
+- `Dev` — local or internal smoke builds, never polls for updates
 - `Beta` — pre-release, polls `beta-macos-{arch}.xml`
 - `Stable` — GA builds, polls `stable-macos-{arch}.xml`
 

--- a/docs/impl/macos-release.md
+++ b/docs/impl/macos-release.md
@@ -24,6 +24,17 @@ Scripts live in [`scripts/macos`](../../scripts/macos):
 - `verify.sh` runs `codesign`, `spctl`, and stapler validation checks
 - `verify.sh` fails the release if the bundled `con-cli` executable is missing
 
+`con-cli` exposure is deliberately layered:
+
+- Homebrew casks install a `con-cli` binary shim from the app bundle.
+- `install.sh` links `~/.local/bin/con-cli` to the bundled CLI after copying
+  the app into `/Applications`.
+- Sparkle updates replace only the app bundle, so the app also performs a
+  conservative launch-time self-heal: it creates or repairs
+  `~/.local/bin/con-cli` only when the path is missing or already points to a
+  Con `.app` bundle. It never overwrites a real user-managed binary or an
+  unrelated symlink.
+
 GitHub Actions release workflow:
 
 - [`.github/workflows/release-macos.yml`](../../.github/workflows/release-macos.yml)
@@ -255,9 +266,11 @@ Before shipping a beta or stable build, verify these flows from the bundled app:
 2. Open `About con` and confirm the app icon, version, build, and channel are visible.
 3. Run `con-cli identify` from a new shell after installing by Homebrew or
    `install.sh`; it should connect to the running app and print app identity.
-4. Open Settings → Updates and confirm the same version/build information is shown there.
-5. Run `Check for Updates…` against the intended channel and confirm Sparkle presents the expected UI.
-6. After installation, reopen `About con` and confirm the build number changed.
+4. For a manual DMG/Sparkle-updated app, confirm launching the app creates or
+   repairs `~/.local/bin/con-cli` when that path is missing.
+5. Open Settings → Updates and confirm the same version/build information is shown there.
+6. Run `Check for Updates…` against the intended channel and confirm Sparkle presents the expected UI.
+7. After installation, reopen `About con` and confirm the build number changed.
 
 ### Release Channel Runtime
 

--- a/docs/impl/macos-release.md
+++ b/docs/impl/macos-release.md
@@ -272,6 +272,24 @@ Before shipping a beta or stable build, verify these flows from the bundled app:
 6. Run `Check for Updates…` against the intended channel and confirm Sparkle presents the expected UI.
 7. After installation, reopen `About con` and confirm the build number changed.
 
+### Automated Release Gates
+
+Release safety is enforced in two layers:
+
+1. Platform release jobs verify artifact shape before upload. macOS checks the
+   app bundle, ZIP, DMG, checksums, and bundled `con-cli`; Linux checks the
+   tarball layout, checksum, and `con-cli --help`; Windows expands the ZIP,
+   verifies `con-app.exe` and `con-cli.exe`, runs `con-cli.exe --help`, and
+   checks `SHA256SUMS-windows.txt`.
+2. `release-finalize.yml` refuses to promote the draft release unless the
+   expected GitHub Release assets exist, stable/beta appcasts point at the
+   same tag's artifacts, and the gh-pages installer scripts expose `con-cli`
+   / `con-cli.exe`.
+
+This means a failed or incomplete platform build can upload nothing more than
+a private draft. Fresh installs keep resolving the previous public release, and
+older clients keep polling the previous valid appcast entry.
+
 ### Release Channel Runtime
 
 `con-core/src/release_channel.rs` provides a cross-platform `ReleaseChannel` enum:

--- a/docs/impl/macos-release.md
+++ b/docs/impl/macos-release.md
@@ -3,6 +3,8 @@
 This repo now ships a first-pass macOS release pipeline for `con` that:
 
 - builds a native `.app` bundle without depending on `cargo-bundle`
+- embeds `con-cli` in the app bundle so installers and Homebrew can expose the
+  control-plane CLI without a separate source build
 - signs with a Developer ID Application certificate
 - notarizes with `notarytool`
 - staples the `.app`
@@ -15,9 +17,12 @@ This repo now ships a first-pass macOS release pipeline for `con` that:
 Scripts live in [`scripts/macos`](../../scripts/macos):
 
 - `build-app.sh` builds `con` and assembles `con.app`
+- `build-app.sh` also builds `con-cli` and places it at
+  `Contents/MacOS/con-cli`
 - `import-certificate.sh` imports the Developer ID cert into a temporary keychain for CI
 - `release.sh` runs build, sign, notarize, staple, package, and checksum generation
 - `verify.sh` runs `codesign`, `spctl`, and stapler validation checks
+- `verify.sh` fails the release if the bundled `con-cli` executable is missing
 
 GitHub Actions release workflow:
 
@@ -248,9 +253,11 @@ Before shipping a beta or stable build, verify these flows from the bundled app:
 
 1. Open the app from Finder and confirm the terminal renders normally.
 2. Open `About con` and confirm the app icon, version, build, and channel are visible.
-3. Open Settings → Updates and confirm the same version/build information is shown there.
-4. Run `Check for Updates…` against the intended channel and confirm Sparkle presents the expected UI.
-5. After installation, reopen `About con` and confirm the build number changed.
+3. Run `con-cli identify` from a new shell after installing by Homebrew or
+   `install.sh`; it should connect to the running app and print app identity.
+4. Open Settings → Updates and confirm the same version/build information is shown there.
+5. Run `Check for Updates…` against the intended channel and confirm Sparkle presents the expected UI.
+6. After installation, reopen `About con` and confirm the build number changed.
 
 ### Release Channel Runtime
 

--- a/docs/impl/macos-release.md
+++ b/docs/impl/macos-release.md
@@ -148,6 +148,11 @@ are not marked as prereleases while Con is still in the all-beta era, so fresh
 installs resolve to the newest public beta after the finalizer promotes the
 draft.
 
+The release finalizer always syncs `install.sh` and `install.ps1` from the
+tagged commit to `gh-pages` before it promotes the draft. This keeps internal dev
+smoke tags useful for installer E2E without moving beta/stable appcasts or
+Homebrew casks.
+
 ## Reusing Existing Apple Credentials
 
 If your existing `nowledge-identities.p12` contains the same Apple team's `Developer ID Application` identity, it can be reused for `con`.

--- a/docs/impl/pane-surfaces.md
+++ b/docs/impl/pane-surfaces.md
@@ -162,6 +162,11 @@ backend that uses `con-cli --json` instead of parsing cmux text handles:
 This avoids cmux's `identify --surface` round trip because Con returns the
 worker pane id directly from `surfaces split`.
 
+Release artifacts now include `con-cli` as part of the core install. Homebrew
+and the one-line installers expose it on PATH, so an orchestrator adapter can
+depend on `con-cli` being present after a normal Con install instead of asking
+users to build the workspace from source.
+
 ## CLI Examples
 
 First create a visible worker pane:

--- a/postmortem/2026-05-04-release-installer-gates.md
+++ b/postmortem/2026-05-04-release-installer-gates.md
@@ -1,0 +1,37 @@
+# Release Installer Gates
+
+## What Happened
+
+`con-cli` became part of the normal install contract, but the release pipeline
+only verified parts of that contract. A platform workflow could succeed with a
+bad artifact shape, or the shared draft release could be promoted before the
+assets, appcasts, and gh-pages installer scripts were all aligned.
+
+## Root Cause
+
+The pipeline relied on several independent checks:
+
+- macOS verified the app bundle, but Linux and Windows did not verify the
+  installed artifact shape before upload.
+- The finalizer only checked that the three platform workflows succeeded. It did
+  not independently verify that the draft release and appcast state were safe
+  for fresh installs and in-app updates.
+- PR CI did not run for release-workflow/script-only changes unless crate files
+  changed too.
+
+## Fix Applied
+
+- Added `scripts/release/verify-artifacts.sh` for macOS/Linux artifact contract
+  checks.
+- Added a Windows ZIP contract check in `release-windows.yml`.
+- Added `scripts/release/verify-release-gate.sh`, called by
+  `release-finalize.yml` before publishing a draft.
+- Extended portable CI path filters and added script/parser checks so release
+  workflow and installer script changes receive CI coverage in PRs.
+
+## What We Learned
+
+Release safety needs a final promotion gate, not just platform-local checks. The
+public release boundary is where fresh installers and older clients converge, so
+that boundary must verify the exact assets and appcast entries users will
+consume.

--- a/postmortem/2026-05-04-release-installer-gates.md
+++ b/postmortem/2026-05-04-release-installer-gates.md
@@ -26,6 +26,9 @@ The pipeline relied on several independent checks:
 - Added a Windows ZIP contract check in `release-windows.yml`.
 - Added `scripts/release/verify-release-gate.sh`, called by
   `release-finalize.yml` before publishing a draft.
+- Made `release-finalize.yml` sync `install.sh` and `install.ps1` from the
+  tagged commit to `gh-pages` before running the final gate, so dev smoke tags
+  can exercise the hosted installer without appcast or Homebrew movement.
 - Extended portable CI path filters and added script/parser checks so release
   workflow and installer script changes receive CI coverage in PRs.
 - Made internal `v*-dev.*` release handling explicit across the macOS release

--- a/postmortem/2026-05-04-release-installer-gates.md
+++ b/postmortem/2026-05-04-release-installer-gates.md
@@ -28,6 +28,9 @@ The pipeline relied on several independent checks:
   `release-finalize.yml` before publishing a draft.
 - Extended portable CI path filters and added script/parser checks so release
   workflow and installer script changes receive CI coverage in PRs.
+- Made internal `v*-dev.*` release handling explicit across the macOS release
+  scripts, appcast jobs, Homebrew job, and final gate so a smoke tag cannot
+  accidentally move a public stable/beta update feed.
 
 ## What We Learned
 
@@ -35,3 +38,8 @@ Release safety needs a final promotion gate, not just platform-local checks. The
 public release boundary is where fresh installers and older clients converge, so
 that boundary must verify the exact assets and appcast entries users will
 consume.
+
+Channel handling must be explicit in every release job. A review comment can be
+wrong about one symptom and still point near a real class of failure: internal
+smoke tags must never inherit public-channel publishing behavior by falling
+through a default `stable` branch.

--- a/postmortem/2026-05-04-release-installer-gates.md
+++ b/postmortem/2026-05-04-release-installer-gates.md
@@ -30,7 +30,7 @@ The pipeline relied on several independent checks:
   workflow and installer script changes receive CI coverage in PRs.
 - Made internal `v*-dev.*` release handling explicit across the macOS release
   scripts, appcast jobs, Homebrew job, and final gate so a smoke tag cannot
-  accidentally move a public stable/beta update feed.
+  accidentally embed or move a public stable/beta update feed.
 
 ## What We Learned
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -211,6 +211,13 @@ if (-not (Test-Path $exePath)) {
 Write-Host "`r$(' ' * 40)`r" -NoNewline
 Pass "installed  $DIM$InstallRoot$RESET"
 
+$cliPath = Join-Path $InstallRoot 'con-cli.exe'
+if (Test-Path $cliPath) {
+    Pass "installed  $DIM$cliPath$RESET"
+} else {
+    Write-Host "   $DIM$MID$RESET  con-cli.exe is not bundled in this release artifact"
+}
+
 # --- PATH (HKCU) ------------------------------------------------------------
 # Persist in the user Environment registry hive so new shells pick it
 # up. Current session gets the updated PATH too via `[Environment]::...`.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -284,9 +284,9 @@ target_bin="${bin_dir}/con"
 # directory entry; the running con keeps painting on the old
 # inode and the next launch picks up the new binary.
 tmp_bin="${bin_dir}/.con.tmp.$$"
-# Layer the tmp-bin cleanup on top of the existing tmpdir trap (set
-# above when we created `$tmpdir`), don't replace it. Both run on
-# any exit path; mv removes tmp_bin on success so the rm is a no-op.
+# Keep one EXIT trap that removes the download staging dir and any
+# partially staged binary. If con-cli is present below, the trap is
+# replaced once with the same cleanup plus tmp_cli.
 trap 'rm -rf "$tmpdir"; rm -f "$tmp_bin"' EXIT
 cp "$staged_root/con" "$tmp_bin" \
   || fail "could not copy con binary"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,9 +3,10 @@
 # Usage: curl -fsSL https://con-releases.nowledge.co/install.sh | sh
 #
 # macOS path: download the signed DMG, mount it, copy the bundled
-#   `con*.app` into /Applications, launch it. Same flow that's been
+#   `con*.app` into /Applications, expose the bundled `con-cli`
+#   from ~/.local/bin, then launch it. Same app flow that's been
 #   live since the macOS DMG release pipeline shipped.
-# Linux path: download the channel tarball, extract `con` into
+# Linux path: download the channel tarball, extract `con` and `con-cli` into
 #   ~/.local/bin, drop a `.desktop` entry into ~/.local/share/applications
 #   so it shows up in your launcher, and `chmod +x` the binary. The
 #   binary is self-contained — no shared libs other than the GPUI Linux
@@ -184,6 +185,31 @@ if [ "$os" = "macos" ]; then
   printf "\r\033[K"
   pass "installed  ${DIM}${install_dir}/${app_name}${R}"
 
+  cli_src="${target}/Contents/MacOS/con-cli"
+  cli_installed=0
+  if [ -x "$cli_src" ]; then
+    bin_dir="${HOME}/.local/bin"
+    mkdir -p "$bin_dir"
+    ln -sf "$cli_src" "${bin_dir}/con-cli" \
+      || fail "could not install con-cli into ${bin_dir}"
+    pass "installed  ${DIM}${bin_dir}/con-cli${R}"
+    cli_installed=1
+  else
+    pass "${DIM}note:${R}  ${B}con-cli${R} ${DIM}is not bundled in this release artifact${R}"
+  fi
+
+  if [ "$cli_installed" = "1" ]; then
+    case ":${PATH:-}:" in
+      *":${HOME}/.local/bin:"*) ;;
+      *)
+        printf "\n"
+        pass "${DIM}note:${R}  ${B}~/.local/bin${R} ${DIM}is not on your PATH yet${R}"
+        printf "          ${DIM}add this to your shell rc:${R}\n"
+        printf "          ${DIM}export PATH=\"\$HOME/.local/bin:\$PATH\"${R}\n"
+        ;;
+    esac
+  fi
+
   # Launch
   open_name="${app_name%.app}"
   printf "\n"
@@ -219,6 +245,7 @@ pass "extracted"
 # The release tarball contains:
 #   con-<version>-linux-<arch>/
 #     con            (the binary)
+#     con-cli        (control-plane CLI)
 #     LICENSE
 #     README.md
 #     con.desktop
@@ -268,6 +295,20 @@ chmod +x "$tmp_bin" \
 mv -f "$tmp_bin" "$target_bin" \
   || fail "could not install con binary"
 
+if [ -f "$staged_root/con-cli" ]; then
+  target_cli="${bin_dir}/con-cli"
+  tmp_cli="${bin_dir}/.con-cli.tmp.$$"
+  trap 'rm -rf "$tmpdir"; rm -f "$tmp_bin" "$tmp_cli"' EXIT
+  cp "$staged_root/con-cli" "$tmp_cli" \
+    || fail "could not copy con-cli binary"
+  chmod +x "$tmp_cli" \
+    || fail "could not mark con-cli binary executable"
+  mv -f "$tmp_cli" "$target_cli" \
+    || fail "could not install con-cli binary"
+else
+  target_cli=""
+fi
+
 # Desktop entry — handles "con shows up in the launcher" and
 # "double-clicking a `con://` URL". The tarball ships a templated
 # `con.desktop` that points at /usr/local/bin; rewrite the Exec line
@@ -295,6 +336,9 @@ fi
 
 printf "\r\033[K"
 pass "installed  ${DIM}${target_bin}${R}"
+if [ -n "${target_cli:-}" ]; then
+  pass "installed  ${DIM}${target_cli}${R}"
+fi
 
 # ── PATH check ──────────────────────────────────────────────────────────────
 

--- a/scripts/linux/release.sh
+++ b/scripts/linux/release.sh
@@ -3,11 +3,11 @@
 # Build a Linux release tarball for con. Mirrors the role of
 # `scripts/macos/release.sh` and `release-windows.yml`'s "Package
 # ZIP" step:
-#   - cargo build -p con --release with the channel + version baked
+#   - cargo build -p con -p con-cli --release with the channel + version baked
 #     in via CON_RELEASE_CHANNEL / CON_RELEASE_VERSION (the
 #     non-macOS updater path uses option_env!() to read these),
-#   - stage `con` + LICENSE + README.md + a `.desktop` entry +
-#     a 256x256 icon into a versioned directory,
+#   - stage `con` + `con-cli` + LICENSE + README.md + a `.desktop`
+#     entry + a 256x256 icon into a versioned directory,
 #   - emit `con-<version>-linux-<arch>.tar.gz` plus a sha256 sum file
 #     so the publish step can attach both to the GitHub release.
 #
@@ -78,14 +78,16 @@ echo
 export CON_RELEASE_VERSION="${version}"
 export CON_RELEASE_CHANNEL="${channel}"
 
-echo "==> cargo build -p con --release"
-cargo build -p con --release
+echo "==> cargo build -p con -p con-cli --release"
+cargo build -p con -p con-cli --release
 
 # Resolve the actual target dir cargo wrote to. CARGO_TARGET_DIR
 # overrides override the default.
 target_dir="${CARGO_TARGET_DIR:-target}"
 bin_path="${target_dir}/release/con"
+cli_bin_path="${target_dir}/release/con-cli"
 [[ -x "$bin_path" ]] || { echo "build did not produce $bin_path" >&2; exit 1; }
+[[ -x "$cli_bin_path" ]] || { echo "build did not produce $cli_bin_path" >&2; exit 1; }
 
 # ── Stage ───────────────────────────────────────────────────────────────────
 
@@ -98,6 +100,8 @@ mkdir -p "${stage_dir}"
 # Windows pipeline ships with debug-info stripped at link time.
 cp "$bin_path" "${stage_dir}/con"
 strip --strip-debug "${stage_dir}/con" || true
+cp "$cli_bin_path" "${stage_dir}/con-cli"
+strip --strip-debug "${stage_dir}/con-cli" || true
 
 # Docs.
 [[ -f LICENSE ]] && cp LICENSE "${stage_dir}/"

--- a/scripts/macos/build-app.sh
+++ b/scripts/macos/build-app.sh
@@ -16,11 +16,11 @@ require_cmd mkdir
 
 mkdir -p "$CON_DIST_ROOT"
 
-log "Building con for $CON_RUST_TARGET"
+log "Building con and con-cli for $CON_RUST_TARGET"
 (
   cd "$REPO_ROOT"
   CON_REQUIRE_GHOSTTY_INITIAL_OUTPUT="${CON_REQUIRE_GHOSTTY_INITIAL_OUTPUT:-1}" \
-    cargo build --locked --release --target "$CON_RUST_TARGET" -p con
+    cargo build --locked --release --target "$CON_RUST_TARGET" -p con -p con-cli
 )
 
 app_root="$CON_APP_BUNDLE_PATH"
@@ -28,6 +28,7 @@ contents_dir="$app_root/Contents"
 macos_dir="$contents_dir/MacOS"
 resources_dir="$contents_dir/Resources"
 binary_path="$REPO_ROOT/target/$CON_RUST_TARGET/release/con"
+cli_binary_path="$REPO_ROOT/target/$CON_RUST_TARGET/release/con-cli"
 
 rm -rf "$app_root"
 mkdir -p "$macos_dir" "$resources_dir"
@@ -35,6 +36,8 @@ mkdir -p "$macos_dir" "$resources_dir"
 log "Creating app bundle at $app_root"
 rsync -a "$binary_path" "$macos_dir/con"
 chmod 755 "$macos_dir/con"
+rsync -a "$cli_binary_path" "$macos_dir/con-cli"
+chmod 755 "$macos_dir/con-cli"
 
 ghostty_resources_dir="$(find "$REPO_ROOT/target/$CON_RUST_TARGET/release/build" -path '*/out/ghostty-src/zig-out/share/ghostty' | head -n 1)"
 if [[ -z "$ghostty_resources_dir" || ! -d "$ghostty_resources_dir" ]]; then

--- a/scripts/macos/common.sh
+++ b/scripts/macos/common.sh
@@ -138,7 +138,7 @@ setup_release_env() {
 
   # Derive Sparkle feed URL from channel + arch if not explicitly set.
   # Pattern: https://con-releases.nowledge.co/appcast/{channel}-macos-{arch}.xml
-  if [[ -z "${CON_SPARKLE_FEED_URL:-}" && -n "${CON_SPARKLE_PUBLIC_ED_KEY:-}" ]]; then
+  if [[ "$CON_CHANNEL" != "dev" && -z "${CON_SPARKLE_FEED_URL:-}" && -n "${CON_SPARKLE_PUBLIC_ED_KEY:-}" ]]; then
     export CON_SPARKLE_FEED_URL="https://con-releases.nowledge.co/appcast/${CON_CHANNEL}-macos-${CON_ARCH}.xml"
   fi
 

--- a/scripts/macos/common.sh
+++ b/scripts/macos/common.sh
@@ -142,7 +142,7 @@ setup_release_env() {
   export CON_APP_BUNDLE_PATH="$CON_DIST_ROOT/$CON_APP_NAME.app"
   export CON_APP_ZIP_PATH="$CON_DIST_ROOT/${CON_APP_NAME// /-}-${CON_APP_VERSION}-macos-${CON_ARCH}.zip"
   export CON_DMG_PATH="$CON_DIST_ROOT/${CON_APP_NAME// /-}-${CON_APP_VERSION}-macos-${CON_ARCH}.dmg"
-  export CON_CHECKSUM_PATH="$CON_DIST_ROOT/SHA256SUMS.txt"
+  export CON_CHECKSUM_PATH="$CON_DIST_ROOT/SHA256SUMS-macos-$CON_ARCH.txt"
 }
 
 signing_identity() {

--- a/scripts/macos/common.sh
+++ b/scripts/macos/common.sh
@@ -107,10 +107,10 @@ derive_build_number() {
 setup_release_env() {
   export CON_CHANNEL="${CON_CHANNEL:-stable}"
   case "$CON_CHANNEL" in
-    stable|beta)
+    stable|beta|dev)
       ;;
     *)
-      fail "CON_CHANNEL must be 'stable' or 'beta', got: $CON_CHANNEL"
+      fail "CON_CHANNEL must be 'stable', 'beta', or 'dev', got: $CON_CHANNEL"
       ;;
   esac
 
@@ -129,6 +129,9 @@ setup_release_env() {
   if [[ "$CON_CHANNEL" == "beta" ]]; then
     default_bundle_id="${CON_BUNDLE_ID_BASE}.beta"
     default_app_name="con Beta"
+  elif [[ "$CON_CHANNEL" == "dev" ]]; then
+    default_bundle_id="${CON_BUNDLE_ID_BASE}.dev"
+    default_app_name="con Dev"
   fi
   export CON_BUNDLE_ID="${CON_BUNDLE_ID:-$default_bundle_id}"
   export CON_APP_NAME="${CON_APP_NAME:-$default_app_name}"

--- a/scripts/macos/common.sh
+++ b/scripts/macos/common.sh
@@ -137,8 +137,12 @@ setup_release_env() {
   export CON_APP_NAME="${CON_APP_NAME:-$default_app_name}"
 
   # Derive Sparkle feed URL from channel + arch if not explicitly set.
+  # Dev builds never poll and must not inherit a public feed URL from
+  # the caller's environment.
   # Pattern: https://con-releases.nowledge.co/appcast/{channel}-macos-{arch}.xml
-  if [[ "$CON_CHANNEL" != "dev" && -z "${CON_SPARKLE_FEED_URL:-}" && -n "${CON_SPARKLE_PUBLIC_ED_KEY:-}" ]]; then
+  if [[ "$CON_CHANNEL" == "dev" ]]; then
+    unset CON_SPARKLE_FEED_URL
+  elif [[ -z "${CON_SPARKLE_FEED_URL:-}" && -n "${CON_SPARKLE_PUBLIC_ED_KEY:-}" ]]; then
     export CON_SPARKLE_FEED_URL="https://con-releases.nowledge.co/appcast/${CON_CHANNEL}-macos-${CON_ARCH}.xml"
   fi
 

--- a/scripts/macos/verify.sh
+++ b/scripts/macos/verify.sh
@@ -12,6 +12,11 @@ require_cmd codesign
 require_cmd spctl
 require_cmd xcrun
 
+cli_binary="$CON_APP_BUNDLE_PATH/Contents/MacOS/con-cli"
+if [[ ! -x "$cli_binary" ]]; then
+  fail "con-cli missing from app bundle: $cli_binary"
+fi
+
 log "Verifying code signature for $CON_APP_BUNDLE_PATH"
 codesign --verify --deep --strict --verbose=2 "$CON_APP_BUNDLE_PATH"
 

--- a/scripts/release/verify-artifacts.sh
+++ b/scripts/release/verify-artifacts.sh
@@ -61,8 +61,13 @@ verify_linux() {
   trap 'rm -rf "$tmp"' RETURN
 
   tar -xzf "$tarball" -C "$tmp"
+  local root_count
+  root_count="$(find "$tmp" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d '[:space:]')"
+  [[ "$root_count" == "1" ]] \
+    || fail "$tarball_name must extract to exactly one top-level directory, found $root_count"
+
   local root
-  root="$(find "$tmp" -mindepth 1 -maxdepth 1 -type d | head -1)"
+  root="$(find "$tmp" -mindepth 1 -maxdepth 1 -type d -print -quit)"
   [[ -n "$root" ]] || fail "$tarball_name did not extract to a top-level directory"
 
   require_executable "$root/con"

--- a/scripts/release/verify-artifacts.sh
+++ b/scripts/release/verify-artifacts.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# Release artifact shape checks.
+#
+# These checks run inside the platform release workflows before artifacts are
+# uploaded. They are intentionally boring and strict: a release artifact that
+# cannot expose `con-cli` must fail before it can reach GitHub Releases or an
+# updater appcast.
+
+set -euo pipefail
+
+fail() {
+  printf '[release-verify] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+log() {
+  printf '[release-verify] %s\n' "$*"
+}
+
+require_file() {
+  local path="$1"
+  [[ -f "$path" ]] || fail "missing file: $path"
+}
+
+require_executable() {
+  local path="$1"
+  [[ -x "$path" ]] || fail "missing executable: $path"
+}
+
+verify_linux() {
+  local tarball="$1"
+  local checksum="$2"
+
+  require_file "$tarball"
+  require_file "$checksum"
+
+  local tarball_name
+  tarball_name="$(basename "$tarball")"
+
+  log "checking Linux checksum"
+  (
+    cd "$(dirname "$checksum")"
+    if command -v sha256sum >/dev/null 2>&1; then
+      sha256sum -c "$(basename "$checksum")"
+    else
+      shasum -a 256 -c "$(basename "$checksum")"
+    fi
+  )
+
+  log "checking Linux tarball layout"
+  tar -tzf "$tarball" | grep -E "/con$" >/dev/null \
+    || fail "$tarball_name does not contain con"
+  tar -tzf "$tarball" | grep -E "/con-cli$" >/dev/null \
+    || fail "$tarball_name does not contain con-cli"
+  tar -tzf "$tarball" | grep -E "/con.desktop$" >/dev/null \
+    || fail "$tarball_name does not contain con.desktop"
+
+  local tmp
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  tar -xzf "$tarball" -C "$tmp"
+  local root
+  root="$(find "$tmp" -mindepth 1 -maxdepth 1 -type d | head -1)"
+  [[ -n "$root" ]] || fail "$tarball_name did not extract to a top-level directory"
+
+  require_executable "$root/con"
+  require_executable "$root/con-cli"
+  "$root/con-cli" --help >/dev/null
+  log "Linux artifact OK: $tarball_name"
+}
+
+verify_macos() {
+  local app="$1"
+  local zip="$2"
+  local dmg="$3"
+  local checksum="$4"
+
+  [[ -d "$app" ]] || fail "missing app bundle: $app"
+  require_file "$zip"
+  require_file "$dmg"
+  require_file "$checksum"
+
+  require_executable "$app/Contents/MacOS/con"
+  require_executable "$app/Contents/MacOS/con-cli"
+  "$app/Contents/MacOS/con-cli" --help >/dev/null
+
+  log "checking macOS checksum"
+  (
+    cd "$(dirname "$checksum")"
+    shasum -a 256 -c "$(basename "$checksum")"
+  )
+
+  log "checking macOS ZIP layout"
+  unzip -l "$zip" | grep -F ".app/Contents/MacOS/con-cli" >/dev/null \
+    || fail "$(basename "$zip") does not contain bundled con-cli"
+
+  log "checking macOS DMG layout"
+  local mount_point
+  mount_point="$(mktemp -d)"
+  hdiutil attach -quiet -nobrowse -mountpoint "$mount_point" "$dmg"
+  trap 'hdiutil detach -quiet "$mount_point" >/dev/null 2>&1 || true; rm -rf "$mount_point"' RETURN
+
+  local mounted_app=""
+  for candidate in "$mount_point"/*.app; do
+    if [[ -d "$candidate" ]]; then
+      mounted_app="$candidate"
+      break
+    fi
+  done
+  [[ -n "$mounted_app" ]] || fail "$(basename "$dmg") does not contain an app bundle"
+  require_executable "$mounted_app/Contents/MacOS/con"
+  require_executable "$mounted_app/Contents/MacOS/con-cli"
+  "$mounted_app/Contents/MacOS/con-cli" --help >/dev/null
+
+  log "macOS artifact OK: $(basename "$dmg")"
+}
+
+case "${1:-}" in
+  linux)
+    [[ "$#" -eq 3 ]] || fail "usage: $0 linux <tarball> <checksum>"
+    verify_linux "$2" "$3"
+    ;;
+  macos)
+    [[ "$#" -eq 5 ]] || fail "usage: $0 macos <app> <zip> <dmg> <checksum>"
+    verify_macos "$2" "$3" "$4" "$5"
+    ;;
+  *)
+    fail "usage: $0 {linux|macos} ..."
+    ;;
+esac

--- a/scripts/release/verify-release-gate.sh
+++ b/scripts/release/verify-release-gate.sh
@@ -25,6 +25,15 @@ log() {
   printf '[release-gate] %s\n' "$*"
 }
 
+require_line() {
+  local file="$1"
+  local needle="$2"
+  local description="$3"
+
+  grep -F "$needle" "$file" >/dev/null \
+    || fail "$file does not contain expected installer wiring: $description"
+}
+
 tag="${1:?usage: verify-release-gate.sh <tag> <gh-pages-dir>}"
 pages_dir="${2:?usage: verify-release-gate.sh <tag> <gh-pages-dir>}"
 repo="${GH_REPO:-${GITHUB_REPOSITORY:-}}"
@@ -89,10 +98,18 @@ grep -F "con-${version}-windows-x86_64.zip" "$tmp/SHA256SUMS-windows.txt" >/dev/
 
 [[ -f "$pages_dir/install.sh" ]] || fail "gh-pages install.sh missing"
 [[ -f "$pages_dir/install.ps1" ]] || fail "gh-pages install.ps1 missing"
-grep -F "con-cli" "$pages_dir/install.sh" >/dev/null \
-  || fail "gh-pages install.sh does not expose con-cli"
-grep -F "con-cli.exe" "$pages_dir/install.ps1" >/dev/null \
-  || fail "gh-pages install.ps1 does not expose con-cli.exe"
+require_line "$pages_dir/install.sh" 'cli_src="${target}/Contents/MacOS/con-cli"' \
+  "macOS bundled con-cli source"
+require_line "$pages_dir/install.sh" 'ln -sf "$cli_src" "${bin_dir}/con-cli"' \
+  "macOS PATH symlink"
+require_line "$pages_dir/install.sh" 'target_cli="${bin_dir}/con-cli"' \
+  "Linux con-cli install target"
+require_line "$pages_dir/install.sh" 'mv -f "$tmp_cli" "$target_cli"' \
+  "Linux atomic con-cli install"
+require_line "$pages_dir/install.ps1" "\$cliPath = Join-Path \$InstallRoot 'con-cli.exe'" \
+  "Windows con-cli install path"
+require_line "$pages_dir/install.ps1" 'if (Test-Path $cliPath)' \
+  "Windows con-cli archive verification"
 
 if [[ "$channel" == "dev" ]]; then
   log "dev tag: appcast promotion checks skipped"

--- a/scripts/release/verify-release-gate.sh
+++ b/scripts/release/verify-release-gate.sh
@@ -49,6 +49,8 @@ esac
 mac_prefix="con"
 if [[ "$channel" == "beta" ]]; then
   mac_prefix="con-Beta"
+elif [[ "$channel" == "dev" ]]; then
+  mac_prefix="con-Dev"
 fi
 
 required_assets=(

--- a/scripts/release/verify-release-gate.sh
+++ b/scripts/release/verify-release-gate.sh
@@ -45,8 +45,10 @@ fi
 required_assets=(
   "${mac_prefix}-${version}-macos-arm64.dmg"
   "${mac_prefix}-${version}-macos-arm64.zip"
+  "SHA256SUMS-macos-arm64.txt"
   "${mac_prefix}-${version}-macos-x86_64.dmg"
   "${mac_prefix}-${version}-macos-x86_64.zip"
+  "SHA256SUMS-macos-x86_64.txt"
   "con-${version}-linux-x86_64.tar.gz"
   "SHA256SUMS-linux.txt"
   "con-${version}-windows-x86_64.zip"
@@ -70,10 +72,16 @@ trap 'rm -rf "$tmp"' EXIT
 
 log "checking checksum manifests"
 gh release download "$tag" \
+  --pattern "SHA256SUMS-macos-arm64.txt" \
+  --pattern "SHA256SUMS-macos-x86_64.txt" \
   --pattern "SHA256SUMS-linux.txt" \
   --pattern "SHA256SUMS-windows.txt" \
   --dir "$tmp" >/dev/null
 
+grep -F "${mac_prefix}-${version}-macos-arm64" "$tmp/SHA256SUMS-macos-arm64.txt" >/dev/null \
+  || fail "SHA256SUMS-macos-arm64.txt does not reference arm64 macOS artifacts"
+grep -F "${mac_prefix}-${version}-macos-x86_64" "$tmp/SHA256SUMS-macos-x86_64.txt" >/dev/null \
+  || fail "SHA256SUMS-macos-x86_64.txt does not reference x86_64 macOS artifacts"
 grep -F "con-${version}-linux-x86_64.tar.gz" "$tmp/SHA256SUMS-linux.txt" >/dev/null \
   || fail "SHA256SUMS-linux.txt does not reference the Linux tarball"
 grep -F "con-${version}-windows-x86_64.zip" "$tmp/SHA256SUMS-windows.txt" >/dev/null \
@@ -97,14 +105,39 @@ require_appcast() {
   local short_version="$3"
 
   [[ -f "$file" ]] || fail "missing appcast: $file"
-  grep -F "$asset" "$file" >/dev/null \
-    || fail "$(basename "$file") does not point at $asset"
-  grep -F "sparkle:shortVersionString=\"$short_version\"" "$file" >/dev/null \
-    || fail "$(basename "$file") does not carry shortVersionString=$short_version"
-  grep -F 'sparkle:edSignature="' "$file" >/dev/null \
-    || fail "$(basename "$file") is missing an Ed25519 signature"
-  grep -F 'length="' "$file" >/dev/null \
-    || fail "$(basename "$file") is missing enclosure length"
+  python3 - "$file" "$asset" "$short_version" <<'PYTHON'
+import sys
+import xml.etree.ElementTree as ET
+
+file, asset, short_version = sys.argv[1:]
+sparkle = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+
+try:
+    root = ET.parse(file).getroot()
+except Exception as err:
+    raise SystemExit(f"{file} is not valid XML: {err}")
+
+for item in root.findall("./channel/item"):
+    short = item.find(f"{{{sparkle}}}shortVersionString")
+    enclosure = item.find("enclosure")
+    if short is None or short.text != short_version or enclosure is None:
+        continue
+
+    url = enclosure.get("url") or ""
+    signature = enclosure.get(f"{{{sparkle}}}edSignature") or ""
+    length = enclosure.get("length") or ""
+    if asset not in url:
+        continue
+    if not signature:
+        raise SystemExit(f"{file} item for {asset} is missing edSignature")
+    if not length or int(length) <= 0:
+        raise SystemExit(f"{file} item for {asset} is missing positive length")
+    break
+else:
+    raise SystemExit(
+        f"{file} does not contain {asset} with shortVersionString={short_version}"
+    )
+PYTHON
 
   log "appcast OK: $(basename "$file") -> $asset"
 }

--- a/scripts/release/verify-release-gate.sh
+++ b/scripts/release/verify-release-gate.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# Final release gate.
+#
+# This script runs from release-finalize.yml after the macOS, Linux, and
+# Windows release workflows all reported success but before the draft release
+# is made public. It verifies the public contract that fresh installers and
+# in-app updaters rely on:
+#
+#   - every expected GitHub Release asset exists and is non-empty
+#   - checksum files reference the artifacts they are supposed to protect
+#   - stable/beta appcasts point at the just-built assets
+#   - gh-pages carries the installer scripts used by fresh installs / updates
+#
+# If any of those invariants fail, the draft stays private.
+
+set -euo pipefail
+
+fail() {
+  printf '[release-gate] ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+log() {
+  printf '[release-gate] %s\n' "$*"
+}
+
+tag="${1:?usage: verify-release-gate.sh <tag> <gh-pages-dir>}"
+pages_dir="${2:?usage: verify-release-gate.sh <tag> <gh-pages-dir>}"
+repo="${GH_REPO:-${GITHUB_REPOSITORY:-}}"
+[[ -n "$repo" ]] || fail "GH_REPO or GITHUB_REPOSITORY is required"
+
+version="${tag#v}"
+channel="stable"
+case "$version" in
+  *-beta.*) channel="beta" ;;
+  *-dev.*) channel="dev" ;;
+esac
+
+mac_prefix="con"
+if [[ "$channel" == "beta" ]]; then
+  mac_prefix="con-Beta"
+fi
+
+required_assets=(
+  "${mac_prefix}-${version}-macos-arm64.dmg"
+  "${mac_prefix}-${version}-macos-arm64.zip"
+  "${mac_prefix}-${version}-macos-x86_64.dmg"
+  "${mac_prefix}-${version}-macos-x86_64.zip"
+  "con-${version}-linux-x86_64.tar.gz"
+  "SHA256SUMS-linux.txt"
+  "con-${version}-windows-x86_64.zip"
+  "SHA256SUMS-windows.txt"
+)
+
+log "checking release assets for $tag"
+release_json="$(gh release view "$tag" --json isDraft,assets)"
+is_draft="$(jq -r '.isDraft' <<<"$release_json")"
+[[ "$is_draft" == "true" ]] || fail "$tag is not a draft; refusing to run final gate"
+
+for asset in "${required_assets[@]}"; do
+  size="$(jq -r --arg name "$asset" '.assets[] | select(.name == $name) | .size' <<<"$release_json" | head -1)"
+  [[ -n "$size" && "$size" != "null" ]] || fail "missing release asset: $asset"
+  [[ "$size" -gt 0 ]] || fail "empty release asset: $asset"
+  log "asset OK: $asset (${size} bytes)"
+done
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+log "checking checksum manifests"
+gh release download "$tag" \
+  --pattern "SHA256SUMS-linux.txt" \
+  --pattern "SHA256SUMS-windows.txt" \
+  --dir "$tmp" >/dev/null
+
+grep -F "con-${version}-linux-x86_64.tar.gz" "$tmp/SHA256SUMS-linux.txt" >/dev/null \
+  || fail "SHA256SUMS-linux.txt does not reference the Linux tarball"
+grep -F "con-${version}-windows-x86_64.zip" "$tmp/SHA256SUMS-windows.txt" >/dev/null \
+  || fail "SHA256SUMS-windows.txt does not reference the Windows ZIP"
+
+[[ -f "$pages_dir/install.sh" ]] || fail "gh-pages install.sh missing"
+[[ -f "$pages_dir/install.ps1" ]] || fail "gh-pages install.ps1 missing"
+grep -F "con-cli" "$pages_dir/install.sh" >/dev/null \
+  || fail "gh-pages install.sh does not expose con-cli"
+grep -F "con-cli.exe" "$pages_dir/install.ps1" >/dev/null \
+  || fail "gh-pages install.ps1 does not expose con-cli.exe"
+
+if [[ "$channel" == "dev" ]]; then
+  log "dev tag: appcast promotion checks skipped"
+  exit 0
+fi
+
+require_appcast() {
+  local file="$1"
+  local asset="$2"
+  local short_version="$3"
+
+  [[ -f "$file" ]] || fail "missing appcast: $file"
+  grep -F "$asset" "$file" >/dev/null \
+    || fail "$(basename "$file") does not point at $asset"
+  grep -F "sparkle:shortVersionString=\"$short_version\"" "$file" >/dev/null \
+    || fail "$(basename "$file") does not carry shortVersionString=$short_version"
+  grep -F 'sparkle:edSignature="' "$file" >/dev/null \
+    || fail "$(basename "$file") is missing an Ed25519 signature"
+  grep -F 'length="' "$file" >/dev/null \
+    || fail "$(basename "$file") is missing enclosure length"
+
+  log "appcast OK: $(basename "$file") -> $asset"
+}
+
+marketing_version="${version%%[-+]*}"
+
+log "checking appcasts for $channel"
+require_appcast \
+  "$pages_dir/appcast/${channel}-macos-arm64.xml" \
+  "${mac_prefix}-${version}-macos-arm64.dmg" \
+  "$marketing_version"
+require_appcast \
+  "$pages_dir/appcast/${channel}-macos-x86_64.xml" \
+  "${mac_prefix}-${version}-macos-x86_64.dmg" \
+  "$marketing_version"
+require_appcast \
+  "$pages_dir/appcast/${channel}-linux-x86_64.xml" \
+  "con-${version}-linux-x86_64.tar.gz" \
+  "$version"
+require_appcast \
+  "$pages_dir/appcast/${channel}-windows-x86_64.xml" \
+  "con-${version}-windows-x86_64.zip" \
+  "$version"
+
+log "release gate passed for $tag"


### PR DESCRIPTION
## Summary

- Bundle `con-cli` into every release artifact so Jay's `pi-interactive-subagents` adapter can rely on a normal Con install.
- Expose the CLI through Homebrew cask installs, macOS/Linux one-line installers, and Windows ZIP/script installs.
- Align macOS Sparkle/manual-DMG users with installer users by adding a conservative launch-time `~/.local/bin/con-cli` self-heal that only creates or repairs missing/Con-managed symlinks and never overwrites user-managed binaries.
- Add blocking release gates so bad artifacts/appcasts/installers fail while the GitHub release is still a private draft.
- Update README, HACKING, release docs, changelog, and postmortem coverage for the new install/update contract.

## Installer/update alignment

- macOS Homebrew: cask installs `con Beta.app` and exposes `con-cli` via the bundled app binary.
- macOS install.sh: copies the app into `/Applications` and links `~/.local/bin/con-cli` to `Contents/MacOS/con-cli`.
- macOS Sparkle/manual DMG: the update replaces the app bundle; on launch Con self-heals `~/.local/bin/con-cli` when safe, so older manual-DMG/Sparkle users converge without rerunning the installer.
- Linux install.sh/in-app update: both use the same tarball and installer path; the script installs `con` and `con-cli` into `~/.local/bin`.
- Windows install.ps1/ZIP: the ZIP includes `con-app.exe` and `con-cli.exe`; install.ps1 extracts both into the same PATH directory.

## Release safety gates

- macOS release jobs now verify app bundle, ZIP, DMG, checksums, and bundled `con-cli --help` before artifact upload.
- Linux release jobs now verify tarball layout, checksum, and bundled `con-cli --help` before artifact upload.
- Windows release jobs now expand the ZIP, verify `con-app.exe` and `con-cli.exe`, run `con-cli.exe --help`, and validate `SHA256SUMS-windows.txt` before artifact upload.
- `release-finalize.yml` now refuses to publish the draft unless all expected assets exist, stable/beta appcasts point at this tag's artifacts, and gh-pages `install.sh` / `install.ps1` expose `con-cli` / `con-cli.exe`.
- `ci-portable.yml` now runs on release workflow/script changes and includes Bash/PowerShell parser checks, so installer-only changes get PR CI coverage.

## Validation

- `bash -n scripts/install.sh scripts/linux/release.sh scripts/release/verify-artifacts.sh scripts/release/verify-release-gate.sh scripts/macos/*.sh scripts/sparkle/*.sh`
- YAML parse check for `ci-portable.yml`, `release-finalize.yml`, `release-linux.yml`, `release-macos.yml`, `release-windows.yml`
- PowerShell parser check for `scripts/install.ps1`
- `cargo fmt --check`
- `cargo check -p con-cli`
- `cargo check -p con --bin con`
- `cargo check -p con --bin con-app --no-default-features --features con/bin-con-app`
- `cargo build --release -p con-cli`
- `cargo test -p con-cli`
- `cargo test -p con --bin con cli_shim`
- `cargo test -p con-core --lib control::tests::surface`
- full local macOS release dry run:
  - `CON_CHANNEL=beta CON_APP_VERSION=0.1.0-beta.local CON_BUILD_NUMBER=0 CON_ALLOW_ADHOC_SIGNING=1 CON_SKIP_NOTARIZATION=1 ./scripts/macos/release.sh`
  - verified `codesign --verify --deep --strict` accepts the app bundle and validates `Contents/MacOS/con-cli`
  - verified the generated DMG signature and SHA256SUMS
  - verified the ZIP contains `con Beta.app/Contents/MacOS/con` and `con Beta.app/Contents/MacOS/con-cli`
  - mounted the generated DMG and ran bundled `con-cli --help`
- `./scripts/release/verify-artifacts.sh macos ...` against the local beta app/ZIP/DMG/checksum
- `./scripts/release/verify-artifacts.sh linux ...` against a hermetic fake tarball/checksum
- `./scripts/release/verify-release-gate.sh v0.1.0-beta.58 ...` against a hermetic fake GitHub Release/appcast/installer environment
- simulated macOS installer CLI exposure in a temp prefix by copying the app, symlinking `Contents/MacOS/con-cli`, and running the linked CLI
- ran the packaged `con-cli` against a temporary Unix-socket JSON-RPC mock and verified it sends `system.identify` and decodes the JSON response
- simulated the Linux branch of `install.sh` with fake GitHub release JSON, a fake release tarball, and temporary `$HOME`; verified it installs executable `~/.local/bin/con` and `~/.local/bin/con-cli`
- PR CI after release-gate changes: Ubuntu pass, Windows pass, CodeRabbit pass

## Notes

- `actionlint` is not installed locally, so workflow lint was not run here.
- Cross-target `cargo check -p con-cli --target x86_64-unknown-linux-gnu` and `--target x86_64-pc-windows-msvc` cannot run from this macOS machine because the required Linux GCC cross compiler / Windows SDK headers are not installed locally. Release CI builds those artifacts on native Linux and Windows runners.

Fixes #108 follow-up for bundled `con-cli` distribution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes release/installer workflows across macOS/Linux/Windows and adds a new final promotion gate that can block publishing if checks are wrong or brittle.
> 
> **Overview**
> Bundles `con-cli` into all shipped artifacts and installers: macOS app bundles now include `con-cli` (also exposed via Homebrew and `install.sh`), Linux tarballs/install flow install both binaries, and Windows ZIPs/install flow now include `con-cli.exe`.
> 
> Hardens the release pipeline with **blocking verification**: new `scripts/release/verify-artifacts.sh` validates macOS/Linux artifact layout and runs `con-cli --help`, Windows release builds validate ZIP contents/checksums, and `release-finalize.yml` now runs `scripts/release/verify-release-gate.sh` against GitHub Release assets + gh-pages installers/appcasts before promoting a draft.
> 
> Adds a macOS-only launch-time `con-cli` symlink self-heal (`crates/con-app/src/cli_shim.rs`) that repairs `~/.local/bin/con-cli` only when it already points at (or is missing for) a managed Con install, and updates CI path filters + script syntax checks so workflow/installer-only changes get coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 939ce0e6928b000ce6e8a20b2ab4f3501220b86e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * con-cli is bundled with all release artifacts (macOS, Linux, Windows)
  * macOS app creates/repairs a per-user symlink so con-cli is available on PATH

* **Documentation**
  * Expanded install and macOS release docs explaining con-cli exposure and verification
  * Added postmortem and release-gate guidance

* **Chores**
  * Release pipelines now verify artifacts, gate appcast/homebrew publishing for dev tags, and enforce final release checks
* **Bug Fixes**
  * Installer scripts now report presence/absence of bundled con-cli during install
<!-- end of auto-generated comment: release notes by coderabbit.ai -->