### PR TITLE
chore: wording polishment

### DIFF
--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -2700,7 +2700,7 @@ impl SettingsPanel {
                 .child(group_label("Continuity", &theme))
                 .child(card(theme, card_opacity).child(toggle_row(
                     "Restore Terminal Text",
-                    "Keep bounded private terminal text for restart continuity. Layout profiles never include it.",
+                    "Keep terminal text on restart continuity.",
                     Switch::new("restore-terminal-text-toggle")
                         .checked(self.config.appearance.restore_terminal_text)
                         .small()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the "Restore Terminal Text" continuity toggle description in the General settings panel to clearer, more concise wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->