### PR TITLE
feat: add macOS Dock New Window and just recipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ dist
 .env
 .sparkle
 .claude
+.con
 
 # Documentation screenshots are working artifacts, not committed source.
 # The legitimate shipped images (app icons in crates/con-app/resources/,

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ dist
 .env
 .sparkle
 .claude
-.con
 
 # Documentation screenshots are working artifacts, not committed source.
 # The legitimate shipped images (app icons in crates/con-app/resources/,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ con is still pre-release, so entries may group related beta work while the produ
   and can return focus to the app you were using before it appeared. It is off
   by default; enable it in Settings -> Keys and use Cmd-Backslash or your chosen
   shortcut.
+- Added **New Window** to the macOS Dock menu, so right-clicking the Dock icon
+  can open a fresh Con window without first focusing an existing one.
+
+**Developer Experience**
+
+- Added a cross-platform `justfile` for common build, run, test, release,
+  install, and cleanup flows. The default recipes now dispatch through the
+  Windows-safe `cargo w*` aliases when needed while staying simple on macOS and
+  Linux.
+- Kept project-local `.con/workspace.toml` profiles commit-friendly. Con still
+  treats private runtime state separately, while generated layout profiles can
+  live with the project when a team wants to share them.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,10 @@ Read the component's source in `3pp/gpui-component/crates/ui/src/` to understand
 - **Real Rig integration.** Tools implement `rig::tool::Tool` trait. Agent built via `client.agent(model).tool(T).build()`. Chat via `Chat::chat()` trait.
 - **Agent transparency.** When the built-in agent runs a command, it executes visibly. No hidden subprocesses.
 - **Shared tokio runtime.** The harness owns a single multi-thread tokio runtime — no thread-per-message.
-- **Config is TOML.** User config at `~/Library/Application Support/con/config.toml` (macOS), `%APPDATA%\con-terminal\config.toml` (Windows), `~/.config/con/config.toml` (Linux). Path resolved at runtime via `con-paths::config_file()` → `dirs::config_dir()`.
+- **Config is TOML.** User config resolved at runtime via `con-paths::config_file()` → `dirs::config_dir()`:
+  - **macOS**: `~/Library/Application Support/con/config.toml` (fallback: `~/.config/con/config.toml` if `dirs::config_dir()` returns None — effectively never on macOS)
+  - **Linux**: `$XDG_CONFIG_HOME/con/config.toml` (defaults to `~/.config/con/config.toml` when `XDG_CONFIG_HOME` is unset)
+  - **Windows**: `%APPDATA%\con-terminal\config.toml` (fallback: `~/.config/con-terminal/config.toml`)
 - **GPUI patterns.** Use `cx.spawn(async move |this, cx| { ... })` for async work. Use if/else for conditional UI (FluentBuilder::when() is not re-exported).
 
 ## Branching

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,6 @@ kingston/
 │   ├── con-ghostty/   # Ghostty FFI wrapper — primary macOS backend (libghostty C API)
 │   ├── con-agent/     # AI harness (Rig 0.34, tools, conversation)
 │   └── con-cli/       # CLI + socket client for the live local control plane
-├── postmortem/        # Integration & incident postmortems
 ├── assets/            # Themes, fonts, icons
 └── 3pp/               # Third-party source (READ-ONLY reference, .gitignored)
 ```
@@ -154,7 +153,7 @@ Read the component's source in `3pp/gpui-component/crates/ui/src/` to understand
 - **Real Rig integration.** Tools implement `rig::tool::Tool` trait. Agent built via `client.agent(model).tool(T).build()`. Chat via `Chat::chat()` trait.
 - **Agent transparency.** When the built-in agent runs a command, it executes visibly. No hidden subprocesses.
 - **Shared tokio runtime.** The harness owns a single multi-thread tokio runtime — no thread-per-message.
-- **Config is TOML.** User config at `~/.config/con/config.toml`.
+- **Config is TOML.** User config at `~/Library/Application Support/con/config.toml` (macOS), `%APPDATA%\con-terminal\config.toml` (Windows), `~/.config/con/config.toml` (Linux). Path resolved at runtime via `con-paths::config_file()` → `dirs::config_dir()`.
 - **GPUI patterns.** Use `cx.spawn(async move |this, cx| { ... })` for async work. Use if/else for conditional UI (FluentBuilder::when() is not re-exported).
 
 ## Branching

--- a/HACKING.md
+++ b/HACKING.md
@@ -78,6 +78,24 @@ cargo build
 cargo wbuild -p con --release          # → target\release\con-app.exe
 ```
 
+If you have `just` installed, the root `justfile` wraps the common local
+flows:
+
+```bash
+just build          # debug build for the current platform
+just run            # run from source
+just test           # platform-appropriate test set
+just check          # fast type check
+just install        # build and install to the local platform install path
+```
+
+On Windows, those default recipes dispatch through the `cargo w*` aliases
+above, so they produce and run `con-app.exe` instead of trying to build a
+reserved `con.exe` name. Platform-specific release helpers are also available,
+for example `just channel=beta macos-release`,
+`just channel=beta linux-release`, `just arch=x86_64 macos-bundle`, and
+`just windows-build-release`.
+
 ## Run
 
 ```bash

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -1676,6 +1676,8 @@ fn main() {
             },
         ]);
 
+        cx.set_dock_menu(vec![MenuItem::action("New Window", NewWindow)]);
+
         open_con_window(config.clone(), startup_session(), true, cx);
 
         // Initialize the auto-updater. On macOS this loads Sparkle

--- a/justfile
+++ b/justfile
@@ -27,28 +27,32 @@ default:
     @just --list
 
 # ── universal dev commands ────────────────────────────────────────────────────
+# Note: build/run/test below use the default feature set (macOS + Linux).
+# On Windows use windows-build / windows-run / windows-test instead —
+# the Windows binary requires --no-default-features --features con/bin-con-app
+# (see .cargo/config.toml for the w* aliases that wrap this).
 
-# Debug build (current platform)
+# Debug build — macOS / Linux
 build:
     cargo build -p con
 
-# Release build (current platform)
+# Release build — macOS / Linux
 build-release:
     cargo build --release -p con
 
-# Run from source (current platform)
+# Run from source — macOS / Linux
 run:
     cargo run -p con
 
-# Run all workspace tests (current platform)
+# Run all workspace tests — macOS / Linux
 test:
     cargo test --workspace
 
-# Check without building
+# Check without building (all platforms)
 check:
     cargo check --workspace
 
-# Run clippy on the workspace
+# Run clippy on the workspace (all platforms)
 lint:
     cargo clippy --workspace -- -D warnings
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,153 @@
+# Auto-detect arch: arm64 on Apple Silicon / aarch64 Linux, x86_64 elsewhere
+arch := `uname -m | sed 's/aarch64/arm64/'`
+
+# Release channel for macOS/Linux app bundles (stable | beta | dev)
+channel := "stable"
+
+# ── list ──────────────────────────────────────────────────────────────────────
+
+# List all recipes (default)
+default:
+    @just --list
+
+# ── universal dev commands ────────────────────────────────────────────────────
+
+# Debug build (current platform)
+build:
+    cargo build -p con
+
+# Release build (current platform)
+build-release:
+    cargo build --release -p con
+
+# Run from source (current platform)
+run:
+    cargo run -p con
+
+# Run all workspace tests (current platform)
+test:
+    cargo test --workspace
+
+# Check without building
+check:
+    cargo check --workspace
+
+# Run clippy on the workspace
+lint:
+    cargo clippy --workspace -- -D warnings
+
+# Clean cargo build artifacts
+clean:
+    cargo clean
+
+# Print the current workspace version
+version:
+    @grep -A3 '^\[workspace\.package\]' Cargo.toml | awk -F'"' '/^version/{print $2}'
+
+# ── macOS ─────────────────────────────────────────────────────────────────────
+
+# [macOS] Build a local .app bundle — no signing, no notarization
+# Output: dist/macos/{channel}/{arch}/con.app
+macos-bundle channel=channel arch=arch:
+    CON_CHANNEL={{channel}} CON_ARCH={{arch}} ./scripts/macos/build-app.sh
+
+# [macOS] Build .app and copy to /Applications (replaces existing)
+macos-install channel=channel arch=arch: (macos-bundle channel arch)
+    #!/usr/bin/env bash
+    set -euo pipefail
+    app_name="con"
+    if [[ "{{channel}}" == "beta" ]]; then app_name="con Beta"; fi
+    if [[ "{{channel}}" == "dev" ]];  then app_name="con Dev";  fi
+    src="dist/macos/{{channel}}/{{arch}}/${app_name}.app"
+    dst="/Applications/${app_name}.app"
+    echo "Installing ${src} → ${dst}"
+    rm -rf "${dst}"
+    cp -R "${src}" "${dst}"
+    echo "Done. Launch ${app_name} from /Applications or Spotlight."
+
+# [macOS] Ad-hoc signed bundle (no Apple Developer account needed; Gatekeeper will warn once)
+macos-bundle-adhoc channel=channel arch=arch: (macos-bundle channel arch)
+    #!/usr/bin/env bash
+    set -euo pipefail
+    app_name="con"
+    if [[ "{{channel}}" == "beta" ]]; then app_name="con Beta"; fi
+    if [[ "{{channel}}" == "dev" ]];  then app_name="con Dev";  fi
+    bundle="dist/macos/{{channel}}/{{arch}}/${app_name}.app"
+    echo "Ad-hoc signing ${bundle}"
+    codesign --force --deep --sign - "${bundle}"
+    echo "Signed (ad-hoc): ${bundle}"
+
+# [macOS] Install ad-hoc signed bundle to /Applications
+macos-install-adhoc channel=channel arch=arch: (macos-bundle-adhoc channel arch)
+    #!/usr/bin/env bash
+    set -euo pipefail
+    app_name="con"
+    if [[ "{{channel}}" == "beta" ]]; then app_name="con Beta"; fi
+    if [[ "{{channel}}" == "dev" ]];  then app_name="con Dev";  fi
+    src="dist/macos/{{channel}}/{{arch}}/${app_name}.app"
+    dst="/Applications/${app_name}.app"
+    echo "Installing ${src} → ${dst}"
+    rm -rf "${dst}"
+    cp -R "${src}" "${dst}"
+    echo "Done. Launch ${app_name} from /Applications or Spotlight."
+
+# [macOS] Full release: build + sign + notarize + DMG
+# Requires: APPLE_SIGNING_IDENTITY + APPLE_NOTARY_* or APPLE_ID env vars
+macos-release channel=channel arch=arch:
+    CON_CHANNEL={{channel}} CON_ARCH={{arch}} ./scripts/macos/release.sh
+
+# [macOS] Download Sparkle.framework into .sparkle/ (enables auto-update in bundle)
+macos-sparkle-download:
+    ./scripts/sparkle/download.sh
+
+# [macOS] Open the built app bundle in Finder
+macos-open channel=channel arch=arch:
+    #!/usr/bin/env bash
+    app_name="con"
+    if [[ "{{channel}}" == "beta" ]]; then app_name="con Beta"; fi
+    if [[ "{{channel}}" == "dev" ]];  then app_name="con Dev";  fi
+    open "dist/macos/{{channel}}/{{arch}}/${app_name}.app"
+
+# ── Linux ─────────────────────────────────────────────────────────────────────
+
+# [Linux] Build a release binary and package it
+linux-release arch=arch:
+    CON_ARCH={{arch}} ./scripts/linux/release.sh
+
+# [Linux] Install the release binary to ~/.local/bin
+linux-install arch=arch: (linux-release arch)
+    #!/usr/bin/env bash
+    set -euo pipefail
+    bin="dist/linux/{{arch}}/con"
+    if [[ ! -f "${bin}" ]]; then
+        echo "Binary not found at ${bin} — check scripts/linux/release.sh output"
+        exit 1
+    fi
+    mkdir -p "$HOME/.local/bin"
+    cp "${bin}" "$HOME/.local/bin/con"
+    chmod 755 "$HOME/.local/bin/con"
+    echo "Installed to $HOME/.local/bin/con"
+
+# ── Windows (run from Developer Command Prompt for VS 2022) ───────────────────
+
+# [Windows] Debug build (con-app.exe — CON is a reserved DOS device name)
+windows-build:
+    cargo wbuild -p con
+
+# [Windows] Release build
+windows-build-release:
+    cargo wbuild -p con --release
+
+# [Windows] Run
+windows-run:
+    cargo wrun -p con
+
+# [Windows] Test
+windows-test:
+    cargo wtest -p con-core -p con-cli -p con-agent -p con-terminal
+
+# ── dist cleanup ──────────────────────────────────────────────────────────────
+
+# Remove all dist/ output
+clean-dist:
+    rm -rf dist/

--- a/justfile
+++ b/justfile
@@ -171,17 +171,17 @@ macos-open channel=channel arch=arch:
 
 # [Linux] Build a release binary and package it
 # Output: dist/con-{version}-linux-{arch}.tar.gz
-linux-release arch=arch:
+linux-release channel=channel arch=arch:
     #!/usr/bin/env bash
     set -euo pipefail
     resolved_arch="{{ arch }}"
     if [[ -z "${resolved_arch}" ]]; then
         resolved_arch="$(uname -m | sed 's/aarch64/arm64/')"
     fi
-    CON_LINUX_ARCH="${resolved_arch}" ./scripts/linux/release.sh
+    CON_RELEASE_CHANNEL={{ channel }} CON_LINUX_ARCH="${resolved_arch}" ./scripts/linux/release.sh
 
 # [Linux] Install the release binaries to ~/.local/bin
-linux-install arch=arch: (linux-release arch)
+linux-install channel=channel arch=arch: (linux-release channel arch)
     #!/usr/bin/env bash
     set -euo pipefail
     resolved_arch="{{ arch }}"

--- a/justfile
+++ b/justfile
@@ -111,22 +111,25 @@ macos-open channel=channel arch=arch:
 # ── Linux ─────────────────────────────────────────────────────────────────────
 
 # [Linux] Build a release binary and package it
+# Output: dist/con-{version}-linux-{arch}.tar.gz
 linux-release arch=arch:
-    CON_ARCH={{arch}} ./scripts/linux/release.sh
+    CON_LINUX_ARCH={{arch}} ./scripts/linux/release.sh
 
 # [Linux] Install the release binary to ~/.local/bin
 linux-install arch=arch: (linux-release arch)
     #!/usr/bin/env bash
     set -euo pipefail
-    bin="dist/linux/{{arch}}/con"
-    if [[ ! -f "${bin}" ]]; then
-        echo "Binary not found at ${bin} — check scripts/linux/release.sh output"
+    # scripts/linux/release.sh stages to dist/con-{version}-linux-{arch}/
+    # Resolve the versioned staging dir by globbing.
+    stage_dir="$(ls -d dist/con-*-linux-{{arch}} 2>/dev/null | sort -V | tail -1)"
+    if [[ -z "${stage_dir}" || ! -f "${stage_dir}/con" ]]; then
+        echo "Binary not found under dist/con-*-linux-{{arch}}/ — run 'just linux-release' first"
         exit 1
     fi
     mkdir -p "$HOME/.local/bin"
-    cp "${bin}" "$HOME/.local/bin/con"
+    cp "${stage_dir}/con" "$HOME/.local/bin/con"
     chmod 755 "$HOME/.local/bin/con"
-    echo "Installed to $HOME/.local/bin/con"
+    echo "Installed ${stage_dir}/con → $HOME/.local/bin/con"
 
 # ── Windows (run from Developer Command Prompt for VS 2022) ───────────────────
 

--- a/justfile
+++ b/justfile
@@ -1,8 +1,24 @@
-# Auto-detect arch: arm64 on Apple Silicon / aarch64 Linux, x86_64 elsewhere
-arch := `uname -m | sed 's/aarch64/arm64/'`
+# con — justfile
+# https://github.com/casey/just
+#
+# Usage:
+#   just          # list all recipes
+#   just run      # run from source (current platform)
+#   just install  # build and install (current platform)
+#
+# The `arch` parameter defaults to "" — each Unix recipe auto-detects via
+# `uname -m` inside the shell body. Windows recipes never reference arch so
+# `uname` is never invoked there.
+# Override explicitly when needed: just macos-bundle arch=x86_64
+
+# ── defaults ──────────────────────────────────────────────────────────────────
 
 # Release channel for macOS/Linux app bundles (stable | beta | dev)
 channel := "stable"
+
+# Target architecture. Empty = auto-detect inside each recipe (Unix only).
+# Windows recipes never use this variable so uname is never called there.
+arch := ""
 
 # ── list ──────────────────────────────────────────────────────────────────────
 
@@ -49,16 +65,26 @@ version:
 # [macOS] Build a local .app bundle — no signing, no notarization
 # Output: dist/macos/{channel}/{arch}/con.app
 macos-bundle channel=channel arch=arch:
-    CON_CHANNEL={{channel}} CON_ARCH={{arch}} ./scripts/macos/build-app.sh
+    #!/usr/bin/env bash
+    set -euo pipefail
+    resolved_arch="{{arch}}"
+    if [[ -z "${resolved_arch}" ]]; then
+        resolved_arch="$(uname -m | sed 's/aarch64/arm64/')"
+    fi
+    CON_CHANNEL={{channel}} CON_ARCH="${resolved_arch}" ./scripts/macos/build-app.sh
 
 # [macOS] Build .app and copy to /Applications (replaces existing)
 macos-install channel=channel arch=arch: (macos-bundle channel arch)
     #!/usr/bin/env bash
     set -euo pipefail
+    resolved_arch="{{arch}}"
+    if [[ -z "${resolved_arch}" ]]; then
+        resolved_arch="$(uname -m | sed 's/aarch64/arm64/')"
+    fi
     app_name="con"
     if [[ "{{channel}}" == "beta" ]]; then app_name="con Beta"; fi
     if [[ "{{channel}}" == "dev" ]];  then app_name="con Dev";  fi
-    src="dist/macos/{{channel}}/{{arch}}/${app_name}.app"
+    src="dist/macos/{{channel}}/${resolved_arch}/${app_name}.app"
     dst="/Applications/${app_name}.app"
     echo "Installing ${src} → ${dst}"
     rm -rf "${dst}"
@@ -69,10 +95,14 @@ macos-install channel=channel arch=arch: (macos-bundle channel arch)
 macos-bundle-adhoc channel=channel arch=arch: (macos-bundle channel arch)
     #!/usr/bin/env bash
     set -euo pipefail
+    resolved_arch="{{arch}}"
+    if [[ -z "${resolved_arch}" ]]; then
+        resolved_arch="$(uname -m | sed 's/aarch64/arm64/')"
+    fi
     app_name="con"
     if [[ "{{channel}}" == "beta" ]]; then app_name="con Beta"; fi
     if [[ "{{channel}}" == "dev" ]];  then app_name="con Dev";  fi
-    bundle="dist/macos/{{channel}}/{{arch}}/${app_name}.app"
+    bundle="dist/macos/{{channel}}/${resolved_arch}/${app_name}.app"
     echo "Ad-hoc signing ${bundle}"
     codesign --force --deep --sign - "${bundle}"
     echo "Signed (ad-hoc): ${bundle}"
@@ -81,10 +111,14 @@ macos-bundle-adhoc channel=channel arch=arch: (macos-bundle channel arch)
 macos-install-adhoc channel=channel arch=arch: (macos-bundle-adhoc channel arch)
     #!/usr/bin/env bash
     set -euo pipefail
+    resolved_arch="{{arch}}"
+    if [[ -z "${resolved_arch}" ]]; then
+        resolved_arch="$(uname -m | sed 's/aarch64/arm64/')"
+    fi
     app_name="con"
     if [[ "{{channel}}" == "beta" ]]; then app_name="con Beta"; fi
     if [[ "{{channel}}" == "dev" ]];  then app_name="con Dev";  fi
-    src="dist/macos/{{channel}}/{{arch}}/${app_name}.app"
+    src="dist/macos/{{channel}}/${resolved_arch}/${app_name}.app"
     dst="/Applications/${app_name}.app"
     echo "Installing ${src} → ${dst}"
     rm -rf "${dst}"
@@ -94,7 +128,13 @@ macos-install-adhoc channel=channel arch=arch: (macos-bundle-adhoc channel arch)
 # [macOS] Full release: build + sign + notarize + DMG
 # Requires: APPLE_SIGNING_IDENTITY + APPLE_NOTARY_* or APPLE_ID env vars
 macos-release channel=channel arch=arch:
-    CON_CHANNEL={{channel}} CON_ARCH={{arch}} ./scripts/macos/release.sh
+    #!/usr/bin/env bash
+    set -euo pipefail
+    resolved_arch="{{arch}}"
+    if [[ -z "${resolved_arch}" ]]; then
+        resolved_arch="$(uname -m | sed 's/aarch64/arm64/')"
+    fi
+    CON_CHANNEL={{channel}} CON_ARCH="${resolved_arch}" ./scripts/macos/release.sh
 
 # [macOS] Download Sparkle.framework into .sparkle/ (enables auto-update in bundle)
 macos-sparkle-download:
@@ -103,27 +143,40 @@ macos-sparkle-download:
 # [macOS] Open the built app bundle in Finder
 macos-open channel=channel arch=arch:
     #!/usr/bin/env bash
+    resolved_arch="{{arch}}"
+    if [[ -z "${resolved_arch}" ]]; then
+        resolved_arch="$(uname -m | sed 's/aarch64/arm64/')"
+    fi
     app_name="con"
     if [[ "{{channel}}" == "beta" ]]; then app_name="con Beta"; fi
     if [[ "{{channel}}" == "dev" ]];  then app_name="con Dev";  fi
-    open "dist/macos/{{channel}}/{{arch}}/${app_name}.app"
+    open "dist/macos/{{channel}}/${resolved_arch}/${app_name}.app"
 
 # ── Linux ─────────────────────────────────────────────────────────────────────
 
 # [Linux] Build a release binary and package it
 # Output: dist/con-{version}-linux-{arch}.tar.gz
 linux-release arch=arch:
-    CON_LINUX_ARCH={{arch}} ./scripts/linux/release.sh
+    #!/usr/bin/env bash
+    set -euo pipefail
+    resolved_arch="{{arch}}"
+    if [[ -z "${resolved_arch}" ]]; then
+        resolved_arch="$(uname -m | sed 's/aarch64/arm64/')"
+    fi
+    CON_LINUX_ARCH="${resolved_arch}" ./scripts/linux/release.sh
 
 # [Linux] Install the release binary to ~/.local/bin
 linux-install arch=arch: (linux-release arch)
     #!/usr/bin/env bash
     set -euo pipefail
+    resolved_arch="{{arch}}"
+    if [[ -z "${resolved_arch}" ]]; then
+        resolved_arch="$(uname -m | sed 's/aarch64/arm64/')"
+    fi
     # scripts/linux/release.sh stages to dist/con-{version}-linux-{arch}/
-    # Resolve the versioned staging dir by globbing.
-    stage_dir="$(ls -d dist/con-*-linux-{{arch}} 2>/dev/null | sort -V | tail -1)"
+    stage_dir="$(ls -d dist/con-*-linux-${resolved_arch} 2>/dev/null | sort -V | tail -1)"
     if [[ -z "${stage_dir}" || ! -f "${stage_dir}/con" ]]; then
-        echo "Binary not found under dist/con-*-linux-{{arch}}/ — run 'just linux-release' first"
+        echo "Binary not found under dist/con-*-linux-${resolved_arch}/ — run 'just linux-release' first"
         exit 1
     fi
     mkdir -p "$HOME/.local/bin"

--- a/justfile
+++ b/justfile
@@ -11,6 +11,10 @@
 # `uname` is never invoked there.
 # Override explicitly when needed: just macos-bundle arch=x86_64
 
+# Use cmd.exe on Windows so recipes work in a plain Developer Command Prompt
+# without requiring Git Bash, Cygwin, or sh on PATH.
+set windows-shell := ["cmd.exe", "/c"]
+
 # ── defaults ──────────────────────────────────────────────────────────────────
 
 # Release channel for macOS/Linux app bundles (stable | beta | dev)

--- a/justfile
+++ b/justfile
@@ -178,7 +178,8 @@ linux-install arch=arch: (linux-release arch)
         resolved_arch="$(uname -m | sed 's/aarch64/arm64/')"
     fi
     # scripts/linux/release.sh stages to dist/con-{version}-linux-{arch}/
-    stage_dir="$(ls -d dist/con-*-linux-${resolved_arch} 2>/dev/null | sort -V | tail -1)"
+    # Use || true so set -e doesn't exit when the glob has no matches.
+    stage_dir="$(ls -d dist/con-*-linux-${resolved_arch} 2>/dev/null | sort -V | tail -1 || true)"
     if [[ -z "${stage_dir}" || ! -f "${stage_dir}/con" ]]; then
         echo "Binary not found under dist/con-*-linux-${resolved_arch}/ — run 'just linux-release' first"
         exit 1

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@
 # The `arch` parameter defaults to "" — each Unix recipe auto-detects via
 # `uname -m` inside the shell body. Windows recipes never reference arch so
 # `uname` is never invoked there.
-# Override explicitly when needed: just macos-bundle arch=x86_64
+# Override explicitly when needed: just arch=x86_64 macos-bundle
 
 # Use cmd.exe on Windows so recipes work in a plain Developer Command Prompt
 # without requiring Git Bash, Cygwin, or sh on PATH.
@@ -31,42 +31,49 @@ default:
     @just --list
 
 # ── universal dev commands ────────────────────────────────────────────────────
-# Note: build/run/test below use the default feature set (macOS + Linux).
-# On Windows use windows-build / windows-run / windows-test instead —
-# the Windows binary requires --no-default-features --features con/bin-con-app
-# (see .cargo/config.toml for the w* aliases that wrap this).
+# These dispatch to the right platform recipe. Windows must use the `w*` cargo
+# aliases because `CON` is a reserved DOS device name and the Windows binary is
+# feature-gated as `con-app.exe`.
 
-# Debug build — macOS / Linux
+# Debug build — current platform
 build:
-    cargo build -p con
+    {{ if os() == "windows" { "cargo wbuild -p con" } else { "cargo build -p con" } }}
 
-# Release build — macOS / Linux
+# Release build — current platform
 build-release:
-    cargo build --release -p con
+    {{ if os() == "windows" { "cargo wbuild -p con --release" } else { "cargo build --release -p con" } }}
 
-# Run from source — macOS / Linux
+# Run from source — current platform
 run:
-    cargo run -p con
+    {{ if os() == "windows" { "cargo wrun -p con" } else { "cargo run -p con" } }}
 
-# Run all workspace tests — macOS / Linux
+# Run the platform-appropriate test set
 test:
-    cargo test --workspace
+    {{ if os() == "windows" { "cargo wtest -p con-core -p con-cli -p con-agent -p con-terminal" } else { "cargo test --workspace" } }}
 
-# Check without building (all platforms)
+# Check without building — current platform
 check:
-    cargo check --workspace
+    {{ if os() == "windows" { "cargo wcheck -p con" } else { "cargo check --workspace" } }}
 
-# Run clippy on the workspace (all platforms)
+# Run clippy — current platform
 lint:
-    cargo clippy --workspace -- -D warnings
+    {{ if os() == "windows" { "cargo clippy --workspace --no-default-features --features con/bin-con-app -- -D warnings" } else { "cargo clippy --workspace -- -D warnings" } }}
 
 # Clean cargo build artifacts
 clean:
     cargo clean
 
-# Print the current workspace version
+# Build and install to the current platform's local development install path
+install:
+    just channel={{ channel }} arch={{ arch }} {{ if os() == "macos" { "macos-install" } else if os() == "linux" { "linux-install" } else if os() == "windows" { "windows-install" } else { "unsupported-platform" } }}
+
+# Print the current package id, including the workspace version
 version:
-    @grep -A3 '^\[workspace\.package\]' Cargo.toml | awk -F'"' '/^version/{print $2}'
+    @cargo pkgid -p con
+
+unsupported-platform:
+    @echo "Unsupported platform for this justfile"
+    @exit 1
 
 # ── macOS ─────────────────────────────────────────────────────────────────────
 
@@ -75,24 +82,24 @@ version:
 macos-bundle channel=channel arch=arch:
     #!/usr/bin/env bash
     set -euo pipefail
-    resolved_arch="{{arch}}"
+    resolved_arch="{{ arch }}"
     if [[ -z "${resolved_arch}" ]]; then
         resolved_arch="$(uname -m | sed 's/aarch64/arm64/')"
     fi
-    CON_CHANNEL={{channel}} CON_ARCH="${resolved_arch}" ./scripts/macos/build-app.sh
+    CON_CHANNEL={{ channel }} CON_ARCH="${resolved_arch}" ./scripts/macos/build-app.sh
 
 # [macOS] Build .app and copy to /Applications (replaces existing)
 macos-install channel=channel arch=arch: (macos-bundle channel arch)
     #!/usr/bin/env bash
     set -euo pipefail
-    resolved_arch="{{arch}}"
+    resolved_arch="{{ arch }}"
     if [[ -z "${resolved_arch}" ]]; then
         resolved_arch="$(uname -m | sed 's/aarch64/arm64/')"
     fi
     app_name="con"
-    if [[ "{{channel}}" == "beta" ]]; then app_name="con Beta"; fi
-    if [[ "{{channel}}" == "dev" ]];  then app_name="con Dev";  fi
-    src="dist/macos/{{channel}}/${resolved_arch}/${app_name}.app"
+    if [[ "{{ channel }}" == "beta" ]]; then app_name="con Beta"; fi
+    if [[ "{{ channel }}" == "dev" ]];  then app_name="con Dev";  fi
+    src="dist/macos/{{ channel }}/${resolved_arch}/${app_name}.app"
     dst="/Applications/${app_name}.app"
     echo "Installing ${src} → ${dst}"
     rm -rf "${dst}"
@@ -103,14 +110,14 @@ macos-install channel=channel arch=arch: (macos-bundle channel arch)
 macos-bundle-adhoc channel=channel arch=arch: (macos-bundle channel arch)
     #!/usr/bin/env bash
     set -euo pipefail
-    resolved_arch="{{arch}}"
+    resolved_arch="{{ arch }}"
     if [[ -z "${resolved_arch}" ]]; then
         resolved_arch="$(uname -m | sed 's/aarch64/arm64/')"
     fi
     app_name="con"
-    if [[ "{{channel}}" == "beta" ]]; then app_name="con Beta"; fi
-    if [[ "{{channel}}" == "dev" ]];  then app_name="con Dev";  fi
-    bundle="dist/macos/{{channel}}/${resolved_arch}/${app_name}.app"
+    if [[ "{{ channel }}" == "beta" ]]; then app_name="con Beta"; fi
+    if [[ "{{ channel }}" == "dev" ]];  then app_name="con Dev";  fi
+    bundle="dist/macos/{{ channel }}/${resolved_arch}/${app_name}.app"
     echo "Ad-hoc signing ${bundle}"
     codesign --force --deep --sign - "${bundle}"
     echo "Signed (ad-hoc): ${bundle}"
@@ -119,14 +126,14 @@ macos-bundle-adhoc channel=channel arch=arch: (macos-bundle channel arch)
 macos-install-adhoc channel=channel arch=arch: (macos-bundle-adhoc channel arch)
     #!/usr/bin/env bash
     set -euo pipefail
-    resolved_arch="{{arch}}"
+    resolved_arch="{{ arch }}"
     if [[ -z "${resolved_arch}" ]]; then
         resolved_arch="$(uname -m | sed 's/aarch64/arm64/')"
     fi
     app_name="con"
-    if [[ "{{channel}}" == "beta" ]]; then app_name="con Beta"; fi
-    if [[ "{{channel}}" == "dev" ]];  then app_name="con Dev";  fi
-    src="dist/macos/{{channel}}/${resolved_arch}/${app_name}.app"
+    if [[ "{{ channel }}" == "beta" ]]; then app_name="con Beta"; fi
+    if [[ "{{ channel }}" == "dev" ]];  then app_name="con Dev";  fi
+    src="dist/macos/{{ channel }}/${resolved_arch}/${app_name}.app"
     dst="/Applications/${app_name}.app"
     echo "Installing ${src} → ${dst}"
     rm -rf "${dst}"
@@ -138,11 +145,11 @@ macos-install-adhoc channel=channel arch=arch: (macos-bundle-adhoc channel arch)
 macos-release channel=channel arch=arch:
     #!/usr/bin/env bash
     set -euo pipefail
-    resolved_arch="{{arch}}"
+    resolved_arch="{{ arch }}"
     if [[ -z "${resolved_arch}" ]]; then
         resolved_arch="$(uname -m | sed 's/aarch64/arm64/')"
     fi
-    CON_CHANNEL={{channel}} CON_ARCH="${resolved_arch}" ./scripts/macos/release.sh
+    CON_CHANNEL={{ channel }} CON_ARCH="${resolved_arch}" ./scripts/macos/release.sh
 
 # [macOS] Download Sparkle.framework into .sparkle/ (enables auto-update in bundle)
 macos-sparkle-download:
@@ -151,14 +158,14 @@ macos-sparkle-download:
 # [macOS] Open the built app bundle in Finder
 macos-open channel=channel arch=arch:
     #!/usr/bin/env bash
-    resolved_arch="{{arch}}"
+    resolved_arch="{{ arch }}"
     if [[ -z "${resolved_arch}" ]]; then
         resolved_arch="$(uname -m | sed 's/aarch64/arm64/')"
     fi
     app_name="con"
-    if [[ "{{channel}}" == "beta" ]]; then app_name="con Beta"; fi
-    if [[ "{{channel}}" == "dev" ]];  then app_name="con Dev";  fi
-    open "dist/macos/{{channel}}/${resolved_arch}/${app_name}.app"
+    if [[ "{{ channel }}" == "beta" ]]; then app_name="con Beta"; fi
+    if [[ "{{ channel }}" == "dev" ]];  then app_name="con Dev";  fi
+    open "dist/macos/{{ channel }}/${resolved_arch}/${app_name}.app"
 
 # ── Linux ─────────────────────────────────────────────────────────────────────
 
@@ -167,17 +174,17 @@ macos-open channel=channel arch=arch:
 linux-release arch=arch:
     #!/usr/bin/env bash
     set -euo pipefail
-    resolved_arch="{{arch}}"
+    resolved_arch="{{ arch }}"
     if [[ -z "${resolved_arch}" ]]; then
         resolved_arch="$(uname -m | sed 's/aarch64/arm64/')"
     fi
     CON_LINUX_ARCH="${resolved_arch}" ./scripts/linux/release.sh
 
-# [Linux] Install the release binary to ~/.local/bin
+# [Linux] Install the release binaries to ~/.local/bin
 linux-install arch=arch: (linux-release arch)
     #!/usr/bin/env bash
     set -euo pipefail
-    resolved_arch="{{arch}}"
+    resolved_arch="{{ arch }}"
     if [[ -z "${resolved_arch}" ]]; then
         resolved_arch="$(uname -m | sed 's/aarch64/arm64/')"
     fi
@@ -192,6 +199,11 @@ linux-install arch=arch: (linux-release arch)
     cp "${stage_dir}/con" "$HOME/.local/bin/con"
     chmod 755 "$HOME/.local/bin/con"
     echo "Installed ${stage_dir}/con → $HOME/.local/bin/con"
+    if [[ -f "${stage_dir}/con-cli" ]]; then
+        cp "${stage_dir}/con-cli" "$HOME/.local/bin/con-cli"
+        chmod 755 "$HOME/.local/bin/con-cli"
+        echo "Installed ${stage_dir}/con-cli → $HOME/.local/bin/con-cli"
+    fi
 
 # ── Windows (run from Developer Command Prompt for VS 2022) ───────────────────
 
@@ -202,6 +214,7 @@ windows-build:
 # [Windows] Release build
 windows-build-release:
     cargo wbuild -p con --release
+    cargo build -p con-cli --release
 
 # [Windows] Run
 windows-run:
@@ -211,8 +224,15 @@ windows-run:
 windows-test:
     cargo wtest -p con-core -p con-cli -p con-agent -p con-terminal
 
+# [Windows] Build and install local release binaries to the user install root
+windows-install: windows-build-release
+    if not exist "%LOCALAPPDATA%\Programs\con" mkdir "%LOCALAPPDATA%\Programs\con"
+    copy /Y "target\release\con-app.exe" "%LOCALAPPDATA%\Programs\con\con-app.exe"
+    copy /Y "target\release\con-cli.exe" "%LOCALAPPDATA%\Programs\con\con-cli.exe"
+    echo Installed con-app.exe and con-cli.exe to %LOCALAPPDATA%\Programs\con
+
 # ── dist cleanup ──────────────────────────────────────────────────────────────
 
 # Remove all dist/ output
 clean-dist:
-    rm -rf dist/
+    {{ if os() == "windows" { "if exist dist rmdir /s /q dist" } else { "rm -rf dist/" } }}


### PR DESCRIPTION
## Summary

- Add **New Window** to the macOS Dock right-click menu, wired to the same action as File → New Window.
- Add a cross-platform `justfile` for common build, run, test, release, install, and cleanup workflows.
- Make default `just build/run/test/check/lint/install` dispatch to the right platform; Windows uses the `cargo w*` aliases required for `con-app.exe`.
- Install `con-cli` in the local Linux/Windows install recipes so the dev workflow matches the release installer contract.
- Preserve release channel handling in local Linux recipes, so `just channel=beta linux-release` produces beta-labeled artifacts.
- Document the `just` workflow in `HACKING.md` and add the beta 62 changelog entry.
- Keep `.con/workspace.toml` project profiles commit-friendly instead of ignoring the whole `.con/` directory.
- Clean up `CLAUDE.md` duplicated postmortem entry and clarify platform config paths.

## Test Plan

- [x] `cargo fmt --check`
- [x] `git diff --check`
- [x] `RUSTFLAGS='-D warnings' cargo check -p con`
- [x] `RUSTFLAGS='-D warnings' CON_SKIP_GHOSTTY_VT=1 cargo check -p con --no-default-features --features con/bin-con-app`
- [x] `just --fmt --check`
- [x] `just --list`
- [x] `just version`
- [x] `just --dry-run arch=x86_64 macos-bundle`
- [x] `just --dry-run channel=beta linux-release`
- [x] `just --dry-run channel=beta linux-install`
