### PR TITLE
Fix terminal Ctrl punctuation chords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ con is still pre-release, so entries may group related beta work while the produ
 
 **Windows, Linux**
 
-- Fixed terminal `Ctrl+<punctuation>` chords such as `Ctrl+]`, so tmux prefixes
-  like `set -g prefix C-]` now send the expected C0 control byte instead of
-  being dropped or typed literally.
+- Fixed terminal `Ctrl+<punctuation>` C0 chords such as `Ctrl+]`, `Ctrl+/`,
+  and their `Ctrl+2..8` aliases, so tmux prefixes like `set -g prefix C-]`
+  now send the expected control byte instead of being dropped or typed
+  literally.
 
 ## `v0.1.0-beta.64`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ con is still pre-release, so entries may group related beta work while the produ
 **Windows, Linux**
 
 - Fixed terminal `Ctrl+<punctuation>` C0 chords such as `Ctrl+]`, `Ctrl+/`,
-  and their `Ctrl+2..8` aliases, so tmux prefixes like `set -g prefix C-]`
-  now send the expected control byte instead of being dropped or typed
-  literally.
+  `Ctrl+@`, and `Ctrl+Space`, so tmux prefixes like `set -g prefix C-]` now
+  send the expected control byte instead of being dropped or typed literally.
+  The surface control API also accepts legacy `ctrl-2..8` aliases for
+  automation, while interactive `Ctrl+1..9` remains reserved for tab switching
+  on Windows and Linux.
 
 ## `v0.1.0-beta.64`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## `v0.1.0-beta.65`
+
+### Fixed
+
+**Windows, Linux**
+
+- Fixed terminal `Ctrl+<punctuation>` chords such as `Ctrl+]`, so tmux prefixes
+  like `set -g prefix C-]` now send the expected C0 control byte instead of
+  being dropped or typed literally.
+
 ## `v0.1.0-beta.64`
 
 ### Added

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -627,6 +627,7 @@ impl GhosttyView {
         }
 
         if event.prefer_character_input
+            && !keystroke.modifiers.control
             && keystroke
                 .key_char
                 .as_deref()
@@ -649,10 +650,10 @@ impl GhosttyView {
                 keystroke.modifiers.shift,
             ) {
                 let control = [code];
-                if let Ok(text) = std::str::from_utf8(&control) {
-                    terminal.send_text(text);
-                    return true;
-                }
+                let text = std::str::from_utf8(&control)
+                    .expect("terminal C0 control bytes are always valid UTF-8");
+                terminal.send_text(text);
+                return true;
             }
         }
 

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -637,16 +637,21 @@ impl GhosttyView {
 
         if keystroke.modifiers.control
             && !keystroke.modifiers.alt
-            && !keystroke.modifiers.shift
-            && keystroke.key.len() == 1
+            && (keystroke.key.len() == 1
+                || keystroke
+                    .key_char
+                    .as_deref()
+                    .is_some_and(|text| text.len() == 1))
         {
-            if let Some(ch) = keystroke.key.chars().next() {
-                if ch.is_ascii_alphabetic() {
-                    let control = [ch.to_ascii_uppercase() as u8 - b'@'];
-                    if let Ok(text) = std::str::from_utf8(&control) {
-                        terminal.send_text(text);
-                        return true;
-                    }
+            if let Some(code) = crate::terminal_keys::ctrl_keystroke_to_c0(
+                &keystroke.key,
+                keystroke.key_char.as_deref(),
+                keystroke.modifiers.shift,
+            ) {
+                let control = [code];
+                if let Ok(text) = std::str::from_utf8(&control) {
+                    terminal.send_text(text);
+                    return true;
                 }
             }
         }

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -62,6 +62,7 @@ mod sidebar;
 mod terminal_context_menu;
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 mod terminal_ime;
+mod terminal_keys;
 mod terminal_links;
 mod terminal_pane;
 mod terminal_paste;

--- a/crates/con-app/src/terminal_keys.rs
+++ b/crates/con-app/src/terminal_keys.rs
@@ -53,6 +53,8 @@ pub fn ctrl_chord_to_c0(key: &str) -> Option<u8> {
 #[cfg(any(target_os = "windows", target_os = "linux", test))]
 fn ctrl_keystroke_key_to_c0(key: &str) -> Option<u8> {
     let trimmed = key.trim();
+    // The surface API accepts legacy ctrl-2..8 byte aliases, but human
+    // Windows/Linux keyboard input reserves Ctrl+1..9 for app tab selection.
     if trimmed.len() == 1 && trimmed.as_bytes()[0].is_ascii_digit() {
         return None;
     }

--- a/crates/con-app/src/terminal_keys.rs
+++ b/crates/con-app/src/terminal_keys.rs
@@ -30,6 +30,8 @@ pub fn ctrl_key_to_c0(key: &str) -> Option<u8> {
         '^' => Some(0x1e),
         '_' => Some(0x1f),
         '/' => Some(0x1f),
+        // Mirrors Ghostty / Kitty ctrlSeq for Ctrl+~ rather than treating it
+        // as Ctrl+`'s physical-key NUL alias.
         '~' => Some(0x1e),
         '?' => Some(0x7f),
         ch if ch.is_ascii_alphabetic() => Some(ch.to_ascii_uppercase() as u8 - b'@'),
@@ -49,18 +51,28 @@ pub fn ctrl_chord_to_c0(key: &str) -> Option<u8> {
 }
 
 #[cfg(any(target_os = "windows", target_os = "linux", test))]
+fn ctrl_keystroke_key_to_c0(key: &str) -> Option<u8> {
+    let trimmed = key.trim();
+    if trimmed.len() == 1 && trimmed.as_bytes()[0].is_ascii_digit() {
+        return None;
+    }
+
+    ctrl_key_to_c0(trimmed)
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux", test))]
 pub fn ctrl_keystroke_to_c0(key: &str, key_char: Option<&str>, shift: bool) -> Option<u8> {
     if shift {
         return key_char
             .filter(|text| !text.chars().all(|ch| ch.is_ascii_alphabetic()))
             .and_then(ctrl_key_to_c0)
             .or_else(|| match key {
-                "@" | "^" | "_" | "?" => ctrl_key_to_c0(key),
+                "@" | "^" | "_" | "?" | "~" => ctrl_key_to_c0(key),
                 _ => None,
             });
     }
 
-    ctrl_key_to_c0(key).or_else(|| key_char.and_then(ctrl_key_to_c0))
+    ctrl_keystroke_key_to_c0(key).or_else(|| key_char.and_then(ctrl_keystroke_key_to_c0))
 }
 
 #[cfg(test)]
@@ -110,13 +122,19 @@ mod tests {
         assert_eq!(ctrl_chord_to_c0("C-\\"), Some(0x1c));
         assert_eq!(ctrl_chord_to_c0("C-/"), Some(0x1f));
         assert_eq!(ctrl_chord_to_c0("ctrl-2"), Some(0x00));
+        assert_eq!(ctrl_chord_to_c0("ctrl-~"), Some(0x1e));
     }
 
     #[test]
-    fn ctrl_keystroke_uses_shifted_key_char_without_breaking_tab_shortcuts() {
+    fn ctrl_keystroke_uses_shifted_punctuation_without_breaking_tab_shortcuts() {
+        assert_eq!(ctrl_keystroke_to_c0("2", Some("2"), false), None);
+        assert_eq!(ctrl_keystroke_to_c0("3", Some("3"), false), None);
+        assert_eq!(ctrl_keystroke_to_c0("8", Some("8"), false), None);
+        assert_eq!(ctrl_keystroke_to_c0("2", Some("@"), true), Some(0x00));
         assert_eq!(ctrl_keystroke_to_c0("6", Some("^"), true), Some(0x1e));
         assert_eq!(ctrl_keystroke_to_c0("-", Some("_"), true), Some(0x1f));
         assert_eq!(ctrl_keystroke_to_c0("`", Some("~"), true), Some(0x1e));
+        assert_eq!(ctrl_keystroke_to_c0("~", None, true), Some(0x1e));
         assert_eq!(ctrl_keystroke_to_c0("a", Some("A"), true), None);
         assert_eq!(ctrl_keystroke_to_c0("]", Some("}"), true), None);
         assert_eq!(ctrl_keystroke_to_c0("]", None, false), Some(0x1d));

--- a/crates/con-app/src/terminal_keys.rs
+++ b/crates/con-app/src/terminal_keys.rs
@@ -1,3 +1,8 @@
+/// Map legacy terminal Ctrl-key aliases to the C0/DEL byte they emit.
+///
+/// This intentionally covers the classic byte layer only. Modern protocols
+/// such as Kitty keyboard / modifyOtherKeys belong in libghostty-vt's key
+/// encoder, not in a growing Rust-side terminal keyboard table.
 pub fn ctrl_key_to_c0(key: &str) -> Option<u8> {
     let key = key.trim();
     if key.eq_ignore_ascii_case("space") {
@@ -12,11 +17,20 @@ pub fn ctrl_key_to_c0(key: &str) -> Option<u8> {
 
     match ch {
         '@' => Some(0x00),
+        '2' => Some(0x00),
+        '3' => Some(0x1b),
+        '4' => Some(0x1c),
+        '5' => Some(0x1d),
+        '6' => Some(0x1e),
+        '7' => Some(0x1f),
+        '8' => Some(0x7f),
         '[' => Some(0x1b),
         '\\' => Some(0x1c),
         ']' => Some(0x1d),
         '^' => Some(0x1e),
         '_' => Some(0x1f),
+        '/' => Some(0x1f),
+        '~' => Some(0x1e),
         '?' => Some(0x7f),
         ch if ch.is_ascii_alphabetic() => Some(ch.to_ascii_uppercase() as u8 - b'@'),
         _ => None,
@@ -63,11 +77,20 @@ mod tests {
     fn ctrl_key_maps_defined_ascii_punctuation_to_c0() {
         assert_eq!(ctrl_key_to_c0("space"), Some(0x00));
         assert_eq!(ctrl_key_to_c0("@"), Some(0x00));
+        assert_eq!(ctrl_key_to_c0("2"), Some(0x00));
+        assert_eq!(ctrl_key_to_c0("3"), Some(0x1b));
+        assert_eq!(ctrl_key_to_c0("4"), Some(0x1c));
+        assert_eq!(ctrl_key_to_c0("5"), Some(0x1d));
+        assert_eq!(ctrl_key_to_c0("6"), Some(0x1e));
+        assert_eq!(ctrl_key_to_c0("7"), Some(0x1f));
+        assert_eq!(ctrl_key_to_c0("8"), Some(0x7f));
         assert_eq!(ctrl_key_to_c0("["), Some(0x1b));
         assert_eq!(ctrl_key_to_c0("\\"), Some(0x1c));
         assert_eq!(ctrl_key_to_c0("]"), Some(0x1d));
         assert_eq!(ctrl_key_to_c0("^"), Some(0x1e));
         assert_eq!(ctrl_key_to_c0("_"), Some(0x1f));
+        assert_eq!(ctrl_key_to_c0("/"), Some(0x1f));
+        assert_eq!(ctrl_key_to_c0("~"), Some(0x1e));
         assert_eq!(ctrl_key_to_c0("?"), Some(0x7f));
     }
 
@@ -75,6 +98,8 @@ mod tests {
     fn ctrl_key_rejects_undefined_ascii_punctuation() {
         assert_eq!(ctrl_key_to_c0("}"), None);
         assert_eq!(ctrl_key_to_c0("1"), None);
+        assert_eq!(ctrl_key_to_c0("0"), None);
+        assert_eq!(ctrl_key_to_c0("9"), None);
         assert_eq!(ctrl_key_to_c0("enter"), None);
     }
 
@@ -83,14 +108,18 @@ mod tests {
         assert_eq!(ctrl_chord_to_c0("Ctrl-C"), Some(0x03));
         assert_eq!(ctrl_chord_to_c0("control-]"), Some(0x1d));
         assert_eq!(ctrl_chord_to_c0("C-\\"), Some(0x1c));
+        assert_eq!(ctrl_chord_to_c0("C-/"), Some(0x1f));
+        assert_eq!(ctrl_chord_to_c0("ctrl-2"), Some(0x00));
     }
 
     #[test]
     fn ctrl_keystroke_uses_shifted_key_char_without_breaking_tab_shortcuts() {
         assert_eq!(ctrl_keystroke_to_c0("6", Some("^"), true), Some(0x1e));
         assert_eq!(ctrl_keystroke_to_c0("-", Some("_"), true), Some(0x1f));
+        assert_eq!(ctrl_keystroke_to_c0("`", Some("~"), true), Some(0x1e));
         assert_eq!(ctrl_keystroke_to_c0("a", Some("A"), true), None);
         assert_eq!(ctrl_keystroke_to_c0("]", Some("}"), true), None);
         assert_eq!(ctrl_keystroke_to_c0("]", None, false), Some(0x1d));
+        assert_eq!(ctrl_keystroke_to_c0("/", Some("/"), false), Some(0x1f));
     }
 }

--- a/crates/con-app/src/terminal_keys.rs
+++ b/crates/con-app/src/terminal_keys.rs
@@ -1,0 +1,96 @@
+pub fn ctrl_key_to_c0(key: &str) -> Option<u8> {
+    let key = key.trim();
+    if key.eq_ignore_ascii_case("space") {
+        return Some(0x00);
+    }
+
+    let mut chars = key.chars();
+    let ch = chars.next()?;
+    if chars.next().is_some() {
+        return None;
+    }
+
+    match ch {
+        '@' => Some(0x00),
+        '[' => Some(0x1b),
+        '\\' => Some(0x1c),
+        ']' => Some(0x1d),
+        '^' => Some(0x1e),
+        '_' => Some(0x1f),
+        '?' => Some(0x7f),
+        ch if ch.is_ascii_alphabetic() => Some(ch.to_ascii_uppercase() as u8 - b'@'),
+        _ => None,
+    }
+}
+
+pub fn ctrl_chord_to_c0(key: &str) -> Option<u8> {
+    let key = key.trim();
+    let lower = key.to_ascii_lowercase();
+    for prefix in ["ctrl-", "control-", "c-"] {
+        if lower.starts_with(prefix) {
+            return ctrl_key_to_c0(&key[prefix.len()..]);
+        }
+    }
+    None
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux", test))]
+pub fn ctrl_keystroke_to_c0(key: &str, key_char: Option<&str>, shift: bool) -> Option<u8> {
+    if shift {
+        return key_char
+            .filter(|text| !text.chars().all(|ch| ch.is_ascii_alphabetic()))
+            .and_then(ctrl_key_to_c0)
+            .or_else(|| match key {
+                "@" | "^" | "_" | "?" => ctrl_key_to_c0(key),
+                _ => None,
+            });
+    }
+
+    ctrl_key_to_c0(key).or_else(|| key_char.and_then(ctrl_key_to_c0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ctrl_chord_to_c0, ctrl_key_to_c0, ctrl_keystroke_to_c0};
+
+    #[test]
+    fn ctrl_key_maps_letters_to_c0() {
+        assert_eq!(ctrl_key_to_c0("a"), Some(0x01));
+        assert_eq!(ctrl_key_to_c0("Z"), Some(0x1a));
+    }
+
+    #[test]
+    fn ctrl_key_maps_defined_ascii_punctuation_to_c0() {
+        assert_eq!(ctrl_key_to_c0("space"), Some(0x00));
+        assert_eq!(ctrl_key_to_c0("@"), Some(0x00));
+        assert_eq!(ctrl_key_to_c0("["), Some(0x1b));
+        assert_eq!(ctrl_key_to_c0("\\"), Some(0x1c));
+        assert_eq!(ctrl_key_to_c0("]"), Some(0x1d));
+        assert_eq!(ctrl_key_to_c0("^"), Some(0x1e));
+        assert_eq!(ctrl_key_to_c0("_"), Some(0x1f));
+        assert_eq!(ctrl_key_to_c0("?"), Some(0x7f));
+    }
+
+    #[test]
+    fn ctrl_key_rejects_undefined_ascii_punctuation() {
+        assert_eq!(ctrl_key_to_c0("}"), None);
+        assert_eq!(ctrl_key_to_c0("1"), None);
+        assert_eq!(ctrl_key_to_c0("enter"), None);
+    }
+
+    #[test]
+    fn ctrl_chord_accepts_terminal_spellings() {
+        assert_eq!(ctrl_chord_to_c0("Ctrl-C"), Some(0x03));
+        assert_eq!(ctrl_chord_to_c0("control-]"), Some(0x1d));
+        assert_eq!(ctrl_chord_to_c0("C-\\"), Some(0x1c));
+    }
+
+    #[test]
+    fn ctrl_keystroke_uses_shifted_key_char_without_breaking_tab_shortcuts() {
+        assert_eq!(ctrl_keystroke_to_c0("6", Some("^"), true), Some(0x1e));
+        assert_eq!(ctrl_keystroke_to_c0("-", Some("_"), true), Some(0x1f));
+        assert_eq!(ctrl_keystroke_to_c0("a", Some("A"), true), None);
+        assert_eq!(ctrl_keystroke_to_c0("]", Some("}"), true), None);
+        assert_eq!(ctrl_keystroke_to_c0("]", None, false), Some(0x1d));
+    }
+}

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -1098,21 +1098,27 @@ impl GhosttyView {
             return false;
         }
 
-        // Ctrl + ascii letter → control char (Ctrl-C = 0x03 etc.)
+        // Ctrl + defined ASCII keys → C0 control bytes. This includes
+        // punctuation controls terminals rely on, such as Ctrl+] for tmux's
+        // `C-]` prefix (GS / 0x1d), not just Ctrl+A-Z.
         if keystroke.modifiers.control
             && !keystroke.modifiers.alt
             && !keystroke.modifiers.platform
-            && !keystroke.modifiers.shift
-            && keystroke.key.len() == 1
+            && (keystroke.key.len() == 1
+                || keystroke
+                    .key_char
+                    .as_deref()
+                    .is_some_and(|text| text.len() == 1))
         {
-            if let Some(ch) = keystroke.key.chars().next() {
-                if ch.is_ascii_alphabetic() {
-                    let code = ch.to_ascii_uppercase() as u8 - b'@';
-                    let byte = [code];
-                    if let Ok(s) = std::str::from_utf8(&byte) {
-                        terminal.send_text(s);
-                        return true;
-                    }
+            if let Some(code) = crate::terminal_keys::ctrl_keystroke_to_c0(
+                &keystroke.key,
+                keystroke.key_char.as_deref(),
+                keystroke.modifiers.shift,
+            ) {
+                let byte = [code];
+                if let Ok(s) = std::str::from_utf8(&byte) {
+                    terminal.send_text(s);
+                    return true;
                 }
             }
         }

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -1090,6 +1090,7 @@ impl GhosttyView {
         }
 
         if event.prefer_character_input
+            && !keystroke.modifiers.control
             && keystroke
                 .key_char
                 .as_deref()
@@ -1116,10 +1117,10 @@ impl GhosttyView {
                 keystroke.modifiers.shift,
             ) {
                 let byte = [code];
-                if let Ok(s) = std::str::from_utf8(&byte) {
-                    terminal.send_text(s);
-                    return true;
-                }
+                let text = std::str::from_utf8(&byte)
+                    .expect("terminal C0 control bytes are always valid UTF-8");
+                terminal.send_text(text);
+                return true;
             }
         }
 

--- a/crates/con-app/src/workspace/control_surfaces.rs
+++ b/crates/con-app/src/workspace/control_surfaces.rs
@@ -804,7 +804,7 @@ impl ConWorkspace {
             _ if let Some(code) = crate::terminal_keys::ctrl_chord_to_c0(key) => Ok(vec![code]),
             _ if key.chars().count() == 1 => Ok(key.as_bytes().to_vec()),
             _ => Err(ControlError::invalid_params(format!(
-                "Unsupported surface key `{key}`. Supported keys: escape, enter, tab, backspace, ctrl-<letter>, ctrl-], ctrl-\\, ctrl-[, ctrl-^, ctrl-_, ctrl-?."
+                "Unsupported surface key `{key}`. Supported keys: escape, enter, tab, backspace, ctrl-<letter>, ctrl-space/ctrl-@, ctrl-[, ctrl-\\, ctrl-], ctrl-^, ctrl-_, ctrl-?."
             ))),
         }
     }

--- a/crates/con-app/src/workspace/control_surfaces.rs
+++ b/crates/con-app/src/workspace/control_surfaces.rs
@@ -801,11 +801,10 @@ impl ConWorkspace {
             "enter" | "return" => Ok(b"\n".to_vec()),
             "tab" => Ok(b"\t".to_vec()),
             "backspace" => Ok(vec![0x7f]),
-            "ctrl-c" | "control-c" | "c-c" => Ok(vec![0x03]),
-            "ctrl-d" | "control-d" | "c-d" => Ok(vec![0x04]),
+            _ if let Some(code) = crate::terminal_keys::ctrl_chord_to_c0(key) => Ok(vec![code]),
             _ if key.chars().count() == 1 => Ok(key.as_bytes().to_vec()),
             _ => Err(ControlError::invalid_params(format!(
-                "Unsupported surface key `{key}`. Supported keys: escape, enter, tab, backspace, ctrl-c, ctrl-d."
+                "Unsupported surface key `{key}`. Supported keys: escape, enter, tab, backspace, ctrl-<letter>, ctrl-], ctrl-\\, ctrl-[, ctrl-^, ctrl-_, ctrl-?."
             ))),
         }
     }

--- a/crates/con-app/src/workspace/control_surfaces.rs
+++ b/crates/con-app/src/workspace/control_surfaces.rs
@@ -804,7 +804,7 @@ impl ConWorkspace {
             _ if let Some(code) = crate::terminal_keys::ctrl_chord_to_c0(key) => Ok(vec![code]),
             _ if key.chars().count() == 1 => Ok(key.as_bytes().to_vec()),
             _ => Err(ControlError::invalid_params(format!(
-                "Unsupported surface key `{key}`. Supported keys: escape, enter, tab, backspace, ctrl-<letter>, ctrl-space/ctrl-@, ctrl-[, ctrl-\\, ctrl-], ctrl-^, ctrl-_, ctrl-?."
+                "Unsupported surface key `{key}`. Supported keys: escape, enter, tab, backspace, ctrl-<letter>, ctrl-space/ctrl-@, ctrl-[, ctrl-\\, ctrl-], ctrl-^, ctrl-_, ctrl-/, ctrl-?, ctrl-~, ctrl-2..8."
             ))),
         }
     }

--- a/crates/con-app/src/workspace/tests.rs
+++ b/crates/con-app/src/workspace/tests.rs
@@ -955,6 +955,11 @@ fn surface_key_bytes_matches_named_keys_case_insensitively() {
         ConWorkspace::surface_key_bytes("control-\\").unwrap(),
         vec![0x1c]
     );
+    assert_eq!(ConWorkspace::surface_key_bytes("C-/").unwrap(), vec![0x1f]);
+    assert_eq!(
+        ConWorkspace::surface_key_bytes("ctrl-2").unwrap(),
+        vec![0x00]
+    );
     assert_eq!(ConWorkspace::surface_key_bytes("C-?").unwrap(), vec![0x7f]);
 }
 

--- a/crates/con-app/src/workspace/tests.rs
+++ b/crates/con-app/src/workspace/tests.rs
@@ -947,6 +947,15 @@ fn surface_key_bytes_matches_named_keys_case_insensitively() {
         ConWorkspace::surface_key_bytes("Ctrl-C").unwrap(),
         vec![0x03]
     );
+    assert_eq!(
+        ConWorkspace::surface_key_bytes("Ctrl-]").unwrap(),
+        vec![0x1d]
+    );
+    assert_eq!(
+        ConWorkspace::surface_key_bytes("control-\\").unwrap(),
+        vec![0x1c]
+    );
+    assert_eq!(ConWorkspace::surface_key_bytes("C-?").unwrap(), vec![0x7f]);
 }
 
 #[test]

--- a/docs/impl/linux-port.md
+++ b/docs/impl/linux-port.md
@@ -56,7 +56,8 @@ What that gives you:
   focus/navigation keys reach the Linux pane instead of being swallowed
   by GPUI focus traversal
 - terminal C0 control chords for both letters and defined ASCII punctuation,
-  including `Ctrl+]` -> GS (`0x1d`) for tmux prefix configs such as
+  including `Ctrl+]` -> GS (`0x1d`), `Ctrl+/` -> US (`0x1f`), and the
+  legacy `Ctrl+2..8` aliases for tmux prefix configs such as
   `set -g prefix C-]`
 - IoskeleyMono shaping (the user-facing display name `"Ioskeley
   Mono"` is normalized to the registered TTF family `"IoskeleyMono"`

--- a/docs/impl/linux-port.md
+++ b/docs/impl/linux-port.md
@@ -56,9 +56,10 @@ What that gives you:
   focus/navigation keys reach the Linux pane instead of being swallowed
   by GPUI focus traversal
 - terminal C0 control chords for both letters and defined ASCII punctuation,
-  including `Ctrl+]` -> GS (`0x1d`), `Ctrl+/` -> US (`0x1f`), and the
-  legacy `Ctrl+2..8` aliases for tmux prefix configs such as
-  `set -g prefix C-]`
+  including `Ctrl+]` -> GS (`0x1d`), `Ctrl+/` -> US (`0x1f`), and
+  `Ctrl+@` / `Ctrl+Space` -> NUL (`0x00`). Interactive `Ctrl+1..9` stays
+  reserved for tab switching on Linux; the surface-control parser still accepts
+  legacy `ctrl-2..8` aliases for automation.
 - IoskeleyMono shaping (the user-facing display name `"Ioskeley
   Mono"` is normalized to the registered TTF family `"IoskeleyMono"`
   before lookup so GPUI's CosmicTextSystem resolves the embedded

--- a/docs/impl/linux-port.md
+++ b/docs/impl/linux-port.md
@@ -55,6 +55,9 @@ What that gives you:
 - terminal-local Tab / Shift+Tab capture, so shell completion and TUI
   focus/navigation keys reach the Linux pane instead of being swallowed
   by GPUI focus traversal
+- terminal C0 control chords for both letters and defined ASCII punctuation,
+  including `Ctrl+]` -> GS (`0x1d`) for tmux prefix configs such as
+  `set -g prefix C-]`
 - IoskeleyMono shaping (the user-facing display name `"Ioskeley
   Mono"` is normalized to the registered TTF family `"IoskeleyMono"`
   before lookup so GPUI's CosmicTextSystem resolves the embedded

--- a/docs/impl/windows-port.md
+++ b/docs/impl/windows-port.md
@@ -347,8 +347,10 @@ Phase 3c details now covered by the beta baseline:
 
 - `host_view` translates `VK_*` input into terminal-local xterm sequences, including Tab / Shift+Tab capture, while preserving mouse selection behavior.
 - ASCII C0 control chords include the punctuation controls terminals expect,
-  not only letters. `Ctrl+]` now reaches tmux as GS (`0x1d`), so configs such
-  as `set -g prefix C-]` work on the Windows backend.
+  not only letters. `Ctrl+]` now reaches tmux as GS (`0x1d`), `Ctrl+/`
+  reaches US (`0x1f`), and the legacy `Ctrl+2..8` aliases are covered in the
+  shared control-byte helper. Configs such as `set -g prefix C-]` work on the
+  Windows backend.
 - Wheel and touchpad input scroll libghostty-vt viewport state when mouse tracking is inactive. Alternate-screen mode-1007 wheel gestures translate into cursor keys with the same fractional row accumulator used by primary scrollback.
 - The Windows pane has a visible GPUI scrollback scrollbar backed by cached libghostty-vt scrollbar state, so render no longer polls the expensive scrollbar query on every paint.
 - OSC 52 and ordinary clipboard operations are wired through the Win32 clipboard.

--- a/docs/impl/windows-port.md
+++ b/docs/impl/windows-port.md
@@ -346,6 +346,9 @@ phase keeps the macOS build green.
 Phase 3c details now covered by the beta baseline:
 
 - `host_view` translates `VK_*` input into terminal-local xterm sequences, including Tab / Shift+Tab capture, while preserving mouse selection behavior.
+- ASCII C0 control chords include the punctuation controls terminals expect,
+  not only letters. `Ctrl+]` now reaches tmux as GS (`0x1d`), so configs such
+  as `set -g prefix C-]` work on the Windows backend.
 - Wheel and touchpad input scroll libghostty-vt viewport state when mouse tracking is inactive. Alternate-screen mode-1007 wheel gestures translate into cursor keys with the same fractional row accumulator used by primary scrollback.
 - The Windows pane has a visible GPUI scrollback scrollbar backed by cached libghostty-vt scrollbar state, so render no longer polls the expensive scrollbar query on every paint.
 - OSC 52 and ordinary clipboard operations are wired through the Win32 clipboard.

--- a/docs/impl/windows-port.md
+++ b/docs/impl/windows-port.md
@@ -348,9 +348,10 @@ Phase 3c details now covered by the beta baseline:
 - `host_view` translates `VK_*` input into terminal-local xterm sequences, including Tab / Shift+Tab capture, while preserving mouse selection behavior.
 - ASCII C0 control chords include the punctuation controls terminals expect,
   not only letters. `Ctrl+]` now reaches tmux as GS (`0x1d`), `Ctrl+/`
-  reaches US (`0x1f`), and the legacy `Ctrl+2..8` aliases are covered in the
-  shared control-byte helper. Configs such as `set -g prefix C-]` work on the
-  Windows backend.
+  reaches US (`0x1f`), and shifted punctuation such as `Ctrl+@` / `Ctrl+Space`
+  reaches NUL (`0x00`). The shared surface-control parser also accepts the
+  legacy `ctrl-2..8` aliases for automation. Interactive `Ctrl+1..9` stays
+  reserved for app tab switching on Windows.
 - Wheel and touchpad input scroll libghostty-vt viewport state when mouse tracking is inactive. Alternate-screen mode-1007 wheel gestures translate into cursor keys with the same fractional row accumulator used by primary scrollback.
 - The Windows pane has a visible GPUI scrollback scrollbar backed by cached libghostty-vt scrollbar state, so render no longer polls the expensive scrollbar query on every paint.
 - OSC 52 and ordinary clipboard operations are wired through the Win32 clipboard.

--- a/postmortem/2026-05-07-windows-tmux-ctrl-punctuation-prefix.md
+++ b/postmortem/2026-05-07-windows-tmux-ctrl-punctuation-prefix.md
@@ -20,13 +20,6 @@ terminal bytes themselves. That translation handled `Ctrl+A` through `Ctrl+Z`,
 but it did not handle the defined ASCII control punctuation chords:
 
 - `Ctrl+@` / `Ctrl+Space` -> NUL (`0x00`)
-- `Ctrl+2` -> NUL (`0x00`)
-- `Ctrl+3` -> ESC (`0x1b`)
-- `Ctrl+4` -> FS (`0x1c`)
-- `Ctrl+5` -> GS (`0x1d`)
-- `Ctrl+6` -> RS (`0x1e`)
-- `Ctrl+7` / `Ctrl+/` -> US (`0x1f`)
-- `Ctrl+8` -> DEL (`0x7f`)
 - `Ctrl+[` -> ESC (`0x1b`)
 - `Ctrl+\` -> FS (`0x1c`)
 - `Ctrl+]` -> GS (`0x1d`)
@@ -34,6 +27,12 @@ but it did not handle the defined ASCII control punctuation chords:
 - `Ctrl+_` -> US (`0x1f`)
 - `Ctrl+~` -> RS (`0x1e`)
 - `Ctrl+?` -> DEL (`0x7f`)
+
+The surface control API also accepts the legacy `ctrl-2..8` aliases because an
+orchestrator has no conflict with app navigation. Interactive Windows/Linux
+keyboard input intentionally keeps unshifted `Ctrl+1..9` reserved for tab
+selection; users can still send NUL through `Ctrl+Space` or shifted
+punctuation such as `Ctrl+Shift+2` (`Ctrl+@`).
 
 tmux treats `C-]` as `0x1d`, so Con's letter-only mapper meant the prefix never
 reached tmux.
@@ -53,6 +52,11 @@ That keeps physical user input and orchestrator-driven surface input aligned.
 The helper intentionally does not map shifted bracket variants like `Ctrl+}` or
 `Ctrl+{`, so Windows/Linux app shortcuts such as `Ctrl+Shift+]` for tab
 switching stay app-level.
+
+One deliberate product boundary remains: the keyboard path does not map
+unshifted `Ctrl+2..8` because `Ctrl+1..9` is Con's Windows/Linux tab-selection
+gesture. The surface control API supports those aliases because automation can
+target terminal bytes directly without stealing a human navigation shortcut.
 
 This is the complete legacy C0 control-byte layer, not the complete modern
 keyboard-protocol layer. Full parity with Ghostty on Windows and Linux should

--- a/postmortem/2026-05-07-windows-tmux-ctrl-punctuation-prefix.md
+++ b/postmortem/2026-05-07-windows-tmux-ctrl-punctuation-prefix.md
@@ -20,11 +20,19 @@ terminal bytes themselves. That translation handled `Ctrl+A` through `Ctrl+Z`,
 but it did not handle the defined ASCII control punctuation chords:
 
 - `Ctrl+@` / `Ctrl+Space` -> NUL (`0x00`)
+- `Ctrl+2` -> NUL (`0x00`)
+- `Ctrl+3` -> ESC (`0x1b`)
+- `Ctrl+4` -> FS (`0x1c`)
+- `Ctrl+5` -> GS (`0x1d`)
+- `Ctrl+6` -> RS (`0x1e`)
+- `Ctrl+7` / `Ctrl+/` -> US (`0x1f`)
+- `Ctrl+8` -> DEL (`0x7f`)
 - `Ctrl+[` -> ESC (`0x1b`)
 - `Ctrl+\` -> FS (`0x1c`)
 - `Ctrl+]` -> GS (`0x1d`)
 - `Ctrl+^` -> RS (`0x1e`)
 - `Ctrl+_` -> US (`0x1f`)
+- `Ctrl+~` -> RS (`0x1e`)
 - `Ctrl+?` -> DEL (`0x7f`)
 
 tmux treats `C-]` as `0x1d`, so Con's letter-only mapper meant the prefix never
@@ -46,6 +54,13 @@ The helper intentionally does not map shifted bracket variants like `Ctrl+}` or
 `Ctrl+{`, so Windows/Linux app shortcuts such as `Ctrl+Shift+]` for tab
 switching stay app-level.
 
+This is the complete legacy C0 control-byte layer, not the complete modern
+keyboard-protocol layer. Full parity with Ghostty on Windows and Linux should
+eventually route portable key events through libghostty-vt's key encoder
+(`ghostty_key_encoder_*`) so terminal state such as Kitty keyboard protocol,
+modifyOtherKeys, keypad application mode, and fixterms stays owned by Ghostty
+instead of being hand-maintained in Con.
+
 ## Copy-On-Select Note
 
 The same issue asked about copy-on-select under tmux. This fix does not claim to
@@ -57,5 +72,7 @@ not hide a clipboard protocol gap behind the key-prefix fix.
 ## What We Learned
 
 Terminal control-key support is not just letters. If Con owns key translation on
-a platform, it must implement the complete defined ASCII C0 control set and keep
-those semantics shared with the control-plane surface API.
+a platform, it must implement the complete legacy C0 control-byte layer and keep
+those semantics shared with the control-plane surface API. For anything beyond
+that layer, the long-term answer is not a larger Rust table; it is reusing
+Ghostty's VT key encoder.

--- a/postmortem/2026-05-07-windows-tmux-ctrl-punctuation-prefix.md
+++ b/postmortem/2026-05-07-windows-tmux-ctrl-punctuation-prefix.md
@@ -1,0 +1,61 @@
+# Windows tmux Ctrl-Punctuation Prefix
+
+## What Happened
+
+Issue #148 reported that this tmux config worked in other terminals but not in
+Con on Windows:
+
+```tmux
+unbind C-b
+set -g prefix C-]
+set -g prefix2 C-h
+```
+
+`C-h` worked, but `C-]` did not.
+
+## Root Cause
+
+Con's Windows and Linux preview terminal views translate GPUI key events into
+terminal bytes themselves. That translation handled `Ctrl+A` through `Ctrl+Z`,
+but it did not handle the defined ASCII control punctuation chords:
+
+- `Ctrl+@` / `Ctrl+Space` -> NUL (`0x00`)
+- `Ctrl+[` -> ESC (`0x1b`)
+- `Ctrl+\` -> FS (`0x1c`)
+- `Ctrl+]` -> GS (`0x1d`)
+- `Ctrl+^` -> RS (`0x1e`)
+- `Ctrl+_` -> US (`0x1f`)
+- `Ctrl+?` -> DEL (`0x7f`)
+
+tmux treats `C-]` as `0x1d`, so Con's letter-only mapper meant the prefix never
+reached tmux.
+
+macOS was not affected because it sends keys through Ghostty's native key
+pipeline instead of Con's portable VT key mapper.
+
+## Fix Applied
+
+Con now has one shared ASCII-control helper used by:
+
+- Windows terminal key handling
+- Linux terminal key handling
+- the surface control API's `keys.send` parser
+
+That keeps physical user input and orchestrator-driven surface input aligned.
+The helper intentionally does not map shifted bracket variants like `Ctrl+}` or
+`Ctrl+{`, so Windows/Linux app shortcuts such as `Ctrl+Shift+]` for tab
+switching stay app-level.
+
+## Copy-On-Select Note
+
+The same issue asked about copy-on-select under tmux. This fix does not claim to
+solve that larger workflow. Local Con selection can be copied through the normal
+terminal copy action, and tmux mouse mode still requires terminal-level handling
+or tmux/OSC52 clipboard integration. That should be tracked separately so we do
+not hide a clipboard protocol gap behind the key-prefix fix.
+
+## What We Learned
+
+Terminal control-key support is not just letters. If Con owns key translation on
+a platform, it must implement the complete defined ASCII C0 control set and keep
+those semantics shared with the control-plane surface API.


### PR DESCRIPTION
## Summary
- add one shared terminal C0 key mapping for Windows, Linux, and surface RPC input
- send legacy Ctrl punctuation chords such as Ctrl+], Ctrl+/, Ctrl+@, Ctrl+Space, and Ctrl+~ as terminal control bytes, so tmux prefixes like `set -g prefix C-]` work
- keep interactive Windows/Linux Ctrl+1..9 reserved for app tab switching while allowing surface RPC automation to send legacy `ctrl-2..8` byte aliases directly
- document the behavior, tests, and the long-term boundary: full keyboard protocol parity should use libghostty-vt's key encoder rather than growing a Rust-side table
- record the remaining tmux copy-on-select question as a separate clipboard/selection follow-up

Refs #148.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS='-D warnings' cargo check -p con`
- `RUSTFLAGS='-D warnings' cargo check -p con --no-default-features --features con/bin-con-app`
- `cargo test -p con terminal_keys -- --nocapture`
- `cargo test -p con surface_key_bytes -- --nocapture`
- `cargo test --workspace`
- `python3 scripts/docs/validate-manifest.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-platform terminal input translation and surface-control key parsing; mistakes could regress common shortcuts or send incorrect bytes to shells/TUIs, but the change is scoped and covered by unit tests.
> 
> **Overview**
> Fixes Windows/Linux terminal key handling to emit the full legacy *C0 control-byte* set for `Ctrl+<punctuation>` chords (e.g. `Ctrl+]`, `Ctrl+/`, `Ctrl+@`/`Ctrl+Space`, `Ctrl+?`), enabling tmux prefixes and similar workflows that previously got dropped/typed literally.
> 
> Introduces a shared `terminal_keys` helper used by Windows, Linux, and the surface RPC `keys.send` parser, while **preserving** interactive `Ctrl+1..9` for app tab switching and only allowing legacy `ctrl-2..8` aliases via the automation surface API. Updates tests and docs (plus a postmortem and changelog entry) to lock in the new behavior and its boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd177b9d326b2fc1a2b1209fd2309e35cc09a093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->