### PR TITLE
fix: preserve tab accent colors in pane chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,14 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ### Fixed
 
+**Tabs and Panes**
+
+- Preserved user-assigned tab accent colors across inactive tabs, vertical tab
+  entries, and split-pane title bars at lower emphasis, and shortened pane
+  titles to the final path component on Unix and Windows-style paths. _(PR
+  [#168](https://github.com/nowledge-co/con-terminal/pull/168) by
+  [@sundy-li](https://github.com/sundy-li))_
+
 **macOS**
 
 - Fixed the remaining Intel Mac live-resize flash by ensuring Con no longer

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -682,15 +682,18 @@ impl PaneTree {
 
     fn terminal_title_or_default(terminal: &TerminalPane, cx: &App) -> String {
         let title = terminal.title(cx).unwrap_or_else(|| "Terminal".to_string());
-        // Show only the last path component so narrow panes don't truncate to "..."
-        // e.g. "~/work/con-terminal" → "con-terminal", "~" → "~"
+        Self::short_pane_title(&title).to_string()
+    }
+
+    fn short_pane_title(title: &str) -> &str {
+        // Show only the last path component so narrow panes don't truncate to "...".
+        // OSC titles can contain either Unix or Windows separators regardless of host OS.
         title
-            .trim_end_matches('/')
-            .rsplit('/')
+            .trim_end_matches(['/', '\\'])
+            .rsplit(['/', '\\'])
             .next()
             .filter(|s| !s.is_empty())
-            .unwrap_or(&title)
-            .to_string()
+            .unwrap_or(title)
     }
 
     pub fn pane_title(&self, pane_id: PaneId, cx: &App) -> Option<String> {
@@ -1850,16 +1853,20 @@ impl PaneTree {
         let theme = cx.theme();
         let bar_bg = if is_focused {
             if let Some(color) = tab_accent_color {
-                let mut h = crate::tab_colors::tab_accent_color_hsla(color, cx);
-                h.a = 0.35;
-                h
+                crate::tab_colors::tab_accent_surface_hsla(
+                    color,
+                    crate::tab_colors::TAB_ACCENT_ACTIVE_ALPHA,
+                    cx,
+                )
             } else {
                 theme.tab_bar_segmented
             }
         } else if let Some(color) = tab_accent_color {
-            let mut h = crate::tab_colors::tab_accent_color_hsla(color, cx);
-            h.a = 0.15;
-            h
+            crate::tab_colors::tab_accent_surface_hsla(
+                color,
+                crate::tab_colors::TAB_ACCENT_INACTIVE_ALPHA,
+                cx,
+            )
         } else {
             theme.tab_bar_segmented.opacity(0.78)
         };
@@ -2719,6 +2726,38 @@ mod tests {
             next_split_id: 1,
             dragging: None,
         }
+    }
+
+    #[::core::prelude::v1::test]
+    fn short_pane_title_handles_unix_paths() {
+        assert_eq!(
+            PaneTree::short_pane_title("~/work/con-terminal"),
+            "con-terminal"
+        );
+        assert_eq!(
+            PaneTree::short_pane_title("~/work/con-terminal/"),
+            "con-terminal"
+        );
+        assert_eq!(PaneTree::short_pane_title("/"), "/");
+    }
+
+    #[::core::prelude::v1::test]
+    fn short_pane_title_handles_windows_paths() {
+        assert_eq!(
+            PaneTree::short_pane_title(r"C:\Users\alice\project"),
+            "project"
+        );
+        assert_eq!(
+            PaneTree::short_pane_title(r"C:\Users\alice\project\"),
+            "project"
+        );
+        assert_eq!(PaneTree::short_pane_title(r"C:\"), r"C:");
+    }
+
+    #[::core::prelude::v1::test]
+    fn short_pane_title_preserves_non_path_titles() {
+        assert_eq!(PaneTree::short_pane_title("Terminal"), "Terminal");
+        assert_eq!(PaneTree::short_pane_title("nvim main.rs"), "nvim main.rs");
     }
 
     #[::core::prelude::v1::test]

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -681,7 +681,16 @@ impl PaneTree {
     }
 
     fn terminal_title_or_default(terminal: &TerminalPane, cx: &App) -> String {
-        terminal.title(cx).unwrap_or_else(|| "Terminal".to_string())
+        let title = terminal.title(cx).unwrap_or_else(|| "Terminal".to_string());
+        // Show only the last path component so narrow panes don't truncate to "..."
+        // e.g. "~/work/con-terminal" → "con-terminal", "~" → "~"
+        title
+            .trim_end_matches('/')
+            .rsplit('/')
+            .next()
+            .filter(|s| !s.is_empty())
+            .unwrap_or(&title)
+            .to_string()
     }
 
     pub fn pane_title(&self, pane_id: PaneId, cx: &App) -> Option<String> {
@@ -1847,6 +1856,10 @@ impl PaneTree {
             } else {
                 theme.tab_bar_segmented
             }
+        } else if let Some(color) = tab_accent_color {
+            let mut h = crate::tab_colors::tab_accent_color_hsla(color, cx);
+            h.a = 0.15;
+            h
         } else {
             theme.tab_bar_segmented.opacity(0.78)
         };
@@ -1926,20 +1939,15 @@ impl PaneTree {
 
         let title_el = div()
             .flex_1()
-            .flex()
-            .justify_center()
-            .items_center()
-            .overflow_hidden()
-            .child(
-                div()
-                    .truncate()
-                    .text_size(px(12.0))
-                    .line_height(px(16.0))
-                    .font_family(theme.font_family.clone())
-                    .font_weight(FontWeight::MEDIUM)
-                    .text_color(title_color)
-                    .child(SharedString::from(title)),
-            );
+            .min_w_0()
+            .truncate()
+            .text_size(px(12.0))
+            .line_height(px(16.0))
+            .font_family(theme.font_family.clone())
+            .font_weight(FontWeight::MEDIUM)
+            .text_color(title_color)
+            .text_center()
+            .child(SharedString::from(title));
         let dragged = DraggedTab {
             session_id,
             label: drag_label,

--- a/crates/con-app/src/sidebar.rs
+++ b/crates/con-app/src/sidebar.rs
@@ -833,15 +833,23 @@ impl SessionSidebar {
             };
 
             let tab_bounds = self.tab_bounds.clone();
-            let active_accent_bg_rail: Option<gpui::Hsla> = session.color.map(|c| {
-                let mut h = crate::tab_colors::tab_accent_color_hsla(c, cx);
-                h.a = 0.35;
-                h
-            });
+            let accent_bg_rail: Option<gpui::Hsla> = session
+                .color
+                .map(|c| crate::tab_colors::tab_accent_color_hsla(c, cx));
             let pill_bg = if is_active {
-                active_accent_bg_rail.unwrap_or(active_bg)
+                accent_bg_rail
+                    .map(|mut h| {
+                        h.a = 0.35;
+                        h
+                    })
+                    .unwrap_or(active_bg)
             } else {
-                gpui::transparent_black()
+                accent_bg_rail
+                    .map(|mut h| {
+                        h.a = 0.15;
+                        h
+                    })
+                    .unwrap_or(gpui::transparent_black())
             };
             let mut pill = div()
                 .id(SharedString::from(format!("rail-tab-{i}")))
@@ -1422,15 +1430,23 @@ impl SessionSidebar {
                 gpui::transparent_black()
             });
 
-        let active_accent_bg_row: Option<gpui::Hsla> = session.color.map(|c| {
-            let mut h = crate::tab_colors::tab_accent_color_hsla(c, cx);
-            h.a = 0.35;
-            h
-        });
+        let accent_bg_row: Option<gpui::Hsla> = session
+            .color
+            .map(|c| crate::tab_colors::tab_accent_color_hsla(c, cx));
         let row_bg = if is_active {
-            active_accent_bg_row.unwrap_or_else(|| elevated_surface(theme, self.ui_opacity))
+            accent_bg_row
+                .map(|mut h| {
+                    h.a = 0.35;
+                    h
+                })
+                .unwrap_or_else(|| elevated_surface(theme, self.ui_opacity))
         } else {
-            gpui::transparent_black()
+            accent_bg_row
+                .map(|mut h| {
+                    h.a = 0.15;
+                    h
+                })
+                .unwrap_or(gpui::transparent_black())
         };
         let hover_bg = sidebar_surface(theme, self.ui_opacity, 0.075);
 

--- a/crates/con-app/src/sidebar.rs
+++ b/crates/con-app/src/sidebar.rs
@@ -32,8 +32,8 @@
 //! Visual rules
 //! ---
 //! - Active row: elevated pill bg + foreground text. **No accent
-//!   bar.** A single, unambiguous selection cue is enough; doubling
-//!   it (pill + bar + bold + accent color) is decorative chrome.
+//!   bar.** A single, unambiguous selection cue is enough; tab accent
+//!   colors render as the row surface itself at active/inactive alpha.
 //! - Action affordances (rename pencil, close X) are hover-only on
 //!   every row, including the active one. Quiet by default; reveal
 //!   on intent.
@@ -833,24 +833,37 @@ impl SessionSidebar {
             };
 
             let tab_bounds = self.tab_bounds.clone();
-            let accent_bg_rail: Option<gpui::Hsla> = session
-                .color
-                .map(|c| crate::tab_colors::tab_accent_color_hsla(c, cx));
+            let accent_color = session.color;
             let pill_bg = if is_active {
-                accent_bg_rail
-                    .map(|mut h| {
-                        h.a = 0.35;
-                        h
+                accent_color
+                    .map(|color| {
+                        crate::tab_colors::tab_accent_surface_hsla(
+                            color,
+                            crate::tab_colors::TAB_ACCENT_ACTIVE_ALPHA,
+                            cx,
+                        )
                     })
                     .unwrap_or(active_bg)
             } else {
-                accent_bg_rail
-                    .map(|mut h| {
-                        h.a = 0.15;
-                        h
+                accent_color
+                    .map(|color| {
+                        crate::tab_colors::tab_accent_surface_hsla(
+                            color,
+                            crate::tab_colors::TAB_ACCENT_INACTIVE_ALPHA,
+                            cx,
+                        )
                     })
                     .unwrap_or(gpui::transparent_black())
             };
+            let inactive_hover_bg = accent_color
+                .map(|color| {
+                    crate::tab_colors::tab_accent_surface_hsla(
+                        color,
+                        crate::tab_colors::TAB_ACCENT_INACTIVE_HOVER_ALPHA,
+                        cx,
+                    )
+                })
+                .unwrap_or(hover_bg);
             let mut pill = div()
                 .id(SharedString::from(format!("rail-tab-{i}")))
                 .relative()
@@ -861,7 +874,13 @@ impl SessionSidebar {
                 .rounded(px(8.0))
                 .cursor_pointer()
                 .bg(pill_bg)
-                .hover(move |s| if is_active { s } else { s.bg(hover_bg) })
+                .hover(move |s| {
+                    if is_active {
+                        s
+                    } else {
+                        s.bg(inactive_hover_bg)
+                    }
+                })
                 .on_mouse_down(
                     MouseButton::Left,
                     cx.listener(move |_this, _, _, cx| {
@@ -1430,25 +1449,38 @@ impl SessionSidebar {
                 gpui::transparent_black()
             });
 
-        let accent_bg_row: Option<gpui::Hsla> = session
-            .color
-            .map(|c| crate::tab_colors::tab_accent_color_hsla(c, cx));
+        let accent_color = session.color;
         let row_bg = if is_active {
-            accent_bg_row
-                .map(|mut h| {
-                    h.a = 0.35;
-                    h
+            accent_color
+                .map(|color| {
+                    crate::tab_colors::tab_accent_surface_hsla(
+                        color,
+                        crate::tab_colors::TAB_ACCENT_ACTIVE_ALPHA,
+                        cx,
+                    )
                 })
                 .unwrap_or_else(|| elevated_surface(theme, self.ui_opacity))
         } else {
-            accent_bg_row
-                .map(|mut h| {
-                    h.a = 0.15;
-                    h
+            accent_color
+                .map(|color| {
+                    crate::tab_colors::tab_accent_surface_hsla(
+                        color,
+                        crate::tab_colors::TAB_ACCENT_INACTIVE_ALPHA,
+                        cx,
+                    )
                 })
                 .unwrap_or(gpui::transparent_black())
         };
         let hover_bg = sidebar_surface(theme, self.ui_opacity, 0.075);
+        let inactive_hover_bg = accent_color
+            .map(|color| {
+                crate::tab_colors::tab_accent_surface_hsla(
+                    color,
+                    crate::tab_colors::TAB_ACCENT_INACTIVE_HOVER_ALPHA,
+                    cx,
+                )
+            })
+            .unwrap_or(hover_bg);
 
         let dragged = DraggedTab {
             session_id,
@@ -1516,7 +1548,13 @@ impl SessionSidebar {
             } else {
                 theme.muted_foreground.opacity(0.92)
             })
-            .hover(move |s| if is_active { s } else { s.bg(hover_bg) })
+            .hover(move |s| {
+                if is_active {
+                    s
+                } else {
+                    s.bg(inactive_hover_bg)
+                }
+            })
             .on_mouse_down(
                 MouseButton::Left,
                 cx.listener(move |_this, _, _, cx| {

--- a/crates/con-app/src/tab_colors.rs
+++ b/crates/con-app/src/tab_colors.rs
@@ -2,6 +2,10 @@ use con_core::session::TabAccentColor;
 use gpui::{App, Hsla};
 use gpui_component::ActiveTheme;
 
+pub(crate) const TAB_ACCENT_ACTIVE_ALPHA: f32 = 0.35;
+pub(crate) const TAB_ACCENT_INACTIVE_ALPHA: f32 = 0.12;
+pub(crate) const TAB_ACCENT_INACTIVE_HOVER_ALPHA: f32 = 0.20;
+
 /// Map a `TabAccentColor` to an `Hsla` for rendering dots and tab backgrounds.
 pub(crate) fn tab_accent_color_hsla(color: TabAccentColor, cx: &App) -> Hsla {
     let is_dark = cx.theme().is_dark();
@@ -18,6 +22,13 @@ pub(crate) fn tab_accent_color_hsla(color: TabAccentColor, cx: &App) -> Hsla {
         TabAccentColor::Unknown => (142.0, 0.40, 0.45, 0.55),
     };
     gpui::hsla(h / 360.0, s, if is_dark { ld } else { ll }, 1.0)
+}
+
+/// Render a user-assigned tab accent as a low- or high-emphasis chrome surface.
+pub(crate) fn tab_accent_surface_hsla(color: TabAccentColor, alpha: f32, cx: &App) -> Hsla {
+    let mut h = tab_accent_color_hsla(color, cx);
+    h.a = alpha;
+    h
 }
 
 /// Green dot used to indicate the active tab when no explicit accent color is set.

--- a/crates/con-app/src/workspace/render/top_bar.rs
+++ b/crates/con-app/src/workspace/render/top_bar.rs
@@ -548,28 +548,39 @@ impl ConWorkspace {
                         cx.notify();
                     }));
 
-                // Accent color is reserved for the active tab surface.
-                let active_accent_bg: Option<Hsla> = tab_color.map(|c| {
-                    let mut h = crate::tab_colors::tab_accent_color_hsla(c, cx);
-                    h.a = 0.35;
-                    h
-                });
+                let accent_bg: Option<Hsla> =
+                    tab_color.map(|c| crate::tab_colors::tab_accent_color_hsla(c, cx));
                 if is_active {
                     tab_el = tab_el
                         .rounded_t(px(7.0))
-                        .map(|el| match active_accent_bg {
-                            Some(bg) => el.bg(bg),
+                        .map(|el| match accent_bg {
+                            Some(mut h) => {
+                                h.a = 0.35;
+                                el.bg(h)
+                            }
                             None => el.bg(theme.background.opacity(elevated_ui_surface_opacity)),
                         })
                         .text_color(theme.foreground)
                         .font_weight(FontWeight::MEDIUM);
                 } else {
+                    let inactive_bg = accent_bg
+                        .map(|mut h| {
+                            h.a = 0.15;
+                            h
+                        })
+                        .unwrap_or(theme.background.opacity(0.14));
+                    let inactive_hover_bg = accent_bg
+                        .map(|mut h| {
+                            h.a = 0.22;
+                            h
+                        })
+                        .unwrap_or(theme.background.opacity(0.20));
                     tab_el = tab_el
                         .rounded_t(px(6.0))
-                        .bg(theme.background.opacity(0.14))
+                        .bg(inactive_bg)
                         .text_color(theme.muted_foreground.opacity(0.72))
                         .hover(move |s: gpui::StyleRefinement| {
-                            s.bg(theme.background.opacity(0.20))
+                            s.bg(inactive_hover_bg)
                                 .text_color(theme.foreground.opacity(0.82))
                         });
                 }

--- a/crates/con-app/src/workspace/render/top_bar.rs
+++ b/crates/con-app/src/workspace/render/top_bar.rs
@@ -548,31 +548,36 @@ impl ConWorkspace {
                         cx.notify();
                     }));
 
-                let accent_bg: Option<Hsla> =
-                    tab_color.map(|c| crate::tab_colors::tab_accent_color_hsla(c, cx));
                 if is_active {
                     tab_el = tab_el
                         .rounded_t(px(7.0))
-                        .map(|el| match accent_bg {
-                            Some(mut h) => {
-                                h.a = 0.35;
-                                el.bg(h)
-                            }
+                        .map(|el| match tab_color {
+                            Some(color) => el.bg(crate::tab_colors::tab_accent_surface_hsla(
+                                color,
+                                crate::tab_colors::TAB_ACCENT_ACTIVE_ALPHA,
+                                cx,
+                            )),
                             None => el.bg(theme.background.opacity(elevated_ui_surface_opacity)),
                         })
                         .text_color(theme.foreground)
                         .font_weight(FontWeight::MEDIUM);
                 } else {
-                    let inactive_bg = accent_bg
-                        .map(|mut h| {
-                            h.a = 0.15;
-                            h
+                    let inactive_bg = tab_color
+                        .map(|color| {
+                            crate::tab_colors::tab_accent_surface_hsla(
+                                color,
+                                crate::tab_colors::TAB_ACCENT_INACTIVE_ALPHA,
+                                cx,
+                            )
                         })
                         .unwrap_or(theme.background.opacity(0.14));
-                    let inactive_hover_bg = accent_bg
-                        .map(|mut h| {
-                            h.a = 0.22;
-                            h
+                    let inactive_hover_bg = tab_color
+                        .map(|color| {
+                            crate::tab_colors::tab_accent_surface_hsla(
+                                color,
+                                crate::tab_colors::TAB_ACCENT_INACTIVE_HOVER_ALPHA,
+                                cx,
+                            )
                         })
                         .unwrap_or(theme.background.opacity(0.20));
                     tab_el = tab_el

--- a/docs/impl/tab-context-actions.md
+++ b/docs/impl/tab-context-actions.md
@@ -141,7 +141,7 @@ crates/con-app/src/tab_colors.rs
 
 **Horizontal tab strip** (`top_bar.rs`):
 - Active tab: accent color at alpha 0.35 replaces `theme.background.opacity(elevated_ui_surface_opacity)`.
-- Inactive tab: accent color at alpha 0.12; hover at alpha 0.18.
+- Inactive tab: accent color at alpha 0.12; hover at alpha 0.20.
 - Active indicator dot: accent color if set, otherwise `active_tab_indicator_color()`. Only shown on the active tab.
 
 **Vertical rail pill** (`sidebar.rs`):
@@ -155,7 +155,11 @@ crates/con-app/src/tab_colors.rs
 
 **Pane title bar** (`pane_tree.rs`):
 - Focused pane: accent color at alpha 0.35 replaces `theme.tab_bar_segmented`.
-- Unfocused pane: always `theme.tab_bar_segmented.opacity(0.78)` — accent is reserved for the focused/active semantic state only.
+- Unfocused pane: accent color at alpha 0.12 when the tab has a user-assigned accent, otherwise `theme.tab_bar_segmented.opacity(0.78)`.
+
+Tab accent color is treated as user-assigned tab identity. Focused/active state
+is expressed by stronger alpha, not by making inactive instances forget their
+identity color.
 
 ### Persistence
 


### PR DESCRIPTION
## Summary
- Preserve accent-colored backgrounds for inactive tabs using lower alpha instead of falling back to dark surfaces.
- Apply the same active/inactive accent alpha treatment to split pane title bars.
- Shorten pane titles to their final path component and simplify title truncation so narrow panes remain readable.

## Test Plan
- [x] cargo fmt --check
- [x] cargo build -p con
- [x] cargo test --workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Pane titles now display with simplified path formatting, showing only the final directory component
  * Sidebar and tab styling updated for consistent accent color application across active and inactive states
  * Improved visual consistency in tab backgrounds and pinned panel rendering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->