### PR TITLE
fix: uniform vertical tab row height to prevent layout jitter

### DIFF
--- a/crates/con-app/src/sidebar.rs
+++ b/crates/con-app/src/sidebar.rs
@@ -67,7 +67,6 @@ pub const PANEL_MAX_WIDTH: f32 = 360.0;
 const HOVER_CARD_WIDTH: f32 = 240.0;
 /// Per-row height in pinned mode (two-line layout — name + subtitle).
 const ROW_HEIGHT: f32 = 44.0;
-const ROW_HEIGHT_NO_SUBTITLE: f32 = 32.0;
 /// Per-icon size in the rail.
 const RAIL_ICON_SIZE: f32 = 32.0;
 /// Vertical gap between rail icons. Used to compute the icon's
@@ -989,11 +988,7 @@ impl SessionSidebar {
         let drop_above = drop_slot == Some(i) && cx.has_active_drag();
         let drop_below = i + 1 == total && drop_slot == Some(total) && cx.has_active_drag();
 
-        let row_h = if session.subtitle.is_some() {
-            ROW_HEIGHT
-        } else {
-            ROW_HEIGHT_NO_SUBTITLE
-        };
+        let row_h = ROW_HEIGHT;
 
         let label_block: AnyElement = if is_renaming {
             if let Some(input) = rename_input {


### PR DESCRIPTION
## Summary

Remove the conditional row height logic in `render_panel_row()` that switched between `ROW_HEIGHT` (44px) and `ROW_HEIGHT_NO_SUBTITLE` (32px) based on whether the session had a subtitle.

## Problem

When a terminal tab initializes without a subtitle and later gains one (e.g., once CWD metadata becomes available), the row height jumps from 32px to 44px. This causes every tab below it to shift downward, producing a visible layout jitter in the vertical tabs panel.

## Fix

Use a uniform `ROW_HEIGHT (44px)` for all vertical tab rows, regardless of subtitle presence. This keeps the tab list stable.

## Test plan

- [ ] Enable vertical tabs
- [ ] Open a new tab and observe the panel — no height change as subtitle appears
- [ ] Open multiple tabs — no shift in subsequent rows

Fixes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized row heights in the sidebar for improved visual consistency. All rows now use uniform spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->