### PR TITLE
Polish install docs and screenshot guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ con is still pre-release, so entries may group related beta work while the produ
   [#162](https://github.com/nowledge-co/con-terminal/pull/162) by
   [@sundy-li](https://github.com/sundy-li))_
 
+### Changed
+
+**Docs**
+
+- Clarified official install paths versus community package-manager paths,
+  including AUR `con-bin` maintainer credit for `czyt`, Scoop bucket credit for
+  `EFLKumo`, and screenshot placement across the public docs. _(PR
+  [#164](https://github.com/nowledge-co/con-terminal/pull/164) by
+  [@wey-gu](https://github.com/wey-gu))_
+
 ### Fixed
 
 **macOS**

--- a/README.md
+++ b/README.md
@@ -48,12 +48,9 @@ If you're an old-school terminal user and only want enough AI harness when neede
   </a>
 </p>
 
-
-
 <p align="center">
   <a href="docs/screenshots.md">View the full screenshot gallery</a>
 </p>
-
 
 ## 2 min know-how
 
@@ -99,7 +96,7 @@ This installs the app into `/Applications` and links `con-cli` into
 `~/.local/bin`. Or download the DMG directly from
 [Releases](https://github.com/nowledge-co/con-terminal/releases).
 
-**Linux** (preview)
+**Linux** (preview, official installer)
 
 ```sh
 curl -fsSL https://con-releases.nowledge.co/install.sh | sh
@@ -109,11 +106,18 @@ This installs both `con` and `con-cli` into `~/.local/bin`. Or download
 `con-<version>-linux-x86_64.tar.gz` from the latest
 [Release](https://github.com/nowledge-co/con-terminal/releases).
 
-Arch Linux
+**Arch Linux / AUR** (community)
 
-Arch Linux users can install con via `pacman -S con-bin` or `paru -S con-bin` or `yay -S con-bin` .
+```sh
+yay -S con-bin
+```
 
-**Windows**
+`con-bin` is maintained on AUR by
+[`czyt`](https://aur.archlinux.org/account/czyt). `paru -S con-bin` works too.
+Use the official installer above if you need the newest beta immediately after
+a release.
+
+**Windows** (official installer)
 
 ```powershell
 irm https://con-releases.nowledge.co/install.ps1 | iex
@@ -123,14 +127,17 @@ This installs `con-app.exe` and `con-cli.exe` into the same PATH directory.
 Or download `con-windows-x86_64.zip` from the latest
 [Release](https://github.com/nowledge-co/con-terminal/releases).
 
-For Scoop users, here's how to install:
+**Windows / Scoop** (community)
 
 ```powershell
 scoop bucket add jam https://github.com/EFLKumo/jam
 scoop install jam/con-terminal
 ```
 
-This will make con portable and add `con-app` and `con-cli` to your PATH.
+The Scoop manifest is maintained by
+[`EFLKumo`](https://github.com/EFLKumo) in the
+[`jam`](https://github.com/EFLKumo/jam) bucket. It installs a portable Con and
+adds `con-app` and `con-cli` to your PATH.
 
 To build from source, see `HACKING.md`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,12 @@
 con is a terminal first. If you hide the input bar and agent panel, it should
 feel like a fast, elegant terminal with nothing extra in the way.
 
+<p align="center">
+  <a href="screenshots.md">
+    <img width="1080" alt="Con main window with terminal panes and the agent panel" src="https://github.com/user-attachments/assets/389898d6-56bf-46aa-9279-65e59a57ed23" />
+  </a>
+</p>
+
 When you ask for AI, con uses the terminal objects you already work with:
 panes, SSH sessions, tmux panes, TUIs, visible output, and working directories.
 When a one-off routine becomes worth repeating, skills let you keep it as a

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -6,6 +6,10 @@ The agent panel is there when terminal context matters and a model can help. It
 reads the pane you are using, acts in view, and asks before doing work that
 should not happen silently.
 
+<p align="center">
+  <img width="1080" alt="Con agent panel next to a terminal workspace" src="https://github.com/user-attachments/assets/e1972fac-9df3-443b-be08-c0eec4697cf3" />
+</p>
+
 ## When to use it
 
 Use the agent when the answer depends on terminal state:

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,6 +6,10 @@ builds are available as previews.
 Every installer includes the app and `con-cli`. The CLI is used by scripts,
 test runners, and external agent orchestrators to talk to a running con session.
 
+Use the official installer when you want the newest beta as soon as it ships.
+Community packages are convenient if they already fit your system workflow, but
+they may trail the GitHub release for a short time.
+
 ## macOS with Homebrew
 
 ```sh
@@ -26,24 +30,35 @@ You can also download the DMG from
 
 ## Windows preview
 
+### Official installer
+
 ```powershell
 irm https://con-releases.nowledge.co/install.ps1 | iex
 ```
 
 This installs `con-app.exe` and `con-cli.exe` into the same PATH directory.
 
-Scoop users can install the community package:
+### Scoop
+
+Scoop users can install Con from the community-maintained `jam` bucket:
 
 ```powershell
 scoop bucket add jam https://github.com/EFLKumo/jam
 scoop install jam/con-terminal
 ```
 
+The Scoop manifest is maintained by
+[`EFLKumo`](https://github.com/EFLKumo) in
+[`EFLKumo/jam`](https://github.com/EFLKumo/jam). It installs Con as a portable
+app and adds both `con-app` and `con-cli` to your PATH.
+
 Windows is still early. Follow the
 [Windows tracker](https://github.com/nowledge-co/con-terminal/issues/34) for
 current limits and fixes.
 
 ## Linux preview
+
+### Official installer
 
 ```sh
 curl -fsSL https://con-releases.nowledge.co/install.sh | sh
@@ -53,6 +68,18 @@ This installs `con` and `con-cli` into `~/.local/bin`, registers the desktop
 launcher, and refreshes the app icon. You can also download the Linux tarball
 from the latest
 [Release](https://github.com/nowledge-co/con-terminal/releases).
+
+### Arch Linux / AUR
+
+Arch users can install the community AUR package:
+
+```sh
+yay -S con-bin
+```
+
+`paru -S con-bin` works as well. The AUR package is maintained by
+[`czyt`](https://aur.archlinux.org/account/czyt), and the package page is
+[`con-bin`](https://aur.archlinux.org/packages/con-bin).
 
 Linux is in preview. Follow the
 [Linux tracker](https://github.com/nowledge-co/con-terminal/issues/18) for

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -1,29 +1,33 @@
 # Screenshots
 
 The README shows one representative view. This page keeps the full gallery in
-one place.
+one place, so the other docs can stay focused.
 
 ## Gallery
 
+### Main window
+
+<img alt="Con main window with terminal panes, tabs, and the agent panel" src="https://github.com/user-attachments/assets/389898d6-56bf-46aa-9279-65e59a57ed23" />
+
 ### Agent panel
 
-<img alt="con screenshot 1" src="https://github.com/user-attachments/assets/e1972fac-9df3-443b-be08-c0eec4697cf3" />
+<img alt="Con agent panel next to a terminal workspace" src="https://github.com/user-attachments/assets/e1972fac-9df3-443b-be08-c0eec4697cf3" />
 
 ### Agent panel with terminal context
 
-<img alt="con screenshot 2" src="https://github.com/user-attachments/assets/15299d3d-7484-4229-a979-43001d504b14" />
+<img alt="Con agent panel using visible terminal context" src="https://github.com/user-attachments/assets/15299d3d-7484-4229-a979-43001d504b14" />
 
 ### Theme settings
 
-<img alt="con screenshot 3" src="https://github.com/user-attachments/assets/c730d158-139b-46d5-adbb-0cd48d38b603" />
+<img alt="Con Appearance settings with theme and transparency controls" src="https://github.com/user-attachments/assets/c730d158-139b-46d5-adbb-0cd48d38b603" />
 
 ### Pane broadcast picker
 
-<img alt="con screenshot 4" src="https://github.com/user-attachments/assets/21e295c9-34eb-465c-90b8-5ba3163182e5" />
+<img alt="Con pane broadcast picker mirroring the current split-pane layout" src="https://github.com/user-attachments/assets/21e295c9-34eb-465c-90b8-5ba3163182e5" />
 
-### Main window
+### Clean terminal layout
 
-<img alt="con screenshot 5" src="https://github.com/user-attachments/assets/81dcf6e4-6074-497e-98b8-00c884442cc2" />
+<img alt="Con terminal workspace with panels minimized" src="https://github.com/user-attachments/assets/81dcf6e4-6074-497e-98b8-00c884442cc2" />
 
 ## Demo
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -36,6 +36,10 @@ con shows it beside the action.
 
 Appearance controls the parts of con you look at all day:
 
+<p align="center">
+  <img width="1080" alt="Con Appearance settings with theme and transparency controls" src="https://github.com/user-attachments/assets/c730d158-139b-46d5-adbb-0cd48d38b603" />
+</p>
+
 - terminal theme
 - terminal and UI fonts
 - terminal opacity and blur

--- a/docs/terminal-workflows.md
+++ b/docs/terminal-workflows.md
@@ -9,6 +9,10 @@ agent, opening a split, or focusing a worker.
 
 con uses a few names consistently:
 
+<p align="center">
+  <img width="1080" alt="Con workspace with terminal panes, tabs, and the agent panel" src="https://github.com/user-attachments/assets/81dcf6e4-6074-497e-98b8-00c884442cc2" />
+</p>
+
 | Name | Meaning | Use it for |
 | --- | --- | --- |
 | Window | A top-level app window | Separate projects or monitors |
@@ -93,6 +97,10 @@ Command mode can target more than one pane. Use the pane picker to send a
 command to the focused pane, every pane, or a selected set. The picker mirrors
 the current pane layout, so you can choose by position instead of remembering
 pane numbers.
+
+<p align="center">
+  <img width="1080" alt="Con pane broadcast picker mirroring the current split-pane layout" src="https://github.com/user-attachments/assets/21e295c9-34eb-465c-90b8-5ba3163182e5" />
+</p>
 
 ## Advanced: surfaces
 


### PR DESCRIPTION
## Summary

- Clarify official install paths versus community package-manager paths.
- Add Arch/AUR instructions for `con-bin` with maintainer credit for `czyt`.
- Add Scoop instructions for `EFLKumo/jam` with maintainer credit for `EFLKumo`.
- Place existing screenshots in the docs chapters where they help users understand the feature being described.
- Tighten screenshot alt text and the public docs landing page.
- Add the beta 65 changelog note for the docs/install polish.

## Validation

- `python3 scripts/docs/validate-manifest.py`
- `git diff --check`
