### PR TITLE
fix: revalidate macOS surface geometry on focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ con is still pre-release, so entries may group related beta work while the produ
 
 **macOS**
 
+- Added **Quick Terminal** to the command palette on macOS, matching the View
+  menu entry so it can be opened while Con is frontmost even when the global
+  hotkey is disabled.
 - Fixed pane-local surface geometry drift that could make TUI output appear
   clipped after switching between surfaces or changing pane layouts. Activating
   a surface now revalidates Ghostty's embedded terminal size against the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,18 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ## `v0.1.0-beta.63`
 
-### Fixed
+### Added
 
 **macOS**
 
 - Added **Quick Terminal** to the command palette on macOS, matching the View
   menu entry so it can be opened while Con is frontmost even when the global
   hotkey is disabled.
+
+### Fixed
+
+**macOS**
+
 - Fixed pane-local surface geometry drift that could make TUI output appear
   clipped after switching between surfaces or changing pane layouts. Activating
   a surface now revalidates Ghostty's embedded terminal size against the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
-## `v0.1.0-beta.63` - 2026-05-06
+## `v0.1.0-beta.63`
 
 ### Fixed
 
@@ -14,6 +14,21 @@ con is still pre-release, so entries may group related beta work while the produ
   clipped after switching between surfaces or changing pane layouts. Activating
   a surface now revalidates Ghostty's embedded terminal size against the
   current pane before exposing it.
+
+**Linux**
+
+- Fixed Linux preview terminal rows wrapping like prose in split panes. Rows now
+  stay on one fixed terminal line and clip at the pane edge, which prevents TUI
+  layouts from reflowing into later rows.
+
+### Changed
+
+**Developer Experience**
+
+- Added low-noise macOS surface geometry diagnostics behind
+  `CON_GHOSTTY_PROFILE`, so reproduced pane/surface clipping reports can include
+  a log file and `con-cli surfaces list` snapshot without requiring a special
+  debug build.
 
 ## `v0.1.0-beta.62` - 2026-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## `v0.1.0-beta.63` - 2026-05-06
+
+### Fixed
+
+**macOS**
+
+- Fixed pane-local surface geometry drift that could make TUI output appear
+  clipped after switching between surfaces or changing pane layouts. Activating
+  a surface now revalidates Ghostty's embedded terminal size against the
+  current pane before exposing it.
+
 ## `v0.1.0-beta.62` - 2026-05-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Quick controls:
 - Command mode runs shell commands. With multiple panes, the pane mini map lets you choose the focused pane, all panes, or a selected set.
 - Agent mode sends text directly to the built-in agent.
 
+Quick Terminal is off by default. On macOS, enable its global shortcut in
+Settings -> Keys, or open it from the command palette / View menu while Con is
+frontmost.
+
 ## Install
 
 **macOS, Homebrew**

--- a/crates/con-app/src/command_palette.rs
+++ b/crates/con-app/src/command_palette.rs
@@ -66,6 +66,13 @@ const PALETTE_ACTIONS: &[PaletteAction] = &[
         shortcut: "secondary-n",
         category: "App",
     },
+    #[cfg(target_os = "macos")]
+    PaletteAction {
+        id: "quick-terminal",
+        label: "Quick Terminal",
+        shortcut: "",
+        category: "App",
+    },
     PaletteAction {
         id: "new-tab",
         label: "New Tab",

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -882,9 +882,14 @@ impl GhosttyView {
 
     #[cfg(target_os = "macos")]
     fn update_frame(&mut self, bounds: Bounds<Pixels>) {
+        // `last_bounds` is Con's layout cache, not Ghostty's protocol state.
+        // Pane-local surfaces can be hidden, focused, and resized without
+        // repainting every sibling; always verify the embedded surface still
+        // reports the pixel size that maps to these bounds before skipping.
         if self.last_bounds.as_ref() == Some(&bounds)
             && !self.awaiting_first_layout_visibility
             && !self.pending_native_layout
+            && self.terminal_matches_bounds(bounds)
         {
             return;
         }
@@ -1079,6 +1084,16 @@ impl GhosttyView {
                 .max(1.0)
                 .round() as u32,
         )
+    }
+
+    #[cfg(target_os = "macos")]
+    fn terminal_matches_bounds(&self, bounds: Bounds<Pixels>) -> bool {
+        let Some(ref terminal) = self.terminal else {
+            return false;
+        };
+        let (width_px, height_px) = self.surface_size_in_backing_pixels(bounds);
+        let size = terminal.size();
+        size.width_px == width_px && size.height_px == height_px
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -1093,7 +1093,22 @@ impl GhosttyView {
         };
         let (width_px, height_px) = self.surface_size_in_backing_pixels(bounds);
         let size = terminal.size();
-        size.width_px == width_px && size.height_px == height_px
+        let matches = size.width_px == width_px && size.height_px == height_px;
+        if !matches && perf_trace_enabled() {
+            log::info!(
+                target: "con::perf",
+                "surface geometry mismatch terminal_px={}x{} terminal_grid={}x{} expected_px={}x{} logical_pt={:.1}x{:.1}",
+                size.width_px,
+                size.height_px,
+                size.columns,
+                size.rows,
+                width_px,
+                height_px,
+                bounds.size.width.as_f32(),
+                bounds.size.height.as_f32()
+            );
+        }
+        matches
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -257,11 +257,12 @@ use crate::ghostty_view::{
 };
 use crate::{
     AddWorkspaceLayoutTabs, ClearRestoredTerminalHistory, ClearTerminal, ClosePane, CloseSurface,
-    CloseTab, CycleInputMode, ExportWorkspaceLayout, FocusInput, NewSurface, NewSurfaceSplitDown,
-    NewSurfaceSplitRight, NewTab, NextSurface, NextTab, OpenWorkspaceLayoutWindow, PreviousSurface,
-    PreviousTab, Quit, RenameSurface, SelectTab1, SelectTab2, SelectTab3, SelectTab4, SelectTab5,
-    SelectTab6, SelectTab7, SelectTab8, SelectTab9, SplitDown, SplitLeft, SplitRight, SplitUp,
-    ToggleAgentPanel, TogglePaneScopePicker, TogglePaneZoom, ToggleVerticalTabs, CollapseSidebar,
+    CloseTab, CollapseSidebar, CycleInputMode, ExportWorkspaceLayout, FocusInput, NewSurface,
+    NewSurfaceSplitDown, NewSurfaceSplitRight, NewTab, NextSurface, NextTab,
+    OpenWorkspaceLayoutWindow, PreviousSurface, PreviousTab, Quit, RenameSurface, SelectTab1,
+    SelectTab2, SelectTab3, SelectTab4, SelectTab5, SelectTab6, SelectTab7, SelectTab8, SelectTab9,
+    SplitDown, SplitLeft, SplitRight, SplitUp, ToggleAgentPanel, TogglePaneScopePicker,
+    TogglePaneZoom, ToggleVerticalTabs,
 };
 use con_agent::{
     AgentConfig, Conversation, ProviderKind, TerminalExecRequest, TerminalExecResponse,
@@ -3551,14 +3552,30 @@ impl ConWorkspace {
                                     return;
                                 }
                             };
+                            let active_tab_needs_focus_sync = tab_idx == self.active_tab;
+                            #[cfg(target_os = "macos")]
+                            let should_notify = changed || active_tab_needs_focus_sync;
+                            #[cfg(not(target_os = "macos"))]
+                            let should_notify = changed;
+
+                            #[cfg(target_os = "macos")]
+                            if active_tab_needs_focus_sync {
+                                self.mark_tab_terminal_native_layout_pending(tab_idx, cx);
+                                self.notify_tab_terminal_views(tab_idx, cx);
+                                self.sync_active_terminal_focus_states(cx);
+                                self.schedule_active_terminal_focus(cx);
+                            }
+                            #[cfg(not(target_os = "macos"))]
+                            if changed && active_tab_needs_focus_sync {
+                                self.sync_active_tab_native_view_visibility(cx);
+                                self.sync_active_terminal_focus_states(cx);
+                                self.schedule_active_terminal_focus(cx);
+                            }
                             if changed {
-                                if tab_idx == self.active_tab {
-                                    self.sync_active_tab_native_view_visibility(cx);
-                                    self.sync_active_terminal_focus_states(cx);
-                                    self.schedule_active_terminal_focus(cx);
-                                }
                                 self.sync_sidebar(cx);
                                 self.save_session(cx);
+                            }
+                            if should_notify {
                                 cx.notify();
                             }
                             Self::send_control_result(
@@ -9630,18 +9647,39 @@ impl ConWorkspace {
             .pane_tree
             .focus_surface(surface_id);
         if !changed {
-            return;
+            #[cfg(not(target_os = "macos"))]
+            {
+                return;
+            }
+            #[cfg(target_os = "macos")]
+            if !self.tabs[self.active_tab]
+                .pane_tree
+                .surface_infos(None)
+                .into_iter()
+                .any(|surface| surface.surface_id == surface_id)
+            {
+                return;
+            }
         }
+        #[cfg(target_os = "macos")]
+        self.mark_active_tab_terminal_native_layout_pending(cx);
+        #[cfg(target_os = "macos")]
+        self.notify_active_tab_terminal_views(cx);
         let terminal = self.tabs[self.active_tab]
             .pane_tree
             .focused_terminal()
             .clone();
         terminal.ensure_surface(window, cx);
+        #[cfg(target_os = "macos")]
+        self.sync_active_tab_native_view_visibility_now_or_after_layout(false, window, cx);
+        #[cfg(not(target_os = "macos"))]
         self.sync_active_tab_native_view_visibility(cx);
-        self.sync_sidebar(cx);
+        if changed {
+            self.sync_sidebar(cx);
+            self.save_session(cx);
+        }
         terminal.focus(window, cx);
         self.sync_active_terminal_focus_states(cx);
-        self.save_session(cx);
         cx.notify();
     }
 

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -1706,16 +1706,21 @@ impl ConWorkspace {
         }
     }
 
-    fn hide_active_tab_native_views_not_visible_after_focus(&self, cx: &App) {
+    fn hide_active_tab_native_views_not_visible_after_layout(&self, cx: &App) {
         if !self.has_active_tab() {
             return;
         }
         let tab = &self.tabs[self.active_tab];
         let zoomed_pane_id = tab.pane_tree.zoomed_pane_id();
+        let focused_pane_id = tab.pane_tree.focused_pane_id();
 
         for surface in tab.pane_tree.surface_infos(None) {
             let pane_visible = zoomed_pane_id.is_none_or(|zoomed| zoomed == surface.pane_id);
-            if !pane_visible || !surface.is_active {
+            // Same-pane surface switches should keep the old surface visible
+            // until the newly active one has a committed frame. Hiding it here
+            // creates a one-frame blank pane. Panes outside the focused layout
+            // cannot stay visible because their native frames would be stale.
+            if !pane_visible || surface.pane_id != focused_pane_id {
                 surface.terminal.set_native_view_visible(false, cx);
             }
         }
@@ -1762,7 +1767,7 @@ impl ConWorkspace {
         // surfaces that are definitely no longer visible immediately, but
         // delay revealing newly-visible surfaces until GPUI has committed one
         // layout frame so they do not flash at stale split coordinates.
-        self.hide_active_tab_native_views_not_visible_after_focus(cx);
+        self.hide_active_tab_native_views_not_visible_after_layout(cx);
         cx.on_next_frame(window, |_workspace, window, cx| {
             cx.notify();
             cx.on_next_frame(window, |workspace, _window, cx| {

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -5139,6 +5139,10 @@ impl ConWorkspace {
             "new-window" => {
                 cx.dispatch_action(&crate::NewWindow);
             }
+            #[cfg(target_os = "macos")]
+            "quick-terminal" => {
+                cx.dispatch_action(&crate::ToggleQuickTerminal);
+            }
             "toggle-agent" => {
                 self.toggle_agent_panel(&ToggleAgentPanel, window, cx);
             }

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -1957,7 +1957,7 @@ impl ConWorkspace {
         });
     }
 
-    fn schedule_active_terminal_focus(&self, cx: &mut Context<Self>) {
+    fn schedule_active_terminal_focus(&self, was_zoomed: bool, cx: &mut Context<Self>) {
         let window_handle = self.window_handle;
         let workspace_handle = self.workspace_handle.clone();
         cx.defer(move |cx| {
@@ -1972,7 +1972,9 @@ impl ConWorkspace {
                             .focused_terminal()
                             .clone();
                         terminal.ensure_surface(window, cx);
-                        workspace.sync_active_tab_native_view_visibility(cx);
+                        workspace.sync_active_tab_native_view_visibility_now_or_after_layout(
+                            was_zoomed, window, cx,
+                        );
                         terminal.focus(window, cx);
                         workspace.sync_active_terminal_focus_states(cx);
                         cx.notify();
@@ -3541,6 +3543,8 @@ impl ConWorkspace {
                     Ok(tab_idx) => match self.resolve_surface_target_for_tab(tab_idx, target) {
                         Ok(resolved) => {
                             let surface_id = resolved.surface_id;
+                            let was_zoomed =
+                                self.tabs[tab_idx].pane_tree.zoomed_pane_id().is_some();
                             let changed = self.tabs[tab_idx].pane_tree.focus_surface(surface_id);
                             let resolved = match self.resolve_surface_target_for_tab(
                                 tab_idx,
@@ -3552,30 +3556,24 @@ impl ConWorkspace {
                                     return;
                                 }
                             };
+                            #[cfg(target_os = "macos")]
                             let active_tab_needs_focus_sync = tab_idx == self.active_tab;
-                            #[cfg(target_os = "macos")]
-                            let should_notify = changed || active_tab_needs_focus_sync;
                             #[cfg(not(target_os = "macos"))]
-                            let should_notify = changed;
+                            let active_tab_needs_focus_sync = changed && tab_idx == self.active_tab;
 
-                            #[cfg(target_os = "macos")]
                             if active_tab_needs_focus_sync {
+                                #[cfg(target_os = "macos")]
                                 self.mark_tab_terminal_native_layout_pending(tab_idx, cx);
+                                #[cfg(target_os = "macos")]
                                 self.notify_tab_terminal_views(tab_idx, cx);
                                 self.sync_active_terminal_focus_states(cx);
-                                self.schedule_active_terminal_focus(cx);
-                            }
-                            #[cfg(not(target_os = "macos"))]
-                            if changed && active_tab_needs_focus_sync {
-                                self.sync_active_tab_native_view_visibility(cx);
-                                self.sync_active_terminal_focus_states(cx);
-                                self.schedule_active_terminal_focus(cx);
+                                self.schedule_active_terminal_focus(was_zoomed, cx);
                             }
                             if changed {
                                 self.sync_sidebar(cx);
                                 self.save_session(cx);
                             }
-                            if should_notify {
+                            if changed || active_tab_needs_focus_sync {
                                 cx.notify();
                             }
                             Self::send_control_result(
@@ -9643,6 +9641,10 @@ impl ConWorkspace {
         if !self.has_active_tab() {
             return;
         }
+        let was_zoomed = self.tabs[self.active_tab]
+            .pane_tree
+            .zoomed_pane_id()
+            .is_some();
         let changed = self.tabs[self.active_tab]
             .pane_tree
             .focus_surface(surface_id);
@@ -9671,7 +9673,7 @@ impl ConWorkspace {
             .clone();
         terminal.ensure_surface(window, cx);
         #[cfg(target_os = "macos")]
-        self.sync_active_tab_native_view_visibility_now_or_after_layout(false, window, cx);
+        self.sync_active_tab_native_view_visibility_now_or_after_layout(was_zoomed, window, cx);
         #[cfg(not(target_os = "macos"))]
         self.sync_active_tab_native_view_visibility(cx);
         if changed {

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -2405,6 +2405,7 @@ impl ConWorkspace {
         if tab_is_active {
             terminal.focus(window, cx);
             self.sync_active_terminal_focus_states(cx);
+            #[cfg(not(target_os = "macos"))]
             self.sync_active_tab_native_view_visibility(cx);
         } else {
             terminal.set_focus_state(false, cx);

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -1958,6 +1958,9 @@ impl ConWorkspace {
     }
 
     fn schedule_active_terminal_focus(&self, was_zoomed: bool, cx: &mut Context<Self>) {
+        #[cfg(not(target_os = "macos"))]
+        let _ = was_zoomed;
+
         let window_handle = self.window_handle;
         let workspace_handle = self.workspace_handle.clone();
         cx.defer(move |cx| {
@@ -9648,6 +9651,9 @@ impl ConWorkspace {
             .pane_tree
             .zoomed_pane_id()
             .is_some();
+        #[cfg(not(target_os = "macos"))]
+        let _ = was_zoomed;
+
         let changed = self.tabs[self.active_tab]
             .pane_tree
             .focus_surface(surface_id);

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -1972,9 +1972,12 @@ impl ConWorkspace {
                             .focused_terminal()
                             .clone();
                         terminal.ensure_surface(window, cx);
+                        #[cfg(target_os = "macos")]
                         workspace.sync_active_tab_native_view_visibility_now_or_after_layout(
                             was_zoomed, window, cx,
                         );
+                        #[cfg(not(target_os = "macos"))]
+                        workspace.sync_active_tab_native_view_visibility(cx);
                         terminal.focus(window, cx);
                         workspace.sync_active_terminal_focus_states(cx);
                         cx.notify();

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -1718,9 +1718,9 @@ impl ConWorkspace {
             let pane_visible = zoomed_pane_id.is_none_or(|zoomed| zoomed == surface.pane_id);
             // Same-pane surface switches should keep the old surface visible
             // until the newly active one has a committed frame. Hiding it here
-            // creates a one-frame blank pane. Panes outside the focused layout
-            // cannot stay visible because their native frames would be stale.
-            if !pane_visible || surface.pane_id != focused_pane_id {
+            // creates a one-frame blank pane. Active surfaces in other visible
+            // panes should also stay visible; they are not leaving the layout.
+            if !pane_visible || (!surface.is_active && surface.pane_id != focused_pane_id) {
                 surface.terminal.set_native_view_visible(false, cx);
             }
         }

--- a/crates/con-app/src/workspace.rs
+++ b/crates/con-app/src/workspace.rs
@@ -1706,17 +1706,16 @@ impl ConWorkspace {
         }
     }
 
-    fn hide_active_tab_native_views_not_in_layout(&self, cx: &App) {
+    fn hide_active_tab_native_views_not_visible_after_focus(&self, cx: &App) {
         if !self.has_active_tab() {
             return;
         }
         let tab = &self.tabs[self.active_tab];
-        let Some(zoomed_pane_id) = tab.pane_tree.zoomed_pane_id() else {
-            return;
-        };
+        let zoomed_pane_id = tab.pane_tree.zoomed_pane_id();
 
         for surface in tab.pane_tree.surface_infos(None) {
-            if surface.pane_id != zoomed_pane_id || !surface.is_active {
+            let pane_visible = zoomed_pane_id.is_none_or(|zoomed| zoomed == surface.pane_id);
+            if !pane_visible || !surface.is_active {
                 surface.terminal.set_native_view_visible(false, cx);
             }
         }
@@ -1759,11 +1758,11 @@ impl ConWorkspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        // Native Ghostty NSViews live outside GPUI's element tree. Hide panes
-        // that are definitely leaving the layout immediately, but delay
-        // revealing newly-visible panes until GPUI has committed one layout
-        // frame so they do not flash at stale split coordinates.
-        self.hide_active_tab_native_views_not_in_layout(cx);
+        // Native Ghostty NSViews live outside GPUI's element tree. Hide
+        // surfaces that are definitely no longer visible immediately, but
+        // delay revealing newly-visible surfaces until GPUI has committed one
+        // layout frame so they do not flash at stale split coordinates.
+        self.hide_active_tab_native_views_not_visible_after_focus(cx);
         cx.on_next_frame(window, |_workspace, window, cx| {
             cx.notify();
             cx.on_next_frame(window, |workspace, _window, cx| {

--- a/docs/impl/pane-surfaces.md
+++ b/docs/impl/pane-surfaces.md
@@ -232,6 +232,11 @@ closes.
   inactive surfaces to the visible terminal host bounds even while they are not
   rendered, so TUI agents that start in background surfaces see the correct
   rows and columns before focus moves to them.
+- On macOS, surface focus is also a native geometry checkpoint. Activating a
+  hidden surface must revalidate the embedded Ghostty surface size against the
+  current pane bounds before exposing it, because rows and columns are part of
+  the TUI protocol. Selecting the already-active surface runs the same
+  checkpoint.
 - Tab, pane, window, and app close paths tear down every surface, not just the
   active surface.
 - If a non-last surface exits, Con removes only that surface.

--- a/docs/impl/pane-surfaces.md
+++ b/docs/impl/pane-surfaces.md
@@ -243,6 +243,32 @@ closes.
 - If the last surface in a pane exits, Con follows the existing pane close
   escalation: close pane, then close tab, then close the workspace window.
 
+## Debugging Geometry Drift
+
+If a macOS user reports that a TUI is clipped after pane or surface operations,
+ask for one opt-in diagnostic run before guessing at the layout path. A normal
+beta/dev build is enough; no special instrumented build is required.
+
+For an installed beta app:
+
+```bash
+CON_LOG_FILE="$HOME/Desktop/con-surface-geometry.log" \
+CON_GHOSTTY_PROFILE=1 \
+RUST_LOG=con::perf=info,con_ghostty::perf=info,con=warn,con_core=warn,con_agent=warn \
+"/Applications/con Beta.app/Contents/MacOS/con"
+```
+
+After reproducing the clipping, capture the live surface state:
+
+```bash
+con-cli --json surfaces list > "$HOME/Desktop/con-surfaces.json"
+```
+
+Ask for both files privately if paths or terminal titles are sensitive. Useful
+signals in the log are `surface geometry mismatch`, `surface resize request`,
+and `update_frame`; together with `con-surfaces.json`, they show whether the
+visible pane bounds, Ghostty pixel size, and TUI rows/columns agree.
+
 ## Current Limit
 
 Session restore persists the split layout and active surface cwd, matching the

--- a/docs/quick-controls.md
+++ b/docs/quick-controls.md
@@ -48,6 +48,9 @@ Quick Terminal is an optional macOS-only drop-down terminal. Enable it in
 Settings -> Keys, then use the shortcut to slide down a dedicated Con window
 from the top of the active screen, even when another app is frontmost.
 
+While Con is frontmost, you can also open Quick Terminal from the command
+palette or **View -> Quick Terminal** without enabling the global shortcut.
+
 It is separate from the main window. Hiding it keeps its live tabs, panes, cwd,
 and scrollback. Closing its last tab or exiting its last shell destroys it, and
 the next shortcut creates a fresh one.

--- a/docs/quick-terminal.md
+++ b/docs/quick-terminal.md
@@ -17,8 +17,8 @@ open a terminal over the app you are using.
 The shortcut is global. It works when another app is frontmost, as long as Con
 is running.
 
-You can also open it from **View -> Quick Terminal** while Con is active, even
-if the global shortcut is off.
+You can also open it from **View -> Quick Terminal** or the command palette
+while Con is active, even if the global shortcut is off.
 
 ## How It Feels
 

--- a/postmortem/2026-05-05-tui-scaling-linux.md
+++ b/postmortem/2026-05-05-tui-scaling-linux.md
@@ -1,15 +1,16 @@
 # TUI text wrapping incorrectly in Linux split panes
 
 **Date**: 2026-05-05
-**Issue**: #142
+**Issue**: #142 triage, Linux preview side fix
 
 ## What happened
 
-On Linux, TUI applications (htop, vim, less, etc.) displayed garbled
-layouts in split panes. Continuous text runs like `12345` were broken
-across lines — e.g. `abcde, 123` on one line and `45` on the next —
-instead of being clipped at the pane edge. The same TUI in Ghostty's
-own split rendered correctly.
+While triaging #142, we found a separate Linux preview bug: TUI
+applications (htop, vim, less, etc.) displayed garbled layouts in split
+panes. Continuous text runs like `12345` were broken across lines, for
+example `abcde, 123` on one line and `45` on the next, instead of being
+clipped at the pane edge. The same TUI in Ghostty's own split rendered
+correctly.
 
 ## Root cause
 

--- a/postmortem/2026-05-06-pane-surface-geometry-drift.md
+++ b/postmortem/2026-05-06-pane-surface-geometry-drift.md
@@ -31,6 +31,9 @@ from fresh layout.
 - Re-focusing the already-active surface also runs this geometry checkpoint, so
   a user or orchestrator can repair a drifted pane by selecting the surface it
   is already using.
+- Surface focus preserves Con's zoom/layout visibility sequencing. If focusing
+  a surface clears a pane zoom, native visibility waits for the layout handoff
+  instead of exposing a stale AppKit frame.
 - `GhosttyView::update_frame` no longer trusts cached bounds alone. It also
   checks that Ghostty's embedded surface reports the backing pixel size implied
   by the current GPUI bounds before taking the fast early-return.

--- a/postmortem/2026-05-06-pane-surface-geometry-drift.md
+++ b/postmortem/2026-05-06-pane-surface-geometry-drift.md
@@ -44,11 +44,35 @@ Terminal size is part of the TUI protocol, not presentation. Any place that
 activates a hidden live terminal must be treated as a geometry checkpoint, even
 if the pane rectangle itself did not visibly change.
 
+PR #143 fixed a separate Linux preview renderer bug discovered during the same
+issue triage: GPUI text rows were wrapping like prose. That fix is still valid,
+but it is distinct from Jay's macOS report, which involved a live embedded
+Ghostty surface whose pixel size could drift from the visible pane.
+
+## Diagnostics
+
+If this reproduces again on macOS, use a normal beta/dev build with opt-in
+geometry logs instead of shipping a special debug build first:
+
+```bash
+CON_LOG_FILE="$HOME/Desktop/con-surface-geometry.log" \
+CON_GHOSTTY_PROFILE=1 \
+RUST_LOG=con::perf=info,con_ghostty::perf=info,con=warn,con_core=warn,con_agent=warn \
+"/Applications/con Beta.app/Contents/MacOS/con"
+```
+
+Then capture:
+
+```bash
+con-cli --json surfaces list > "$HOME/Desktop/con-surfaces.json"
+```
+
+The high-signal lines are `surface geometry mismatch`, `surface resize request`,
+and `update_frame`. If those do not explain the drift, a dev-channel build can
+add narrower instrumentation without making beta/stable noisy.
+
 ## Follow-Ups
 
 - Add a control-plane E2E for `surfaces.create`, `surfaces.focus`, pane split
   resize, then `surfaces.list`, asserting all surfaces in the pane report the
   same grid size.
-- Add a compact debug command or documented recipe for issue reports:
-  `CON_GHOSTTY_PROFILE=1 RUST_LOG=con::perf=info,con=debug` plus
-  `con-cli --json surfaces list`.

--- a/postmortem/2026-05-06-pane-surface-geometry-drift.md
+++ b/postmortem/2026-05-06-pane-surface-geometry-drift.md
@@ -1,0 +1,51 @@
+# Pane Surface Geometry Drift
+
+## What Happened
+
+Issue #142 reported TUI text being clipped after working with panes and
+pane-local surfaces. The same TUI looked correct after fully closing and
+reopening Con, which pointed to state drift in the live layout path rather than
+an application-level wrapping problem.
+
+## Root Cause
+
+Con keeps two pieces of geometry in sync on macOS:
+
+- GPUI pane bounds, which decide where a pane is visible.
+- Ghostty surface size, which decides the PTY rows and columns a TUI sees.
+
+The hidden-surface fix from May 2 kept inactive surfaces resized while they
+were not visible, but the focus path still treated surface activation mostly as
+a visibility/focus change. If a surface's cached bounds matched the pane while
+Ghostty's actual pixel size had drifted, `update_frame` could return early and
+skip the resize that sends the corrected rows/columns to the TUI.
+
+That explains the symptom: a TUI can keep rendering for a wider grid than the
+visible pane, so text appears cut off until a restart creates every surface
+from fresh layout.
+
+## Fix Applied
+
+- Surface focus now marks the active tab's native terminal layout as pending
+  and notifies terminal views before changing native visibility.
+- Re-focusing the already-active surface also runs this geometry checkpoint, so
+  a user or orchestrator can repair a drifted pane by selecting the surface it
+  is already using.
+- `GhosttyView::update_frame` no longer trusts cached bounds alone. It also
+  checks that Ghostty's embedded surface reports the backing pixel size implied
+  by the current GPUI bounds before taking the fast early-return.
+
+## What We Learned
+
+Terminal size is part of the TUI protocol, not presentation. Any place that
+activates a hidden live terminal must be treated as a geometry checkpoint, even
+if the pane rectangle itself did not visibly change.
+
+## Follow-Ups
+
+- Add a control-plane E2E for `surfaces.create`, `surfaces.focus`, pane split
+  resize, then `surfaces.list`, asserting all surfaces in the pane report the
+  same grid size.
+- Add a compact debug command or documented recipe for issue reports:
+  `CON_GHOSTTY_PROFILE=1 RUST_LOG=con::perf=info,con=debug` plus
+  `con-cli --json surfaces list`.


### PR DESCRIPTION
## Summary

Refs #142.

#142 should stay open after this merges so Jay can validate the beta build against the original flow.

This treats pane-local surface focus as a macOS native geometry checkpoint. The issue looked like TUI wrapping at first, but the close/reopen recovery pointed to drift between Con-owned GPUI pane bounds and Ghostty's embedded surface size. If Ghostty kept an old pixel/grid size while Con thought the bounds were unchanged, TUIs could render for the wrong column count and appear clipped.

PR #143 fixed a separate Linux preview row-wrapping bug discovered during the same triage. This PR covers the macOS live-surface drift and records both fixes in the next beta changelog.

## Changes

- Verify Ghostty's actual embedded surface pixel size before `GhosttyView::update_frame` takes the cached-bounds early return.
- On macOS, mark terminal native layout pending when a surface is focused, including re-focusing the already-active surface, so users/orchestrators can self-heal a drifted surface.
- Sequence native visibility so inactive/stale surfaces do not flash at old coordinates, while same-pane switches and other active visible panes stay visible until the newly active surface has a committed frame.
- Preserve existing zoom/layout visibility sequencing when surface focus clears pane zoom.
- Keep Windows/Linux behavior unchanged outside the existing changed-surface focus path. The new geometry checkpoint is guarded behind `target_os = "macos"`.
- Add opt-in macOS surface-geometry diagnostics behind `CON_GHOSTTY_PROFILE`, documented with `CON_LOG_FILE` so reproduced user reports can attach a log file.
- Add Quick Terminal to the macOS command palette, routing through the existing `ToggleQuickTerminal` action.
- Document the surface lifecycle rule, update the beta.63 changelog, clarify the Linux side-fix postmortem, and add a postmortem for the macOS failure mode.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `python3 scripts/docs/validate-manifest.py`
- `cargo check -p con-core -p con-cli -p con-agent -p con-terminal -p con-ghostty`
- `cargo check -p con`
- `cargo check -p con --no-default-features --features con/bin-con-app`
- `cargo test -p con-core -p con-cli -p con-agent -p con-terminal`

## Manual QA to Run

- macOS: create multiple surfaces in one pane, split the pane, switch/re-focus surfaces, then run `pi tui` or another wrapping TUI and verify it uses the visible pane width.
- macOS zoom case: zoom a pane, focus a surface in another pane through the control plane, and verify the native terminal view does not flash at stale geometry.
- macOS command palette: open the command palette, search "Quick Terminal", and verify it opens/hides the Quick Terminal while Con is frontmost.
- If a user reports drift again, launch the installed beta with `CON_LOG_FILE`, `CON_GHOSTTY_PROFILE=1`, and `RUST_LOG=con::perf=info,con_ghostty::perf=info,con=warn,con_core=warn,con_agent=warn`, then capture `con-cli --json surfaces list`.
