### PR TITLE
feat: set app_id for Linux Wayland/X11 window identification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ con is still pre-release, so entries may group related beta work while the produ
   dev app names/bundle ids, never embed/update stable/beta appcasts, and never
   update Homebrew casks while the final gate still validates their artifact
   shape.
+- Aligned the Linux runtime app id, desktop entry filename, and
+  `StartupWMClass` as `co.nowledge.con` so Wayland and X11 launchers can group
+  running Con windows with the installed app entry.
 - Made the release finalizer sync hosted installer scripts from the tagged
   commit before promotion, so dev smoke tags can test the real `install.sh` /
   `install.ps1` path without moving beta/stable appcasts or Homebrew casks.

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -362,6 +362,8 @@ fn default_window_options(config: &con_core::Config, cx: &mut App) -> WindowOpti
         // titlebar area to restore the drag-to-move gesture.
         #[cfg(target_os = "macos")]
         is_movable: false,
+        #[cfg(target_os = "linux")]
+        app_id: Some("co.nowledge.con".to_owned()),
         ..Default::default()
     }
 }

--- a/docs/impl/linux-port.md
+++ b/docs/impl/linux-port.md
@@ -91,7 +91,8 @@ What it still does **not** give you:
 - validated mouse selection / reporting
 - native packaging artifacts (`.deb`, AppImage, Flatpak, …); the
   current release pipeline already ships a tarball, one-line installer,
-  desktop entry, icon install, appcast, and notify-only updater
+  `co.nowledge.con.desktop` launcher identity, icon install, appcast,
+  and notify-only updater
 
 Current verification note:
 
@@ -277,7 +278,7 @@ can ship.
 | 3 | Linux backend scaffold | `con-ghostty/src/linux/` plus `con-app/src/linux_view.rs` (or equivalent) with real lifecycle types | Linux no longer routes through the generic stub path conceptually | ✅ landed |
 | 4 | First real terminal surface | PTY spawn, resize, exit, `libghostty-vt` state, GPUI-owned pane paint, real product chrome (no native WM titlebar), embedded mono font, transparent + rounded window with compositor-gated blur | VT-backed Linux pane compiles and displays live shell state with SGR colors / bold / italic / underline / strikethrough / inverse, cursor block, theme palette synced from settings, IoskeleyMono shaping, client-side titlebar with min/max/close caption cluster, transparent ARGB window with rounded corners and per-pane / per-surface opacity, real KWin Wayland blur where available, fast paint pipeline (16 ms keystroke-echo round-trip), no placeholder flash on alt-screen TUIs | ✅ landed (preview) |
 | 5 | Input + selection + glyph-atlas grid renderer | keyboard, mouse, clipboard, bracketed paste, DECCKM, CJK IME text/preedit input, selection, plus the long-term GPUI-owned glyph-atlas grid renderer matching the D3D11/DirectWrite path Windows uses | vim/tmux/fzf/less usable on Linux at full speed | 🚧 in progress (DECCKM, bracketed paste, CJK IME text/preedit input, and terminal-local Tab / Shift+Tab capture are wired; mouse reporting, selection, desktop IME validation matrix, and the glyph-atlas renderer remain) |
-| 6 | Packaging | one-line installer, tarball release, desktop entry, icon integration, appcast / notify-only updater, plus native artifact strategy (`.deb`, AppImage, Flatpak, etc.) | tarball installer exists; native package format decision remains | 🚧 partially landed |
+| 6 | Packaging | one-line installer, tarball release, desktop entry, icon integration, appcast / notify-only updater, plus native artifact strategy (`.deb`, AppImage, Flatpak, etc.) | tarball installer exists; runtime Linux app id, desktop-file basename, and `StartupWMClass` are aligned as `co.nowledge.con`; native package format decision remains | 🚧 partially landed |
 
 ## Immediate next work
 
@@ -313,10 +314,10 @@ With phase 4 landed (preview), the remaining Linux tasks are:
    transparent rounded chrome, htop in the alternate screen,
    keystroke-echo benchmark), but the hardware path still wants a
    real-desktop pass before we drop the "preview" label.
-4. Packaging: the tarball + one-line installer + desktop entry + icon +
-   notify-only appcast path is landed. The remaining packaging decision
-   is whether to add `.deb`, AppImage, Flatpak, or another native
-   artifact for Linux distributions.
+4. Packaging: the tarball + one-line installer + `co.nowledge.con.desktop`
+   launcher entry + icon + notify-only appcast path is landed. The remaining
+   packaging decision is whether to add `.deb`, AppImage, Flatpak, or another
+   native artifact for Linux distributions.
 
 ## Tracker shape for issue #18
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -49,8 +49,9 @@ current limits and fixes.
 curl -fsSL https://con-releases.nowledge.co/install.sh | sh
 ```
 
-This installs `con` and `con-cli` into `~/.local/bin`. You can also download the
-Linux tarball from the latest
+This installs `con` and `con-cli` into `~/.local/bin`, registers the desktop
+launcher, and refreshes the app icon. You can also download the Linux tarball
+from the latest
 [Release](https://github.com/nowledge-co/con-terminal/releases).
 
 Linux is in preview. Follow the

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -248,7 +248,7 @@ pass "extracted"
 #     con-cli        (control-plane CLI)
 #     LICENSE
 #     README.md
-#     con.desktop
+#     co.nowledge.con.desktop
 #     con.png
 staged_root=""
 for d in "$extract_dir"/*; do
@@ -310,14 +310,22 @@ else
 fi
 
 # Desktop entry — handles "con shows up in the launcher" and
-# "double-clicking a `con://` URL". The tarball ships a templated
-# `con.desktop` that points at /usr/local/bin; rewrite the Exec line
-# to the resolved per-user binary path so it works regardless of
-# whether ~/.local/bin is on the user's PATH.
-if [ -f "$staged_root/con.desktop" ]; then
+# "double-clicking a `con://` URL". The desktop-file basename must match the
+# runtime Wayland app_id, and StartupWMClass must match on X11, otherwise Linux
+# desktops can show duplicate launcher icons or fail to group windows.
+linux_app_id="co.nowledge.con"
+if [ -f "$staged_root/${linux_app_id}.desktop" ]; then
+  sed "s|^Exec=.*|Exec=${target_bin} %U|" "$staged_root/${linux_app_id}.desktop" \
+    > "${apps_dir}/${linux_app_id}.desktop"
+  chmod 644 "${apps_dir}/${linux_app_id}.desktop"
+  rm -f "${apps_dir}/con.desktop"
+elif [ -f "$staged_root/con.desktop" ]; then
+  # Legacy tarballs before the reverse-DNS app_id change shipped con.desktop.
+  # Preserve compatibility when CON_INSTALL_VERSION points at an older release.
   sed "s|^Exec=.*|Exec=${target_bin} %U|" "$staged_root/con.desktop" \
     > "${apps_dir}/con.desktop"
   chmod 644 "${apps_dir}/con.desktop"
+  rm -f "${apps_dir}/${linux_app_id}.desktop"
 fi
 
 if [ -f "$staged_root/con.png" ]; then

--- a/scripts/linux/release.sh
+++ b/scripts/linux/release.sh
@@ -60,6 +60,7 @@ stage_name="con-${version}-linux-${art_arch}"
 stage_dir="dist/${stage_name}"
 tarball="dist/${stage_name}.tar.gz"
 sha_file="dist/SHA256SUMS-linux.txt"
+linux_app_id="co.nowledge.con"
 
 echo "==> con linux release"
 echo "    version : ${version}"
@@ -107,11 +108,13 @@ strip --strip-debug "${stage_dir}/con-cli" || true
 [[ -f LICENSE ]] && cp LICENSE "${stage_dir}/"
 [[ -f README.md ]] && cp README.md "${stage_dir}/"
 
-# Desktop entry. The install.sh script rewrites the Exec line to
+# Desktop entry. The filename, StartupWMClass, and runtime GPUI app_id must stay
+# in sync so Wayland and X11 desktops group the running window with the launcher.
+# The install.sh script rewrites the Exec line to
 # point at the per-user install path before dropping it into
 # ~/.local/share/applications, so the path here is just a default
 # for users who hand-extract the tarball into /usr/local.
-cat > "${stage_dir}/con.desktop" <<'EOF'
+cat > "${stage_dir}/${linux_app_id}.desktop" <<EOF
 [Desktop Entry]
 Type=Application
 Name=con
@@ -122,7 +125,7 @@ Icon=con
 Terminal=false
 Categories=System;TerminalEmulator;Utility;
 Keywords=terminal;shell;command;cli;ai;agent;
-StartupWMClass=con
+StartupWMClass=${linux_app_id}
 EOF
 
 # 256x256 icon — freedesktop hicolor's bread-and-butter size, and

--- a/scripts/release/verify-artifacts.sh
+++ b/scripts/release/verify-artifacts.sh
@@ -53,8 +53,8 @@ verify_linux() {
     || fail "$tarball_name does not contain con"
   tar -tzf "$tarball" | grep -E "/con-cli$" >/dev/null \
     || fail "$tarball_name does not contain con-cli"
-  tar -tzf "$tarball" | grep -E "/con.desktop$" >/dev/null \
-    || fail "$tarball_name does not contain con.desktop"
+  tar -tzf "$tarball" | grep -E "/co\\.nowledge\\.con\\.desktop$" >/dev/null \
+    || fail "$tarball_name does not contain co.nowledge.con.desktop"
 
   local tmp
   tmp="$(mktemp -d)"


### PR DESCRIPTION
Sets `co.nowledge.con` as the app_id in WindowOptions on Linux, which GPUI propagates to Wayland's xdg_toplevel.set_app_id() and X11's WM_CLASS for proper desktop environment integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux window registration so app windows correctly group with the installed desktop launcher and behave more consistently in the desktop environment.
* **Documentation**
  * Clarified Linux installation and packaging docs to reflect installer and desktop-launcher behavior.
* **Chores**
  * Installer and release tooling updated to prefer the modern desktop launcher filename with a fallback to the legacy name, and to verify its presence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->