### PR TITLE
fix: disable ghostty shell-integration cursor override

### DIFF
--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -155,6 +155,10 @@ impl GhosttyConfigPatch {
             s.push_str("cursor-color = cell-foreground\n");
             s.push_str("cursor-text = cell-background\n");
         }
+        // Disable ghostty shell-integration cursor override so con's
+        // cursor-style setting is respected. Ghostty's integration
+        // unconditionally forces a bar cursor at prompts otherwise.
+        s.push_str("shell-integration-features = no-cursor\n");
         if let Some(background_image) = &self.background_image {
             s.push_str(&format!("background-image = {:?}\n", background_image));
             if let Some(background_image_opacity) = self.background_image_opacity {


### PR DESCRIPTION
## Problem

Settings → Appearance → Cursor Style has no visible effect. No matter what the user selects (Block, Underline, Hollow Block), the cursor always appears as a thin bar.

## Root Cause

Ghostty's shell integration unconditionally forces a bar cursor at prompts by sending `ESC[5 q`, overriding the `cursor-style` configuration. This is documented behavior — see [Ghostty Config Reference](https://ghostty.org/docs/config/reference).

## Fix

Add `shell-integration-features = no-cursor` to the ghostty runtime config generated by con-ghostty. This preserves all other shell integration features (CWD reporting, semantic prompts, sudo password hiding) while allowing con's cursor-style setting to take effect.

## Related

- ghostty-org/ghostty#5144
- ghostty-org/ghostty#3893

## Test Plan

1. Open Settings → Appearance → Cursor Style
2. Select Block / Underline / Hollow Block
3. Observe cursor shape changes immediately in the terminal