### PR TITLE
feat: enable ssh-terminfo and ssh-env shell integration features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ## `v0.1.0-beta.65`
 
+### Added
+
+**macOS**
+
+- Enabled Ghostty SSH shell-integration features for macOS terminal sessions,
+  so remote SSH hosts can receive `xterm-ghostty` terminfo and terminal
+  environment hints while Con still preserves its own cursor-style setting.
+
 ### Fixed
 
 **Windows, Linux**

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -158,7 +158,9 @@ impl GhosttyConfigPatch {
         // Disable ghostty shell-integration cursor override so con's
         // cursor-style setting is respected. Ghostty's integration
         // unconditionally forces a bar cursor at prompts otherwise.
-        s.push_str("shell-integration-features = no-cursor\n");
+        // Enable ssh-env and ssh-terminfo so Ghostty's shell integration
+        // auto-installs xterm-ghostty terminfo on remote SSH hosts.
+        s.push_str("shell-integration-features = no-cursor,ssh-env,ssh-terminfo\n");
         if let Some(background_image) = &self.background_image {
             s.push_str(&format!("background-image = {:?}\n", background_image));
             if let Some(background_image_opacity) = self.background_image_opacity {

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -26,6 +26,7 @@ use parking_lot::Mutex;
 use crate::ffi;
 
 const DEFAULT_GHOSTTY_FONT_FAMILY: &str = "Ioskeley Mono";
+const CON_SHELL_INTEGRATION_FEATURES: &str = "no-cursor,ssh-env,ssh-terminfo";
 
 fn sanitize_font_family_for_ghostty(font_family: &str) -> &str {
     let trimmed = font_family.trim();
@@ -160,7 +161,9 @@ impl GhosttyConfigPatch {
         // unconditionally forces a bar cursor at prompts otherwise.
         // Enable ssh-env and ssh-terminfo so Ghostty's shell integration
         // auto-installs xterm-ghostty terminfo on remote SSH hosts.
-        s.push_str("shell-integration-features = no-cursor,ssh-env,ssh-terminfo\n");
+        s.push_str("shell-integration-features = ");
+        s.push_str(CON_SHELL_INTEGRATION_FEATURES);
+        s.push('\n');
         if let Some(background_image) = &self.background_image {
             s.push_str(&format!("background-image = {:?}\n", background_image));
             if let Some(background_image_opacity) = self.background_image_opacity {
@@ -208,23 +211,13 @@ fn build_ghostty_config(patch: &GhosttyConfigPatch) -> Result<ffi::ghostty_confi
         return Err("ghostty_config_new returned null".into());
     }
 
-    if patch.colors.is_some()
-        || patch.font_family.is_some()
-        || patch.font_size.is_some()
-        || patch.background_opacity.is_some()
-        || patch.background_blur.is_some()
-        || patch.cursor_style.is_some()
-        || patch.background_image.is_some()
-        || patch.background_image_opacity.is_some()
-        || patch.background_image_position.is_some()
-        || patch.background_image_fit.is_some()
-        || patch.background_image_repeat.is_some()
-    {
-        let path = patch.write_config_file()?;
-        let path_str = path.to_str().ok_or("non-UTF8 path")?;
-        let cpath = CString::new(path_str).map_err(|e| format!("CString: {}", e))?;
-        unsafe { ffi::ghostty_config_load_file(config, cpath.as_ptr()) };
-    }
+    // Always load Con's runtime config, even when no appearance patch fields
+    // are present. Some terminal behavior is part of Con's product default
+    // rather than a user patch, most notably shell integration features.
+    let path = patch.write_config_file()?;
+    let path_str = path.to_str().ok_or("non-UTF8 path")?;
+    let cpath = CString::new(path_str).map_err(|e| format!("CString: {}", e))?;
+    unsafe { ffi::ghostty_config_load_file(config, cpath.as_ptr()) };
 
     unsafe { ffi::ghostty_config_finalize(config) };
     Ok(config)
@@ -1659,5 +1652,12 @@ mod tests {
         let config = patch.to_config_string();
         assert!(config.contains("font-family = \"Ioskeley Mono\""));
         assert!(!config.contains(".ZedMono"));
+    }
+
+    #[test]
+    fn ghostty_config_always_includes_con_shell_integration_features() {
+        let config = GhosttyConfigPatch::default().to_config_string();
+
+        assert!(config.contains("shell-integration-features = no-cursor,ssh-env,ssh-terminfo"));
     }
 }


### PR DESCRIPTION
## Summary

Enable Ghostty's `ssh-terminfo` and `ssh-env` shell-integration features for macOS embedded libghostty sessions.

Ghostty's `shell-integration-features` defaults `ssh-terminfo` and `ssh-env` to `false`. This can leave `xterm-ghostty` terminfo missing on remote SSH hosts, which breaks line editing and key behavior in remote shells.

With this change, Con's macOS Ghostty runtime config now always loads Con's shell-integration defaults:
- preserve Con's cursor-style setting with `no-cursor`
- enable SSH environment forwarding with `ssh-env`
- enable remote `xterm-ghostty` terminfo setup with `ssh-terminfo`

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `RUSTFLAGS='-D warnings' cargo check -p con-ghostty`
- `RUSTFLAGS='-D warnings' cargo check -p con`
- `RUSTFLAGS='-D warnings' cargo check -p con --no-default-features --features con/bin-con-app`
- `cargo test -p con-ghostty ghostty_config -- --nocapture`
- `cargo test --workspace`
- `python3 scripts/docs/validate-manifest.py`
