### PR TITLE
Docs: clarify terminal-first product guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,12 @@ Start here:
 
 - [Install](docs/install.md): get con on macOS, Windows, or Linux.
 - [Quick controls](docs/quick-controls.md): focus switching, agent panel, and command modes.
+- [Terminal workflows](docs/terminal-workflows.md): tabs, panes, broadcast, pane zoom, links, and surfaces.
 - [Built-in agent](docs/agent.md): use AI help without leaving the terminal.
 - [Settings](docs/settings.md): choose providers, themes, suggestions, skills, and shortcuts.
-- [Screenshot gallery](docs/screenshots.md): a visual tour of the app.
 - [Workspace layout profiles](docs/workspace-layout-profiles-guide.md): save a project layout, reopen it later, or share it with a team.
+- [con-cli and surfaces](docs/con-cli.md): drive con from scripts, test runners, and external agent orchestrators.
+- [Screenshot gallery](docs/screenshots.md): a visual tour of the app.
 - [Release notes](CHANGELOG.md): what changed in each beta.
 
 For contributors:

--- a/README.md
+++ b/README.md
@@ -26,15 +26,11 @@
 
 If you're an old-school terminal user and only want enough AI harness when needed, nothing more or less, `con` is for you.
 
-With one tab open and the panels hidden, `con` is just a fast, quiet, beautiful terminal. No sidebar tax. No chat-first shell. No ceremony.
-
 ## What it does
 
-- a terminal that is fast, elegant, and good-looking out of the box
-- a three-mode input bar: Smart, Command, and Agent, so one surface can run commands, ask the agent, or choose for you
-- a built-in AI harness that understands terminal objects: panes, SSH sessions, tmux panes, TUIs, visible output, and current working directories
-- visible, approval-based agent work in the terminal you can already see
-- pane-local surfaces and `con-cli` for people building subagent orchestration on top of a real terminal
+- a terminal that is fast and elegant
+- a built-in AI harness that can read context, ask before acting, and work directly in the terminal you can already see
+- terminal-native workflows for CLI work, with `ssh`, `tmux`, and coding-agent-aware orchestration
 
 ## Status
 
@@ -138,6 +134,7 @@ Start here:
 - [Terminal workflows](docs/terminal-workflows.md): tabs, panes, broadcast, pane zoom, links, and surfaces.
 - [Built-in agent](docs/agent.md): use AI help without leaving the terminal.
 - [Settings](docs/settings.md): choose providers, themes, suggestions, skills, and shortcuts.
+- [Skills and workflows](docs/skills-and-workflows.md): turn repeated terminal routines into project or personal slash commands.
 - [Workspace layout profiles](docs/workspace-layout-profiles-guide.md): save a project layout, reopen it later, or share it with a team.
 - [con-cli and surfaces](docs/con-cli.md): build scripts, test runners, and external agent orchestrators on top of con.
 - [Screenshot gallery](docs/screenshots.md): a visual tour of the app.

--- a/README.md
+++ b/README.md
@@ -26,11 +26,15 @@
 
 If you're an old-school terminal user and only want enough AI harness when needed, nothing more or less, `con` is for you.
 
+With one tab open and the panels hidden, `con` is just a fast, quiet, beautiful terminal. No sidebar tax. No chat-first shell. No ceremony.
+
 ## What it does
 
-- a terminal that is fast and elegant
-- a built-in AI harness that can read context, ask before acting, and work directly in the terminal you can already see
-- terminal-native workflows for CLI work, with `ssh`, `tmux`, and coding-agent-aware orchestration
+- a terminal that is fast, elegant, and good-looking out of the box
+- a three-mode input bar: Smart, Command, and Agent, so one surface can run commands, ask the agent, or choose for you
+- a built-in AI harness that understands terminal objects: panes, SSH sessions, tmux panes, TUIs, visible output, and current working directories
+- visible, approval-based agent work in the terminal you can already see
+- pane-local surfaces and `con-cli` for people building subagent orchestration on top of a real terminal
 
 ## Status
 
@@ -135,7 +139,7 @@ Start here:
 - [Built-in agent](docs/agent.md): use AI help without leaving the terminal.
 - [Settings](docs/settings.md): choose providers, themes, suggestions, skills, and shortcuts.
 - [Workspace layout profiles](docs/workspace-layout-profiles-guide.md): save a project layout, reopen it later, or share it with a team.
-- [con-cli and surfaces](docs/con-cli.md): drive con from scripts, test runners, and external agent orchestrators.
+- [con-cli and surfaces](docs/con-cli.md): build scripts, test runners, and external agent orchestrators on top of con.
 - [Screenshot gallery](docs/screenshots.md): a visual tour of the app.
 - [Release notes](CHANGELOG.md): what changed in each beta.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,9 @@ feel like a fast, elegant terminal with nothing extra in the way.
 
 When you ask for AI, con uses the terminal objects you already work with:
 panes, SSH sessions, tmux panes, TUIs, visible output, and working directories.
-When you build on top of con, `con-cli` and surfaces give external agents a real
-terminal to drive.
+When a one-off routine becomes worth repeating, skills let you keep it as a
+slash command. When you build on top of con, `con-cli` and surfaces give
+external agents a real terminal to drive.
 
 Start with the page that matches what you are trying to do.
 
@@ -24,6 +25,7 @@ Start with the page that matches what you are trying to do.
 | Need | Read |
 | --- | --- |
 | Use the agent panel without leaving the terminal | [Built-in agent](agent.md) |
+| Turn a repeated terminal routine into a slash command | [Skills and workflows](skills-and-workflows.md) |
 | Save or share a project layout | [Workspace profiles](workspace-layout-profiles-guide.md) |
 | See the app | [Screenshots](screenshots.md) |
 | See what changed | [Changelog](../CHANGELOG.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,12 @@
 # con docs
 
-con is a terminal with an agent built into the work surface. The terminal stays
-the center of the app; the agent, input bar, workspace restore, and automation
-tools are there when they make the terminal easier to use.
+con is a terminal first. If you hide the input bar and agent panel, it should
+feel like a fast, elegant terminal with nothing extra in the way.
+
+When you ask for AI, con uses the terminal objects you already work with:
+panes, SSH sessions, tmux panes, TUIs, visible output, and working directories.
+When you build on top of con, `con-cli` and surfaces give external agents a real
+terminal to drive.
 
 Start with the page that matches what you are trying to do.
 
@@ -12,7 +16,7 @@ Start with the page that matches what you are trying to do.
 | --- | --- |
 | Install con | [Install](install.md) |
 | Learn the main controls | [Quick controls](quick-controls.md) |
-| Work with tabs, panes, broadcast, and surfaces | [Terminal workflows](terminal-workflows.md) |
+| Work with tabs, panes, broadcast, links, and pane zoom | [Terminal workflows](terminal-workflows.md) |
 | Connect providers, tune appearance, and edit shortcuts | [Settings](settings.md) |
 
 ## Use con every day
@@ -21,9 +25,14 @@ Start with the page that matches what you are trying to do.
 | --- | --- |
 | Use the agent panel without leaving the terminal | [Built-in agent](agent.md) |
 | Save or share a project layout | [Workspace profiles](workspace-layout-profiles-guide.md) |
-| Drive con from scripts or external agents | [con-cli and surfaces](con-cli.md) |
 | See the app | [Screenshots](screenshots.md) |
 | See what changed | [Changelog](../CHANGELOG.md) |
+
+## Build on con
+
+| Need | Read |
+| --- | --- |
+| Drive con from scripts, test runners, or external agents | [con-cli and surfaces](con-cli.md) |
 
 ## Platform status
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,30 +1,46 @@
 # con docs
 
-con is a terminal first, with agent help only when you ask for it. The agent
-works from the terminal context you already have on screen.
+con is a terminal with an agent built into the work surface. The terminal stays
+the center of the app; the agent, input bar, workspace restore, and automation
+tools are there when they make the terminal easier to use.
 
-Choose the guide for what you want to do.
+Start with the page that matches what you are trying to do.
 
-## Get started
+## Start
 
 | Need | Read |
 | --- | --- |
 | Install con | [Install](install.md) |
 | Learn the main controls | [Quick controls](quick-controls.md) |
-| Use the agent panel | [Built-in agent](agent.md) |
-| Tune providers, themes, skills, and shortcuts | [Settings](settings.md) |
-| Save a project layout | [Workspace profiles](workspace-layout-profiles-guide.md) |
+| Work with tabs, panes, broadcast, and surfaces | [Terminal workflows](terminal-workflows.md) |
+| Connect providers, tune appearance, and edit shortcuts | [Settings](settings.md) |
+
+## Use con every day
+
+| Need | Read |
+| --- | --- |
+| Use the agent panel without leaving the terminal | [Built-in agent](agent.md) |
+| Save or share a project layout | [Workspace profiles](workspace-layout-profiles-guide.md) |
+| Drive con from scripts or external agents | [con-cli and surfaces](con-cli.md) |
 | See the app | [Screenshots](screenshots.md) |
 | See what changed | [Changelog](../CHANGELOG.md) |
 
-## What belongs here
+## Platform status
 
-These public docs are for people using con as their terminal. They cover
-installation, everyday controls, the agent panel, Settings, workspace profiles,
-and release notes.
+- macOS is the primary beta platform.
+- Windows is in preview.
+- Linux is in preview.
 
-If you want to build or change con itself, open the source repository from the
-GitHub link in the top navigation.
+Platform-specific limits are tracked in the source repository:
+[Windows](https://github.com/nowledge-co/con-terminal/issues/34) and
+[Linux](https://github.com/nowledge-co/con-terminal/issues/18).
+
+## Contributor docs
+
+These public docs are for people using con. If you want to build or change con
+itself, start with the contributor quickstart in the source repository. The
+implementation notes in `docs/impl/` and `docs/study/` are written for
+contributors, not for the hosted docs navigation.
 
 ## Source of truth
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -71,3 +71,7 @@ terminal sessions inside a pane without taking over the main terminal layout.
 The built-in agent harness and benchmark loop are open in the repository. They
 exist so terminal-native behavior can be tested and improved, not hidden behind
 a product claim.
+
+If you want to repeat a workflow through the built-in agent itself, write it as
+a [skill](skills-and-workflows.md). Skills are the user-facing way to keep a
+good terminal routine without turning it into a separate app.

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -1,16 +1,20 @@
 # Built-in agent
 
-The agent in con is a side panel for the terminal you are already using. It does
-not replace the shell. It reads context, asks before acting, and works in view.
+The agent in con is not the product. The terminal is.
+
+The agent panel is there when terminal context matters and a model can help. It
+reads the pane you are using, acts in view, and asks before doing work that
+should not happen silently.
 
 ## When to use it
 
-Use the agent when you want help that depends on terminal context:
+Use the agent when the answer depends on terminal state:
 
 - explain an error on screen
 - plan a fix before changing files
 - run a command after checking the current pane
 - work inside an SSH or tmux session
+- reason about a TUI or coding-agent CLI already running in a pane
 - summarize what happened in a long terminal flow
 
 Use the shell directly when you already know the command.
@@ -19,10 +23,17 @@ Provider and model choices live in [Settings](settings.md). Each tab keeps its
 own active provider/model once you choose it. Global settings define the default
 for new sessions and the models available in the picker.
 
-## How it sees context
+## What terminal-native means
 
-The agent starts from the focused pane. It can use nearby terminal state, pane
-metadata, and the current workflow to understand where you are.
+The agent starts from the focused pane. From there it can reason about terminal
+objects instead of loose screenshots:
+
+- visible pane output
+- pane names and working directories
+- SSH session context
+- tmux sessions, windows, and panes
+- shell state and command history
+- TUIs and coding-agent CLIs running inside the terminal
 
 That context is useful, but it is not a license to act silently. Destructive or
 high-impact actions still require approval.
@@ -31,7 +42,7 @@ When the agent streams markdown, con renders code, tables, math, and diagrams in
 the panel instead of treating the answer as a separate web page. Long responses
 stay scrollable so the terminal remains usable.
 
-## Work with SSH and tmux
+## SSH, tmux, and TUIs
 
 con is built for terminal-native workflows. The agent can help while you are
 inside SSH, tmux, shells, editors, and coding-agent CLIs.
@@ -39,10 +50,6 @@ inside SSH, tmux, shells, editors, and coding-agent CLIs.
 Keep the same rule in mind: the terminal remains the source of truth. If the
 agent needs to know what is happening, it should inspect the pane before making
 claims or taking action.
-
-For external coding-agent orchestrators, use [con-cli and surfaces](con-cli.md).
-That path lets other tools create pane-local worker sessions without changing
-the built-in agent's own workflow.
 
 ## Stay in control
 
@@ -54,3 +61,13 @@ the built-in agent's own workflow.
 
 con should feel like a serious terminal with help available, not a chat app
 wrapped around a shell.
+
+## External agents
+
+If you are building an orchestrator or subagent workflow, use
+[con-cli and surfaces](con-cli.md). Surfaces let another agent create worker
+terminal sessions inside a pane without taking over the main terminal layout.
+
+The built-in agent harness and benchmark loop are open in the repository. They
+exist so terminal-native behavior can be tested and improved, not hidden behind
+a product claim.

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -15,9 +15,9 @@ Use the agent when you want help that depends on terminal context:
 
 Use the shell directly when you already know the command.
 
-Provider and model choices live in [Settings](settings.md). Keep the agent on a
-model you trust for reasoning, and use a faster model for inline suggestions if
-you want command help without slowing down the terminal.
+Provider and model choices live in [Settings](settings.md). Each tab keeps its
+own active provider/model once you choose it. Global settings define the default
+for new sessions and the models available in the picker.
 
 ## How it sees context
 
@@ -27,6 +27,10 @@ metadata, and the current workflow to understand where you are.
 That context is useful, but it is not a license to act silently. Destructive or
 high-impact actions still require approval.
 
+When the agent streams markdown, con renders code, tables, math, and diagrams in
+the panel instead of treating the answer as a separate web page. Long responses
+stay scrollable so the terminal remains usable.
+
 ## Work with SSH and tmux
 
 con is built for terminal-native workflows. The agent can help while you are
@@ -35,6 +39,10 @@ inside SSH, tmux, shells, editors, and coding-agent CLIs.
 Keep the same rule in mind: the terminal remains the source of truth. If the
 agent needs to know what is happening, it should inspect the pane before making
 claims or taking action.
+
+For external coding-agent orchestrators, use [con-cli and surfaces](con-cli.md).
+That path lets other tools create pane-local worker sessions without changing
+the built-in agent's own workflow.
 
 ## Stay in control
 

--- a/docs/con-cli.md
+++ b/docs/con-cli.md
@@ -3,8 +3,12 @@
 `con-cli` is the command-line handle for a running con app. It is installed with
 con on macOS, Windows, and Linux.
 
-Use it when another program, script, or agent needs to inspect the visible
-terminal, create panes, drive pane-local surfaces, or ask con's built-in agent.
+Most users do not need it. Use it when another program, script, test runner, or
+agent needs to inspect the visible terminal, create panes, drive pane-local
+surfaces, or ask con's built-in agent.
+
+The design goal is simple: external agents should get a real terminal to work
+with, not a headless shell that behaves differently from what the user sees.
 
 ## Check that con is reachable
 
@@ -114,7 +118,7 @@ con-cli --json surfaces close \
   --close-empty-owned-pane
 ```
 
-## Ask the built-in agent
+## Ask the built-in agent from a script
 
 `agent ask` uses the same in-app agent session you see in the side panel:
 

--- a/docs/con-cli.md
+++ b/docs/con-cli.md
@@ -7,8 +7,8 @@ Most users do not need it. Use it when another program, script, test runner, or
 agent needs to inspect the visible terminal, create panes, drive pane-local
 surfaces, or ask con's built-in agent.
 
-The design goal is simple: external agents should get a real terminal to work
-with, not a headless shell that behaves differently from what the user sees.
+External agents should get a real terminal to work with, not a headless shell
+that behaves differently from what the user sees.
 
 ## Check that con is reachable
 

--- a/docs/con-cli.md
+++ b/docs/con-cli.md
@@ -1,0 +1,152 @@
+# con-cli and surfaces
+
+`con-cli` is the command-line handle for a running con app. It is installed with
+con on macOS, Windows, and Linux.
+
+Use it when another program, script, or agent needs to inspect the visible
+terminal, create panes, drive pane-local surfaces, or ask con's built-in agent.
+
+## Check that con is reachable
+
+Start con first, then run:
+
+```sh
+con-cli identify
+con-cli tabs list
+con-cli panes list
+```
+
+For scripts and agent adapters, prefer JSON:
+
+```sh
+con-cli --json identify
+con-cli --json tree
+```
+
+`con-cli` asks the running app for state instead of guessing from outside the
+terminal.
+
+## Pane commands
+
+Read terminal content:
+
+```sh
+con-cli --json panes read --tab 1 --pane-id 0 --lines 120
+```
+
+Create a visible split:
+
+```sh
+con-cli --json panes create --tab 1 --location right --command "htop"
+```
+
+Run a command visibly in a shell pane:
+
+```sh
+con-cli --json panes exec --tab 1 --pane-id 0 -- cargo test -q
+```
+
+Use `pane_id` for follow-up automation. Pane indexes can change when a user
+splits, closes, or rearranges panes.
+
+## Surface commands
+
+A pane is a visible split region. A surface is a terminal session inside one
+pane. Every pane has one active surface, and a pane can host more surfaces when
+you want pane-local tabs.
+
+This is the pattern most subagent tools want:
+
+1. Create the first worker as a visible split.
+2. Add later workers as surfaces inside that worker pane.
+3. Drive each worker by `surface_id`.
+4. Close each worker surface when it finishes.
+
+Create the first worker pane:
+
+```sh
+con-cli --json surfaces split \
+  --tab 1 \
+  --pane-id 0 \
+  --location right \
+  --title worker-1 \
+  --owner pi-interactive-subagents \
+  --command "codex"
+```
+
+Create another worker inside the same pane:
+
+```sh
+con-cli --json surfaces create \
+  --tab 1 \
+  --pane-id <worker_pane_id> \
+  --title worker-2 \
+  --owner pi-interactive-subagents \
+  --command "codex"
+```
+
+Wait before sending input:
+
+```sh
+con-cli --json surfaces wait-ready --surface-id <surface_id> --timeout 10
+```
+
+Drive the worker:
+
+```sh
+con-cli --json surfaces send-text --surface-id <surface_id> "explain this repo"
+con-cli --json surfaces send-key --surface-id <surface_id> enter
+con-cli --json surfaces read --surface-id <surface_id> --lines 120
+```
+
+Close it:
+
+```sh
+con-cli --json surfaces close --surface-id <surface_id>
+```
+
+If a worker pane was created only for owned surfaces, an orchestrator can ask con
+to close that pane when its last surface closes:
+
+```sh
+con-cli --json surfaces close \
+  --surface-id <surface_id> \
+  --close-empty-owned-pane
+```
+
+## Ask the built-in agent
+
+`agent ask` uses the same in-app agent session you see in the side panel:
+
+```sh
+con-cli --json agent ask --tab 1 "Summarize what is happening in this tab"
+```
+
+That means the response appears in con, uses the tab's current context, and
+follows the same provider and approval settings as the UI.
+
+## Automation rules
+
+- Use `--json` for anything a program will parse.
+- Use `pane_id` and `surface_id` after discovery.
+- Call `surfaces wait-ready` before driving a new surface.
+- Treat `panes exec` as visible shell control, not a hidden subprocess runner.
+- Give orchestrator-created surfaces an `--owner` so cleanup can be scoped.
+- Re-read `tree` after user-visible layout changes.
+
+The socket is local to the user session. It is not a remote API, and it does not
+change shell permissions. If a script can drive `con-cli`, it can drive the
+visible terminal you already opened.
+
+## Socket path
+
+Release builds use the default socket for the installed channel. Debug builds
+use a separate debug socket so a local development build can run beside the
+installed app.
+
+Set `CON_SOCKET_PATH` only when you intentionally run con on a custom endpoint:
+
+```sh
+CON_SOCKET_PATH=/tmp/con-alt.sock con
+con-cli --socket /tmp/con-alt.sock identify
+```

--- a/docs/install.md
+++ b/docs/install.md
@@ -3,6 +3,9 @@
 con is in beta. macOS is the primary supported platform today. Windows and Linux
 builds are available as previews.
 
+Every installer includes the app and `con-cli`. The CLI is used by scripts,
+test runners, and external agent orchestrators to talk to a running con session.
+
 ## macOS with Homebrew
 
 ```sh

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -19,7 +19,9 @@
     {
       "label": "Use con",
       "items": [
+        { "label": "Terminal workflows", "path": "docs/terminal-workflows.md" },
         { "label": "Workspace profiles", "path": "docs/workspace-layout-profiles-guide.md" },
+        { "label": "con-cli and surfaces", "path": "docs/con-cli.md" },
         { "label": "Screenshots", "path": "docs/screenshots.md" },
         { "label": "Changelog", "path": "CHANGELOG.md", "route": "/changelog/" }
       ]

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -20,6 +20,7 @@
       "label": "Use con",
       "items": [
         { "label": "Terminal workflows", "path": "docs/terminal-workflows.md" },
+        { "label": "Skills and workflows", "path": "docs/skills-and-workflows.md" },
         { "label": "Workspace profiles", "path": "docs/workspace-layout-profiles-guide.md" },
         { "label": "Screenshots", "path": "docs/screenshots.md" },
         { "label": "Changelog", "path": "CHANGELOG.md", "route": "/changelog/" }

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -21,9 +21,14 @@
       "items": [
         { "label": "Terminal workflows", "path": "docs/terminal-workflows.md" },
         { "label": "Workspace profiles", "path": "docs/workspace-layout-profiles-guide.md" },
-        { "label": "con-cli and surfaces", "path": "docs/con-cli.md" },
         { "label": "Screenshots", "path": "docs/screenshots.md" },
         { "label": "Changelog", "path": "CHANGELOG.md", "route": "/changelog/" }
+      ]
+    },
+    {
+      "label": "Build on con",
+      "items": [
+        { "label": "con-cli and surfaces", "path": "docs/con-cli.md" }
       ]
     }
   ]

--- a/docs/quick-controls.md
+++ b/docs/quick-controls.md
@@ -16,6 +16,7 @@ Watch the short flow once, then use the table below as a reference.
 | Switch focus between terminal and input | <kbd>⌘</kbd> <kbd>I</kbd> | <kbd>⌃</kbd> <kbd>⇧</kbd> <kbd>I</kbd> |
 | Show or hide the bottom input bar | <kbd>⌃</kbd> <kbd>\`</kbd> | <kbd>⌃</kbd> <kbd>\`</kbd> |
 | Show or hide the agent panel | <kbd>⌘</kbd> <kbd>L</kbd> | <kbd>⌃</kbd> <kbd>⇧</kbd> <kbd>L</kbd> |
+| Show or hide vertical tabs | <kbd>⌘</kbd> <kbd>B</kbd> | <kbd>⌃</kbd> <kbd>⇧</kbd> <kbd>B</kbd> |
 | Cycle bottom-bar mode | <kbd>⌘</kbd> <kbd>;</kbd> | <kbd>⌃</kbd> <kbd>;</kbd> |
 
 ## Input modes
@@ -48,3 +49,6 @@ planning, code help, or a careful change made with your approval.
 
 When you want to tune providers, suggestions, themes, skills, or shortcuts, open
 [Settings](settings.md).
+
+For tabs, panes, broadcast, links, and pane-local surfaces, see
+[Terminal workflows](terminal-workflows.md).

--- a/docs/quick-controls.md
+++ b/docs/quick-controls.md
@@ -24,7 +24,8 @@ Watch the short flow once, then use the table below as a reference.
 ### Smart
 
 Smart mode decides whether your text should run as a shell command or go to the
-agent. Use it when you want con to choose the obvious path.
+agent. Use it when you want con to choose the obvious path without making you
+switch surfaces first.
 
 ### Command
 
@@ -35,6 +36,10 @@ lets you choose the focused pane, all panes, or a selected set.
 
 Agent mode sends text to the built-in agent. Use it when you want explanation,
 planning, code help, or a careful change made with your approval.
+
+These modes are why the input bar exists. It is not a second terminal prompt and
+not a chat box glued to the side. It is a short path from what you are looking at
+to the next action.
 
 ## A good default flow
 

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -1,26 +1,27 @@
 # Screenshots
 
-The README shows one representative view. This page keeps the full gallery in one place.
+The README shows one representative view. This page keeps the full gallery in
+one place.
 
 ## Gallery
 
-### Agent Panel
+### Agent panel
 
 <img alt="con screenshot 1" src="https://github.com/user-attachments/assets/e1972fac-9df3-443b-be08-c0eec4697cf3" />
 
-### Agent Panel: Native Pane aware
+### Agent panel with terminal context
 
 <img alt="con screenshot 2" src="https://github.com/user-attachments/assets/15299d3d-7484-4229-a979-43001d504b14" />
 
-### Settings: themes
+### Theme settings
 
 <img alt="con screenshot 3" src="https://github.com/user-attachments/assets/c730d158-139b-46d5-adbb-0cd48d38b603" />
 
-### Pane Broadcast Picker
+### Pane broadcast picker
 
 <img alt="con screenshot 4" src="https://github.com/user-attachments/assets/21e295c9-34eb-465c-90b8-5ba3163182e5" />
 
-### Main Window
+### Main window
 
 <img alt="con screenshot 5" src="https://github.com/user-attachments/assets/81dcf6e4-6074-497e-98b8-00c884442cc2" />
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -14,12 +14,12 @@ General contains app-level behavior:
 
 - update channel and version
 - manual update check when the current channel supports it
-- restart continuity
+- saved terminal text privacy
 - skill source folders
 
-Continuity controls whether con stores bounded private terminal text for normal
-relaunch restore. Layout profiles never include that text. If you want to turn
-continuity off and wipe saved terminal text, run **Clear Restored Terminal
+If you prefer con not to save terminal text between launches, turn off
+**Restore Terminal Text** in General. Layout profiles never include terminal
+text. To wipe terminal text already saved on disk, run **Clear Restored Terminal
 History** from Command Palette.
 
 ## Command Palette

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -117,6 +117,8 @@ Keep project skills for shared project habits. Keep global skills for personal
 habits. If names collide, the project skill wins so a repository can define its
 own local meaning.
 
+For the workflow loop, see [Skills and workflows](skills-and-workflows.md).
+
 ## Shortcuts
 
 The Keys section shows editable shortcuts for app, pane, and surface actions.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -5,7 +5,22 @@ make the terminal fit your hands: choose a theme, connect an AI provider, tune
 suggestions, add skills, or change shortcuts.
 
 Open Settings from the app menu on macOS, the gear button on Windows and Linux,
-or the Command Palette.
+or the Command Palette. Appearance changes apply as you tune them, so you can
+leave Settings open while checking opacity, blur, fonts, and background images.
+
+## General
+
+General contains app-level behavior:
+
+- update channel and version
+- manual update check when the current channel supports it
+- restart continuity
+- skill source folders
+
+Continuity controls whether con stores bounded private terminal text for normal
+relaunch restore. Layout profiles never include that text. If you want to turn
+continuity off and wipe saved terminal text, run **Clear Restored Terminal
+History** from Command Palette.
 
 ## Command Palette
 
@@ -13,8 +28,9 @@ Press <kbd>⌘</kbd> <kbd>⇧</kbd> <kbd>P</kbd> on macOS, or
 <kbd>⌃</kbd> <kbd>⇧</kbd> <kbd>P</kbd> on Windows and Linux.
 
 The Command Palette is the fastest way to find actions you do not use every
-minute. Search for Settings, workspace profiles, pane actions, updates, and
-other commands. When an action has a shortcut, con shows it beside the action.
+minute. Search for Settings, workspace profiles, pane actions, surface actions,
+updates, privacy actions, and other commands. When an action has a shortcut,
+con shows it beside the action.
 
 ## Appearance
 
@@ -48,7 +64,11 @@ terminal.
 
 ChatGPT and GitHub Copilot can use OAuth, so you can leave the API key empty for
 those sign-in flows. OpenAI-compatible hosts can fetch models from `/models`
-when the host supports it, and you can still type a model ID manually.
+when the host supports it. If the host has no models endpoint, type the model ID
+manually and save it.
+
+The provider picker in the agent panel shows configured providers. If a provider
+is missing there, configure it first in Settings.
 
 ## Tool approval
 
@@ -99,7 +119,10 @@ own local meaning.
 
 ## Shortcuts
 
-The Keys section shows editable shortcuts and fixed shortcuts in one place.
+The Keys section shows editable shortcuts for app, pane, and surface actions.
+It also includes the optional global Summon / Hide Con shortcut. That shortcut
+is off by default because global hotkeys can conflict with launchers and window
+managers.
 
 Change shortcuts when the default conflicts with muscle memory. Leave them alone
 when the built-in flow already works. A good setup should reduce decisions, not

--- a/docs/skills-and-workflows.md
+++ b/docs/skills-and-workflows.md
@@ -1,0 +1,184 @@
+# Skills and workflows
+
+A skill is a slash command backed by a `SKILL.md` file. In con, that matters
+because the skill runs through an agent that understands the terminal you are
+already using.
+
+This is the workflow loop con is built for:
+
+1. Do the work once with the agent in the loop.
+2. Keep the parts that worked.
+3. Ask the agent to turn the routine into a skill.
+4. Review the `SKILL.md`.
+5. Run it next time with `/skill-name`.
+
+The point is not to hide the terminal. The point is to turn a messy terminal
+routine into something you can rerun with context, panes, SSH, tmux, and
+approvals still visible.
+
+## Why skills fit con
+
+Most agents can run a prompt. con can run a prompt while seeing the terminal
+shape around it:
+
+- focused pane output
+- peer panes in the tab
+- current working directories
+- SSH sessions
+- tmux sessions, windows, and panes
+- TUIs and coding-agent CLIs
+- available project and global skills
+
+That lets a skill say things like:
+
+- reuse the existing staging SSH pane if it is healthy
+- create a shell pane only if no release shell exists
+- run checks in tmux instead of typing into the wrong foreground TUI
+- keep the coding agent pane separate from the shell pane
+- ask before tagging, uploading, deploying, or editing protected files
+
+This is still human-in-the-loop. Dangerous tools keep the approval flow unless
+you deliberately enable auto-approve for a trusted workspace.
+
+## A release workflow example
+
+The first time through, you might ask the agent:
+
+```text
+Prepare a beta release. Use this repo, staging over SSH, and the release notes
+we already have. Show me each irreversible step before running it.
+```
+
+The agent can work with the terminal instead of starting from a blank chat:
+
+- inspect the current repo pane
+- create or reuse a test pane
+- create or reuse an SSH pane for staging
+- use tmux targets when the remote host is already inside tmux
+- run local tests and packaging commands visibly
+- check release notes and tags
+- ask before pushing, signing, uploading, or deploying
+
+After the run is good, ask:
+
+```text
+Turn this release routine into a project skill. Keep approval points for tag,
+upload, deploy, and anything destructive. Save it under .con/skills/release/SKILL.md.
+```
+
+The next release can start with:
+
+```text
+/release 0.1.0-beta.60
+```
+
+You still review the plan and approvals. The difference is that the hard-won
+routine now lives with the project instead of in your memory.
+
+## Pair skills with layout profiles
+
+Skills describe behavior. Layout profiles describe workspace shape.
+
+Use a layout profile when the workflow benefits from the same starting layout:
+
+- `Release` tab with local shell, tests, staging SSH, and logs
+- `Incident` tab with app logs, database shell, and deploy host
+- `Agents` tab with a planner pane and worker surfaces
+
+Use a skill when the workflow has repeatable judgment:
+
+- which checks must pass
+- which panes or hosts to reuse
+- what needs approval
+- what should be reported at the end
+
+Together, they give you a repeatable starting point without turning con into a
+closed workflow runner.
+
+## Where skills live
+
+Project skills travel with the workspace:
+
+- `skills/`
+- `.agents/skills/`
+- `.con/skills/`
+
+Global skills follow you across projects:
+
+- `~/.config/con/skills`
+- `~/.agents/skills`
+
+On Windows, the con config skills folder is:
+
+- `~/.config/con-terminal/skills`
+
+Project skills override global skills with the same name. That lets a repo
+define its own `/release` without changing your personal `/release` elsewhere.
+
+## Skill file shape
+
+Each skill is a folder with a `SKILL.md` file:
+
+```text
+.con/skills/release/SKILL.md
+```
+
+Minimal example:
+
+```md
+---
+name: release
+description: Prepare and verify a project release.
+---
+
+# Release
+
+You are helping with a project release from inside con.
+
+First inspect the current panes and working directory. Reuse existing local,
+SSH, and tmux workspaces when they match the task. Do not create duplicate panes
+unless no reusable target exists.
+
+Before tagging, uploading, deploying, or editing release notes, show the exact
+action and wait for approval.
+
+When finished, summarize:
+- version
+- checks run
+- artifacts produced
+- release or deploy actions completed
+- anything left for the user
+```
+
+Invoke it from the input bar or agent panel:
+
+```text
+/release 0.1.0-beta.60
+```
+
+Additional text after the skill name is passed as context for that run.
+
+## What to put in a skill
+
+Good skills are opinionated about the workflow, not over-specific about the
+machine.
+
+Include:
+
+- the goal
+- the expected panes, hosts, or tmux sessions
+- commands that are safe to run
+- commands that need approval
+- checks that must pass
+- the final report shape
+
+Avoid:
+
+- secrets
+- personal absolute paths
+- one-off command output
+- instructions to bypass approvals
+- instructions that assume a pane number will never change
+
+Use stable intent instead: "reuse the staging SSH workspace" is better than
+"use pane 3" unless the layout profile owns that shape.

--- a/docs/terminal-workflows.md
+++ b/docs/terminal-workflows.md
@@ -134,3 +134,6 @@ drop payloads through the terminal path.
 If a project has a workspace shape worth keeping, save it as a layout profile.
 Profiles are project files for recreating tabs, panes, surfaces, names, and
 working directories. See [Workspace profiles](workspace-layout-profiles-guide.md).
+
+If the behavior inside that layout becomes repeatable, turn it into a
+[skill](skills-and-workflows.md).

--- a/docs/terminal-workflows.md
+++ b/docs/terminal-workflows.md
@@ -1,8 +1,9 @@
 # Terminal workflows
 
-con is still a terminal when every AI feature is hidden. Start there. Use the
-agent panel, input bar, surfaces, and automation only when they fit the work in
-front of you.
+con should disappear until you need it. With one tab open and the panels hidden,
+the app is a clean terminal surface. The extra controls are there for the
+moments when they save movement: running a command across panes, asking the
+agent, opening a split, or focusing a worker.
 
 ## The workspace model
 
@@ -15,8 +16,8 @@ con uses a few names consistently:
 | Pane | A visible split region inside a tab | Side-by-side shells, servers, logs, editors |
 | Surface | A terminal session inside one pane | Multiple agent or worker sessions without adding more visible splits |
 
-Most terminal work only needs tabs and panes. Surfaces are for the cases where a
-single visible pane should host several terminal sessions.
+Most terminal work only needs tabs and panes. Surfaces are advanced; they are
+there when one visible pane should host several terminal sessions.
 
 ## Focus without reaching for the mouse
 
@@ -61,20 +62,26 @@ one terminal at once.
 Pane zoom is for short bursts of focus. It does not stop sibling panes; it only
 gives the active pane the full terminal area.
 
-## Command input and broadcast
+## The input bar
 
-The bottom input bar has three modes:
+The input bar is one surface with three modes:
 
-- **Smart** chooses between shell command and agent request.
+- **Smart** decides whether your text is a shell command or an agent request.
 - **Command** sends text to the terminal.
 - **Agent** sends text to the built-in agent.
+
+This keeps con from becoming a chat app wrapped around a shell. You can hide the
+bar when you want a plain terminal, bring it back when you need a command or
+question, and switch modes without changing context.
+
+## Broadcast commands
 
 Command mode can target more than one pane. Use the pane picker to send a
 command to the focused pane, every pane, or a selected set. The picker mirrors
 the current pane layout, so you can choose by position instead of remembering
 pane numbers.
 
-## Surfaces
+## Advanced: surfaces
 
 A surface is a terminal session inside one pane. Think of it as a pane-local
 tab.
@@ -122,10 +129,8 @@ Paste text normally. Dragging files into the terminal sends their paths. When a
 TUI supports image/file paste protocols, con forwards compatible clipboard and
 drop payloads through the terminal path.
 
-## Restore and profiles
+## Project layouts
 
-Normal relaunch restore is automatic: con brings back windows, tabs, panes,
-working directories, and bounded private terminal text.
-
-Layout profiles are different. They are project files for recreating a workspace
-shape later or sharing it with a team. See [Workspace profiles](workspace-layout-profiles-guide.md).
+If a project has a workspace shape worth keeping, save it as a layout profile.
+Profiles are project files for recreating tabs, panes, surfaces, names, and
+working directories. See [Workspace profiles](workspace-layout-profiles-guide.md).

--- a/docs/terminal-workflows.md
+++ b/docs/terminal-workflows.md
@@ -1,0 +1,131 @@
+# Terminal workflows
+
+con is still a terminal when every AI feature is hidden. Start there. Use the
+agent panel, input bar, surfaces, and automation only when they fit the work in
+front of you.
+
+## The workspace model
+
+con uses a few names consistently:
+
+| Name | Meaning | Use it for |
+| --- | --- | --- |
+| Window | A top-level app window | Separate projects or monitors |
+| Tab | A workspace inside a window | One project, task, or long-running shell set |
+| Pane | A visible split region inside a tab | Side-by-side shells, servers, logs, editors |
+| Surface | A terminal session inside one pane | Multiple agent or worker sessions without adding more visible splits |
+
+Most terminal work only needs tabs and panes. Surfaces are for the cases where a
+single visible pane should host several terminal sessions.
+
+## Focus without reaching for the mouse
+
+| Action | macOS | Windows / Linux |
+| --- | --- | --- |
+| Switch focus between terminal and input | <kbd>⌘</kbd> <kbd>I</kbd> | <kbd>⌃</kbd> <kbd>⇧</kbd> <kbd>I</kbd> |
+| Show or hide the input bar | <kbd>⌃</kbd> <kbd>`</kbd> | <kbd>⌃</kbd> <kbd>`</kbd> |
+| Show or hide the agent panel | <kbd>⌘</kbd> <kbd>L</kbd> | <kbd>⌃</kbd> <kbd>⇧</kbd> <kbd>L</kbd> |
+| Show or hide vertical tabs | <kbd>⌘</kbd> <kbd>B</kbd> | <kbd>⌃</kbd> <kbd>⇧</kbd> <kbd>B</kbd> |
+| Open Command Palette | <kbd>⌘</kbd> <kbd>⇧</kbd> <kbd>P</kbd> | <kbd>⌃</kbd> <kbd>⇧</kbd> <kbd>P</kbd> |
+
+When in doubt, open Command Palette and search by the action name.
+
+## Tabs and windows
+
+Use a new tab when the work belongs to the same window. Use a new window when
+you want a separate space, usually for another project or display.
+
+| Action | macOS | Windows / Linux |
+| --- | --- | --- |
+| New window | <kbd>⌘</kbd> <kbd>N</kbd> | <kbd>⌃</kbd> <kbd>⇧</kbd> <kbd>N</kbd> |
+| New tab | <kbd>⌘</kbd> <kbd>T</kbd> | <kbd>⌃</kbd> <kbd>⇧</kbd> <kbd>T</kbd> |
+| Next tab | <kbd>⌃</kbd> <kbd>Tab</kbd> | <kbd>⌃</kbd> <kbd>Tab</kbd> |
+| Previous tab | <kbd>⌃</kbd> <kbd>⇧</kbd> <kbd>Tab</kbd> | <kbd>⌃</kbd> <kbd>⇧</kbd> <kbd>Tab</kbd> |
+| Select tab 1-9 | <kbd>⌘</kbd> <kbd>1</kbd> ... <kbd>9</kbd> | <kbd>⌃</kbd> <kbd>1</kbd> ... <kbd>9</kbd> |
+
+Vertical tabs are useful once tab titles matter more than tab position. Rename a
+tab when its purpose is stable.
+
+## Panes
+
+Panes are visible splits. They are the right tool when you need to see more than
+one terminal at once.
+
+| Action | macOS | Windows / Linux |
+| --- | --- | --- |
+| Split right | <kbd>⌘</kbd> <kbd>D</kbd> | <kbd>Alt</kbd> <kbd>D</kbd> |
+| Split down | <kbd>⌘</kbd> <kbd>⇧</kbd> <kbd>D</kbd> | <kbd>Alt</kbd> <kbd>⇧</kbd> <kbd>D</kbd> |
+| Toggle pane zoom | <kbd>⌘</kbd> <kbd>⇧</kbd> <kbd>Enter</kbd> | <kbd>Alt</kbd> <kbd>⇧</kbd> <kbd>Enter</kbd> |
+| Close pane | <kbd>⌘</kbd> <kbd>⌥</kbd> <kbd>W</kbd> | <kbd>Alt</kbd> <kbd>⇧</kbd> <kbd>W</kbd> |
+
+Pane zoom is for short bursts of focus. It does not stop sibling panes; it only
+gives the active pane the full terminal area.
+
+## Command input and broadcast
+
+The bottom input bar has three modes:
+
+- **Smart** chooses between shell command and agent request.
+- **Command** sends text to the terminal.
+- **Agent** sends text to the built-in agent.
+
+Command mode can target more than one pane. Use the pane picker to send a
+command to the focused pane, every pane, or a selected set. The picker mirrors
+the current pane layout, so you can choose by position instead of remembering
+pane numbers.
+
+## Surfaces
+
+A surface is a terminal session inside one pane. Think of it as a pane-local
+tab.
+
+Use surfaces when you want several live terminal sessions but do not want to
+keep splitting the screen smaller. This is especially useful for coding agents,
+subagents, or task-specific shells that should share one visible worker area.
+
+| Action | macOS | Windows / Linux |
+| --- | --- | --- |
+| New surface in focused pane | <kbd>⌘</kbd> <kbd>⌥</kbd> <kbd>T</kbd> | <kbd>Alt</kbd> <kbd>⇧</kbd> <kbd>T</kbd> |
+| New surface pane right | <kbd>⌘</kbd> <kbd>⌥</kbd> <kbd>D</kbd> | <kbd>Alt</kbd> <kbd>⇧</kbd> <kbd>→</kbd> |
+| New surface pane down | <kbd>⌘</kbd> <kbd>⌥</kbd> <kbd>⇧</kbd> <kbd>D</kbd> | <kbd>Alt</kbd> <kbd>⇧</kbd> <kbd>↓</kbd> |
+| Next surface | <kbd>⌘</kbd> <kbd>⌥</kbd> <kbd>]</kbd> | <kbd>Alt</kbd> <kbd>⇧</kbd> <kbd>]</kbd> |
+| Previous surface | <kbd>⌘</kbd> <kbd>⌥</kbd> <kbd>[</kbd> | <kbd>Alt</kbd> <kbd>⇧</kbd> <kbd>[</kbd> |
+| Rename surface | <kbd>⌘</kbd> <kbd>⌥</kbd> <kbd>R</kbd> | <kbd>Alt</kbd> <kbd>⇧</kbd> <kbd>R</kbd> |
+| Close surface | <kbd>⌘</kbd> <kbd>⌥</kbd> <kbd>⇧</kbd> <kbd>W</kbd> | <kbd>Alt</kbd> <kbd>⇧</kbd> <kbd>X</kbd> |
+
+Only panes with multiple surfaces, owned orchestrator sessions, or explicit
+surface names show the in-pane surface strip. Ordinary panes stay clean.
+
+## Terminal menu
+
+Right-click the terminal for common actions:
+
+- copy and paste
+- clear terminal
+- split or close panes
+- zoom the pane
+- create, rename, switch, or close surfaces
+- focus the input bar
+- open Settings or Command Palette
+
+The menu uses the same actions as shortcuts and Command Palette. If an action
+has a shortcut, the menu shows it.
+
+## Links, paste, and files
+
+Use the platform modifier to open links from terminal output:
+
+- macOS: hold <kbd>⌘</kbd>, then click a URL.
+- Windows and Linux: hold <kbd>⌃</kbd>, then click a URL.
+
+Paste text normally. Dragging files into the terminal sends their paths. When a
+TUI supports image/file paste protocols, con forwards compatible clipboard and
+drop payloads through the terminal path.
+
+## Restore and profiles
+
+Normal relaunch restore is automatic: con brings back windows, tabs, panes,
+working directories, and bounded private terminal text.
+
+Layout profiles are different. They are project files for recreating a workspace
+shape later or sharing it with a team. See [Workspace profiles](workspace-layout-profiles-guide.md).

--- a/docs/workspace-layout-profiles-guide.md
+++ b/docs/workspace-layout-profiles-guide.md
@@ -165,3 +165,12 @@ tmux attach -t app || tmux new -s app
 ```
 
 con recreates the layout and directory. tmux restores the running session.
+
+## Skills
+
+If a layout is the workspace shape, a skill is the routine that runs inside it.
+A release layout might open local tests, staging SSH, and logs. A `/release`
+skill can then decide which targets to reuse, which checks to run, and where it
+must stop for approval.
+
+See [Skills and workflows](skills-and-workflows.md).

--- a/docs/workspace-layout-profiles-guide.md
+++ b/docs/workspace-layout-profiles-guide.md
@@ -1,14 +1,8 @@
 # Workspace layout profiles
 
-con has two workspace behaviors.
-
-The first is automatic: after rebooting, upgrading, or relaunching con, your
-ordinary workspace should come back. Windows, tabs, panes, surfaces, working
-directories, and private terminal text history are continuity. You should not
-need to manage it.
-
-The second is deliberate: when a workspace shape is worth keeping for a project,
-you can save it as a layout profile. This guide is for that explicit workflow.
+When a workspace shape is worth keeping for a project, save it as a layout
+profile. A profile is for starting a project in the right shape again, or for
+sharing that shape with a team.
 
 ## What a layout profile is
 
@@ -46,11 +40,8 @@ session backup. It is safe to review because it describes shape, not activity.
 The profile captures the workspace you designed. It does not capture what you
 typed, what the agent said, or what processes were running.
 
-Private terminal text restore can be disabled in **Settings -> General ->
-Continuity**. Use **Clear Restored Terminal History** from Command Palette when
-you want to turn it off and wipe the saved terminal text already stored by con.
-Continuity is default-on for new installs and existing beta users; the opt-out
-is explicit because restart continuity is part of con's default workspace model.
+Private terminal text settings live in **Settings -> General**. Layout profiles
+never include terminal text, regardless of that setting.
 
 ## Save a profile
 
@@ -104,8 +95,7 @@ con ~/dev/app/.con/workspace.toml
 ```
 
 If the requested profile is malformed, con opens a fresh shell and shows the
-profile error in the terminal. It does not silently restore an unrelated
-workspace.
+profile error in the terminal. It does not silently open an unrelated workspace.
 
 Inside the app, use:
 
@@ -114,11 +104,6 @@ Inside the app, use:
   one fresh tab rooted there.
 - **Open Layout Profile in New Window** to choose a project folder or profile
   file and open it separately.
-
-Plain `con` without a path still favors private session restore. That keeps
-normal relaunch behavior predictable: quitting, upgrading, or rebooting should
-bring back the last private workspace, not silently replace it with a project
-profile because the process happened to start from a repo directory.
 
 To open a project profile, pass the project path or the profile file path
 explicitly.
@@ -155,22 +140,20 @@ Use these rules:
 - **Open Layout Profile in New Window** is the explicit "new window from this
   profile" flow.
 - **New Window** stays scratch by default. A global "default new-window layout"
-  setting is intentionally deferred because it can fight with private restore
-  and project memory.
+  setting is intentionally deferred because it can fight with project memory.
 
 ## Entry points
 
 | Gesture | Result |
 | --- | --- |
-| Launch con normally | Restore the private workspace you left behind. |
 | Cmd+N / New Window | Open one clean scratch shell with shared history. |
 | `con ~/dev/app` | Open the project's profile if present; otherwise one shell rooted there. |
 | `con ~/dev/app/.con/workspace.toml` | Open that profile directly. |
 | Add Tabs from Layout Profile | Add the selected project/profile into the current window. |
 | Open Layout Profile in New Window | Open the selected project/profile separately. |
 
-This keeps every entry point legible: restore is automatic, scratch is fresh,
-and project layout is explicit.
+This keeps every entry point legible: scratch is fresh, and project layout is
+explicit.
 
 ## Process continuity
 
@@ -181,4 +164,4 @@ want processes to survive app restarts:
 tmux attach -t app || tmux new -s app
 ```
 
-con restores the layout and directory. tmux restores the running session.
+con recreates the layout and directory. tmux restores the running session.

--- a/docs/workspace-layout-profiles-guide.md
+++ b/docs/workspace-layout-profiles-guide.md
@@ -1,11 +1,11 @@
 # Workspace layout profiles
 
-con has two workspace promises.
+con has two workspace behaviors.
 
-The first is invisible: after rebooting, upgrading, or relaunching con, your
+The first is automatic: after rebooting, upgrading, or relaunching con, your
 ordinary workspace should come back. Windows, tabs, panes, surfaces, working
 directories, and private terminal text history are continuity. You should not
-need a guide for that.
+need to manage it.
 
 The second is deliberate: when a workspace shape is worth keeping for a project,
 you can save it as a layout profile. This guide is for that explicit workflow.
@@ -109,9 +109,9 @@ workspace.
 
 Inside the app, use:
 
-- **Add Tabs from Layout Profile** to choose a project folder or profile file and add
-  its tabs to the current window. If the folder has no profile, con adds one
-  fresh tab rooted there.
+- **Add Tabs from Layout Profile** to choose a project folder or profile file
+  and add its tabs to the current window. If the folder has no profile, con adds
+  one fresh tab rooted there.
 - **Open Layout Profile in New Window** to choose a project folder or profile
   file and open it separately.
 
@@ -120,9 +120,8 @@ normal relaunch behavior predictable: quitting, upgrading, or rebooting should
 bring back the last private workspace, not silently replace it with a project
 profile because the process happened to start from a repo directory.
 
-The more aggressive `cd ~/dev/app && con` project-detection flow is deferred
-until con has full single-instance forwarding and project-memory state. At that
-point con can distinguish "open this project" from "restore my last app".
+To open a project profile, pass the project path or the profile file path
+explicitly.
 
 ## Share a profile
 
@@ -159,7 +158,7 @@ Use these rules:
   setting is intentionally deferred because it can fight with private restore
   and project memory.
 
-## Gesture Semantics
+## Entry points
 
 | Gesture | Result |
 | --- | --- |
@@ -173,7 +172,7 @@ Use these rules:
 This keeps every entry point legible: restore is automatic, scratch is fresh,
 and project layout is explicit.
 
-## Process Continuity
+## Process continuity
 
 Layout profiles do not resume running processes. Use tmux or zellij when you
 want processes to survive app restarts:


### PR DESCRIPTION
## Summary
- refocus README and hosted docs around Con as a terminal first, with AI only when it earns its place
- add public guides for terminal workflows, skills/repeatable workflows, and con-cli/surfaces
- document the Con-specific loop: do a complex terminal workflow once with human review, turn it into a skill, pair it with a layout profile when useful, and rerun it later from terminal context
- move con-cli/surfaces into a Build on con docs group, separate from everyday use
- polish settings, agent, quick controls, screenshots, workspace profile docs, and README links

## Validation
- python3 -m json.tool docs/manifest.json
- manifest path existence check
- markdown relative-link check
- AI-flavor wording scan for common generated-copy patterns
- git diff --check