### PR TITLE
Fix macOS con-cli release signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ con is still pre-release, so entries may group related beta work while the produ
 - Made the release finalizer sync hosted installer scripts from the tagged
   commit before promotion, so dev smoke tags can test the real `install.sh` /
   `install.ps1` path without moving beta/stable appcasts or Homebrew casks.
+- Fixed macOS release signing order so the bundled `con-cli` executable is
+  signed before the main app executable and notarized DMGs are not blocked by
+  unsigned nested code.
 - Documented that `con-cli` is part of the normal install path for surface
   orchestrators such as `pi-interactive-subagents`.
 

--- a/postmortem/2026-05-04-release-installer-gates.md
+++ b/postmortem/2026-05-04-release-installer-gates.md
@@ -29,6 +29,9 @@ The pipeline relied on several independent checks:
 - Made `release-finalize.yml` sync `install.sh` and `install.ps1` from the
   tagged commit to `gh-pages` before running the final gate, so dev smoke tags
   can exercise the hosted installer without appcast or Homebrew movement.
+- Fixed macOS app signing order so bundled auxiliary executables such as
+  `Contents/MacOS/con-cli` are signed before the main app executable and the
+  top-level bundle.
 - Extended portable CI path filters and added script/parser checks so release
   workflow and installer script changes receive CI coverage in PRs.
 - Made internal `v*-dev.*` release handling explicit across the macOS release

--- a/scripts/macos/release.sh
+++ b/scripts/macos/release.sh
@@ -88,9 +88,17 @@ sign_app_bundle() {
     done < <(find "$frameworks_dir" -maxdepth 1 -name '*.framework' -print0 2>/dev/null || true)
   fi
 
-  # 4. Sign loose executables in the app (the main binary, etc.),
-  #    excluding anything already covered by the framework pass.
+  # 4. Sign loose executables in the app, excluding anything already covered
+  #    by the framework pass. Sign auxiliary executables before the main app
+  #    binary: codesign validates nested/sibling executable code when signing
+  #    the bundle's main executable, so con-cli must already be signed.
+  local main_executable="$app_path/Contents/MacOS/con"
+  local has_main_executable=0
   while IFS= read -r nested; do
+    if [[ "$nested" == "$main_executable" ]]; then
+      has_main_executable=1
+      continue
+    fi
     sign_code "$nested"
   done < <(
     find "$app_path/Contents" -type f \
@@ -99,6 +107,10 @@ sign_app_bundle() {
       ! -path '*/Frameworks/*' \
       | sort
   )
+
+  if [[ "$has_main_executable" == "1" ]]; then
+    sign_code "$main_executable"
+  fi
 
   # 5. Sign the top-level app bundle.
   sign_code "$app_path"


### PR DESCRIPTION
## Summary\n- sign bundled Contents/MacOS/con-cli before the main con executable during macOS app signing\n- keep the release-installer-gate postmortem and changelog aligned with the dev smoke failure\n\n## Verification\n- bash -n scripts/macos/release.sh scripts/macos/build-app.sh scripts/macos/verify.sh\n- git diff --check\n- local ad-hoc dev macOS package: CON_CHANNEL=dev CON_APP_VERSION=0.1.0-dev.local-sign CON_BUILD_NUMBER=0 CON_ARCH=arm64 CON_RUST_TARGET=aarch64-apple-darwin CON_ALLOW_ADHOC_SIGNING=1 CON_SKIP_NOTARIZATION=1 ./scripts/macos/release.sh\n\nCaught by the v0.1.0-dev.59 smoke release: Linux and Windows assets stayed draft/private, macOS x86_64 failed because con-cli was unsigned nested code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS app notarization to prevent blocked installations due to unsigned nested code.

* **Chores**
  * Updated macOS release packaging to sign bundled executables in the correct order, ensuring compliance with macOS security requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches macOS release signing logic used for notarized artifacts; a mistake could break release packaging/notarization despite being a small, well-scoped ordering change.
> 
> **Overview**
> Fixes macOS release signing by ensuring auxiliary executables (notably `Contents/MacOS/con-cli`) are codesigned *before* the main `con` executable, preventing notarization failures due to unsigned nested code.
> 
> Updates the changelog and the release-installer-gates postmortem to document the signing-order issue and its resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c904608ea497dac01cda1e24c85f938041355c02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->