### PR TITLE
docs: scoop installation for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ This installs `con-app.exe` and `con-cli.exe` into the same PATH directory.
 Or download `con-windows-x86_64.zip` from the latest
 [Release](https://github.com/nowledge-co/con-terminal/releases).
 
+For Scoop users, here's how to install:
+
+```powershell
+scoop bucket add jam https://github.com/EFLKumo/jam
+scoop install jam/con-terminal
+```
+
+This will make con portable and add `con-app` to your PATH.
+
 To build from source, see `HACKING.md`.
 
 ## Docs

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ scoop bucket add jam https://github.com/EFLKumo/jam
 scoop install jam/con-terminal
 ```
 
-This will make con portable and add `con-app` to your PATH.
+This will make con portable and add `con-app` and `con-cli` to your PATH.
 
 To build from source, see `HACKING.md`.
 


### PR DESCRIPTION
This PR adds instructions for installing con-terminal using Scoop to the README.

[Scoop](https://scoop.sh) is an application manager for Windows, similar to WinGet. Its advantages include:
- Better handling of PATH
- Portable handling of data stored by con
- Enables the large Scoop user base to install it quickly

Regarding security:
- The `jam` bucket used for installation in the README is [open-source](https://github.com/EFLKumo/jam); installing the bucket does not introduce code execution; it merely provides the source for the Scoop package manifest
- This approach was taken because the PR for the official Scoop repository is still under review: https://github.com/ScoopInstaller/Versions/pull/2840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Windows installation guide with additional instructions for Scoop users, including bucket setup and package installation commands.
  * Added clarification on maintaining application portability and PATH environment variable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->