### PR TITLE
docs: add Quick Terminal guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ con is still pre-release, so entries may group related beta work while the produ
   and can return focus to the app you were using before it appeared. It is off
   by default; enable it in Settings -> Keys and use Cmd-Backslash or your chosen
   shortcut.
+- Added public Quick Terminal documentation covering setup, hide/show behavior,
+  live state, destruction, and the difference from Summon / Hide Con.
 - Added **New Window** to the macOS Dock menu, so right-clicking the Dock icon
   can open a fresh Con window without first focusing an existing one.
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Quick controls:
 | Show or hide the bottom input bar | <kbd>⌃</kbd> <kbd>\`</kbd> | <kbd>⌃</kbd> <kbd>\`</kbd> |
 | Show or hide the agent panel | <kbd>⌘</kbd> <kbd>L</kbd> | <kbd>⌃</kbd> <kbd>⇧</kbd> <kbd>L</kbd> |
 | Cycle bottom-bar mode | <kbd>⌘</kbd> <kbd>;</kbd> | <kbd>⌃</kbd> <kbd>;</kbd> |
+| Show or hide Quick Terminal | <kbd>⌘</kbd> <kbd>Backslash</kbd> after enabling | Not available |
 
 - Smart mode decides whether your text is a shell command or an agent request.
 - Command mode runs shell commands. With multiple panes, the pane mini map lets you choose the focused pane, all panes, or a selected set.
@@ -135,6 +136,7 @@ Start here:
 
 - [Install](docs/install.md): get con on macOS, Windows, or Linux.
 - [Quick controls](docs/quick-controls.md): focus switching, agent panel, and command modes.
+- [Quick Terminal](docs/quick-terminal.md): set up the optional macOS drop-down terminal.
 - [Terminal workflows](docs/terminal-workflows.md): tabs, panes, broadcast, pane zoom, links, and surfaces.
 - [Built-in agent](docs/agent.md): use AI help without leaving the terminal.
 - [Settings](docs/settings.md): choose providers, themes, suggestions, skills, and shortcuts.

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Start with the page that matches what you are trying to do.
 | --- | --- |
 | Install con | [Install](install.md) |
 | Learn the main controls | [Quick controls](quick-controls.md) |
+| Open a drop-down terminal from anywhere on macOS | [Quick Terminal](quick-terminal.md) |
 | Work with tabs, panes, broadcast, links, and pane zoom | [Terminal workflows](terminal-workflows.md) |
 | Connect providers, tune appearance, and edit shortcuts | [Settings](settings.md) |
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -13,6 +13,7 @@
         { "label": "Welcome", "path": "docs/README.md", "route": "/docs/" },
         { "label": "Install", "path": "docs/install.md" },
         { "label": "Quick controls", "path": "docs/quick-controls.md" },
+        { "label": "Quick Terminal", "path": "docs/quick-terminal.md" },
         { "label": "Built-in agent", "path": "docs/agent.md" },
         { "label": "Settings", "path": "docs/settings.md" }
       ]

--- a/docs/quick-controls.md
+++ b/docs/quick-controls.md
@@ -44,13 +44,16 @@ to the next action.
 
 ## Quick Terminal on macOS
 
-Quick Terminal is an optional macOS-only floating terminal. Enable it in
+Quick Terminal is an optional macOS-only drop-down terminal. Enable it in
 Settings -> Keys, then use the shortcut to slide down a dedicated Con window
-from the top of the active screen.
+from the top of the active screen, even when another app is frontmost.
 
 It is separate from the main window. Hiding it keeps its live tabs, panes, cwd,
 and scrollback. Closing its last tab or exiting its last shell destroys it, and
 the next shortcut creates a fresh one.
+
+For setup, behavior, and the difference from Summon / Hide Con, see
+[Quick Terminal](quick-terminal.md).
 
 ## A good default flow
 

--- a/docs/quick-terminal.md
+++ b/docs/quick-terminal.md
@@ -1,0 +1,90 @@
+# Quick Terminal
+
+Quick Terminal is a macOS-only drop-down Con window for short terminal work
+from anywhere on the system.
+
+It is off by default. Turn it on only if you want a global shortcut that can
+open a terminal over the app you are using.
+
+## Turn It On
+
+1. Open **Settings**.
+2. Go to **Keys**.
+3. Enable **Quick Terminal**.
+4. Use the default <kbd>⌘</kbd> <kbd>Backslash</kbd> shortcut, or record a
+   different shortcut if that conflicts with your setup.
+
+The shortcut is global. It works when another app is frontmost, as long as Con
+is running.
+
+You can also open it from **View -> Quick Terminal** while Con is active, even
+if the global shortcut is off.
+
+## How It Feels
+
+Press the shortcut and Con slides a dedicated terminal down from the top of the
+active display. Press it again and the window hides. When you hide it with the
+shortcut, Con returns focus to the app you were using before.
+
+Clicking another app also hides Quick Terminal. In that case macOS keeps focus
+on what you clicked.
+
+The window is intentionally simple:
+
+- it has no titlebar or traffic-light buttons
+- it spans the visible width of the active screen
+- it starts at about half the screen height
+- you can drag the bottom edge to change its height while it is alive
+
+## What It Keeps
+
+Quick Terminal is a real Con workspace. As long as you hide it instead of
+closing it, it keeps the things you expect a live terminal to keep:
+
+- tabs
+- panes
+- working directories
+- running shells and TUIs
+- visible scrollback
+
+That makes it useful for small loops: check a server, run a one-off command,
+peek at logs, or keep a scratch shell close without moving your main Con
+windows.
+
+## What Ends It
+
+Hiding is not the same as closing.
+
+If you close the last tab or exit the last shell, the Quick Terminal window is
+destroyed. The next shortcut creates a fresh Quick Terminal from your home
+directory.
+
+Quick Terminal does not keep a separate saved layout, remembered height, or
+private workspace after it is destroyed. If a workspace matters, keep it in a
+normal Con window or save a [workspace profile](workspace-layout-profiles-guide.md).
+
+## Quick Terminal vs Summon / Hide Con
+
+Con has two macOS global-window features. They solve different problems.
+
+| Feature | What it does | Use it when |
+| --- | --- | --- |
+| Quick Terminal | Opens a dedicated top-pinned terminal window. | You want an iTerm-style scratch terminal from any app. |
+| Summon / Hide Con | Shows or hides the normal Con app window. | You want to jump back to your main Con workspace. |
+
+Both are off by default because global shortcuts can collide with launchers,
+window managers, and other terminal apps.
+
+## If the Shortcut Does Nothing
+
+- Make sure Con is running.
+- Make sure **Settings -> Keys -> Quick Terminal** is enabled.
+- Try a different shortcut if another app already owns
+  <kbd>⌘</kbd> <kbd>Backslash</kbd>.
+- If you are recording a shortcut in Settings, Con temporarily suspends its
+  global hotkeys so the shortcut can be captured instead of triggered.
+
+## Platform Support
+
+Quick Terminal is macOS-only. Windows and Linux keep the normal Con window
+model for now.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -131,6 +131,9 @@ it opens a dedicated floating Con window from anywhere, separate from the main
 window. The default shortcut is <kbd>⌘</kbd> <kbd>Backslash</kbd>, and you can
 record a different one if it conflicts with your setup.
 
+For the full behavior, including hide/show state and how it differs from Summon
+/ Hide Con, see [Quick Terminal](quick-terminal.md).
+
 Change shortcuts when the default conflicts with muscle memory. Leave them alone
 when the built-in flow already works. A good setup should reduce decisions, not
 create a private language you have to remember.

--- a/docs/terminal-workflows.md
+++ b/docs/terminal-workflows.md
@@ -31,6 +31,10 @@ there when one visible pane should host several terminal sessions.
 
 When in doubt, open Command Palette and search by the action name.
 
+On macOS, [Quick Terminal](quick-terminal.md) can give you a separate
+drop-down terminal from anywhere on the system. It is optional and off by
+default.
+
 ## Tabs and windows
 
 Use a new tab when the work belongs to the same window. Use a new window when


### PR DESCRIPTION
## Summary

- Add a public Quick Terminal guide for macOS users.
- Link the guide from README, hosted docs navigation, Quick controls, Settings, and Terminal workflows.
- Update the beta 62 changelog entry so the shipped Quick Terminal feature points to user-facing documentation.

## Test Plan

- [x] `python3 scripts/docs/validate-manifest.py`
- [x] `git diff --check`
- [x] local markdown link check for README, CHANGELOG, and docs pages
