### PR TITLE
fix(tabs): add Shift+Cmd+B to collapse sidebar; fix #139 H/V toggle fallback

### DIFF
--- a/crates/con-app/src/command_palette.rs
+++ b/crates/con-app/src/command_palette.rs
@@ -27,6 +27,10 @@ const TOGGLE_VERTICAL_TABS_SHORTCUT: &str = "secondary-b";
 #[cfg(not(target_os = "macos"))]
 const TOGGLE_VERTICAL_TABS_SHORTCUT: &str = "ctrl-shift-b";
 #[cfg(target_os = "macos")]
+const COLLAPSE_SIDEBAR_SHORTCUT: &str = "secondary-shift-b";
+#[cfg(not(target_os = "macos"))]
+const COLLAPSE_SIDEBAR_SHORTCUT: &str = "ctrl-alt-b";
+#[cfg(target_os = "macos")]
 const NEW_SURFACE_SHORTCUT: &str = "secondary-alt-t";
 #[cfg(not(target_os = "macos"))]
 const NEW_SURFACE_SHORTCUT: &str = "alt-shift-t";
@@ -216,6 +220,12 @@ const PALETTE_ACTIONS: &[PaletteAction] = &[
         id: "toggle-vertical-tabs",
         label: "Toggle Vertical Tabs",
         shortcut: TOGGLE_VERTICAL_TABS_SHORTCUT,
+        category: "View",
+    },
+    PaletteAction {
+        id: "collapse-sidebar",
+        label: "Collapse/Expand Sidebar",
+        shortcut: COLLAPSE_SIDEBAR_SHORTCUT,
         category: "View",
     },
     PaletteAction {

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -107,6 +107,7 @@ actions!(
         ToggleAgentPanel,
         ToggleInputBar,
         ToggleVerticalTabs,
+        CollapseSidebar,
         CloseTab,
         ClosePane,
         TogglePaneZoom,
@@ -1207,6 +1208,7 @@ pub(crate) fn bind_app_keybindings(cx: &mut App, kb: &KeybindingConfig) {
         KeyBinding::new(&kb.toggle_input_bar, ToggleInputBar, None),
         KeyBinding::new(&kb.toggle_pane_scope, TogglePaneScopePicker, None),
         KeyBinding::new(&kb.toggle_vertical_tabs, ToggleVerticalTabs, None),
+        KeyBinding::new(&kb.collapse_sidebar, CollapseSidebar, None),
         KeyBinding::new(&kb.quit, Quit, Some("Input")),
         KeyBinding::new(&kb.new_window, NewWindow, Some("Input")),
         KeyBinding::new(&kb.new_tab, NewTab, Some("Input")),
@@ -1255,6 +1257,7 @@ pub(crate) fn bind_app_keybindings(cx: &mut App, kb: &KeybindingConfig) {
         KeyBinding::new(&kb.toggle_input_bar, ToggleInputBar, Some("Input")),
         KeyBinding::new(&kb.toggle_pane_scope, TogglePaneScopePicker, Some("Input")),
         KeyBinding::new(&kb.toggle_vertical_tabs, ToggleVerticalTabs, Some("Input")),
+        KeyBinding::new(&kb.collapse_sidebar, CollapseSidebar, Some("Input")),
     ]);
 
     // Hide app / Hide others / Show all are macOS system-menu conventions

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -2216,6 +2216,7 @@ impl SettingsPanel {
             "split_down" => self.config.keybindings.split_down = binding,
             "toggle_pane_scope" => self.config.keybindings.toggle_pane_scope = binding,
             "toggle_vertical_tabs" => self.config.keybindings.toggle_vertical_tabs = binding,
+            "collapse_sidebar" => self.config.keybindings.collapse_sidebar = binding,
             "new_surface" => self.config.keybindings.new_surface = binding,
             "new_surface_split_right" => self.config.keybindings.new_surface_split_right = binding,
             "new_surface_split_down" => self.config.keybindings.new_surface_split_down = binding,
@@ -2252,6 +2253,7 @@ impl SettingsPanel {
             "split_down" => &self.config.keybindings.split_down,
             "toggle_pane_scope" => &self.config.keybindings.toggle_pane_scope,
             "toggle_vertical_tabs" => &self.config.keybindings.toggle_vertical_tabs,
+            "collapse_sidebar" => &self.config.keybindings.collapse_sidebar,
             "new_surface" => &self.config.keybindings.new_surface,
             "new_surface_split_right" => &self.config.keybindings.new_surface_split_right,
             "new_surface_split_down" => &self.config.keybindings.new_surface_split_down,
@@ -4354,6 +4356,7 @@ impl SettingsPanel {
             ("Cycle Input Mode", "cycle_input_mode"),
             ("Toggle Pane Scope", "toggle_pane_scope"),
             ("Toggle Vertical Tabs", "toggle_vertical_tabs"),
+            ("Collapse/Expand Sidebar", "collapse_sidebar"),
             ("Quit", "quit"),
         ];
 

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -407,6 +407,11 @@ pub struct ConWorkspace {
     agent_panel_motion: MotionValue,
     agent_panel_width: f32,
     tab_strip_motion: MotionValue,
+    /// When true, the horizontal tab strip is hidden even though
+    /// `tabs_orientation` is `Horizontal` and there are multiple tabs.
+    /// Toggled by `ToggleVerticalTabs` while in horizontal mode so the
+    /// user can collapse the strip without switching to vertical tabs.
+    horizontal_tabs_collapsed: bool,
     input_bar_visible: bool,
     input_bar_motion: MotionValue,
     /// Tracks whether a modal was open on the last render, so we can
@@ -1530,6 +1535,7 @@ impl ConWorkspace {
             agent_panel_motion: MotionValue::new(if agent_panel_open { 1.0 } else { 0.0 }),
             agent_panel_width,
             tab_strip_motion: MotionValue::new(if has_multiple_tabs { 1.0 } else { 0.0 }),
+            horizontal_tabs_collapsed: false,
             input_bar_visible: session.input_bar_visible,
             input_bar_motion: MotionValue::new(if session.input_bar_visible { 1.0 } else { 0.0 }),
             modal_was_open: false,
@@ -1602,7 +1608,9 @@ impl ConWorkspace {
     }
 
     fn horizontal_tabs_visible(&self) -> bool {
-        matches!(self.tabs_orientation, TabsOrientation::Horizontal) && self.tabs.len() > 1
+        matches!(self.tabs_orientation, TabsOrientation::Horizontal)
+            && self.tabs.len() > 1
+            && !self.horizontal_tabs_collapsed
     }
 
     fn vertical_tabs_active(&self) -> bool {
@@ -5402,6 +5410,11 @@ impl ConWorkspace {
         }
         self.config.appearance.tabs_orientation = orientation;
         self.tabs_orientation = orientation;
+        // When switching away from horizontal tabs, reset the collapsed
+        // state so the strip is visible if the user switches back.
+        if matches!(orientation, TabsOrientation::Vertical) {
+            self.horizontal_tabs_collapsed = false;
+        }
         if persist_config {
             self.sync_settings_panels_tabs_orientation(orientation, cx);
         }
@@ -6970,7 +6983,16 @@ impl ConWorkspace {
             self.save_session(cx);
             cx.notify();
         } else {
-            self.apply_tabs_orientation(TabsOrientation::Vertical, true, cx);
+            // Horizontal-tabs mode: toggle the tab strip collapsed state.
+            // This lets the user hide the strip without switching to
+            // vertical tabs — the strip can be restored with another Cmd+B.
+            self.horizontal_tabs_collapsed = !self.horizontal_tabs_collapsed;
+            if self.sync_tab_strip_motion() {
+                #[cfg(target_os = "macos")]
+                self.arm_top_chrome_snap_guard(cx);
+            }
+            self.save_session(cx);
+            cx.notify();
         }
     }
 
@@ -10952,6 +10974,8 @@ impl Render for ConWorkspace {
             } else {
                 "Expand sidebar"
             }
+        } else if self.horizontal_tabs_collapsed {
+            "Show tab strip"
         } else {
             "Use vertical tabs"
         };

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -6958,12 +6958,20 @@ impl ConWorkspace {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let next = if self.vertical_tabs_active() {
-            TabsOrientation::Horizontal
+        if self.vertical_tabs_active() {
+            // Already in vertical-tabs mode: toggle the sidebar between
+            // collapsed (rail) and pinned (full panel) without switching
+            // to horizontal tabs. This matches the issue #139 expectation
+            // that Cmd+B hides/shows the sidebar rather than falling back
+            // to a horizontal tab strip.
+            self.sidebar.update(cx, |sidebar, cx| {
+                sidebar.toggle_pinned(cx);
+            });
+            self.save_session(cx);
+            cx.notify();
         } else {
-            TabsOrientation::Vertical
-        };
-        self.apply_tabs_orientation(next, true, cx);
+            self.apply_tabs_orientation(TabsOrientation::Vertical, true, cx);
+        }
     }
 
     fn toggle_pane_scope_picker(
@@ -10939,7 +10947,11 @@ impl Render for ConWorkspace {
         );
 
         let vertical_tabs_tooltip = if self.vertical_tabs_active() {
-            "Use horizontal tabs"
+            if self.sidebar.read(cx).is_pinned() {
+                "Collapse sidebar"
+            } else {
+                "Expand sidebar"
+            }
         } else {
             "Use vertical tabs"
         };

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -261,7 +261,7 @@ use crate::{
     NewSurfaceSplitRight, NewTab, NextSurface, NextTab, OpenWorkspaceLayoutWindow, PreviousSurface,
     PreviousTab, Quit, RenameSurface, SelectTab1, SelectTab2, SelectTab3, SelectTab4, SelectTab5,
     SelectTab6, SelectTab7, SelectTab8, SelectTab9, SplitDown, SplitLeft, SplitRight, SplitUp,
-    ToggleAgentPanel, TogglePaneScopePicker, TogglePaneZoom, ToggleVerticalTabs,
+    ToggleAgentPanel, TogglePaneScopePicker, TogglePaneZoom, ToggleVerticalTabs, CollapseSidebar,
 };
 use con_agent::{
     AgentConfig, Conversation, ProviderKind, TerminalExecRequest, TerminalExecResponse,
@@ -407,11 +407,6 @@ pub struct ConWorkspace {
     agent_panel_motion: MotionValue,
     agent_panel_width: f32,
     tab_strip_motion: MotionValue,
-    /// When true, the horizontal tab strip is hidden even though
-    /// `tabs_orientation` is `Horizontal` and there are multiple tabs.
-    /// Toggled by `ToggleVerticalTabs` while in horizontal mode so the
-    /// user can collapse the strip without switching to vertical tabs.
-    horizontal_tabs_collapsed: bool,
     input_bar_visible: bool,
     input_bar_motion: MotionValue,
     /// Tracks whether a modal was open on the last render, so we can
@@ -1535,7 +1530,6 @@ impl ConWorkspace {
             agent_panel_motion: MotionValue::new(if agent_panel_open { 1.0 } else { 0.0 }),
             agent_panel_width,
             tab_strip_motion: MotionValue::new(if has_multiple_tabs { 1.0 } else { 0.0 }),
-            horizontal_tabs_collapsed: false,
             input_bar_visible: session.input_bar_visible,
             input_bar_motion: MotionValue::new(if session.input_bar_visible { 1.0 } else { 0.0 }),
             modal_was_open: false,
@@ -1608,9 +1602,7 @@ impl ConWorkspace {
     }
 
     fn horizontal_tabs_visible(&self) -> bool {
-        matches!(self.tabs_orientation, TabsOrientation::Horizontal)
-            && self.tabs.len() > 1
-            && !self.horizontal_tabs_collapsed
+        matches!(self.tabs_orientation, TabsOrientation::Horizontal) && self.tabs.len() > 1
     }
 
     fn vertical_tabs_active(&self) -> bool {
@@ -5228,6 +5220,9 @@ impl ConWorkspace {
             "toggle-vertical-tabs" => {
                 self.toggle_vertical_tabs(&ToggleVerticalTabs, window, cx);
             }
+            "collapse-sidebar" => {
+                self.collapse_sidebar(&CollapseSidebar, window, cx);
+            }
             "cycle-input-mode" => {
                 self.input_bar.update(cx, |bar, cx| {
                     bar.cycle_mode(window, cx);
@@ -5410,11 +5405,6 @@ impl ConWorkspace {
         }
         self.config.appearance.tabs_orientation = orientation;
         self.tabs_orientation = orientation;
-        // When switching away from horizontal tabs, reset the collapsed
-        // state so the strip is visible if the user switches back.
-        if matches!(orientation, TabsOrientation::Vertical) {
-            self.horizontal_tabs_collapsed = false;
-        }
         if persist_config {
             self.sync_settings_panels_tabs_orientation(orientation, cx);
         }
@@ -6971,29 +6961,28 @@ impl ConWorkspace {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.vertical_tabs_active() {
-            // Already in vertical-tabs mode: toggle the sidebar between
-            // collapsed (rail) and pinned (full panel) without switching
-            // to horizontal tabs. This matches the issue #139 expectation
-            // that Cmd+B hides/shows the sidebar rather than falling back
-            // to a horizontal tab strip.
-            self.sidebar.update(cx, |sidebar, cx| {
-                sidebar.toggle_pinned(cx);
-            });
-            self.save_session(cx);
-            cx.notify();
+        let next = if self.vertical_tabs_active() {
+            TabsOrientation::Horizontal
         } else {
-            // Horizontal-tabs mode: toggle the tab strip collapsed state.
-            // This lets the user hide the strip without switching to
-            // vertical tabs — the strip can be restored with another Cmd+B.
-            self.horizontal_tabs_collapsed = !self.horizontal_tabs_collapsed;
-            if self.sync_tab_strip_motion() {
-                #[cfg(target_os = "macos")]
-                self.arm_top_chrome_snap_guard(cx);
-            }
-            self.save_session(cx);
-            cx.notify();
+            TabsOrientation::Vertical
+        };
+        self.apply_tabs_orientation(next, true, cx);
+    }
+
+    fn collapse_sidebar(
+        &mut self,
+        _: &CollapseSidebar,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.vertical_tabs_active() {
+            return;
         }
+        self.sidebar.update(cx, |sidebar, cx| {
+            sidebar.toggle_pinned(cx);
+        });
+        self.save_session(cx);
+        cx.notify();
     }
 
     fn toggle_pane_scope_picker(
@@ -10969,13 +10958,7 @@ impl Render for ConWorkspace {
         );
 
         let vertical_tabs_tooltip = if self.vertical_tabs_active() {
-            if self.sidebar.read(cx).is_pinned() {
-                "Collapse sidebar"
-            } else {
-                "Expand sidebar"
-            }
-        } else if self.horizontal_tabs_collapsed {
-            "Show tab strip"
+            "Use horizontal tabs"
         } else {
             "Use vertical tabs"
         };
@@ -11330,6 +11313,7 @@ impl Render for ConWorkspace {
                 .on_action(cx.listener(Self::toggle_agent_panel))
                 .on_action(cx.listener(Self::toggle_input_bar))
                 .on_action(cx.listener(Self::toggle_vertical_tabs))
+                .on_action(cx.listener(Self::collapse_sidebar))
                 .on_action(cx.listener(Self::toggle_settings))
                 .on_action(cx.listener(Self::toggle_command_palette))
                 .on_action(cx.listener(Self::new_tab))

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -282,6 +282,14 @@ fn default_toggle_vertical_tabs() -> String {
     // real terminal control character. Ctrl+Shift+B stays app-level.
     "ctrl-shift-b".into()
 }
+#[cfg(target_os = "macos")]
+fn default_collapse_sidebar() -> String {
+    "secondary-shift-b".into()
+}
+#[cfg(not(target_os = "macos"))]
+fn default_collapse_sidebar() -> String {
+    "ctrl-alt-b".into()
+}
 
 #[cfg(target_os = "macos")]
 fn default_new_surface() -> String {
@@ -380,6 +388,7 @@ pub struct KeybindingConfig {
     pub toggle_input_bar: String,
     pub toggle_pane_scope: String,
     pub toggle_vertical_tabs: String,
+    pub collapse_sidebar: String,
     pub new_surface: String,
     pub new_surface_split_right: String,
     pub new_surface_split_down: String,
@@ -414,6 +423,7 @@ impl Default for KeybindingConfig {
             toggle_input_bar: default_toggle_input_bar(),
             toggle_pane_scope: default_toggle_pane_scope(),
             toggle_vertical_tabs: default_toggle_vertical_tabs(),
+            collapse_sidebar: default_collapse_sidebar(),
             new_surface: default_new_surface(),
             new_surface_split_right: default_new_surface_split_right(),
             new_surface_split_down: default_new_surface_split_down(),


### PR DESCRIPTION
Fixes #139

## What changed

### Cmd+B — restored to original behaviour
`ToggleVerticalTabs` (Cmd+B) switches between Horizontal and Vertical tab modes, exactly as before.

### Shift+Cmd+B — new `CollapseSidebar` action
When vertical tabs are active, Shift+Cmd+B toggles the sidebar between **collapsed (rail, 44px)** and **pinned (full panel)**. No-op in horizontal mode.

| Platform | Keybinding |
|---|---|
| macOS | Shift+Cmd+B |
| Windows / Linux | Ctrl+Alt+B |

## Behaviour summary

| Action | Keybinding | Effect |
|---|---|---|
| Toggle tab mode | Cmd+B | Horizontal ↔ Vertical |
| Collapse/expand sidebar | Shift+Cmd+B | Rail ↔ Pinned panel (vertical tabs only) |

## Other changes
- Command palette: new "Collapse/Expand Sidebar" entry (Shift+Cmd+B)
- Settings → Keybindings: new "Collapse/Expand Sidebar" row, user-remappable
- `collapse_sidebar` keybinding field added to `KeybindingConfig` with sane defaults
