### PR TITLE
Settings: show last saved time and add cmd-s | cmd - w shortcut

### DIFF
--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -4865,6 +4865,13 @@ impl Render for SettingsPanel {
                     "s" if event.keystroke.modifiers.platform => {
                         this.save(window, cx);
                     }
+                    "w" if event.keystroke.modifiers.platform => {
+                        if this.standalone {
+                            window.remove_window();
+                        } else {
+                            this.save(window, cx);
+                        }
+                    }
                     _ => {}
                 }
             }))

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -4869,6 +4869,7 @@ impl Render for SettingsPanel {
                     }
                     "w" if event.keystroke.modifiers.platform => {
                         if this.standalone {
+                            this.revert_standalone_preview(cx);
                             window.remove_window();
                         } else {
                             this.save(window, cx);

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -139,6 +139,7 @@ pub struct SettingsPanel {
     background_image_fit_select: Entity<SelectState<Vec<String>>>,
     background_image_repeat: bool,
     save_error: Option<String>,
+    last_saved_at: Option<std::time::SystemTime>,
 
     // Theme import
     custom_theme_name_input: Entity<InputState>,
@@ -1358,6 +1359,7 @@ impl SettingsPanel {
             background_image_fit_select,
             background_image_repeat: config.appearance.background_image_repeat,
             save_error: None,
+            last_saved_at: None,
             custom_theme_name_input,
             custom_theme_preview: None,
             custom_theme_status: None,
@@ -2107,6 +2109,7 @@ impl SettingsPanel {
         match self.persist_config() {
             Ok(()) => {
                 self.save_error = None;
+                self.last_saved_at = Some(std::time::SystemTime::now());
                 self.preview_snapshot = Some(self.config.clone());
                 if !self.standalone {
                     self.visible = false;
@@ -4859,6 +4862,9 @@ impl Render for SettingsPanel {
                     "enter" if event.keystroke.modifiers.platform => {
                         this.save(window, cx);
                     }
+                    "s" if event.keystroke.modifiers.platform => {
+                        this.save(window, cx);
+                    }
                     _ => {}
                 }
             }))
@@ -4931,17 +4937,55 @@ impl Render for SettingsPanel {
                                             )
                                             .child("config.toml"),
                                     )
+                                    .children(self.last_saved_at.map(|saved_at| {
+                                        let elapsed = saved_at
+                                            .elapsed()
+                                            .unwrap_or_default()
+                                            .as_secs();
+                                        let label = if elapsed < 60 {
+                                            "Saved just now".to_string()
+                                        } else if elapsed < 3600 {
+                                            format!("Saved {}m ago", elapsed / 60)
+                                        } else {
+                                            format!("Saved {}h ago", elapsed / 3600)
+                                        };
+                                        div()
+                                            .flex()
+                                            .items_center()
+                                            .gap(px(4.0))
+                                            .child(
+                                                svg()
+                                                    .path("phosphor/check-circle-fill.svg")
+                                                    .size(px(11.0))
+                                                    .text_color(theme.muted_foreground.opacity(0.45)),
+                                            )
+                                            .child(
+                                                div()
+                                                    .text_size(px(10.5))
+                                                    .text_color(theme.muted_foreground.opacity(0.45))
+                                                    .child(label),
+                                            )
+                                    }))
                                     .children(self.standalone.then(|| {
-                                        Button::new("settings-apply")
-                                            .small()
-                                            .compact()
-                                            .rounded(px(8.0))
-                                            .custom(save_button_style)
-                                            .icon(Icon::default().path("phosphor/check.svg"))
-                                            .label("Save Changes")
-                                            .on_click(cx.listener(|this, _, window, cx| {
-                                                this.save(window, cx);
-                                            }))
+                                        div()
+                                            .flex()
+                                            .items_center()
+                                            .gap(px(6.0))
+                                            .child(
+                                                crate::keycaps::keycaps_for_binding("cmd-s", theme),
+                                            )
+                                            .child(
+                                                Button::new("settings-apply")
+                                                    .small()
+                                                    .compact()
+                                                    .rounded(px(8.0))
+                                                    .custom(save_button_style)
+                                                    .icon(Icon::default().path("phosphor/check.svg"))
+                                                    .label("Save Changes")
+                                                    .on_click(cx.listener(|this, _, window, cx| {
+                                                        this.save(window, cx);
+                                                    })),
+                                            )
                                     })),
                             ),
                     )

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -1359,7 +1359,9 @@ impl SettingsPanel {
             background_image_fit_select,
             background_image_repeat: config.appearance.background_image_repeat,
             save_error: None,
-            last_saved_at: None,
+            last_saved_at: std::fs::metadata(Config::config_path())
+                .and_then(|m| m.modified())
+                .ok(),
             custom_theme_name_input,
             custom_theme_preview: None,
             custom_theme_status: None,


### PR DESCRIPTION
## Summary

- Display save status in the settings header — shows \"Saved just now\", \"Saved Xm ago\", or \"Saved Xh ago\" with a check-circle icon after a successful save
- Add \`cmd-s\` (macOS) / \`ctrl-s\` (Windows/Linux) keyboard shortcut to trigger Save Changes
- Add \`cmd-w\` (macOS) / \`ctrl-w\` (Windows/Linux) to close the settings window (standalone mode) or save and dismiss (panel mode)
- Show the \`⌘ S\` keycap hint next to the Save Changes button in standalone settings window

## Test Plan
- [x] Open Settings (standalone window), make a change, press cmd-s — config saves and header shows "Saved just now"
- [x] Click Save Changes button — same save status appears
- [x] Reopen settings after a minute — header shows "Saved Xm ago"
- [x] Press cmd-w in standalone settings window — window closes
- [x] Press cmd-w in panel mode — panel saves and dismisses
- [x] Keycap hint renders correctly on macOS (⌘ S) and Windows/Linux (Ctrl S)