### PR TITLE
Add Zig mirror fallback to release workflows

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -84,7 +84,20 @@ jobs:
           ZIG_ARCH="x86_64"
           ZIG_DIR="zig-${ZIG_ARCH}-linux-${ZIG_VERSION}"
           ZIG_TARBALL="${ZIG_DIR}.tar.xz"
-          curl -sSfL "https://ziglang.org/download/${ZIG_VERSION}/${ZIG_TARBALL}" -o "/tmp/${ZIG_TARBALL}"
+          for base_url in \
+            "https://zigmirror.hryx.net/zig" \
+            "https://zig.linus.dev/zig" \
+            "https://zig.mirror.mschae23.de/zig" \
+            "https://ziglang.freetls.fastly.net" \
+            "https://pkg.hexops.org/zig" \
+            "https://ziglang.org/download/${ZIG_VERSION}"; do
+            if curl --retry 3 --retry-all-errors --retry-delay 5 --connect-timeout 30 \
+              -sSfL "${base_url}/${ZIG_TARBALL}" \
+              -o "/tmp/${ZIG_TARBALL}"; then
+              break
+            fi
+          done
+          test -s "/tmp/${ZIG_TARBALL}"
           mkdir -p "$HOME/.local"
           tar -xJf "/tmp/${ZIG_TARBALL}" -C "$HOME/.local"
           echo "$HOME/.local/${ZIG_DIR}" >> "$GITHUB_PATH"

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -60,7 +60,20 @@ jobs:
           esac
           ZIG_DIR="zig-${ZIG_ARCH}-macos-${ZIG_VERSION}"
           ZIG_TARBALL="${ZIG_DIR}.tar.xz"
-          curl -sSfL "https://ziglang.org/download/${ZIG_VERSION}/${ZIG_TARBALL}" -o "/tmp/${ZIG_TARBALL}"
+          for base_url in \
+            "https://zigmirror.hryx.net/zig" \
+            "https://zig.linus.dev/zig" \
+            "https://zig.mirror.mschae23.de/zig" \
+            "https://ziglang.freetls.fastly.net" \
+            "https://pkg.hexops.org/zig" \
+            "https://ziglang.org/download/${ZIG_VERSION}"; do
+            if curl --retry 3 --retry-all-errors --retry-delay 5 --connect-timeout 30 \
+              -sSfL "${base_url}/${ZIG_TARBALL}" \
+              -o "/tmp/${ZIG_TARBALL}"; then
+              break
+            fi
+          done
+          test -s "/tmp/${ZIG_TARBALL}"
           mkdir -p "$HOME/.local"
           tar -xf "/tmp/${ZIG_TARBALL}" -C "$HOME/.local"
           echo "$HOME/.local/${ZIG_DIR}" >> "$GITHUB_PATH"

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -106,11 +106,38 @@ jobs:
           $ZigVersion = "0.15.2"
           $ZigDir    = "zig-x86_64-windows-$ZigVersion"
           $ZigZip    = "$ZigDir.zip"
-          $Url       = "https://ziglang.org/download/$ZigVersion/$ZigZip"
           $Dest      = "$env:USERPROFILE\.local"
+          $Out       = Join-Path $env:TEMP $ZigZip
+          $Urls      = @(
+            "https://zigmirror.hryx.net/zig/$ZigZip",
+            "https://zig.linus.dev/zig/$ZigZip",
+            "https://zig.mirror.mschae23.de/zig/$ZigZip",
+            "https://ziglang.freetls.fastly.net/$ZigZip",
+            "https://pkg.hexops.org/zig/$ZigZip",
+            "https://ziglang.org/download/$ZigVersion/$ZigZip"
+          )
           New-Item -ItemType Directory -Force -Path $Dest | Out-Null
-          Invoke-WebRequest -Uri $Url -OutFile "$env:TEMP\$ZigZip"
-          Expand-Archive -Path "$env:TEMP\$ZigZip" -DestinationPath $Dest -Force
+          Remove-Item -Force -ErrorAction SilentlyContinue $Out
+          $Downloaded = $false
+          foreach ($Url in $Urls) {
+            for ($Attempt = 1; $Attempt -le 3; $Attempt++) {
+              try {
+                Invoke-WebRequest -Uri $Url -OutFile $Out -TimeoutSec 120
+                if ((Test-Path $Out) -and ((Get-Item $Out).Length -gt 0)) {
+                  $Downloaded = $true
+                  break
+                }
+              } catch {
+                Write-Warning "Zig download failed from $Url on attempt ${Attempt}: $($_.Exception.Message)"
+                Start-Sleep -Seconds 5
+              }
+            }
+            if ($Downloaded) { break }
+          }
+          if (-not $Downloaded) {
+            throw "Failed to download Zig $ZigVersion from all mirrors"
+          }
+          Expand-Archive -Path $Out -DestinationPath $Dest -Force
           Add-Content -Path $env:GITHUB_PATH -Value "$Dest\$ZigDir"
           & "$Dest\$ZigDir\zig.exe" version
 


### PR DESCRIPTION
## Summary

The `v0.1.0-beta.64` release tag exposed a release-infra gap: macOS, Linux, and Windows release workflows all downloaded Zig 0.15.2 directly from `ziglang.org`, and GitHub-hosted runners hit repeated connection resets before Con build/package steps started.

This ports the mirror + retry strategy already used by portable CI into all three platform release workflows.

## What Changed

- macOS release workflow now tries known Zig mirrors before `ziglang.org` and verifies the tarball is non-empty.
- Linux release workflow now uses the same mirror/retry path.
- Windows release workflow now retries multiple mirror URLs before falling back to `ziglang.org`.

## Validation

- `ruby -e 'require "yaml"; ... YAML.load_file(...)'` for all three release workflows
- `git diff --check`
- `python3 scripts/docs/validate-manifest.py`
- `bash -n scripts/install.sh scripts/linux/release.sh scripts/release/verify-artifacts.sh scripts/release/verify-release-gate.sh`

## Release Note

No user-facing app change. This is release-hardening required before retrying beta 64.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release-infra hardening only: it changes how Zig is downloaded in GitHub Actions, with no impact on app/runtime code. Main risk is a release build failing if mirror URLs change or the download loop logic misbehaves.
> 
> **Overview**
> Release workflows for **Linux, macOS, and Windows** now download Zig `0.15.2` via a *mirror-first* URL list with retries, instead of relying solely on `ziglang.org`.
> 
> Linux/macOS add a `curl` retry loop across multiple base URLs and validate the tarball is non-empty before extracting; Windows adds a multi-URL, multi-attempt `Invoke-WebRequest` loop and errors out with a clear message if all mirrors fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a3992b5cf953e3c85173d62eccea968860fd59a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->