### PR TITLE
Polish settings window titlebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## `v0.1.0-beta.66` - Unreleased
+
+### Changed
+
+**Settings**
+
+- Matched the standalone Settings window titlebar to Con's main macOS window
+  chrome while leaving the existing Windows and Linux settings-window frame
+  behavior unchanged.
+
+**Docs**
+
+- Added the Quick Terminal screenshot to the user guide and screenshot gallery,
+  and credited its original contributor. _(Quick Terminal was introduced in PR
+  [#135](https://github.com/nowledge-co/con-terminal/pull/135) by
+  [@sundy-li](https://github.com/sundy-li))_
+
 ## `v0.1.0-beta.65` - 2026-05-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ con is still pre-release, so entries may group related beta work while the produ
 **Docs**
 
 - Added the Quick Terminal screenshot to the user guide and screenshot gallery,
-  and credited its original contributor. _(Quick Terminal was introduced in PR
-  [#135](https://github.com/nowledge-co/con-terminal/pull/135) by
+  credited its original contributor, and linked the hosted docs, changelog, and
+  `llms.txt` agent index from the README. _(Quick Terminal was introduced in
+  PR [#135](https://github.com/nowledge-co/con-terminal/pull/135) by
   [@sundy-li](https://github.com/sundy-li))_
 
 ## `v0.1.0-beta.65` - 2026-05-07

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
   <a href="https://github.com/nowledge-co/con-terminal/issues/34"><img alt="Windows preview (tracker)" src="https://img.shields.io/badge/Windows-preview-0078D4?logo=windows&logoColor=white&style=flat"></a>
   <a href="https://github.com/nowledge-co/con-terminal/issues/18"><img alt="Linux preview (tracker)" src="https://img.shields.io/badge/Linux-preview-1D4ED8?logo=linux&logoColor=white&style=flat"></a>
   <a href="https://www.rust-lang.org/"><img alt="Rust" src="https://img.shields.io/badge/Rust-CE422B?logo=rust&logoColor=white&style=flat"></a>
-  <a href="https://con.nowledge.co/docs"><img alt="Docs" src="https://img.shields.io/badge/Docs-con.nowledge.co-2F4F4F?style=flat"></a>
-  <a href="https://con.nowledge.co/changelog"><img alt="Changelog" src="https://img.shields.io/badge/Changelog-latest-4A5568?style=flat"></a>
-  <a href="https://con.nowledge.co/llms.txt"><img alt="llms.txt for AI agents" src="https://img.shields.io/badge/llms.txt-agent_readable-6B7280?style=flat"></a>
+  <a href="https://con.nowledge.co/docs"><img alt="Docs" src="https://img.shields.io/badge/Docs-con-2F4F4F?style=flat"></a>
+  <a href="https://con.nowledge.co/changelog"><img alt="Changelog" src="https://img.shields.io/badge/changelog-latest-4A5568?logo=git&style=flat&color=white"></a>
+  <a href="https://con.nowledge.co/llms.txt"><img alt="llms.txt for AI agents" src="https://img.shields.io/badge/llms.txt-agent_readable-6B7280?logo=dependabot&style=flat"></a>
 </p>
 
 ## Why con?

--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@
 <p align="center">
   Built for SSH, tmux, and agent-native workflows.
 </p>
-
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-blue?style=flat"></a>
   <a href="https://github.com/nowledge-co/con-terminal/releases/latest"><img alt="Latest GitHub release" src="https://img.shields.io/github/v/release/nowledge-co/con-terminal?sort=semver&logo=github&style=flat"></a>
   <a href="https://developer.apple.com/macos/"><img alt="Native on macOS (Metal)" src="https://img.shields.io/badge/macOS-beta-3D3D3D?logo=apple&logoColor=white&style=flat"></a>
-  <a href="https://github.com/nowledge-co/con-terminal/issues/34"><img alt="Windows preview (tracker)" src="https://img.shields.io/badge/Windows-preview-0078D4?logo=windows&logoColor=white&style=flat"></a>
+  <a href="https://github.com/nowledge-co/con-terminal/issues/34"><img alt="Windows preview (tracker)" src="https://custom-icon-badges.demolab.com/badge/Windows-preview-0078D6?logo=windows11&logoColor=white"></a>
   <a href="https://github.com/nowledge-co/con-terminal/issues/18"><img alt="Linux preview (tracker)" src="https://img.shields.io/badge/Linux-preview-1D4ED8?logo=linux&logoColor=white&style=flat"></a>
   <a href="https://www.rust-lang.org/"><img alt="Rust" src="https://img.shields.io/badge/Rust-CE422B?logo=rust&logoColor=white&style=flat"></a>
-  <a href="https://con.nowledge.co/docs"><img alt="Docs" src="https://img.shields.io/badge/Docs-con-2F4F4F?style=flat"></a>
-  <a href="https://con.nowledge.co/changelog"><img alt="Changelog" src="https://img.shields.io/badge/changelog-latest-4A5568?logo=git&style=flat&color=white"></a>
-  <a href="https://con.nowledge.co/llms.txt"><img alt="llms.txt for AI agents" src="https://img.shields.io/badge/llms.txt-agent_readable-6B7280?logo=dependabot&style=flat"></a>
+  <a href="https://con.nowledge.co/docs"><img alt="Docs" src="https://img.shields.io/badge/Docs-8CA1AF?logo=readthedocs&logoColor=fff"></a>
+  <a href="https://con.nowledge.co/changelog"><img alt="Changelog" src="https://img.shields.io/badge/changelog-4A5568?logo=git&style=flat&color=white"></a>
+  <a href="https://con.nowledge.co/llms.txt"><img alt="llms.txt for AI agents" src="https://img.shields.io/badge/llms.txt-for_agent-6B7280?logo=dependabot&style=flat"></a>
 </p>
+
 
 ## Why con?
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
   <a href="https://github.com/nowledge-co/con-terminal/issues/34"><img alt="Windows preview (tracker)" src="https://img.shields.io/badge/Windows-preview-0078D4?logo=windows&logoColor=white&style=flat"></a>
   <a href="https://github.com/nowledge-co/con-terminal/issues/18"><img alt="Linux preview (tracker)" src="https://img.shields.io/badge/Linux-preview-1D4ED8?logo=linux&logoColor=white&style=flat"></a>
   <a href="https://www.rust-lang.org/"><img alt="Rust" src="https://img.shields.io/badge/Rust-CE422B?logo=rust&logoColor=white&style=flat"></a>
+  <a href="https://con.nowledge.co/docs"><img alt="Docs" src="https://img.shields.io/badge/Docs-con.nowledge.co-2F4F4F?style=flat"></a>
+  <a href="https://con.nowledge.co/changelog"><img alt="Changelog" src="https://img.shields.io/badge/Changelog-latest-4A5568?style=flat"></a>
+  <a href="https://con.nowledge.co/llms.txt"><img alt="llms.txt for AI agents" src="https://img.shields.io/badge/llms.txt-agent_readable-6B7280?style=flat"></a>
 </p>
 
 ## Why con?

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -5057,6 +5057,36 @@ impl Render for SettingsPanel {
             .opacity(if theme.is_dark() { 0.84 } else { 0.78 });
         let save_button_style = ButtonCustomVariant::new(cx).color(save_button_tint);
         let surface_rounding = if self.standalone { px(0.0) } else { px(12.0) };
+        let header_left_padding = if self.standalone && cfg!(target_os = "macos") {
+            px(78.0)
+        } else {
+            px(20.0)
+        };
+        let mut header_title_area = div()
+            .id("settings-titlebar-drag-area")
+            .flex()
+            .items_center()
+            .h_full()
+            .flex_1()
+            .min_w_0()
+            .pl(header_left_padding)
+            .pr(px(12.0))
+            .child(
+                div()
+                    .text_size(px(13.0))
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .text_color(theme.foreground)
+                    .child("Settings"),
+            );
+        if self.standalone {
+            header_title_area = header_title_area
+                .window_control_area(WindowControlArea::Drag)
+                .on_click(|event, window, _cx| {
+                    if event.click_count() == 2 {
+                        window.titlebar_double_click();
+                    }
+                });
+        }
         let surface = div()
             .id("settings-card")
             .w(if self.standalone {
@@ -5120,19 +5150,14 @@ impl Render for SettingsPanel {
                             .items_center()
                             .justify_between()
                             .h(px(44.0))
-                            .px(px(20.0))
-                            .child(
-                                div()
-                                    .text_size(px(13.0))
-                                    .font_weight(FontWeight::SEMIBOLD)
-                                    .text_color(theme.foreground)
-                                    .child("Settings"),
-                            )
+                            .child(header_title_area)
                             .child(
                                 div()
                                     .flex()
                                     .items_center()
                                     .gap(px(8.0))
+                                    .flex_shrink_0()
+                                    .pr(px(20.0))
                                     .child(
                                         div()
                                             .id("open-config-file")

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -5078,7 +5078,7 @@ impl Render for SettingsPanel {
                     .text_color(theme.foreground)
                     .child("Settings"),
             );
-        if self.standalone {
+        if self.standalone && cfg!(target_os = "macos") {
             header_title_area = header_title_area
                 .window_control_area(WindowControlArea::Drag)
                 .on_click(|event, window, _cx| {

--- a/crates/con-app/src/workspace/window_actions.rs
+++ b/crates/con-app/src/workspace/window_actions.rs
@@ -161,7 +161,9 @@ impl ConWorkspace {
             window_bounds: Some(WindowBounds::centered(size(px(920.0), px(680.0)), cx)),
             titlebar: Some(TitlebarOptions {
                 title: Some("Settings".into()),
-                appears_transparent: false,
+                // Match the main macOS window: the system owns the traffic
+                // lights, while Con paints the titlebar surface itself.
+                appears_transparent: cfg!(target_os = "macos"),
                 ..Default::default()
             }),
             window_background: WindowBackgroundAppearance::Opaque,

--- a/docs/quick-terminal.md
+++ b/docs/quick-terminal.md
@@ -3,6 +3,8 @@
 Quick Terminal is a macOS-only drop-down Con window for short terminal work
 from anywhere on the system.
 
+<img alt="Quick Terminal open over the desktop on macOS" src="https://github.com/user-attachments/assets/a668bca2-eb75-4fcc-a579-719f2babde45" />
+
 It is off by default. Turn it on only if you want a global shortcut that can
 open a terminal over the app you are using.
 
@@ -83,6 +85,12 @@ window managers, and other terminal apps.
   <kbd>⌘</kbd> <kbd>Backslash</kbd>.
 - If you are recording a shortcut in Settings, Con temporarily suspends its
   global hotkeys so the shortcut can be captured instead of triggered.
+
+## Credit
+
+Quick Terminal was introduced by
+[`sundy-li`](https://github.com/sundy-li) in
+[PR #135](https://github.com/nowledge-co/con-terminal/pull/135).
 
 ## Platform Support
 

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -9,6 +9,10 @@ one place, so the other docs can stay focused.
 
 <img alt="Con main window with terminal panes, tabs, and the agent panel" src="https://github.com/user-attachments/assets/389898d6-56bf-46aa-9279-65e59a57ed23" />
 
+### Quick Terminal
+
+<img alt="Quick Terminal open over the desktop on macOS" src="https://github.com/user-attachments/assets/a668bca2-eb75-4fcc-a579-719f2babde45" />
+
 ### Agent panel
 
 <img alt="Con agent panel next to a terminal workspace" src="https://github.com/user-attachments/assets/e1972fac-9df3-443b-be08-c0eec4697cf3" />


### PR DESCRIPTION
## Summary

- align the standalone Settings window titlebar with Con's main macOS chrome
- keep Windows and Linux on the existing native settings-window frame path
- add the Quick Terminal screenshot to the guide and gallery, with credit for @sundy-li's original Quick Terminal contribution

## Verification

- python3 scripts/docs/validate-manifest.py
- cargo check -p con
- cargo check -p con --no-default-features --features con/bin-con-app
- git diff --check

## Notes

The chrome behavior change is macOS-gated through TitlebarOptions.appears_transparent. Non-macOS settings windows retain their existing native titlebar/frame behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: macOS-gated titlebar/window-drag tweaks to the standalone Settings window plus documentation/README updates, with no core terminal or data-path changes.
> 
> **Overview**
> Aligns the standalone **Settings** window chrome with Con’s main macOS window by making the titlebar transparent on macOS and adding a dedicated draggable title area (including double-click titlebar behavior), while keeping Windows/Linux behavior unchanged.
> 
> Updates docs by adding a **Quick Terminal** screenshot to the guide and screenshot gallery (with contributor credit), and updates the README badges/links to point to hosted docs, changelog, and `llms.txt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e785f0d7375f9fb2cda33f6cd0d79762f9bbf5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Settings window titlebar styling on macOS now aligns with the main window appearance.
  * Settings window titlebar double-click functionality added for macOS.
  * Windows and Linux Settings window behavior unchanged.

* **Documentation**
  * Added Quick Terminal contributor credit and screenshot to user guide and screenshot gallery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->