### PR TITLE
Fix macOS Ghostty display scale sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ### Fixed
 
+**macOS**
+
+- Fixed embedded Ghostty surface scale sync when moving a window between Retina
+  and non-Retina displays. Existing panes now update display id, backing scale,
+  layer scale, and pixel size together instead of keeping stale cell metrics.
+
 **Panes**
 
 - Fixed pane-drag preview cleanup so canceled or completed drags do not leave a

--- a/crates/con-app/build.rs
+++ b/crates/con-app/build.rs
@@ -39,6 +39,7 @@ fn main() {
             .file("src/objc/sparkle_trampoline.m")
             .file("src/objc/global_hotkey_trampoline.m")
             .file("src/objc/quick_terminal_trampoline.m")
+            .file("src/objc/ghostty_surface_trampoline.m")
             .flag("-fobjc-arc")
             .flag("-fmodules")
             .compile("con_objc_trampolines");
@@ -46,6 +47,7 @@ fn main() {
         println!("cargo:rerun-if-changed=src/objc/sparkle_trampoline.m");
         println!("cargo:rerun-if-changed=src/objc/global_hotkey_trampoline.m");
         println!("cargo:rerun-if-changed=src/objc/quick_terminal_trampoline.m");
+        println!("cargo:rerun-if-changed=src/objc/ghostty_surface_trampoline.m");
         println!("cargo:rustc-link-lib=framework=Carbon");
     }
 

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -64,9 +64,32 @@ static NATIVE_TRANSITION_UNDERLAY_OWNERS_ASSOCIATION_KEY: u8 = 0;
 static NEXT_NATIVE_TRANSITION_OWNER_ID: AtomicU64 = AtomicU64::new(1);
 
 #[cfg(target_os = "macos")]
+#[derive(Debug, Clone, Copy)]
+struct NativeBackingSync {
+    scale_x: f64,
+    scale_y: f64,
+    width_px: u32,
+    height_px: u32,
+}
+
+#[cfg(target_os = "macos")]
 unsafe extern "C" {
     fn objc_getAssociatedObject(object: id, key: *const c_void) -> id;
     fn objc_setAssociatedObject(object: id, key: *const c_void, value: id, policy: usize);
+    fn con_ghostty_surface_install_backing_observer(view: *mut c_void, surface: *mut c_void);
+    fn con_ghostty_surface_remove_backing_observer(view: *mut c_void);
+    fn con_ghostty_surface_sync_backing(
+        view: *mut c_void,
+        surface: *mut c_void,
+        logical_width: f64,
+        logical_height: f64,
+        fallback_scale: f64,
+        out_scale_x: *mut f64,
+        out_scale_y: *mut f64,
+        out_width: *mut u32,
+        out_height: *mut u32,
+        out_display_id: *mut u32,
+    ) -> bool;
 }
 
 #[cfg(target_os = "macos")]
@@ -122,6 +145,8 @@ pub struct GhosttyView {
     initialized: bool,
     last_bounds: Option<Bounds<Pixels>>,
     scale_factor: f32,
+    #[cfg(target_os = "macos")]
+    display_id: Option<u32>,
     last_title: Option<String>,
     last_cwd: Option<String>,
     /// Data queued for the PTY before the surface was created.
@@ -196,6 +221,8 @@ impl GhosttyView {
             initialized: false,
             last_bounds: None,
             scale_factor: 1.0,
+            #[cfg(target_os = "macos")]
+            display_id: None,
             last_title: None,
             last_cwd: cwd,
             pending_write: None,
@@ -394,6 +421,11 @@ impl GhosttyView {
             );
         }
         self.native_underlay_view = None;
+        if let Some(nsview) = self.nsview {
+            unsafe {
+                con_ghostty_surface_remove_backing_observer(nsview as *mut c_void);
+            }
+        }
         if let Some(host_view) = self.host_view.take() {
             unsafe {
                 let superview: id = msg_send![host_view, superview];
@@ -551,7 +583,7 @@ impl GhosttyView {
             return;
         }
 
-        self.scale_factor = window.scale_factor();
+        self.scale_factor = window.scale_factor().max(f32::EPSILON);
 
         let raw_handle: raw_window_handle::WindowHandle<'_> =
             match HasWindowHandle::window_handle(window) {
@@ -628,7 +660,9 @@ impl GhosttyView {
             (host, document, surface, underlay)
         };
 
-        let scale = self.scale_factor as f64;
+        let scale =
+            Self::view_backing_scale(nsview, f64::from(window.scale_factor().max(f32::EPSILON)));
+        self.scale_factor = scale as f32;
         match self.app.new_surface(
             nsview as *mut c_void,
             scale,
@@ -637,12 +671,9 @@ impl GhosttyView {
             Some(self.initial_font_size),
         ) {
             Ok(terminal) => {
-                let width_px = (f32::from(bounds.size.width) * self.scale_factor) as u32;
-                let height_px = (f32::from(bounds.size.height) * self.scale_factor) as u32;
-                terminal.set_size(width_px, height_px);
-                terminal.set_content_scale(scale);
                 terminal.set_focus(self.surface_focused.get());
-                self.terminal = Some(Arc::new(terminal));
+                let terminal = Arc::new(terminal);
+                self.terminal = Some(terminal.clone());
                 self.restored_screen_text = None;
                 self.host_view = Some(host_view);
                 self.document_view = Some(document_view);
@@ -650,19 +681,27 @@ impl GhosttyView {
                 self.native_underlay_view = Some(underlay_view);
                 self.initialized = true;
                 self.next_surface_init_retry_at = None;
+                unsafe {
+                    con_ghostty_surface_install_backing_observer(
+                        nsview as *mut c_void,
+                        terminal.raw_surface() as *mut c_void,
+                    );
+                }
                 self.sync_native_backing_background();
                 self.apply_transition_underlay_visibility();
                 self.sync_window_background_blur();
+                let backing = self.sync_native_backing_properties(bounds, window);
                 // Force update_frame() to position the newly-created host.
                 // If a previous layout recorded the same bounds while the
                 // surface was still pending, an early-return here leaves the
                 // NSView at its bootstrap origin until a manual divider resize.
                 self.last_bounds = None;
+                let size = terminal.size();
                 log::info!(
                     "Ghostty surface created: {}x{} px, scale {}",
-                    width_px,
-                    height_px,
-                    scale
+                    backing.map_or(size.width_px, |backing| backing.width_px),
+                    backing.map_or(size.height_px, |backing| backing.height_px),
+                    self.scale_factor
                 );
                 self.sync_native_scroll_view();
 
@@ -859,7 +898,7 @@ impl GhosttyView {
         };
 
         self.ensure_initialized(bounds, window, cx);
-        self.update_frame(bounds);
+        self.update_frame(bounds, window);
         if showed_layout_fallback != self.show_layout_fallback() {
             cx.notify();
         }
@@ -874,14 +913,140 @@ impl GhosttyView {
     ) {
         let showed_layout_fallback = self.show_layout_fallback();
         self.ensure_initialized(bounds, window, cx);
-        self.update_frame(bounds);
+        self.update_frame(bounds, window);
         if showed_layout_fallback != self.show_layout_fallback() {
             cx.notify();
         }
     }
 
     #[cfg(target_os = "macos")]
-    fn update_frame(&mut self, bounds: Bounds<Pixels>) {
+    fn view_backing_scale(view: id, fallback_scale: f64) -> f64 {
+        if view.is_null() {
+            return fallback_scale.max(f64::EPSILON);
+        }
+
+        unsafe {
+            let unit = cocoa::foundation::NSSize::new(1.0, 1.0);
+            let backing: cocoa::foundation::NSSize = msg_send![view, convertSizeToBacking:unit];
+            if backing.height.is_finite() && backing.height > 0.0 {
+                backing.height
+            } else if backing.width.is_finite() && backing.width > 0.0 {
+                backing.width
+            } else {
+                fallback_scale.max(f64::EPSILON)
+            }
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn cached_scale_matches_native(&self, window: &Window) -> bool {
+        let Some(nsview) = self.nsview else {
+            return true;
+        };
+        let fallback_scale = f64::from(window.scale_factor().max(f32::EPSILON));
+        let native_scale = Self::view_backing_scale(nsview, fallback_scale);
+        (f64::from(self.scale_factor) - native_scale).abs() <= 0.001
+    }
+
+    #[cfg(target_os = "macos")]
+    fn sync_native_backing_properties(
+        &mut self,
+        bounds: Bounds<Pixels>,
+        window: &Window,
+    ) -> Option<NativeBackingSync> {
+        let Some(nsview) = self.nsview else {
+            self.scale_factor = window.scale_factor().max(f32::EPSILON);
+            return None;
+        };
+        let Some(terminal) = self.terminal.clone() else {
+            self.scale_factor = Self::view_backing_scale(
+                nsview,
+                f64::from(window.scale_factor().max(f32::EPSILON)),
+            ) as f32;
+            return None;
+        };
+
+        let before_size = terminal.size();
+        let previous_scale = self.scale_factor;
+        let previous_display_id = self.display_id;
+        let mut scale_x = 0.0;
+        let mut scale_y = 0.0;
+        let mut width_px = 0;
+        let mut height_px = 0;
+        let mut display_id = 0;
+        let fallback_scale =
+            Self::view_backing_scale(nsview, f64::from(window.scale_factor().max(f32::EPSILON)));
+
+        let ok = unsafe {
+            con_ghostty_surface_install_backing_observer(
+                nsview as *mut c_void,
+                terminal.raw_surface() as *mut c_void,
+            );
+            con_ghostty_surface_sync_backing(
+                nsview as *mut c_void,
+                terminal.raw_surface() as *mut c_void,
+                f64::from(bounds.size.width.as_f32().max(1.0)),
+                f64::from(bounds.size.height.as_f32().max(1.0)),
+                fallback_scale,
+                &mut scale_x,
+                &mut scale_y,
+                &mut width_px,
+                &mut height_px,
+                &mut display_id,
+            )
+        };
+        if !ok {
+            return None;
+        }
+
+        let display_id = (display_id != 0).then_some(display_id);
+        self.scale_factor = scale_y.max(f64::EPSILON) as f32;
+        if display_id.is_some() {
+            self.display_id = display_id;
+        }
+
+        let result = NativeBackingSync {
+            scale_x,
+            scale_y,
+            width_px,
+            height_px,
+        };
+        let scale_changed = (previous_scale - self.scale_factor).abs() > 0.001;
+        let display_changed = previous_display_id != self.display_id;
+        let size_changed = before_size.width_px != width_px || before_size.height_px != height_px;
+        if scale_changed || display_changed || size_changed {
+            terminal.draw();
+        }
+
+        if perf_trace_enabled() && (scale_changed || display_changed || size_changed) {
+            let after_size = terminal.size();
+            log::info!(
+                target: "con::perf",
+                "native backing sync scale={:.3}x{:.3}->{:.3}x{:.3} display={:?}->{:?} old_px={}x{} old_grid={}x{} new_px={}x{} new_grid={}x{} logical_pt={:.1}x{:.1}",
+                f64::from(previous_scale),
+                f64::from(previous_scale),
+                result.scale_x,
+                result.scale_y,
+                previous_display_id,
+                self.display_id,
+                before_size.width_px,
+                before_size.height_px,
+                before_size.columns,
+                before_size.rows,
+                after_size.width_px,
+                after_size.height_px,
+                after_size.columns,
+                after_size.rows,
+                bounds.size.width.as_f32(),
+                bounds.size.height.as_f32()
+            );
+        }
+
+        Some(result)
+    }
+
+    #[cfg(target_os = "macos")]
+    fn update_frame(&mut self, bounds: Bounds<Pixels>, window: &Window) {
         // `last_bounds` is Con's layout cache, not Ghostty's protocol state.
         // Pane-local surfaces can be hidden, focused, and resized without
         // repainting every sibling; always verify the embedded surface still
@@ -890,6 +1055,7 @@ impl GhosttyView {
             && !self.awaiting_first_layout_visibility
             && !self.pending_native_layout
             && self.terminal_matches_bounds(bounds)
+            && self.cached_scale_matches_native(window)
         {
             return;
         }
@@ -925,7 +1091,8 @@ impl GhosttyView {
             }
         }
 
-        self.commit_surface_resize(bounds);
+        self.sync_native_scroll_view();
+        self.sync_native_backing_properties(bounds, window);
         self.sync_native_scroll_view();
 
         if let Some(started) = started {
@@ -1051,7 +1218,7 @@ impl GhosttyView {
         #[cfg(target_os = "macos")]
         {
             self.ensure_initialized(bounds, window, cx);
-            self.update_frame(bounds);
+            self.update_frame(bounds, window);
         }
         if showed_layout_fallback != self.show_layout_fallback() {
             cx.notify();
@@ -1109,39 +1276,6 @@ impl GhosttyView {
             );
         }
         matches
-    }
-
-    #[cfg(target_os = "macos")]
-    fn commit_surface_resize(&mut self, bounds: Bounds<Pixels>) {
-        let Some(ref terminal) = self.terminal else {
-            return;
-        };
-
-        let (width_px, height_px) = self.surface_size_in_backing_pixels(bounds);
-        let size = terminal.size();
-        if size.width_px == width_px && size.height_px == height_px {
-            return;
-        }
-
-        let started = perf_trace_enabled().then(Instant::now);
-        terminal.set_size(width_px, height_px);
-        terminal.draw();
-        if let Some(started) = started {
-            let elapsed = started.elapsed();
-            log::info!(
-                target: "con::perf",
-                "surface resize request old_px={}x{} old_grid={}x{} new_px={}x{} logical_pt={:.1}x{:.1} call_ms={:.3}",
-                size.width_px,
-                size.height_px,
-                size.columns,
-                size.rows,
-                width_px,
-                height_px,
-                bounds.size.width.as_f32(),
-                bounds.size.height.as_f32(),
-                elapsed.as_secs_f64() * 1000.0
-            );
-        }
     }
 
     /// Show or hide the native NSView. Used to manage z-order when

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -66,8 +66,6 @@ static NEXT_NATIVE_TRANSITION_OWNER_ID: AtomicU64 = AtomicU64::new(1);
 #[cfg(target_os = "macos")]
 #[derive(Debug, Clone, Copy)]
 struct NativeBackingSync {
-    scale_x: f64,
-    scale_y: f64,
     width_px: u32,
     height_px: u32,
 }
@@ -88,7 +86,6 @@ unsafe extern "C" {
         out_scale_y: *mut f64,
         out_width: *mut u32,
         out_height: *mut u32,
-        out_display_id: *mut u32,
     ) -> bool;
 }
 
@@ -145,8 +142,6 @@ pub struct GhosttyView {
     initialized: bool,
     last_bounds: Option<Bounds<Pixels>>,
     scale_factor: f32,
-    #[cfg(target_os = "macos")]
-    display_id: Option<u32>,
     last_title: Option<String>,
     last_cwd: Option<String>,
     /// Data queued for the PTY before the surface was created.
@@ -221,8 +216,6 @@ impl GhosttyView {
             initialized: false,
             last_bounds: None,
             scale_factor: 1.0,
-            #[cfg(target_os = "macos")]
-            display_id: None,
             last_title: None,
             last_cwd: cwd,
             pending_write: None,
@@ -968,12 +961,10 @@ impl GhosttyView {
 
         let before_size = terminal.size();
         let previous_scale = self.scale_factor;
-        let previous_display_id = self.display_id;
         let mut scale_x = 0.0;
         let mut scale_y = 0.0;
         let mut width_px = 0;
         let mut height_px = 0;
-        let mut display_id = 0;
         let fallback_scale =
             Self::view_backing_scale(nsview, f64::from(window.scale_factor().max(f32::EPSILON)));
 
@@ -992,43 +983,33 @@ impl GhosttyView {
                 &mut scale_y,
                 &mut width_px,
                 &mut height_px,
-                &mut display_id,
             )
         };
         if !ok {
             return None;
         }
 
-        let display_id = (display_id != 0).then_some(display_id);
         self.scale_factor = scale_y.max(f64::EPSILON) as f32;
-        if display_id.is_some() {
-            self.display_id = display_id;
-        }
 
         let result = NativeBackingSync {
-            scale_x,
-            scale_y,
             width_px,
             height_px,
         };
         let scale_changed = (previous_scale - self.scale_factor).abs() > 0.001;
-        let display_changed = previous_display_id != self.display_id;
         let size_changed = before_size.width_px != width_px || before_size.height_px != height_px;
-        if scale_changed || display_changed || size_changed {
+        if scale_changed || size_changed {
             terminal.draw();
         }
 
-        if perf_trace_enabled() && (scale_changed || display_changed || size_changed) {
+        if perf_trace_enabled() && (scale_changed || size_changed) {
             let after_size = terminal.size();
             log::info!(
                 target: "con::perf",
-                "native backing sync scale={:.3}x{:.3}->{:.3}x{:.3} display={:?}->{:?} old_px={}x{} old_grid={}x{} new_px={}x{} new_grid={}x{} logical_pt={:.1}x{:.1}",
+                "native backing sync scale={:.3}x{:.3}->{:.3}x{:.3} old_px={}x{} old_grid={}x{} new_px={}x{} new_grid={}x{} logical_pt={:.1}x{:.1}",
                 f64::from(previous_scale),
                 f64::from(previous_scale),
-                result.scale_x,
-                result.scale_y,
-                previous_display_id,
-                self.display_id,
+                scale_x,
+                scale_y,
                 before_size.width_px,
                 before_size.height_px,
                 before_size.columns,

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -1725,15 +1725,10 @@ impl Drop for GhosttyView {
     fn drop(&mut self) {
         #[cfg(target_os = "macos")]
         {
-            if let Some(underlay_view) = self.native_underlay_view.take() {
-                Self::set_transition_underlay_owner_visible(
-                    underlay_view,
-                    self.native_transition_underlay_owner_id,
-                    false,
-                );
-            }
-            self.document_view = None;
-            self.nsview = None;
+            // The AppKit backing observer stores Ghostty's raw surface pointer.
+            // Detach it before `terminal` is dropped so a late screen/backing
+            // notification cannot call into freed libghostty state.
+            self.detach_host_view();
         }
         self.host_view = None;
     }

--- a/crates/con-app/src/objc/ghostty_surface_trampoline.m
+++ b/crates/con-app/src/objc/ghostty_surface_trampoline.m
@@ -1,0 +1,236 @@
+#import <AppKit/AppKit.h>
+#import <QuartzCore/QuartzCore.h>
+#include <math.h>
+#include <objc/runtime.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+extern void ghostty_surface_set_content_scale(void *surface, double x, double y);
+extern void ghostty_surface_set_display_id(void *surface, uint32_t display_id);
+extern void ghostty_surface_set_size(void *surface, uint32_t width, uint32_t height);
+
+static char kConGhosttySurfaceBackingObserverKey;
+
+static double con_valid_scale(double scale, double fallback) {
+    if (!isfinite(scale) || scale <= 0.0) {
+        return fallback > 0.0 ? fallback : 1.0;
+    }
+    return scale;
+}
+
+static uint32_t con_ghostty_display_id_for_window(NSWindow *window) {
+    NSScreen *screen = window.screen;
+    if (screen == nil) {
+        return 0;
+    }
+
+    NSNumber *number = screen.deviceDescription[@"NSScreenNumber"];
+    return number == nil ? 0 : number.unsignedIntValue;
+}
+
+bool con_ghostty_surface_sync_backing(
+    void *view_ptr,
+    void *surface_ptr,
+    double logical_width,
+    double logical_height,
+    double fallback_scale,
+    double *out_scale_x,
+    double *out_scale_y,
+    uint32_t *out_width,
+    uint32_t *out_height,
+    uint32_t *out_display_id
+) {
+    NSView *view = (__bridge NSView *)view_ptr;
+    if (view == nil || surface_ptr == NULL) {
+        return false;
+    }
+
+    fallback_scale = con_valid_scale(fallback_scale, 1.0);
+
+    NSWindow *window = view.window;
+    double layer_scale = fallback_scale;
+    uint32_t display_id = 0;
+    if (window != nil) {
+        layer_scale = con_valid_scale(window.backingScaleFactor, fallback_scale);
+        display_id = con_ghostty_display_id_for_window(window);
+    }
+
+    CALayer *layer = view.layer;
+    if (layer != nil) {
+        [CATransaction begin];
+        [CATransaction setDisableActions:YES];
+        layer.contentsScale = layer_scale;
+        [CATransaction commit];
+    }
+
+    NSRect frame = view.frame;
+    NSRect backing_frame = [view convertRectToBacking:frame];
+    double scale_x = frame.size.width > 0.0
+        ? backing_frame.size.width / frame.size.width
+        : fallback_scale;
+    double scale_y = frame.size.height > 0.0
+        ? backing_frame.size.height / frame.size.height
+        : fallback_scale;
+    scale_x = con_valid_scale(scale_x, fallback_scale);
+    scale_y = con_valid_scale(scale_y, fallback_scale);
+
+    NSSize logical_size = NSMakeSize(fmax(logical_width, 1.0), fmax(logical_height, 1.0));
+    NSSize backing_size = [view convertSizeToBacking:logical_size];
+    uint32_t width = (uint32_t)llround(fmax(backing_size.width, 1.0));
+    uint32_t height = (uint32_t)llround(fmax(backing_size.height, 1.0));
+
+    if (display_id != 0) {
+        ghostty_surface_set_display_id(surface_ptr, display_id);
+    }
+    ghostty_surface_set_content_scale(surface_ptr, scale_x, scale_y);
+    ghostty_surface_set_size(surface_ptr, width, height);
+
+    if (out_scale_x != NULL) {
+        *out_scale_x = scale_x;
+    }
+    if (out_scale_y != NULL) {
+        *out_scale_y = scale_y;
+    }
+    if (out_width != NULL) {
+        *out_width = width;
+    }
+    if (out_height != NULL) {
+        *out_height = height;
+    }
+    if (out_display_id != NULL) {
+        *out_display_id = display_id;
+    }
+
+    return true;
+}
+
+@interface ConGhosttySurfaceBackingObserver : NSObject
+@property(nonatomic, weak) NSView *view;
+@property(nonatomic, assign) void *surface;
+@property(nonatomic, weak) NSWindow *window;
+@property(nonatomic, strong) id screenObserver;
+@property(nonatomic, strong) id backingObserver;
+- (void)installForView:(NSView *)view surface:(void *)surface;
+- (void)invalidate;
+- (void)sync;
+@end
+
+@implementation ConGhosttySurfaceBackingObserver
+
+- (void)dealloc {
+    [self invalidate];
+}
+
+- (void)installForView:(NSView *)view surface:(void *)surface {
+    NSWindow *window = view.window;
+    if (_window == window && _surface == surface && _screenObserver != nil && _backingObserver != nil) {
+        [self sync];
+        return;
+    }
+
+    [self invalidate];
+    _view = view;
+    _surface = surface;
+    _window = window;
+
+    if (window == nil || surface == NULL) {
+        return;
+    }
+
+    __weak ConGhosttySurfaceBackingObserver *weakSelf = self;
+    NSNotificationCenter *center = NSNotificationCenter.defaultCenter;
+    _screenObserver = [center addObserverForName:NSWindowDidChangeScreenNotification
+                                          object:window
+                                           queue:NSOperationQueue.mainQueue
+                                      usingBlock:^(__unused NSNotification *notification) {
+        ConGhosttySurfaceBackingObserver *observer = weakSelf;
+        [observer sync];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [observer sync];
+        });
+    }];
+    _backingObserver = [center addObserverForName:NSWindowDidChangeBackingPropertiesNotification
+                                           object:window
+                                            queue:NSOperationQueue.mainQueue
+                                       usingBlock:^(__unused NSNotification *notification) {
+        [weakSelf sync];
+    }];
+
+    [self sync];
+}
+
+- (void)invalidate {
+    NSNotificationCenter *center = NSNotificationCenter.defaultCenter;
+    if (_screenObserver != nil) {
+        [center removeObserver:_screenObserver];
+        _screenObserver = nil;
+    }
+    if (_backingObserver != nil) {
+        [center removeObserver:_backingObserver];
+        _backingObserver = nil;
+    }
+    _window = nil;
+    _surface = NULL;
+}
+
+- (void)sync {
+    NSView *view = _view;
+    if (view == nil || _surface == NULL) {
+        return;
+    }
+
+    NSSize size = view.bounds.size;
+    double fallback_scale = view.window == nil ? 1.0 : view.window.backingScaleFactor;
+    con_ghostty_surface_sync_backing(
+        (__bridge void *)view,
+        _surface,
+        size.width,
+        size.height,
+        fallback_scale,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL
+    );
+}
+
+@end
+
+void con_ghostty_surface_install_backing_observer(void *view_ptr, void *surface_ptr) {
+    NSView *view = (__bridge NSView *)view_ptr;
+    if (view == nil || surface_ptr == NULL) {
+        return;
+    }
+
+    ConGhosttySurfaceBackingObserver *observer =
+        objc_getAssociatedObject(view, &kConGhosttySurfaceBackingObserverKey);
+    if (observer == nil) {
+        observer = [[ConGhosttySurfaceBackingObserver alloc] init];
+        objc_setAssociatedObject(
+            view,
+            &kConGhosttySurfaceBackingObserverKey,
+            observer,
+            OBJC_ASSOCIATION_RETAIN_NONATOMIC
+        );
+    }
+
+    [observer installForView:view surface:surface_ptr];
+}
+
+void con_ghostty_surface_remove_backing_observer(void *view_ptr) {
+    NSView *view = (__bridge NSView *)view_ptr;
+    if (view == nil) {
+        return;
+    }
+
+    ConGhosttySurfaceBackingObserver *observer =
+        objc_getAssociatedObject(view, &kConGhosttySurfaceBackingObserverKey);
+    [observer invalidate];
+    objc_setAssociatedObject(
+        view,
+        &kConGhosttySurfaceBackingObserverKey,
+        nil,
+        OBJC_ASSOCIATION_RETAIN_NONATOMIC
+    );
+}

--- a/crates/con-app/src/objc/ghostty_surface_trampoline.m
+++ b/crates/con-app/src/objc/ghostty_surface_trampoline.m
@@ -37,8 +37,7 @@ bool con_ghostty_surface_sync_backing(
     double *out_scale_x,
     double *out_scale_y,
     uint32_t *out_width,
-    uint32_t *out_height,
-    uint32_t *out_display_id
+    uint32_t *out_height
 ) {
     NSView *view = (__bridge NSView *)view_ptr;
     if (view == nil || surface_ptr == NULL) {
@@ -96,9 +95,6 @@ bool con_ghostty_surface_sync_backing(
     }
     if (out_height != NULL) {
         *out_height = height;
-    }
-    if (out_display_id != NULL) {
-        *out_display_id = display_id;
     }
 
     return true;
@@ -187,7 +183,6 @@ bool con_ghostty_surface_sync_backing(
         size.width,
         size.height,
         fallback_scale,
-        NULL,
         NULL,
         NULL,
         NULL,

--- a/crates/con-app/src/objc/ghostty_surface_trampoline.m
+++ b/crates/con-app/src/objc/ghostty_surface_trampoline.m
@@ -47,31 +47,24 @@ bool con_ghostty_surface_sync_backing(
     fallback_scale = con_valid_scale(fallback_scale, 1.0);
 
     NSWindow *window = view.window;
-    double layer_scale = fallback_scale;
+    double window_scale = fallback_scale;
     uint32_t display_id = 0;
     if (window != nil) {
-        layer_scale = con_valid_scale(window.backingScaleFactor, fallback_scale);
+        window_scale = con_valid_scale(window.backingScaleFactor, fallback_scale);
         display_id = con_ghostty_display_id_for_window(window);
     }
+
+    NSSize unit_backing = [view convertSizeToBacking:NSMakeSize(1.0, 1.0)];
+    double scale_x = con_valid_scale(unit_backing.width, window_scale);
+    double scale_y = con_valid_scale(unit_backing.height, window_scale);
 
     CALayer *layer = view.layer;
     if (layer != nil) {
         [CATransaction begin];
         [CATransaction setDisableActions:YES];
-        layer.contentsScale = layer_scale;
+        layer.contentsScale = scale_y;
         [CATransaction commit];
     }
-
-    NSRect frame = view.frame;
-    NSRect backing_frame = [view convertRectToBacking:frame];
-    double scale_x = frame.size.width > 0.0
-        ? backing_frame.size.width / frame.size.width
-        : fallback_scale;
-    double scale_y = frame.size.height > 0.0
-        ? backing_frame.size.height / frame.size.height
-        : fallback_scale;
-    scale_x = con_valid_scale(scale_x, fallback_scale);
-    scale_y = con_valid_scale(scale_y, fallback_scale);
 
     NSSize logical_size = NSMakeSize(fmax(logical_width, 1.0), fmax(logical_height, 1.0));
     NSSize backing_size = [view convertSizeToBacking:logical_size];
@@ -120,7 +113,6 @@ bool con_ghostty_surface_sync_backing(
 - (void)installForView:(NSView *)view surface:(void *)surface {
     NSWindow *window = view.window;
     if (_window == window && _surface == surface && _screenObserver != nil && _backingObserver != nil) {
-        [self sync];
         return;
     }
 
@@ -152,7 +144,6 @@ bool con_ghostty_surface_sync_backing(
         [weakSelf sync];
     }];
 
-    [self sync];
 }
 
 - (void)invalidate {

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -718,11 +718,6 @@ impl GhosttyTerminal {
         unsafe { ffi::ghostty_surface_set_content_scale(self.surface, scale, scale) }
     }
 
-    /// Set the display that owns this surface.
-    pub fn set_display_id(&self, display_id: u32) {
-        unsafe { ffi::ghostty_surface_set_display_id(self.surface, display_id) }
-    }
-
     /// Set focus state.
     pub fn set_focus(&self, focused: bool) {
         unsafe { ffi::ghostty_surface_set_focus(self.surface, focused) }

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -718,6 +718,11 @@ impl GhosttyTerminal {
         unsafe { ffi::ghostty_surface_set_content_scale(self.surface, scale, scale) }
     }
 
+    /// Set the display that owns this surface.
+    pub fn set_display_id(&self, display_id: u32) {
+        unsafe { ffi::ghostty_surface_set_display_id(self.surface, display_id) }
+    }
+
     /// Set focus state.
     pub fn set_focus(&self, focused: bool) {
         unsafe { ffi::ghostty_surface_set_focus(self.surface, focused) }

--- a/postmortem/2026-05-06-macos-display-scale-sync.md
+++ b/postmortem/2026-05-06-macos-display-scale-sync.md
@@ -39,11 +39,19 @@ coordinate system.
   `ghostty_surface_set_display_id`, `ghostty_surface_set_content_scale`, and
   `ghostty_surface_set_size` in the same order as Ghostty's upstream AppKit
   view.
+- The content scale comes from a stable 1x1 point-to-backing conversion, not an
+  arbitrary frame-to-backing ratio, so fractional layout sizes during live
+  resize cannot perturb Ghostty's cell metrics.
 - Registered native window screen/backing-property observers for each embedded
   Ghostty `NSView`, so cross-display moves trigger a backing sync even when the
   GPUI pane bounds do not change.
 - Changed Con's macOS layout path to use the same backing sync helper instead of
   directly setting content scale from GPUI layout.
+- Detached the backing observer in `GhosttyView::drop` before the terminal field
+  releases Ghostty's raw surface pointer.
+- Kept the layout-path observer install as a window-move safety net, but made
+  the Objective-C installer observer-only so the explicit Rust sync does not
+  duplicate `ghostty_surface_set_*` calls on every layout pass.
 
 ## What We Learned
 

--- a/postmortem/2026-05-06-macos-display-scale-sync.md
+++ b/postmortem/2026-05-06-macos-display-scale-sync.md
@@ -1,0 +1,58 @@
+# macOS Display Scale Sync
+
+## What Happened
+
+Moving an existing Con window from a built-in Retina display to a 1920x1080
+external display could leave existing terminal panes with far fewer rows and
+columns than a newly-created pane in the same window.
+
+The failure only affected already-created Ghostty surfaces. Creating a new tab
+or pane after the move used the correct grid size.
+
+An initial fix synchronized Ghostty's content scale and display id from GPUI's
+layout path. That corrected PTY rows and columns after the move, but could leave
+the rendered font tiny because the native layer presentation scale and Ghostty's
+font/cell DPI scale were no longer updated as one AppKit backing transaction.
+
+## Root Cause
+
+The macOS host resized the embedded Ghostty surface from the current AppKit
+backing size, but the already-created surface kept the content scale that was
+captured when it was first created. A surface created on a 2x Retina display
+could therefore be resized to a 1x external display backing size while Ghostty
+still used 2x content-scale semantics for cell metrics.
+
+Con also exposed Ghostty's `ghostty_surface_set_display_id` binding in FFI but
+did not drive it from the AppKit screen that currently owns the window.
+
+The missing piece was AppKit's backing-property lifecycle. Ghostty's own macOS
+view updates the surface layer's `contentsScale`, Ghostty content scale, and
+framebuffer size together from `convertToBacking(...)`. Updating only
+`ghostty_surface_set_content_scale` changed Ghostty's font DPI without also
+keeping Core Animation's layer scale and the surface pixel size in the same
+coordinate system.
+
+## Fix Applied
+
+- Added a native AppKit trampoline for embedded Ghostty surfaces.
+- The trampoline synchronizes `layer.contentsScale`,
+  `ghostty_surface_set_display_id`, `ghostty_surface_set_content_scale`, and
+  `ghostty_surface_set_size` in the same order as Ghostty's upstream AppKit
+  view.
+- Registered native window screen/backing-property observers for each embedded
+  Ghostty `NSView`, so cross-display moves trigger a backing sync even when the
+  GPUI pane bounds do not change.
+- Changed Con's macOS layout path to use the same backing sync helper instead of
+  directly setting content scale from GPUI layout.
+
+## What We Learned
+
+For embedded native terminal surfaces, display identity and content scale are
+part of geometry state. Bounds alone are not enough: a pane can have the same
+logical size after a cross-display move while its backing pixel scale and
+display id have changed underneath it.
+
+For GPU-backed AppKit content, content scale is not just metadata. In Ghostty it
+feeds font DPI and cell metrics, while Core Animation also needs the hosted
+layer's `contentsScale` to avoid compositor scaling. These values must be kept
+in sync with the framebuffer size as one geometry update.


### PR DESCRIPTION
## Summary
- synchronize embedded Ghostty AppKit layer contentsScale, content scale, framebuffer size, and display id together
- register native screen/backing-property observers so cross-display moves update existing surfaces
- add a postmortem for the Retina-to-external display geometry bug

## Validation
- cargo check -p con
- cargo build -p con
- CON_CHANNEL=beta scripts/macos/build-app.sh
- codesign --verify --deep --strict /Applications/con Beta.app
- manual test: moving an existing terminal from built-in display to 1920x1080 external display keeps stty size and visual font scale correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed macOS display scale synchronization when moving Ghostty windows between displays with different scaling factors
* Improved native backing surface alignment with AppKit display properties on macOS

<!-- end of auto-generated comment: release notes by coderabbit.ai -->