### PR TITLE
docs: add settings save UX to v0.1.0-beta.59 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ### Added
 
+**Settings**
+
+- Added a save-status indicator in the settings header that shows "Saved just now", "Saved Xm ago", or "Saved Xh ago" with a check-circle icon after a successful save. The timestamp is seeded from `config.toml`'s modification time on open, so the indicator persists correctly across settings window reopens.
+- Added `cmd-s` (macOS) / `ctrl-s` (Windows/Linux) keyboard shortcut to save settings from anywhere in the settings panel. A `⌘ S` / `Ctrl S` keycap hint is shown next to the Save Changes button in the standalone settings window.
+- Added `cmd-w` (macOS) / `ctrl-w` (Windows/Linux) to close the standalone settings window or save-and-dismiss the settings panel. Closing via `cmd-w` correctly reverts any unsaved appearance/theme preview changes, matching the existing Escape behavior.
+
 **Distribution**
 
 - Bundled `con-cli` with every release artifact. macOS now ships it inside the


### PR DESCRIPTION
## Summary

Adds changelog entries for PR #126 into the existing `v0.1.0-beta.59` release section (same day, no new version bump).

## Changes

- New **Settings** group under `v0.1.0-beta.59` in `CHANGELOG.md`:
  - Save-status indicator ("Saved just now / Xm ago / Xh ago") with check-circle icon, seeded from `config.toml` mtime
  - `cmd-s` / `ctrl-s` keybinding to save settings, with keycap hint next to Save Changes button
  - `cmd-w` / `ctrl-w` to close/dismiss settings with correct unsaved-preview revert

Follows #126.