### PR TITLE
fix: rewrite if-let guard to stable Rust in surface_key_bytes

### DIFF
--- a/crates/con-app/src/workspace/control_surfaces.rs
+++ b/crates/con-app/src/workspace/control_surfaces.rs
@@ -801,11 +801,17 @@ impl ConWorkspace {
             "enter" | "return" => Ok(b"\n".to_vec()),
             "tab" => Ok(b"\t".to_vec()),
             "backspace" => Ok(vec![0x7f]),
-            _ if let Some(code) = crate::terminal_keys::ctrl_chord_to_c0(key) => Ok(vec![code]),
-            _ if key.chars().count() == 1 => Ok(key.as_bytes().to_vec()),
-            _ => Err(ControlError::invalid_params(format!(
-                "Unsupported surface key `{key}`. Supported keys: escape, enter, tab, backspace, ctrl-<letter>, ctrl-space/ctrl-@, ctrl-[, ctrl-\\, ctrl-], ctrl-^, ctrl-_, ctrl-/, ctrl-?, ctrl-~, ctrl-2..8."
-            ))),
+            _ => {
+                if let Some(code) = crate::terminal_keys::ctrl_chord_to_c0(key) {
+                    return Ok(vec![code]);
+                }
+                if key.chars().count() == 1 {
+                    return Ok(key.as_bytes().to_vec());
+                }
+                return Err(ControlError::invalid_params(format!(
+                    "Unsupported surface key `{key}`. Supported keys: escape, enter, tab, backspace, ctrl-<letter>, ctrl-space/ctrl-@, ctrl-[, ctrl-\\, ctrl-], ctrl-^, ctrl-_, ctrl-/, ctrl-?, ctrl-~, ctrl-2..8."
+                )));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

`if let` guards in match arms are an unstable feature (rust-lang/rust#51114) and caused a compile error on stable Rust:

```
error[E0658]: `if let` guards are experimental
  --> crates/con-app/src/workspace/control_surfaces.rs:804:15
```

## Fix

Replaced the two `_ if let` / `_ if` guard arms in `surface_key_bytes` with a single `_` catch-all arm that uses ordinary `if let` / `if` expressions and early returns. Semantics are identical.

## Tested

`cargo build -p con` compiles cleanly on stable aarch64-apple-darwin.