### PR TITLE
Fix macOS Intel live-resize flashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
-## `v0.1.0-beta.65`
+## `v0.1.0-beta.64`
 
 ### Added
 
@@ -12,28 +12,7 @@ con is still pre-release, so entries may group related beta work while the produ
 
 - Enabled Ghostty SSH shell-integration features for macOS terminal sessions,
   so remote SSH hosts can receive `xterm-ghostty` terminfo and terminal
-  environment hints while Con still preserves its own cursor-style setting.
-
-### Fixed
-
-**macOS**
-
-- Fixed a live-resize flash regression on Intel Macs by committing embedded
-  Ghostty backing size before moving the AppKit surface hierarchy, avoiding a
-  one-frame mismatch between the Metal surface and terminal framebuffer.
-
-**Windows, Linux**
-
-- Fixed terminal `Ctrl+<punctuation>` C0 chords such as `Ctrl+]`, `Ctrl+/`,
-  `Ctrl+@`, and `Ctrl+Space`, so tmux prefixes like `set -g prefix C-]` now
-  send the expected control byte instead of being dropped or typed literally.
-  The surface control API also accepts legacy `ctrl-2..8` aliases for
-  automation, while interactive `Ctrl+1..9` remains reserved for tab switching
-  on Windows and Linux.
-
-## `v0.1.0-beta.64`
-
-### Added
+  environment hints while Con still preserves its own cursor-style setting. _(PR [#159](https://github.com/nowledge-co/con-terminal/pull/159) by [@chenghuzi](https://github.com/chenghuzi))_
 
 **Panes**
 
@@ -51,6 +30,18 @@ con is still pre-release, so entries may group related beta work while the produ
 - Fixed embedded Ghostty surface scale sync when moving a window between Retina
   and non-Retina displays. Existing panes now update display id, backing scale,
   layer scale, and pixel size together instead of keeping stale cell metrics. _(PR [#150](https://github.com/nowledge-co/con-terminal/pull/150) by [@chenghuzi](https://github.com/chenghuzi))_
+- Fixed a live-resize flash regression on Intel Macs by committing embedded
+  Ghostty backing size before moving the AppKit surface hierarchy, avoiding a
+  one-frame mismatch between the Metal surface and terminal framebuffer. _(PR [#152](https://github.com/nowledge-co/con-terminal/pull/152) by [@wey-gu](https://github.com/wey-gu))_
+
+**Windows, Linux**
+
+- Fixed terminal `Ctrl+<punctuation>` C0 chords such as `Ctrl+]`, `Ctrl+/`,
+  `Ctrl+@`, and `Ctrl+Space`, so tmux prefixes like `set -g prefix C-]` now
+  send the expected control byte instead of being dropped or typed literally.
+  The surface control API also accepts legacy `ctrl-2..8` aliases for
+  automation, while interactive `Ctrl+1..9` remains reserved for tab switching
+  on Windows and Linux. _(PR [#156](https://github.com/nowledge-co/con-terminal/pull/156) by [@wey-gu](https://github.com/wey-gu))_
 
 **Panes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ### Fixed
 
+**macOS**
+
+- Fixed a live-resize flash regression on Intel Macs by committing embedded
+  Ghostty backing size before moving the AppKit surface hierarchy, avoiding a
+  one-frame mismatch between the Metal surface and terminal framebuffer.
+
 **Windows, Linux**
 
 - Fixed terminal `Ctrl+<punctuation>` C0 chords such as `Ctrl+]`, `Ctrl+/`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,12 +89,20 @@ Windows-named binary requires.
 - Implementation details live in `docs/impl/socket-api.md`.
 - The current live E2E workflow lives in `docs/impl/con-cli-e2e.md`.
 
-## Local Skill
+## Local Skills
 
-- Project-local skill: `skills/con-cli-e2e/SKILL.md`
-- Project-local skill: `skills/gpui-cache-aware/SKILL.md`
-- Use it when validating the control plane from an external agent or when writing eval automation against a real running Con session.
-- The skill expects agents to prefer `con-cli --json`, verify pane capabilities before acting, and treat `panes create` as provisional until the new pane reports as alive and shell-ready.
+- `skills/con-cli-e2e/SKILL.md` — use when validating the control plane from
+  an external agent or when writing eval automation against a real running Con
+  session. Prefer `con-cli --json`, verify pane capabilities before acting, and
+  treat `panes create` as provisional until the new pane reports as alive and
+  shell-ready.
+- `skills/gpui-cache-aware/SKILL.md` — use when reviewing or changing UI
+  performance, especially markdown/chat rendering, terminal-adjacent UI, or
+  resize/animation paths.
+- `skills/changelog-release-notes/SKILL.md` — use before editing
+  `CHANGELOG.md`, release notes, or PR descriptions that summarize
+  release-visible work. Always check the latest shipped beta and add PR +
+  GitHub author credit for every PR-derived changelog item.
 
 ## Design Language
 

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -1044,6 +1044,14 @@ impl GhosttyView {
         self.last_bounds = Some(bounds);
         self.sync_native_backing_background();
 
+        // Keep libghostty's framebuffer/PTY size ahead of every AppKit frame
+        // commit. Moving the host/document/surface hierarchy before the backing
+        // size is updated creates one live-resize frame where AppKit can
+        // present a Metal surface at the new pane bounds while Ghostty is still
+        // drawing the previous size. Intel macOS compositors expose that
+        // transient mismatch as a resize flash.
+        self.sync_native_backing_properties(bounds, window);
+
         if let Some(host_view) = self.host_view {
             unsafe {
                 let superview: id = msg_send![host_view, superview];
@@ -1072,8 +1080,6 @@ impl GhosttyView {
             }
         }
 
-        self.sync_native_scroll_view();
-        self.sync_native_backing_properties(bounds, window);
         self.sync_native_scroll_view();
 
         if let Some(started) = started {

--- a/postmortem/2026-05-07-macos-intel-live-resize-flash.md
+++ b/postmortem/2026-05-07-macos-intel-live-resize-flash.md
@@ -1,0 +1,69 @@
+# macOS Intel Live Resize Flash
+
+## What Happened
+
+Issue #70 regressed after the macOS surface-geometry and display-scale work.
+Intel Mac users again saw aggressive flashing while dragging a Con window
+resize, especially with transparent terminal glass enabled.
+
+The report arrived after the workspace refactor, but the timeline showed the
+regression was already present before that refactor merged. The relevant change
+window was the macOS embedded Ghostty surface path, not the workspace module
+split.
+
+## Root Cause
+
+PR #150 correctly moved display scale, backing scale, and pixel-size sync into
+a single Objective-C bridge. During that change, `GhosttyView::update_frame`
+started committing native geometry in this order:
+
+1. Move the AppKit host scroll view.
+2. Move the document view and Ghostty surface view through an early
+   `sync_native_scroll_view()` call.
+3. Ask libghostty to adopt the new backing size.
+4. Move the document view and Ghostty surface view again.
+
+The unsafe step was the first document/surface move. For one live-resize frame,
+macOS can present the embedded Metal surface at the new pane bounds while
+Ghostty is still drawing the previous framebuffer size. Apple Silicon tended to
+hide the mismatch; Intel compositors exposed it as a flash.
+
+The pre-regression path also moved the outer host before resizing Ghostty, but
+it did not present the document/surface view at the new pane geometry until
+after the terminal resize transaction had run.
+
+This is the same class of bug as the earlier terminal-glass seam work: two
+systems commit independently, and a temporary mismatch becomes visible through
+the transparent window. The correct fix is not a matte or a border. It is to
+make the terminal-size transaction ordered.
+
+## Fix Applied
+
+`GhosttyView::update_frame` now updates Ghostty's backing properties first and
+then performs one deterministic AppKit scroll/document/surface geometry commit.
+
+This restores the important ordering boundary from the pre-regression path:
+terminal framebuffer and PTY size are ready before the native Ghostty surface
+view is presented at the new bounds.
+
+## What We Learned
+
+Live window resize is a stricter path than ordinary pane layout. It can expose
+intermediate AppKit states that normal layout coalesces away.
+
+For embedded native terminal surfaces on macOS:
+
+- resize Ghostty's framebuffer before moving the hosted surface view
+- commit the AppKit hierarchy once per layout pass when possible
+- do not solve resize flashes with full-terminal mattes or opaque underlays
+- keep this path macOS-only; Windows and Linux do not embed Ghostty through an
+  AppKit child view
+
+## Follow-Ups
+
+- If issue #70 still reproduces on Intel hardware, collect
+  `CON_GHOSTTY_PROFILE=1 RUST_LOG=con::perf=info,con=debug` logs around a live
+  resize and compare `update_frame` duration against `native backing sync`
+  timing.
+- Add an Intel resize smoke item to release QA: transparent terminal, blur on,
+  dark terminal theme, light desktop, resize a content-heavy terminal window.

--- a/skills/changelog-release-notes/SKILL.md
+++ b/skills/changelog-release-notes/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: changelog-release-notes
+description: Maintain Con's CHANGELOG.md and release notes. Use when updating changelog entries, preparing a beta/dev release, reviewing PR release-note coverage, or ensuring contributor PR credit is present.
+---
+
+# Changelog Release Notes
+
+Use this skill whenever `CHANGELOG.md`, PR release notes, or release summaries
+are touched.
+
+## Workflow
+
+1. Verify the latest released beta before choosing a heading:
+   - `git fetch --tags origin`
+   - `git tag --sort=-v:refname | rg '^v[0-9]+\\.[0-9]+\\.[0-9]+-beta\\.' | head`
+   - `gh release view <tag>` when GitHub release state matters
+2. Put pending work under the next unreleased beta only. If the latest shipped
+   beta is `v0.1.0-beta.63`, the top unreleased heading is
+   `v0.1.0-beta.64`; do not create `beta.65` until `beta.64` is tagged and
+   released.
+3. Gather PR and author context for every entry:
+   - `gh pr view <number> --json number,title,author,url,mergedAt`
+   - for merged work, `git log <latest-tag>..HEAD --merges --oneline` helps
+     find the included PRs
+4. Every PR-derived changelog bullet must end with PR and author credit:
+   - `_(PR [#149](https://github.com/nowledge-co/con-terminal/pull/149) by [@sundy-li](https://github.com/sundy-li))_`
+5. Credit contributors exactly by GitHub login. Preserve external contributor
+   credit even when follow-up commits refine the same feature.
+6. Keep shipped historical sections stable. Only edit old sections to correct a
+   factual mistake, missing credit, or broken link.
+
+## Writing Rules
+
+- Write for users first: describe the visible behavior or benefit, not the
+  internal implementation unless it explains a risk or platform boundary.
+- Use `Added`, `Changed`, and `Fixed` sections. Group bullets under concise
+  audience/platform labels such as `macOS`, `Windows, Linux`, `Panes`, or
+  `Developer Experience`.
+- Do not mention "workspace restore" or other baseline continuity as novelty
+  unless the user-facing behavior truly changed. Default expected behavior
+  should read as polish or reliability, not marketing.
+- Add release dates only when a version is actually tagged/released.
+- If a bullet combines multiple PRs, include all relevant PR/author credits.
+
+## Validation
+
+- Confirm the heading matches the latest shipped beta plus one.
+- Confirm every new PR-derived bullet has `PR [#...]` and `by [@...]`.
+- Run `python3 scripts/docs/validate-manifest.py` when docs routing may be
+  affected.
+- Run `git diff --check` before committing.


### PR DESCRIPTION
## Summary

Fixes #70.

This reorders the macOS embedded Ghostty resize transaction so libghostty adopts the new backing/PTY size before Con moves the AppKit document/surface hierarchy. The previous #150 path briefly moved the native surface before the matching framebuffer size was ready, which can show as an Intel live-resize flash through the transparent window.

## What Changed

- Update Ghostty backing properties before AppKit frame mutation in `GhosttyView::update_frame`.
- Remove the extra pre-resize `sync_native_scroll_view()` pass, leaving one deterministic native geometry commit.
- Normalize the unreleased changelog under `v0.1.0-beta.64` because beta 64 has not shipped yet.
- Add PR + author credit for the pending beta 64 changelog items, including contributor PRs #149, #150, and #159.
- Add a project-local changelog/release-notes skill so future agents check the latest shipped beta and preserve contributor credit.
- Add a postmortem for the issue #70 regression and follow-up Intel QA notes.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `RUSTFLAGS='-D warnings' cargo check -p con`
- `RUSTFLAGS='-D warnings' cargo check -p con --no-default-features --features con/bin-con-app`
- `cargo test -p con workspace:: -- --nocapture`
- `cargo test --workspace`
- `python3 scripts/docs/validate-manifest.py`
- GitHub CI: `ci-portable / check (windows-latest)` passed before the changelog-only follow-up; rerunning after latest push
- GitHub CI: `ci-portable / check (ubuntu-latest)` passed before the changelog-only follow-up; rerunning after latest push
- CodeRabbit: no actionable comments before the changelog-only follow-up

## Notes

I cannot directly validate Intel macOS hardware from this machine. The runtime fix is grounded in the regression diff and keeps Windows/Linux untouched because it only changes the macOS embedded AppKit/Ghostty path. The latest pushed follow-up is changelog/docs/skill guidance only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches macOS-native `GhosttyView::update_frame` layout/resize ordering; a mistake could regress terminal sizing, scrolling, or painting during live resize. Other changes are documentation/changelog-only.
> 
> **Overview**
> Fixes macOS Intel live-resize flashing by reordering `GhosttyView::update_frame` to sync Ghostty backing/framebuffer properties *before* mutating the AppKit host/document/surface view hierarchy, and by removing the extra pre-resize `sync_native_scroll_view()` pass so native geometry is committed once per layout.
> 
> Updates the unreleased `v0.1.0-beta.64` changelog (including PR/author credits), adds a new `postmortem/2026-05-07-macos-intel-live-resize-flash.md`, and documents a new `skills/changelog-release-notes` workflow in `CLAUDE.md` + `skills/changelog-release-notes/SKILL.md` to keep future release notes consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b53e54bd66c54d3a9e487e334ed11540cc2e6e47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->