### PR TITLE
Polish Windows terminal rendering and portable selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,11 @@ con is still pre-release, so entries may group related beta work while the produ
   [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
   [@wey-gu](https://github.com/wey-gu))_
 - Raised the Windows alternate-screen background opacity floor for full-screen
-  TUIs such as htop and vim, so their default-background canvas stays readable
-  while ordinary shell panes keep the configured terminal glass effect. _(Issue
-  [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR
-  [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
+  TUIs such as htop and vim to a solid app canvas, so their default-background
+  screens match Windows Terminal/Ghostty instead of compositing with shell
+  content underneath. Ordinary shell panes still keep the configured terminal
+  glass effect. _(Issue [#34](https://github.com/nowledge-co/con-terminal/issues/34),
+  PR [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
   [@wey-gu](https://github.com/wey-gu))_
 - Polished Windows and Linux caption-button hover states so minimize and
   maximize/restore give visible feedback instead of only the close button
@@ -98,6 +99,13 @@ con is still pre-release, so entries may group related beta work while the produ
   stale highlights when fresh terminal output replaces the grid. _(Issues
   [#177](https://github.com/nowledge-co/con-terminal/issues/177),
   [#18](https://github.com/nowledge-co/con-terminal/issues/18), and
+  [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR
+  [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
+  [@wey-gu](https://github.com/wey-gu))_
+- Made portable terminal selections scrollback-stable: when the viewport moves
+  while text is selected, the highlight now remains attached to the selected
+  terminal content instead of staying pinned to the same screen rows. _(Issues
+  [#18](https://github.com/nowledge-co/con-terminal/issues/18) and
   [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR
   [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
   [@wey-gu](https://github.com/wey-gu))_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,13 +66,23 @@ con is still pre-release, so entries may group related beta work while the produ
   ConPTY launch/current-directory fallback until shell integration reports a
   newer path. Con now also installs a lightweight PowerShell/pwsh prompt hook
   that emits cwd updates, so restored Windows sessions follow directory
-  changes made after startup. _(Issue
+  changes made after startup; the portable VT wrapper now captures OSC 7
+  directly because libghostty-vt's terminal-only stream intentionally ignores
+  cwd reports. _(Issue
   [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR
   [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
   [@wey-gu](https://github.com/wey-gu))_
 
 **Windows and Linux**
 
+- Tightened portable terminal chrome coverage so pane dividers, vertical-tab
+  edges, input bar motion, and agent-panel drag/show/hide transitions use
+  terminal-colored seam covers instead of transparent hit areas that could leak
+  the desktop/window backdrop during fast movement. _(Issues
+  [#18](https://github.com/nowledge-co/con-terminal/issues/18) and
+  [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR
+  [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
+  [@wey-gu](https://github.com/wey-gu))_
 - Fixed terminal selection copy semantics on the portable backends:
   `Ctrl+C` now copies and clears the current selection when text is selected,
   while still sending interrupt when nothing is selected. The Linux preview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,10 @@ con is still pre-release, so entries may group related beta work while the produ
 **Windows**
 
 - Improved Windows CJK rendering by anchoring fallback CJK glyphs to the
-  terminal cell baseline and slightly increasing grayscale glyph contrast,
-  reducing the vertical drift and too-thin strokes reported in Windows font
-  rendering feedback. _(Issues
+  terminal cell baseline and applying a stronger grayscale contrast only to
+  wide CJK fallback glyphs, reducing vertical drift and the too-thin strokes
+  reported in Windows font rendering feedback without changing the Latin glyph
+  path. _(Issues
   [#124](https://github.com/nowledge-co/con-terminal/issues/124),
   [#78](https://github.com/nowledge-co/con-terminal/issues/78), and
   [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,19 @@ con is still pre-release, so entries may group related beta work while the produ
   [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR
   [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
   [@wey-gu](https://github.com/wey-gu))_
+- Raised the Windows alternate-screen background opacity floor for full-screen
+  TUIs such as htop and vim, so their default-background canvas stays readable
+  while ordinary shell panes keep the configured terminal glass effect. _(Issue
+  [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR
+  [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
+  [@wey-gu](https://github.com/wey-gu))_
+- Polished Windows and Linux caption-button hover states so minimize and
+  maximize/restore give visible feedback instead of only the close button
+  feeling interactive. _(Issues
+  [#18](https://github.com/nowledge-co/con-terminal/issues/18) and
+  [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR
+  [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
+  [@wey-gu](https://github.com/wey-gu))_
 
 ## `v0.1.0-beta.68` - 2026-05-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ con is still pre-release, so entries may group related beta work while the produ
 
 - Improved the default Windows terminal pane presentation with a small content
   inset and native-edge caption alignment, so the prompt no longer sits flush
-  against the window edge and the close button reaches the right edge of the
-  titlebar. _(Issues
+  against the window edge, the inset gutter matches the terminal background,
+  and the close button reaches the right edge of the titlebar. _(Issues
   [#131](https://github.com/nowledge-co/con-terminal/issues/131) and
   [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR
   [#169](https://github.com/nowledge-co/con-terminal/pull/169) by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,10 +30,10 @@ con is still pre-release, so entries may group related beta work while the produ
 **Windows**
 
 - Improved Windows CJK rendering by anchoring fallback CJK glyphs to the
-  terminal cell baseline and applying a stronger grayscale contrast only to
-  wide CJK fallback glyphs, reducing vertical drift and the too-thin strokes
-  reported in Windows font rendering feedback without changing the Latin glyph
-  path. _(Issues
+  terminal cell baseline, drawing East Asian text through a medium-weight
+  DirectWrite format, and applying only a moderate CJK-specific grayscale
+  contrast boost. This reduces vertical drift and thin-looking Chinese strokes
+  without over-darkening Latin text or Nerd-Font prompt icons. _(Issues
   [#124](https://github.com/nowledge-co/con-terminal/issues/124),
   [#78](https://github.com/nowledge-co/con-terminal/issues/78), and
   [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,13 +56,17 @@ con is still pre-release, so entries may group related beta work while the produ
   [@wey-gu](https://github.com/wey-gu))_
 - Stopped stale Windows terminal frames from stretching while panes close,
   split, or resize, so existing terminal content no longer appears briefly
-  zoomed before the next renderer frame arrives. _(Issue
+  zoomed before the next renderer frame arrives, and covered newly exposed
+  stale-frame gaps with the terminal background instead of leaking transparent
+  window content. _(Issue
   [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR
   [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
   [@wey-gu](https://github.com/wey-gu))_
 - Fixed restored Windows sessions so the saved working directory remains the
   ConPTY launch/current-directory fallback until shell integration reports a
-  newer path. _(Issue
+  newer path. Con now also installs a lightweight PowerShell/pwsh prompt hook
+  that emits cwd updates, so restored Windows sessions follow directory
+  changes made after startup. _(Issue
   [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR
   [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
   [@wey-gu](https://github.com/wey-gu))_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,14 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ### Changed
 
+**Windows**
+
+- Improved the default Windows terminal pane presentation with a small content
+  inset and native-edge caption alignment, so the prompt no longer sits flush
+  against the window edge and the close button reaches the right edge of the
+  titlebar. _(Issues [#131](https://github.com/nowledge-co/con-terminal/issues/131)
+  and [#34](https://github.com/nowledge-co/con-terminal/issues/34))_
+
 **Settings**
 
 - Matched the standalone Settings window titlebar to Con's main macOS window
@@ -117,6 +125,18 @@ con is still pre-release, so entries may group related beta work while the produ
   titles to the final path component on Unix and Windows-style paths. _(PR
   [#168](https://github.com/nowledge-co/con-terminal/pull/168) by
   [@sundy-li](https://github.com/sundy-li))_
+
+### Fixed
+
+**Windows**
+
+- Improved Windows CJK rendering by anchoring fallback CJK glyphs to the
+  terminal cell baseline and slightly increasing grayscale glyph contrast,
+  reducing the vertical drift and too-thin strokes reported in Windows font
+  rendering feedback. _(Issues
+  [#124](https://github.com/nowledge-co/con-terminal/issues/124),
+  [#78](https://github.com/nowledge-co/con-terminal/issues/78), and
+  [#34](https://github.com/nowledge-co/con-terminal/issues/34))_
 
 ## `v0.1.0-beta.65` - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,18 @@ con is still pre-release, so entries may group related beta work while the produ
   [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
   [@wey-gu](https://github.com/wey-gu))_
 
+**Windows and Linux**
+
+- Fixed terminal selection copy semantics on the portable backends:
+  `Ctrl+C` now copies and clears the current selection when text is selected,
+  while still sending interrupt when nothing is selected. The Linux preview
+  also now supports left-drag text selection in the terminal pane. _(Issues
+  [#177](https://github.com/nowledge-co/con-terminal/issues/177),
+  [#18](https://github.com/nowledge-co/con-terminal/issues/18), and
+  [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR
+  [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
+  [@wey-gu](https://github.com/wey-gu))_
+
 ## `v0.1.0-beta.68` - 2026-05-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ con is still pre-release, so entries may group related beta work while the produ
 - Fixed pane-local surface tab strips so they use the same themed chrome
   backing as split-pane title bars instead of leaking transparent window
   content, and tightened their spacing, typography, and active/hover states.
+  _(PR [#184](https://github.com/nowledge-co/con-terminal/pull/184) by
+  [@wey-gu](https://github.com/wey-gu))_
 
 **Windows**
 
@@ -52,13 +54,26 @@ con is still pre-release, so entries may group related beta work while the produ
   [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR
   [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
   [@wey-gu](https://github.com/wey-gu))_
+- Stopped stale Windows terminal frames from stretching while panes close,
+  split, or resize, so existing terminal content no longer appears briefly
+  zoomed before the next renderer frame arrives. _(Issue
+  [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR
+  [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
+  [@wey-gu](https://github.com/wey-gu))_
+- Fixed restored Windows sessions so the saved working directory remains the
+  ConPTY launch/current-directory fallback until shell integration reports a
+  newer path. _(Issue
+  [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR
+  [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
+  [@wey-gu](https://github.com/wey-gu))_
 
 **Windows and Linux**
 
 - Fixed terminal selection copy semantics on the portable backends:
   `Ctrl+C` now copies and clears the current selection when text is selected,
   while still sending interrupt when nothing is selected. The Linux preview
-  also now supports left-drag text selection in the terminal pane. _(Issues
+  also now supports left-drag text selection in the terminal pane and clears
+  stale highlights when fresh terminal output replaces the grid. _(Issues
   [#177](https://github.com/nowledge-co/con-terminal/issues/177),
   [#18](https://github.com/nowledge-co/con-terminal/issues/18), and
   [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ## `v0.1.0-beta.69` - unreleased
 
+### Changed
+
+**Windows**
+
+- Improved the default Windows terminal pane presentation with a small content
+  inset and native-edge caption alignment, so the prompt no longer sits flush
+  against the window edge and the close button reaches the right edge of the
+  titlebar. _(Issues
+  [#131](https://github.com/nowledge-co/con-terminal/issues/131) and
+  [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR
+  [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
+  [@wey-gu](https://github.com/wey-gu))_
+
 ### Fixed
 
 **Panes**
@@ -13,6 +26,18 @@ con is still pre-release, so entries may group related beta work while the produ
 - Fixed pane-local surface tab strips so they use the same themed chrome
   backing as split-pane title bars instead of leaking transparent window
   content, and tightened their spacing, typography, and active/hover states.
+
+**Windows**
+
+- Improved Windows CJK rendering by anchoring fallback CJK glyphs to the
+  terminal cell baseline and slightly increasing grayscale glyph contrast,
+  reducing the vertical drift and too-thin strokes reported in Windows font
+  rendering feedback. _(Issues
+  [#124](https://github.com/nowledge-co/con-terminal/issues/124),
+  [#78](https://github.com/nowledge-co/con-terminal/issues/78), and
+  [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR
+  [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
+  [@wey-gu](https://github.com/wey-gu))_
 
 ## `v0.1.0-beta.68` - 2026-05-09
 
@@ -90,14 +115,6 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ### Changed
 
-**Windows**
-
-- Improved the default Windows terminal pane presentation with a small content
-  inset and native-edge caption alignment, so the prompt no longer sits flush
-  against the window edge and the close button reaches the right edge of the
-  titlebar. _(Issues [#131](https://github.com/nowledge-co/con-terminal/issues/131)
-  and [#34](https://github.com/nowledge-co/con-terminal/issues/34))_
-
 **Settings**
 
 - Matched the standalone Settings window titlebar to Con's main macOS window
@@ -125,18 +142,6 @@ con is still pre-release, so entries may group related beta work while the produ
   titles to the final path component on Unix and Windows-style paths. _(PR
   [#168](https://github.com/nowledge-co/con-terminal/pull/168) by
   [@sundy-li](https://github.com/sundy-li))_
-
-### Fixed
-
-**Windows**
-
-- Improved Windows CJK rendering by anchoring fallback CJK glyphs to the
-  terminal cell baseline and slightly increasing grayscale glyph contrast,
-  reducing the vertical drift and too-thin strokes reported in Windows font
-  rendering feedback. _(Issues
-  [#124](https://github.com/nowledge-co/con-terminal/issues/124),
-  [#78](https://github.com/nowledge-co/con-terminal/issues/78), and
-  [#34](https://github.com/nowledge-co/con-terminal/issues/34))_
 
 ## `v0.1.0-beta.65` - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,8 +77,16 @@ con is still pre-release, so entries may group related beta work while the produ
 
 - Tightened portable terminal chrome coverage so pane dividers, vertical-tab
   edges, input bar motion, and agent-panel drag/show/hide transitions use
-  terminal-colored seam covers instead of transparent hit areas that could leak
-  the desktop/window backdrop during fast movement. _(Issues
+  terminal-colored seam covers and terminal-matched backing instead of
+  transparent hit areas that could leak the desktop/window backdrop during fast
+  movement. _(Issues
+  [#18](https://github.com/nowledge-co/con-terminal/issues/18) and
+  [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR
+  [#169](https://github.com/nowledge-co/con-terminal/pull/169) by
+  [@wey-gu](https://github.com/wey-gu))_
+- Matched macOS terminal behavior on the portable backends: when a user has
+  scrolled back and then types or pastes input, the viewport now returns to the
+  live prompt instead of leaving the terminal parked in history. _(Issues
   [#18](https://github.com/nowledge-co/con-terminal/issues/18) and
   [#34](https://github.com/nowledge-co/con-terminal/issues/34), PR
   [#169](https://github.com/nowledge-co/con-terminal/pull/169) by

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -470,6 +470,7 @@ impl GhosttyView {
         if !self.seen_any_output && snapshot.cells.iter().any(|c| c.codepoint != 0) {
             self.seen_any_output = true;
         }
+        self.clear_selection();
         self.snapshot = Some(snapshot);
         true
     }
@@ -478,7 +479,7 @@ impl GhosttyView {
         self.pane_bounds = Some(bounds);
         self.scale_factor = scale_factor;
 
-        let Some(terminal) = self.terminal.as_ref() else {
+        let Some(terminal) = self.terminal.as_ref().cloned() else {
             return false;
         };
 
@@ -664,7 +665,7 @@ impl GhosttyView {
         window: &Window,
         cx: &mut Context<Self>,
     ) -> bool {
-        let Some(terminal) = self.terminal.as_ref() else {
+        let Some(terminal) = self.terminal.as_ref().cloned() else {
             return false;
         };
 
@@ -716,7 +717,7 @@ impl GhosttyView {
                     return true;
                 }
                 "v" => {
-                    paste_from_clipboard(terminal, cx);
+                    paste_from_clipboard(&terminal, cx);
                     return true;
                 }
                 _ => {}

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -29,8 +29,7 @@ use gpui_component::menu::ContextMenuExt;
 use crate::terminal_ime::{TerminalImeInputHandler, TerminalImeView};
 use crate::terminal_links::{self, TerminalLink};
 use crate::terminal_paste::{
-    TerminalPastePayload, copy_selection_to_clipboard, payload_from_clipboard,
-    payload_from_external_paths,
+    TerminalPastePayload, payload_from_clipboard, payload_from_external_paths,
 };
 use crate::terminal_restore::{key_down_may_write_terminal, restored_terminal_output};
 
@@ -106,6 +105,8 @@ pub struct GhosttyView {
     suppress_link_mouse_up: bool,
     hovered_link: Option<TerminalLink>,
     last_mouse_position: Option<Point<Pixels>>,
+    selection: Option<TerminalSelection>,
+    drag_anchor: Option<(u16, u16)>,
 }
 
 pub fn init(cx: &mut App) {
@@ -184,6 +185,8 @@ impl GhosttyView {
             suppress_link_mouse_up: false,
             hovered_link: None,
             last_mouse_position: None,
+            selection: None,
+            drag_anchor: None,
         }
     }
 
@@ -194,6 +197,7 @@ impl GhosttyView {
     pub fn write_or_queue(&mut self, data: &[u8]) {
         if !data.is_empty() {
             self.clear_restored_screen_text();
+            self.clear_selection();
         }
 
         if let Some(terminal) = &self.terminal {
@@ -229,9 +233,31 @@ impl GhosttyView {
         self.initialized
     }
 
-    #[allow(dead_code)]
     pub fn selection_text(&self) -> Option<String> {
-        None
+        extract_selection_text(self.snapshot.as_ref()?, self.selection?)
+    }
+
+    fn clear_selection(&mut self) -> bool {
+        let changed = self.selection.take().is_some() || self.drag_anchor.take().is_some();
+        changed
+    }
+
+    fn copy_current_selection_to_clipboard(&mut self, cx: &mut App) -> bool {
+        if self.selection.is_none() {
+            return false;
+        }
+
+        let Some(selection) = self
+            .selection_text()
+            .filter(|selection| !selection.is_empty())
+        else {
+            self.clear_selection();
+            return true;
+        };
+
+        cx.write_to_clipboard(ClipboardItem::new_string(selection));
+        self.clear_selection();
+        true
     }
 
     pub fn shutdown_surface(&mut self) {
@@ -256,6 +282,8 @@ impl GhosttyView {
         self.suppress_link_mouse_up = false;
         self.hovered_link = None;
         self.last_mouse_position = None;
+        self.selection = None;
+        self.drag_anchor = None;
     }
 
     pub fn set_surface_focus_state(&mut self, focused: bool) {
@@ -378,7 +406,7 @@ impl GhosttyView {
     }
 
     fn ensure_session(&mut self, cx: &mut Context<Self>) -> bool {
-        let Some(terminal) = self.terminal.as_ref() else {
+        let Some(terminal) = self.terminal.as_ref().cloned() else {
             return false;
         };
 
@@ -411,7 +439,7 @@ impl GhosttyView {
     }
 
     fn refresh_snapshot(&mut self) -> bool {
-        let Some(terminal) = self.terminal.as_ref() else {
+        let Some(terminal) = self.terminal.as_ref().cloned() else {
             return false;
         };
         let Some(snapshot) = terminal.snapshot() else {
@@ -460,6 +488,7 @@ impl GhosttyView {
             return false;
         }
 
+        self.clear_selection();
         terminal.resize_surface(size);
         self.last_surface_size = Some(signature);
         false
@@ -498,15 +527,33 @@ impl GhosttyView {
     }
 
     fn cell_from_event_position(&self, pos: Point<Pixels>) -> Option<(u16, u16)> {
+        self.cell_from_event_position_impl(pos, false)
+    }
+
+    fn clamped_cell_from_event_position(&self, pos: Point<Pixels>) -> Option<(u16, u16)> {
+        self.cell_from_event_position_impl(pos, true)
+    }
+
+    fn cell_from_event_position_impl(
+        &self,
+        pos: Point<Pixels>,
+        clamp_to_grid: bool,
+    ) -> Option<(u16, u16)> {
         let bounds = self.pane_bounds?;
         let snapshot = self.snapshot.as_ref()?;
         let font_size_px = effective_font_size(self.initial_font_size);
         let cell_width_px = (font_size_px * DEFAULT_CELL_WIDTH_RATIO).round().max(7.0);
         let cell_height_px = (font_size_px * DEFAULT_CELL_HEIGHT_RATIO).round().max(14.0);
 
-        let local_x = f32::from(pos.x) - f32::from(bounds.origin.x) - TERMINAL_PADDING_X_PX;
-        let local_y = f32::from(pos.y) - f32::from(bounds.origin.y) - TERMINAL_PADDING_Y_PX;
-        if local_x < 0.0 || local_y < 0.0 {
+        let mut local_x = f32::from(pos.x) - f32::from(bounds.origin.x) - TERMINAL_PADDING_X_PX;
+        let mut local_y = f32::from(pos.y) - f32::from(bounds.origin.y) - TERMINAL_PADDING_Y_PX;
+        let grid_width = snapshot.cols as f32 * cell_width_px;
+        let grid_height = snapshot.rows as f32 * cell_height_px;
+        if clamp_to_grid {
+            local_x = local_x.clamp(0.0, (grid_width - f32::EPSILON).max(0.0));
+            local_y = local_y.clamp(0.0, (grid_height - f32::EPSILON).max(0.0));
+        } else if local_x < 0.0 || local_y < 0.0 || local_x >= grid_width || local_y >= grid_height
+        {
             return None;
         }
 
@@ -542,6 +589,50 @@ impl GhosttyView {
         let changed = self.hovered_link.take().is_some();
         self.last_mouse_position = None;
         changed
+    }
+
+    fn begin_selection(&mut self, pos: Point<Pixels>) -> bool {
+        let Some(cell) = self.cell_from_event_position(pos) else {
+            return self.clear_selection();
+        };
+        self.drag_anchor = Some(cell);
+        self.selection = Some(TerminalSelection {
+            anchor: cell,
+            extent: cell,
+        });
+        true
+    }
+
+    fn update_selection_drag(&mut self, pos: Point<Pixels>) -> bool {
+        let Some(anchor) = self.drag_anchor else {
+            return false;
+        };
+        let Some(extent) = self.clamped_cell_from_event_position(pos) else {
+            return false;
+        };
+        let next = TerminalSelection { anchor, extent };
+        if self.selection == Some(next) {
+            return false;
+        }
+        self.selection = Some(next);
+        true
+    }
+
+    fn finish_selection(&mut self, pos: Point<Pixels>) -> bool {
+        let anchor = self.drag_anchor.take();
+        let Some(anchor) = anchor else {
+            return false;
+        };
+        let extent = self.clamped_cell_from_event_position(pos).unwrap_or(anchor);
+        if anchor == extent {
+            return self.clear_selection();
+        }
+        let next = TerminalSelection { anchor, extent };
+        if self.selection == Some(next) {
+            return false;
+        }
+        self.selection = Some(next);
+        true
     }
 
     fn render_link_cursor_overlay(
@@ -602,6 +693,18 @@ impl GhosttyView {
             return false;
         }
 
+        // Plain Ctrl+C copies a terminal selection; without a selection it
+        // keeps the shell's interrupt semantics.
+        if keystroke.modifiers.control
+            && !keystroke.modifiers.shift
+            && !keystroke.modifiers.alt
+            && !keystroke.modifiers.platform
+            && keystroke.key == "c"
+            && self.copy_current_selection_to_clipboard(cx)
+        {
+            return true;
+        }
+
         if keystroke.modifiers.control
             && keystroke.modifiers.shift
             && !keystroke.modifiers.alt
@@ -609,7 +712,7 @@ impl GhosttyView {
         {
             match keystroke.key.as_str() {
                 "c" => {
-                    copy_selection_to_clipboard(terminal, cx);
+                    self.copy_current_selection_to_clipboard(cx);
                     return true;
                 }
                 "v" => {
@@ -771,8 +874,15 @@ impl GhosttyView {
                 break;
             };
             let cursor_for_row = cursor_col_for_row(snapshot.cursor, row_idx);
-            self.row_cache[row_idx] =
-                build_terminal_row(cells, default_fg, default_bg, base_font, cursor_for_row);
+            self.row_cache[row_idx] = build_terminal_row(
+                cells,
+                default_fg,
+                default_bg,
+                base_font,
+                cursor_for_row,
+                None,
+                default_bg,
+            );
         }
 
         self.row_cache_generation = Some(snapshot.generation);
@@ -848,6 +958,7 @@ impl TerminalImeView for GhosttyView {
         let _ = self.ensure_session(cx);
         if !text.is_empty() {
             self.clear_restored_screen_text();
+            self.clear_selection();
         }
         if let Some(terminal) = &self.terminal {
             terminal.send_text(text);
@@ -904,6 +1015,8 @@ impl Render for GhosttyView {
         let foreground = theme.foreground;
         let status_color = foreground.opacity(0.5);
         let pane_opacity = self.app.background_opacity().clamp(0.0, 1.0);
+        let selection = self.selection;
+        let selection_bg = theme.selection.opacity(0.42);
         self.sync_row_cache(
             foreground,
             theme.background,
@@ -930,7 +1043,30 @@ impl Render for GhosttyView {
 
         if let Some(snapshot) = self.snapshot.as_ref() {
             for row_idx in 0..usize::from(snapshot.rows) {
-                if let Some(row) = self.row_cache.get(row_idx) {
+                if let Some(selection_cols) =
+                    selection.and_then(|selection| selection.row_range(row_idx, snapshot.cols))
+                {
+                    let row_start = row_idx * usize::from(snapshot.cols);
+                    let row_end = row_start + usize::from(snapshot.cols);
+                    if let Some(cells) = snapshot.cells.get(row_start..row_end) {
+                        let cursor_for_row = cursor_col_for_row(snapshot.cursor, row_idx);
+                        let row = build_terminal_row(
+                            cells,
+                            foreground,
+                            theme.background,
+                            &mono_font,
+                            cursor_for_row,
+                            Some(selection_cols),
+                            selection_bg,
+                        );
+                        rows.push(render_cached_terminal_row(
+                            &row,
+                            px(font_size_px),
+                            px(line_height_px),
+                            theme.background.opacity(pane_opacity),
+                        ));
+                    }
+                } else if let Some(row) = self.row_cache.get(row_idx) {
                     rows.push(render_cached_terminal_row(
                         row,
                         px(font_size_px),
@@ -1013,8 +1149,8 @@ impl Render for GhosttyView {
                 cx.notify();
             }))
             .on_action(cx.listener(|this, _: &crate::Copy, _window, cx| {
-                if let Some(terminal) = &this.terminal {
-                    copy_selection_to_clipboard(terminal, cx);
+                if this.copy_current_selection_to_clipboard(cx) {
+                    cx.notify();
                 }
             }))
             .on_action(cx.listener(|this, _: &crate::Paste, _window, cx| {
@@ -1048,9 +1184,16 @@ impl Render for GhosttyView {
                     encode_special_key(&event.keystroke.key, &event.keystroke.modifiers, false)
                         .is_some();
                 let clears_restore = key_down_may_write_terminal(event, special_key_writes);
+                let copy_shortcut = event.keystroke.modifiers.control
+                    && !event.keystroke.modifiers.alt
+                    && !event.keystroke.modifiers.platform
+                    && event.keystroke.key == "c";
                 let _ = this.ensure_session(cx);
                 if clears_restore {
                     this.clear_restored_screen_text();
+                }
+                if clears_restore && !copy_shortcut {
+                    this.clear_selection();
                 }
                 if this.handle_key_down(event, window, cx) {
                     window.prevent_default();
@@ -1099,7 +1242,11 @@ impl Render for GhosttyView {
                         this.suppress_link_mouse_up = true;
                         window.prevent_default();
                         cx.stop_propagation();
+                        cx.emit(GhosttyFocusChanged);
+                        cx.notify();
+                        return;
                     }
+                    this.begin_selection(event.position);
                     cx.emit(GhosttyFocusChanged);
                     cx.notify();
                 }),
@@ -1125,7 +1272,13 @@ impl Render for GhosttyView {
                     }
                     return;
                 }
-                if this.update_hovered_link(&event.modifiers) {
+                let mut changed = this.update_hovered_link(&event.modifiers);
+                if event.pressed_button == Some(MouseButton::Left) {
+                    changed |= this.update_selection_drag(event.position);
+                } else if this.drag_anchor.is_some() {
+                    changed |= this.finish_selection(event.position);
+                }
+                if changed {
                     cx.notify();
                 }
             }))
@@ -1144,6 +1297,12 @@ impl Render for GhosttyView {
                         window.prevent_default();
                         cx.stop_propagation();
                         let _ = this.update_hovered_link(&event.modifiers);
+                        cx.notify();
+                        return;
+                    }
+                    let mut changed = this.finish_selection(event.position);
+                    changed |= this.update_hovered_link(&event.modifiers);
+                    if changed {
                         cx.notify();
                     }
                 }),
@@ -1203,6 +1362,94 @@ impl Drop for GhosttyView {
         if let Some(terminal) = &self.terminal {
             terminal.request_close();
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct TerminalSelection {
+    anchor: (u16, u16),
+    extent: (u16, u16),
+}
+
+impl TerminalSelection {
+    fn contains(self, col: u16, row: u16, cols: u16) -> bool {
+        let to_linear = |point: (u16, u16)| point.1 as u32 * cols as u32 + point.0 as u32;
+        let anchor = to_linear(self.anchor);
+        let extent = to_linear(self.extent);
+        let (start, end) = if anchor <= extent {
+            (anchor, extent)
+        } else {
+            (extent, anchor)
+        };
+        let current = to_linear((col, row));
+        current >= start && current <= end
+    }
+
+    fn row_range(self, row: usize, cols: u16) -> Option<(usize, usize)> {
+        if cols == 0 || row > u16::MAX as usize {
+            return None;
+        }
+
+        let row = row as u16;
+        let mut start = None;
+        let mut end = None;
+        for col in 0..cols {
+            if self.contains(col, row, cols) {
+                start.get_or_insert(usize::from(col));
+                end = Some(usize::from(col));
+            }
+        }
+
+        start.zip(end)
+    }
+}
+
+fn extract_selection_text(
+    snapshot: &ScreenSnapshot,
+    selection: TerminalSelection,
+) -> Option<String> {
+    if snapshot.cols == 0 || snapshot.rows == 0 || snapshot.cells.is_empty() {
+        return None;
+    }
+
+    let cols = usize::from(snapshot.cols);
+    let mut output = String::new();
+    for row in 0..snapshot.rows {
+        let Some((start, end)) = selection.row_range(usize::from(row), snapshot.cols) else {
+            continue;
+        };
+
+        let row_start = usize::from(row) * cols;
+        let Some(cells) = snapshot.cells.get(row_start + start..=row_start + end) else {
+            continue;
+        };
+
+        let mut row_text = String::with_capacity(cells.len());
+        let mut last_non_blank = None;
+        for cell in cells {
+            let ch = match cell.codepoint {
+                0 => ' ',
+                cp => char::from_u32(cp).unwrap_or('\u{FFFD}'),
+            };
+            if ch != ' ' {
+                last_non_blank = Some(row_text.len() + ch.len_utf8());
+            }
+            row_text.push(ch);
+        }
+
+        if let Some(end_byte) = last_non_blank {
+            output.push_str(&row_text[..end_byte]);
+        }
+        output.push('\n');
+    }
+
+    if output.ends_with('\n') {
+        output.pop();
+    }
+    if output.is_empty() {
+        None
+    } else {
+        Some(output)
     }
 }
 
@@ -1293,6 +1540,8 @@ fn build_terminal_row(
     default_bg: Hsla,
     base_font: &Font,
     cursor_col: Option<usize>,
+    selection_cols: Option<(usize, usize)>,
+    selection_bg: Hsla,
 ) -> CachedTerminalRow {
     // First pass: find the last column we have to keep. A column
     // matters if it has a real glyph, OR if it carries a non-default
@@ -1312,7 +1561,9 @@ fn build_terminal_row(
             let styled_blank = (cell.bg & 0xFF) != 0
                 || (cell.attrs & (ATTR_INVERSE | ATTR_UNDERLINE | ATTR_STRIKE)) != 0;
             let cursor_here = cursor_col == Some(col_idx);
-            glyph_present || styled_blank || cursor_here
+            let selected_here =
+                selection_cols.is_some_and(|(start, end)| col_idx >= start && col_idx <= end);
+            glyph_present || styled_blank || cursor_here || selected_here
         })
         // `rposition` already returns the index relative to `cells`,
         // not `iter().enumerate()`'s output. Map it back to a slice
@@ -1324,7 +1575,7 @@ fn build_terminal_row(
 
     let mut text = String::with_capacity(kept.len());
     let mut runs: Vec<TextRun> = Vec::new();
-    let mut last_signature: Option<(u32, u32, u8, bool)> = None;
+    let mut last_signature: Option<(u32, u32, u8, bool, bool)> = None;
     let mut active_run_len: usize = 0;
     let mut active_style: Option<RowStyle> = None;
 
@@ -1350,8 +1601,18 @@ fn build_terminal_row(
 
     for (col_idx, cell) in kept.iter().enumerate() {
         let is_cursor = cursor_col == Some(col_idx);
-        let signature = (cell.fg, cell.bg, cell.attrs, is_cursor);
-        let style = RowStyle::from_cell(cell, default_fg, default_bg, base_font, is_cursor);
+        let is_selected =
+            selection_cols.is_some_and(|(start, end)| col_idx >= start && col_idx <= end);
+        let signature = (cell.fg, cell.bg, cell.attrs, is_cursor, is_selected);
+        let style = RowStyle::from_cell(
+            cell,
+            default_fg,
+            default_bg,
+            base_font,
+            is_cursor,
+            is_selected,
+            selection_bg,
+        );
 
         let glyph: char = match cell.codepoint {
             0 => ' ',
@@ -1408,6 +1669,8 @@ impl RowStyle {
         default_bg: Hsla,
         base_font: &Font,
         is_cursor: bool,
+        is_selected: bool,
+        selection_bg: Hsla,
     ) -> Self {
         let mut font = base_font.clone();
         if cell.attrs & ATTR_BOLD != 0 {
@@ -1424,6 +1687,10 @@ impl RowStyle {
             let resolved_bg = bg.unwrap_or(default_bg);
             bg = Some(fg);
             fg = resolved_bg;
+        }
+
+        if is_selected {
+            bg = Some(selection_bg);
         }
 
         if is_cursor {
@@ -1545,7 +1812,10 @@ fn encode_special_key(key: &str, modifiers: &Modifiers, decckm: bool) -> Option<
 
 #[cfg(test)]
 mod tests {
-    use super::{build_terminal_row, rows_needing_refresh, vt_color_to_hsla};
+    use super::{
+        TerminalSelection, build_terminal_row, extract_selection_text, rows_needing_refresh,
+        vt_color_to_hsla,
+    };
     use con_ghostty::{ATTR_BOLD, ATTR_INVERSE, ATTR_UNDERLINE, ScreenSnapshot, VtCell, VtCursor};
     use gpui::{Font, FontFeatures, FontStyle, FontWeight, Hsla, Rgba};
 
@@ -1603,8 +1873,53 @@ mod tests {
             make_cell(' ', 0, 0, 0),
             make_cell('!', ATTR_INVERSE, 0, 0),
         ];
-        let _no_cursor = build_terminal_row(&cells, fg(), bg(), &base_font(), None);
-        let _with_cursor = build_terminal_row(&cells, fg(), bg(), &base_font(), Some(2));
+        let _no_cursor = build_terminal_row(&cells, fg(), bg(), &base_font(), None, None, bg());
+        let _with_cursor =
+            build_terminal_row(&cells, fg(), bg(), &base_font(), Some(2), None, bg());
+    }
+
+    #[test]
+    fn terminal_selection_row_range_handles_reverse_drag() {
+        let selection = TerminalSelection {
+            anchor: (3, 1),
+            extent: (1, 0),
+        };
+
+        assert_eq!(selection.row_range(0, 5), Some((1, 4)));
+        assert_eq!(selection.row_range(1, 5), Some((0, 3)));
+        assert_eq!(selection.row_range(2, 5), None);
+    }
+
+    #[test]
+    fn extracts_selected_text_from_snapshot() {
+        let mut cells = vec![VtCell::default(); 12];
+        for (idx, ch) in "one two     ".chars().enumerate() {
+            cells[idx].codepoint = ch as u32;
+        }
+        let snapshot = ScreenSnapshot {
+            cols: 4,
+            rows: 3,
+            cells,
+            dirty_rows: Vec::new(),
+            cursor: VtCursor {
+                col: 0,
+                row: 0,
+                visible: false,
+            },
+            alternate_screen: false,
+            title: None,
+            generation: 1,
+        };
+
+        let selection = TerminalSelection {
+            anchor: (1, 0),
+            extent: (2, 1),
+        };
+
+        assert_eq!(
+            extract_selection_text(&snapshot, selection),
+            Some("ne\ntwo".to_string())
+        );
     }
 
     #[test]

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -1619,6 +1619,7 @@ mod tests {
                 row: 2,
                 visible: true,
             },
+            alternate_screen: false,
             title: None,
             generation: 7,
         };

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -106,7 +106,7 @@ pub struct GhosttyView {
     hovered_link: Option<TerminalLink>,
     last_mouse_position: Option<Point<Pixels>>,
     selection: Option<TerminalSelection>,
-    drag_anchor: Option<(u16, u16)>,
+    drag_anchor: Option<(u16, u64)>,
 }
 
 pub fn init(cx: &mut App) {
@@ -593,13 +593,13 @@ impl GhosttyView {
     }
 
     fn begin_selection(&mut self, pos: Point<Pixels>) -> bool {
-        let Some(cell) = self.cell_from_event_position(pos) else {
+        let Some(point) = self.selection_point_from_event_position(pos) else {
             return self.clear_selection();
         };
-        self.drag_anchor = Some(cell);
+        self.drag_anchor = Some(point);
         self.selection = Some(TerminalSelection {
-            anchor: cell,
-            extent: cell,
+            anchor: point,
+            extent: point,
         });
         true
     }
@@ -608,7 +608,7 @@ impl GhosttyView {
         let Some(anchor) = self.drag_anchor else {
             return false;
         };
-        let Some(extent) = self.clamped_cell_from_event_position(pos) else {
+        let Some(extent) = self.clamped_selection_point_from_event_position(pos) else {
             return false;
         };
         let next = TerminalSelection { anchor, extent };
@@ -624,7 +624,9 @@ impl GhosttyView {
         let Some(anchor) = anchor else {
             return false;
         };
-        let extent = self.clamped_cell_from_event_position(pos).unwrap_or(anchor);
+        let extent = self
+            .clamped_selection_point_from_event_position(pos)
+            .unwrap_or(anchor);
         if anchor == extent {
             return self.clear_selection();
         }
@@ -634,6 +636,28 @@ impl GhosttyView {
         }
         self.selection = Some(next);
         true
+    }
+
+    fn selection_point_from_event_position(&self, pos: Point<Pixels>) -> Option<(u16, u64)> {
+        self.cell_from_event_position(pos)
+            .map(|cell| self.selection_point_from_cell(cell))
+    }
+
+    fn clamped_selection_point_from_event_position(
+        &self,
+        pos: Point<Pixels>,
+    ) -> Option<(u16, u64)> {
+        self.clamped_cell_from_event_position(pos)
+            .map(|cell| self.selection_point_from_cell(cell))
+    }
+
+    fn selection_point_from_cell(&self, cell: (u16, u16)) -> (u16, u64) {
+        let viewport_offset = self
+            .snapshot
+            .as_ref()
+            .and_then(|snapshot| snapshot.scrollbar)
+            .map_or(0, |scrollbar| scrollbar.offset);
+        (cell.0, viewport_offset.saturating_add(cell.1 as u64))
     }
 
     fn render_link_cursor_overlay(
@@ -1015,7 +1039,17 @@ impl Render for GhosttyView {
 
         let foreground = theme.foreground;
         let status_color = foreground.opacity(0.5);
-        let pane_opacity = self.app.background_opacity().clamp(0.0, 1.0);
+        let configured_pane_opacity = self.app.background_opacity().clamp(0.0, 1.0);
+        let pane_opacity = if self
+            .snapshot
+            .as_ref()
+            .is_some_and(|snapshot| snapshot.alternate_screen)
+            && configured_pane_opacity > f32::EPSILON
+        {
+            1.0
+        } else {
+            configured_pane_opacity
+        };
         let selection = self.selection;
         let selection_bg = theme.selection.opacity(0.42);
         self.sync_row_cache(
@@ -1045,7 +1079,7 @@ impl Render for GhosttyView {
         if let Some(snapshot) = self.snapshot.as_ref() {
             for row_idx in 0..usize::from(snapshot.rows) {
                 if let Some(selection_cols) =
-                    selection.and_then(|selection| selection.row_range(row_idx, snapshot.cols))
+                    selection.and_then(|selection| selection.row_range(row_idx, snapshot))
                 {
                     let row_start = row_idx * usize::from(snapshot.cols);
                     let row_end = row_start + usize::from(snapshot.cols);
@@ -1368,13 +1402,15 @@ impl Drop for GhosttyView {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct TerminalSelection {
-    anchor: (u16, u16),
-    extent: (u16, u16),
+    anchor: (u16, u64),
+    extent: (u16, u64),
 }
 
 impl TerminalSelection {
-    fn contains(self, col: u16, row: u16, cols: u16) -> bool {
-        let to_linear = |point: (u16, u16)| point.1 as u32 * cols as u32 + point.0 as u32;
+    fn contains(self, col: u16, row: u16, snapshot: &ScreenSnapshot) -> bool {
+        let cols = snapshot.cols;
+        let viewport_offset = snapshot.scrollbar.map_or(0, |scrollbar| scrollbar.offset);
+        let to_linear = |point: (u16, u64)| point.1 as u128 * cols as u128 + point.0 as u128;
         let anchor = to_linear(self.anchor);
         let extent = to_linear(self.extent);
         let (start, end) = if anchor <= extent {
@@ -1382,11 +1418,12 @@ impl TerminalSelection {
         } else {
             (extent, anchor)
         };
-        let current = to_linear((col, row));
+        let current = to_linear((col, viewport_offset.saturating_add(row as u64)));
         current >= start && current <= end
     }
 
-    fn row_range(self, row: usize, cols: u16) -> Option<(usize, usize)> {
+    fn row_range(self, row: usize, snapshot: &ScreenSnapshot) -> Option<(usize, usize)> {
+        let cols = snapshot.cols;
         if cols == 0 || row > u16::MAX as usize {
             return None;
         }
@@ -1395,7 +1432,7 @@ impl TerminalSelection {
         let mut start = None;
         let mut end = None;
         for col in 0..cols {
-            if self.contains(col, row, cols) {
+            if self.contains(col, row, snapshot) {
                 start.get_or_insert(usize::from(col));
                 end = Some(usize::from(col));
             }
@@ -1416,7 +1453,7 @@ fn extract_selection_text(
     let cols = usize::from(snapshot.cols);
     let mut output = String::new();
     for row in 0..snapshot.rows {
-        let Some((start, end)) = selection.row_range(usize::from(row), snapshot.cols) else {
+        let Some((start, end)) = selection.row_range(usize::from(row), snapshot) else {
             continue;
         };
 
@@ -1881,14 +1918,29 @@ mod tests {
 
     #[test]
     fn terminal_selection_row_range_handles_reverse_drag() {
+        let snapshot = ScreenSnapshot {
+            cols: 5,
+            rows: 3,
+            cells: Vec::new(),
+            dirty_rows: Vec::new(),
+            cursor: VtCursor {
+                col: 0,
+                row: 0,
+                visible: false,
+            },
+            alternate_screen: false,
+            scrollbar: None,
+            title: None,
+            generation: 1,
+        };
         let selection = TerminalSelection {
             anchor: (3, 1),
             extent: (1, 0),
         };
 
-        assert_eq!(selection.row_range(0, 5), Some((1, 4)));
-        assert_eq!(selection.row_range(1, 5), Some((0, 3)));
-        assert_eq!(selection.row_range(2, 5), None);
+        assert_eq!(selection.row_range(0, &snapshot), Some((1, 4)));
+        assert_eq!(selection.row_range(1, &snapshot), Some((0, 3)));
+        assert_eq!(selection.row_range(2, &snapshot), None);
     }
 
     #[test]
@@ -1908,6 +1960,7 @@ mod tests {
                 visible: false,
             },
             alternate_screen: false,
+            scrollbar: None,
             title: None,
             generation: 1,
         };
@@ -1936,6 +1989,7 @@ mod tests {
                 visible: true,
             },
             alternate_screen: false,
+            scrollbar: None,
             title: None,
             generation: 7,
         };

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -1619,37 +1619,6 @@ impl PaneTree {
                 let divider_id = ElementId::Name(format!("divider-{}", sid).into());
                 let divider = match dir {
                     SplitDirection::Horizontal => {
-                        #[cfg(not(target_os = "macos"))]
-                        {
-                            let hover_color = cx.theme().foreground.opacity(0.10);
-                            div()
-                                .id(divider_id)
-                                .relative()
-                                .w(px(5.0))
-                                .ml(px(-2.0))
-                                .mr(px(-2.0))
-                                .h_full()
-                                .flex_shrink_0()
-                                .cursor_col_resize()
-                                .bg(gpui::transparent_black())
-                                .hover(move |s| s.bg(hover_color))
-                                .child(
-                                    div()
-                                        .absolute()
-                                        .top_0()
-                                        .bottom_0()
-                                        .left(px(2.0))
-                                        .w(px(1.0))
-                                        .bg(divider_color),
-                                )
-                                .on_mouse_down(
-                                    MouseButton::Left,
-                                    move |event: &MouseDownEvent, _window, _cx| {
-                                        cb_divider(sid, f32::from(event.position.x));
-                                    },
-                                )
-                        }
-                        #[cfg(target_os = "macos")]
                         let handle = div()
                             .absolute()
                             .top_0()
@@ -1658,7 +1627,6 @@ impl PaneTree {
                             .w(px(5.0))
                             .cursor_col_resize()
                             .bg(gpui::transparent_black());
-                        #[cfg(target_os = "macos")]
                         div()
                             .id(divider_id)
                             .relative()
@@ -1674,37 +1642,6 @@ impl PaneTree {
                             ))
                     }
                     SplitDirection::Vertical => {
-                        #[cfg(not(target_os = "macos"))]
-                        {
-                            let hover_color = cx.theme().foreground.opacity(0.10);
-                            div()
-                                .id(divider_id)
-                                .relative()
-                                .h(px(5.0))
-                                .mt(px(-2.0))
-                                .mb(px(-2.0))
-                                .w_full()
-                                .flex_shrink_0()
-                                .cursor_row_resize()
-                                .bg(gpui::transparent_black())
-                                .hover(move |s| s.bg(hover_color))
-                                .child(
-                                    div()
-                                        .absolute()
-                                        .left_0()
-                                        .right_0()
-                                        .top(px(2.0))
-                                        .h(px(1.0))
-                                        .bg(divider_color),
-                                )
-                                .on_mouse_down(
-                                    MouseButton::Left,
-                                    move |event: &MouseDownEvent, _window, _cx| {
-                                        cb_divider(sid, f32::from(event.position.y));
-                                    },
-                                )
-                        }
-                        #[cfg(target_os = "macos")]
                         let handle = div()
                             .absolute()
                             .left_0()
@@ -1713,7 +1650,6 @@ impl PaneTree {
                             .h(px(5.0))
                             .cursor_row_resize()
                             .bg(gpui::transparent_black());
-                        #[cfg(target_os = "macos")]
                         div()
                             .id(divider_id)
                             .relative()

--- a/crates/con-app/src/terminal_paste.rs
+++ b/crates/con-app/src/terminal_paste.rs
@@ -53,10 +53,12 @@ pub fn copy_selection_to_clipboard(terminal: &GhosttyTerminal, cx: &mut gpui::Ap
         .selection_text()
         .filter(|selection| !selection.is_empty())
     else {
-        return false;
+        terminal.clear_selection();
+        return true;
     };
 
     cx.write_to_clipboard(ClipboardItem::new_string(selection));
+    terminal.clear_selection();
     true
 }
 

--- a/crates/con-app/src/terminal_paste.rs
+++ b/crates/con-app/src/terminal_paste.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[cfg(target_os = "windows")]
 use con_ghostty::GhosttyTerminal;
 use gpui::{ClipboardEntry, ClipboardItem, ExternalPaths};
 
@@ -43,23 +43,44 @@ pub fn payload_from_external_paths(paths: &ExternalPaths) -> Option<TerminalPast
     quoted_paths_text(paths.paths()).map(TerminalPastePayload::Text)
 }
 
-#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[cfg(target_os = "windows")]
 pub fn copy_selection_to_clipboard(terminal: &GhosttyTerminal, cx: &mut gpui::App) -> bool {
-    if !terminal.has_selection() {
-        return false;
+    let has_selection = terminal.has_selection();
+    let selection = has_selection.then(|| terminal.selection_text()).flatten();
+    match copy_selection_decision(has_selection, selection.as_deref()) {
+        CopySelectionDecision::NoSelection => false,
+        CopySelectionDecision::ClearOnly => {
+            terminal.clear_selection();
+            true
+        }
+        CopySelectionDecision::CopyAndClear(selection) => {
+            cx.write_to_clipboard(ClipboardItem::new_string(selection.to_string()));
+            terminal.clear_selection();
+            true
+        }
     }
+}
 
-    let Some(selection) = terminal
-        .selection_text()
-        .filter(|selection| !selection.is_empty())
-    else {
-        terminal.clear_selection();
-        return true;
-    };
+#[derive(Debug, Eq, PartialEq)]
+#[cfg(any(target_os = "windows", test))]
+enum CopySelectionDecision<'a> {
+    NoSelection,
+    ClearOnly,
+    CopyAndClear(&'a str),
+}
 
-    cx.write_to_clipboard(ClipboardItem::new_string(selection));
-    terminal.clear_selection();
-    true
+#[cfg(any(target_os = "windows", test))]
+fn copy_selection_decision(
+    has_selection: bool,
+    selection: Option<&str>,
+) -> CopySelectionDecision<'_> {
+    if !has_selection {
+        return CopySelectionDecision::NoSelection;
+    }
+    match selection {
+        Some(selection) if !selection.is_empty() => CopySelectionDecision::CopyAndClear(selection),
+        _ => CopySelectionDecision::ClearOnly,
+    }
 }
 
 fn external_paths_from_entries(entries: &[ClipboardEntry]) -> Vec<PathBuf> {
@@ -189,7 +210,30 @@ mod tests {
 
     use gpui::{ClipboardEntry, ClipboardItem, ClipboardString, ExternalPaths, Image, ImageFormat};
 
-    use super::{TerminalPastePayload, payload_from_clipboard, quoted_paths_text};
+    use super::{
+        CopySelectionDecision, TerminalPastePayload, copy_selection_decision,
+        payload_from_clipboard, quoted_paths_text,
+    };
+
+    #[test]
+    fn copy_selection_decision_distinguishes_empty_and_absent_selection() {
+        assert_eq!(
+            copy_selection_decision(false, Some("ignored")),
+            CopySelectionDecision::NoSelection
+        );
+        assert_eq!(
+            copy_selection_decision(true, None),
+            CopySelectionDecision::ClearOnly
+        );
+        assert_eq!(
+            copy_selection_decision(true, Some("")),
+            CopySelectionDecision::ClearOnly
+        );
+        assert_eq!(
+            copy_selection_decision(true, Some("selected")),
+            CopySelectionDecision::CopyAndClear("selected")
+        );
+    }
 
     #[test]
     fn quoted_paths_are_space_padded() {

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -1461,13 +1461,15 @@ impl Render for GhosttyView {
             | SyncRenderResult::Unchanged => {}
         }
 
-        let placeholder_background = if self.cached_image.is_none() {
-            self.placeholder_background()
+        let terminal_background = self.placeholder_background();
+        let background = if self.cached_image.is_none() {
+            terminal_background
         } else {
             None
-        };
-        let background =
-            placeholder_background.unwrap_or_else(|| cx.theme().background.opacity(0.0));
+        }
+        .unwrap_or_else(|| cx.theme().background.opacity(0.0));
+        let padding_background =
+            terminal_background.unwrap_or_else(|| cx.theme().background.opacity(0.0));
         let entity = cx.entity().downgrade();
         let input_entity = entity.clone();
         let mut terminal_children = self.image_children();
@@ -1720,6 +1722,42 @@ impl Render for GhosttyView {
                     // Measure a dedicated full-size wrapper child so the
                     // prepaint callback always sees content bounds rather than
                     // whichever image/layout child happens to be present.
+                    .child(
+                        div()
+                            .absolute()
+                            .left_0()
+                            .right_0()
+                            .top_0()
+                            .h(px(TERMINAL_PADDING_Y_PX))
+                            .bg(padding_background),
+                    )
+                    .child(
+                        div()
+                            .absolute()
+                            .left_0()
+                            .right_0()
+                            .bottom_0()
+                            .h(px(TERMINAL_PADDING_Y_PX))
+                            .bg(padding_background),
+                    )
+                    .child(
+                        div()
+                            .absolute()
+                            .left_0()
+                            .top(px(TERMINAL_PADDING_Y_PX))
+                            .bottom(px(TERMINAL_PADDING_Y_PX))
+                            .w(px(TERMINAL_PADDING_X_PX))
+                            .bg(padding_background),
+                    )
+                    .child(
+                        div()
+                            .absolute()
+                            .right_0()
+                            .top(px(TERMINAL_PADDING_Y_PX))
+                            .bottom(px(TERMINAL_PADDING_Y_PX))
+                            .w(px(TERMINAL_PADDING_X_PX))
+                            .bg(padding_background),
+                    )
                     .child(
                         div()
                             .absolute()

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -150,6 +150,7 @@ pub struct GhosttyView {
     /// `Window::drop_image` to evict sprite-atlas tiles.
     images_to_drop: Vec<Arc<RenderImage>>,
     scrollbar_drag: Option<ScrollbarDrag>,
+    terminal_mouse_sequence_active: bool,
     mouse_down_link: Option<TerminalLink>,
     suppress_link_mouse_up: bool,
     hovered_link: Option<TerminalLink>,
@@ -230,6 +231,7 @@ impl GhosttyView {
             scrollbar_cache: None,
             images_to_drop: Vec::new(),
             scrollbar_drag: None,
+            terminal_mouse_sequence_active: false,
             mouse_down_link: None,
             suppress_link_mouse_up: false,
             hovered_link: None,
@@ -290,6 +292,7 @@ impl GhosttyView {
         self.cached_frame_size = None;
         self.scrollbar_cache = None;
         self.scrollbar_drag = None;
+        self.terminal_mouse_sequence_active = false;
         self.ime_marked_text = None;
         self.ime_selected_range = None;
         self.mouse_down_link = None;
@@ -714,14 +717,19 @@ impl GhosttyView {
     /// (col, row) cell address. Returns `None` when we don't yet have a
     /// session / bounds to project into.
     fn cell_from_event_position(&self, pos: Point<Pixels>) -> Option<(u16, u16)> {
+        self.cell_from_event_position_impl(pos, false)
+    }
+
+    fn clamped_cell_from_event_position(&self, pos: Point<Pixels>) -> Option<(u16, u16)> {
+        self.cell_from_event_position_impl(pos, true)
+    }
+
+    fn cell_from_event_position_impl(
+        &self,
+        pos: Point<Pixels>,
+        clamp_to_grid: bool,
+    ) -> Option<(u16, u16)> {
         let bounds = self.pane_bounds?;
-        if pos.x < bounds.origin.x
-            || pos.y < bounds.origin.y
-            || pos.x >= bounds.origin.x + bounds.size.width
-            || pos.y >= bounds.origin.y + bounds.size.height
-        {
-            return None;
-        }
         let terminal = self.terminal.as_ref()?;
         let inner = terminal.inner();
         let guard = inner.lock();
@@ -730,12 +738,31 @@ impl GhosttyView {
         if metrics.cell_width_px == 0 || metrics.cell_height_px == 0 {
             return None;
         }
+        let scale = self.scale_factor.max(f32::EPSILON);
+        let width_px = ((f32::from(bounds.size.width) * scale).ceil() as u32).max(1);
+        let height_px = ((f32::from(bounds.size.height) * scale).ceil() as u32).max(1);
+        let cols = (width_px / metrics.cell_width_px.max(1)).max(1);
+        let rows = (height_px / metrics.cell_height_px.max(1)).max(1);
+        let grid_width_px = (cols * metrics.cell_width_px.max(1)) as f32;
+        let grid_height_px = (rows * metrics.cell_height_px.max(1)) as f32;
         let local_x = f32::from(pos.x) - f32::from(bounds.origin.x);
         let local_y = f32::from(pos.y) - f32::from(bounds.origin.y);
-        let phys_x = (local_x * self.scale_factor) as u32;
-        let phys_y = (local_y * self.scale_factor) as u32;
-        let col = (phys_x / metrics.cell_width_px.max(1)) as u16;
-        let row = (phys_y / metrics.cell_height_px.max(1)) as u16;
+        let mut phys_x = local_x * scale;
+        let mut phys_y = local_y * scale;
+        if clamp_to_grid {
+            phys_x = phys_x.clamp(0.0, (grid_width_px - f32::EPSILON).max(0.0));
+            phys_y = phys_y.clamp(0.0, (grid_height_px - f32::EPSILON).max(0.0));
+        } else if phys_x < 0.0
+            || phys_y < 0.0
+            || phys_x >= width_px as f32
+            || phys_y >= height_px as f32
+            || phys_x >= grid_width_px
+            || phys_y >= grid_height_px
+        {
+            return None;
+        }
+        let col = ((phys_x as u32) / metrics.cell_width_px.max(1)).min(cols - 1) as u16;
+        let row = ((phys_y as u32) / metrics.cell_height_px.max(1)).min(rows - 1) as u16;
         Some((col, row))
     }
 
@@ -794,19 +821,26 @@ impl GhosttyView {
         )
     }
 
-    fn forward_mouse_down(&self, pos: Point<Pixels>, mods: MouseEventMods) {
+    fn forward_mouse_down(&self, pos: Point<Pixels>, mods: MouseEventMods) -> bool {
         if let Some((col, row)) = self.cell_from_event_position(pos) {
             if let Some(terminal) = &self.terminal {
                 let inner = terminal.inner();
                 if let Some(session) = inner.lock().as_ref() {
                     session.mouse_down(col, row, mods);
+                    return true;
                 }
             }
         }
+        false
     }
 
-    fn forward_mouse_drag(&self, pos: Point<Pixels>, mods: MouseEventMods) {
-        if let Some((col, row)) = self.cell_from_event_position(pos) {
+    fn forward_mouse_drag(&self, pos: Point<Pixels>, mods: MouseEventMods, clamp: bool) {
+        let cell = if clamp {
+            self.clamped_cell_from_event_position(pos)
+        } else {
+            self.cell_from_event_position(pos)
+        };
+        if let Some((col, row)) = cell {
             if let Some(terminal) = &self.terminal {
                 let inner = terminal.inner();
                 if let Some(session) = inner.lock().as_ref() {
@@ -816,8 +850,13 @@ impl GhosttyView {
         }
     }
 
-    fn forward_mouse_up(&self, pos: Point<Pixels>, mods: MouseEventMods) {
-        if let Some((col, row)) = self.cell_from_event_position(pos) {
+    fn forward_mouse_up(&self, pos: Point<Pixels>, mods: MouseEventMods, clamp: bool) {
+        let cell = if clamp {
+            self.clamped_cell_from_event_position(pos)
+        } else {
+            self.cell_from_event_position(pos)
+        };
+        if let Some((col, row)) = cell {
             if let Some(terminal) = &self.terminal {
                 let inner = terminal.inner();
                 if let Some(session) = inner.lock().as_ref() {
@@ -1532,6 +1571,7 @@ impl Render for GhosttyView {
                 cx.listener(move |this, event: &MouseDownEvent, window, cx| {
                     window.focus(&context_focus, cx);
                     this.last_mouse_position = Some(event.position);
+                    this.terminal_mouse_sequence_active = false;
                     this.mouse_down_link = None;
                     this.suppress_link_mouse_up = false;
                     let _ = this.update_hovered_link(&event.modifiers);
@@ -1544,6 +1584,7 @@ impl Render for GhosttyView {
                 cx.listener(move |this, event: &MouseDownEvent, window, cx| {
                     window.focus(&focus, cx);
                     this.last_mouse_position = Some(event.position);
+                    this.terminal_mouse_sequence_active = false;
                     this.mouse_down_link = None;
                     this.suppress_link_mouse_up = false;
                     let _ = this.update_hovered_link(&event.modifiers);
@@ -1558,7 +1599,8 @@ impl Render for GhosttyView {
                         cx.notify();
                         return;
                     }
-                    this.forward_mouse_down(event.position, mouse_mods_from(&event.modifiers));
+                    this.terminal_mouse_sequence_active =
+                        this.forward_mouse_down(event.position, mouse_mods_from(&event.modifiers));
                     cx.emit(GhosttyFocusChanged);
                     cx.notify();
                 }),
@@ -1597,7 +1639,15 @@ impl Render for GhosttyView {
                 }
                 let hover_changed = this.update_hovered_link(&event.modifiers);
                 if event.pressed_button == Some(MouseButton::Left) {
-                    this.forward_mouse_drag(event.position, mouse_mods_from(&event.modifiers));
+                    this.forward_mouse_drag(
+                        event.position,
+                        mouse_mods_from(&event.modifiers),
+                        this.terminal_mouse_sequence_active,
+                    );
+                    cx.notify();
+                } else if this.terminal_mouse_sequence_active {
+                    this.forward_mouse_up(event.position, mouse_mods_from(&event.modifiers), true);
+                    this.terminal_mouse_sequence_active = false;
                     cx.notify();
                 } else if hover_changed {
                     cx.notify();
@@ -1612,6 +1662,7 @@ impl Render for GhosttyView {
                         cx.notify();
                         return;
                     }
+                    let had_terminal_mouse_sequence = this.terminal_mouse_sequence_active;
                     if this.suppress_link_mouse_up {
                         let down_link = this.mouse_down_link.take();
                         this.suppress_link_mouse_up = false;
@@ -1626,7 +1677,12 @@ impl Render for GhosttyView {
                         cx.notify();
                         return;
                     }
-                    this.forward_mouse_up(event.position, mouse_mods_from(&event.modifiers));
+                    this.forward_mouse_up(
+                        event.position,
+                        mouse_mods_from(&event.modifiers),
+                        had_terminal_mouse_sequence,
+                    );
+                    this.terminal_mouse_sequence_active = false;
                     let _ = this.update_hovered_link(&event.modifiers);
                     cx.notify();
                 }),

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -697,8 +697,8 @@ impl GhosttyView {
         self.restored_screen_text = None;
     }
 
-    fn image_children(&self) -> Vec<AnyElement> {
-        let mut children = Vec::with_capacity(usize::from(self.cached_image.is_some()));
+    fn image_children(&self, gap_background: Option<Hsla>) -> Vec<AnyElement> {
+        let mut children = Vec::with_capacity(usize::from(self.cached_image.is_some()) + 2);
         if let Some(img_arc) = self.cached_image.clone() {
             // Keep stale D3D readback frames at their original logical
             // size while pane layout is changing. Stretching the old
@@ -709,9 +709,37 @@ impl GhosttyView {
             let image = img(ImageSource::Render(img_arc)).object_fit(ObjectFit::Fill);
             let image = if let Some((frame_width, frame_height)) = self.cached_image_size {
                 let scale_factor = self.scale_factor.max(f32::EPSILON);
-                image
-                    .w(px(frame_width as f32 / scale_factor))
-                    .h(px(frame_height as f32 / scale_factor))
+                let image_width = frame_width as f32 / scale_factor;
+                let image_height = frame_height as f32 / scale_factor;
+                if let (Some(bounds), Some(background)) = (self.pane_bounds, gap_background) {
+                    let content_width = f32::from(bounds.size.width);
+                    let content_height = f32::from(bounds.size.height);
+                    if image_width + 0.5 < content_width {
+                        children.push(
+                            div()
+                                .absolute()
+                                .left(px(image_width))
+                                .right_0()
+                                .top_0()
+                                .bottom_0()
+                                .bg(background)
+                                .into_any_element(),
+                        );
+                    }
+                    if image_height + 0.5 < content_height {
+                        children.push(
+                            div()
+                                .absolute()
+                                .left_0()
+                                .w(px(image_width.min(content_width).max(0.0)))
+                                .top(px(image_height))
+                                .bottom_0()
+                                .bg(background)
+                                .into_any_element(),
+                        );
+                    }
+                }
+                image.w(px(image_width)).h(px(image_height))
             } else {
                 // `ObjectFit::Fill` keeps each image quad exactly equal
                 // to its logical bounds. The default `Contain` applies
@@ -1502,7 +1530,7 @@ impl Render for GhosttyView {
             terminal_background.unwrap_or_else(|| cx.theme().background.opacity(0.0));
         let entity = cx.entity().downgrade();
         let input_entity = entity.clone();
-        let mut terminal_children = self.image_children();
+        let mut terminal_children = self.image_children(terminal_background);
         if let Some(overlay) = self.render_link_cursor_overlay() {
             terminal_children.push(overlay);
         }

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -139,6 +139,7 @@ pub struct GhosttyView {
     /// required while the terminal background is translucent: GPUI image
     /// children alpha-composite, so row-strip overlays would blend with
     /// stale text instead of erasing it.
+    cached_image_size: Option<(u32, u32)>,
     cached_frame: Option<Vec<u8>>,
     cached_frame_size: Option<(u32, u32)>,
     /// `GHOSTTY_TERMINAL_DATA_SCROLLBAR` is an expensive VT query.
@@ -226,6 +227,7 @@ impl GhosttyView {
             last_physical_size: None,
             last_scale_factor: 0.0,
             cached_image: None,
+            cached_image_size: None,
             cached_frame: None,
             cached_frame_size: None,
             scrollbar_cache: None,
@@ -288,6 +290,7 @@ impl GhosttyView {
         // the window closes; no way to reach `Window::drop_image` from
         // here. A per-pane ~2×framebytes residue is acceptable.
         self.cached_image = None;
+        self.cached_image_size = None;
         self.cached_frame = None;
         self.cached_frame_size = None;
         self.scrollbar_cache = None;
@@ -677,6 +680,7 @@ impl GhosttyView {
             if let Some(old) = self.cached_image.replace(image) {
                 self.images_to_drop.push(old);
             }
+            self.cached_image_size = Some((frame_width, frame_height));
             self.cached_frame_size = Some((frame_width, frame_height));
             return true;
         }
@@ -695,19 +699,30 @@ impl GhosttyView {
 
     fn image_children(&self) -> Vec<AnyElement> {
         let mut children = Vec::with_capacity(usize::from(self.cached_image.is_some()));
-        // `ObjectFit::Fill` keeps each image quad exactly equal to its
-        // logical bounds. The default `Contain` applies aspect-ratio
-        // letterboxing using float math, which produces a quad a
-        // fraction of a pixel smaller than our source texture; the
-        // LINEAR sprite sampler then blends neighbouring texels and the
-        // terminal cells show faint speckles below the glyph baseline.
         if let Some(img_arc) = self.cached_image.clone() {
-            children.push(
-                img(ImageSource::Render(img_arc))
-                    .size_full()
-                    .object_fit(ObjectFit::Fill)
-                    .into_any_element(),
-            );
+            // Keep stale D3D readback frames at their original logical
+            // size while pane layout is changing. Stretching the old
+            // texture to the new pane bounds makes terminal text appear
+            // zoomed for a frame when closing/splitting panes; the
+            // clipped parent background is a safer placeholder until the
+            // resized renderer publishes the next frame.
+            let image = img(ImageSource::Render(img_arc)).object_fit(ObjectFit::Fill);
+            let image = if let Some((frame_width, frame_height)) = self.cached_image_size {
+                let scale_factor = self.scale_factor.max(f32::EPSILON);
+                image
+                    .w(px(frame_width as f32 / scale_factor))
+                    .h(px(frame_height as f32 / scale_factor))
+            } else {
+                // `ObjectFit::Fill` keeps each image quad exactly equal
+                // to its logical bounds. The default `Contain` applies
+                // aspect-ratio letterboxing using float math, which
+                // produces a quad a fraction of a pixel smaller than our
+                // source texture; the LINEAR sprite sampler then blends
+                // neighbouring texels and terminal cells show faint
+                // speckles below the glyph baseline.
+                image.size_full()
+            };
+            children.push(image.into_any_element());
         }
 
         children
@@ -1658,12 +1673,16 @@ impl Render for GhosttyView {
                 }
                 let hover_changed = this.update_hovered_link(&event.modifiers);
                 if event.pressed_button == Some(MouseButton::Left) {
-                    this.forward_mouse_drag(
-                        event.position,
-                        mouse_mods_from(&event.modifiers),
-                        this.terminal_mouse_sequence_active,
-                    );
-                    cx.notify();
+                    if this.terminal_mouse_sequence_active {
+                        this.forward_mouse_drag(
+                            event.position,
+                            mouse_mods_from(&event.modifiers),
+                            true,
+                        );
+                        cx.notify();
+                    } else if hover_changed {
+                        cx.notify();
+                    }
                 } else if this.terminal_mouse_sequence_active {
                     this.forward_mouse_up(event.position, mouse_mods_from(&event.modifiers), true);
                     this.terminal_mouse_sequence_active = false;
@@ -1696,11 +1715,13 @@ impl Render for GhosttyView {
                         cx.notify();
                         return;
                     }
-                    this.forward_mouse_up(
-                        event.position,
-                        mouse_mods_from(&event.modifiers),
-                        had_terminal_mouse_sequence,
-                    );
+                    if had_terminal_mouse_sequence {
+                        this.forward_mouse_up(
+                            event.position,
+                            mouse_mods_from(&event.modifiers),
+                            true,
+                        );
+                    }
                     this.terminal_mouse_sequence_active = false;
                     let _ = this.update_hovered_link(&event.modifiers);
                     cx.notify();

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -909,14 +909,14 @@ impl GhosttyView {
         }
     }
 
-    fn forward_scroll(&self, pos: Point<Pixels>, delta: ScrollDelta, mods: MouseEventMods) {
+    fn forward_scroll(&self, pos: Point<Pixels>, delta: ScrollDelta, mods: MouseEventMods) -> bool {
         let Some(terminal) = &self.terminal else {
-            return;
+            return false;
         };
         let inner = terminal.inner();
         let guard = inner.lock();
         let Some(session) = guard.as_ref() else {
-            return;
+            return false;
         };
         let delta_y_px = match delta {
             ScrollDelta::Pixels(p) => f32::from(p.y),
@@ -926,7 +926,7 @@ impl GhosttyView {
             }
         };
         if delta_y_px.abs() < f32::EPSILON {
-            return;
+            return false;
         }
 
         // Only report wheel to the shell when it has explicitly enabled
@@ -936,14 +936,15 @@ impl GhosttyView {
         // `set mouse=a`.
         if !session.mouse_tracking_active() || mods.shift {
             session.scroll_viewport_or_alt_screen(delta_y_px, !mods.shift);
-            return;
+            return true;
         }
 
         let Some((col0, row0)) = self.cell_from_event_position(pos) else {
-            return;
+            return false;
         };
         // `forward_wheel` expects 1-based SGR coordinates.
         session.forward_wheel(col0 + 1, row0 + 1, delta_y_px, mods);
+        false
     }
 
     fn scrollbar_visible(scrollbar: &GhosttyScrollbar) -> bool {
@@ -1758,11 +1759,18 @@ impl Render for GhosttyView {
             .on_scroll_wheel(cx.listener(|this, event: &ScrollWheelEvent, _window, cx| {
                 this.last_mouse_position = Some(event.position);
                 let _ = this.update_hovered_link(&event.modifiers);
-                this.forward_scroll(
+                let scrolled_viewport = this.forward_scroll(
                     event.position,
                     event.delta,
                     mouse_mods_from(&event.modifiers),
                 );
+                if scrolled_viewport && this.terminal_mouse_sequence_active {
+                    this.forward_mouse_drag(
+                        event.position,
+                        mouse_mods_from(&event.modifiers),
+                        true,
+                    );
+                }
                 cx.notify();
             }))
             .child(

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -1719,9 +1719,33 @@ impl Render for GhosttyView {
                             });
                         }
                     })
-                    // Measure a dedicated full-size wrapper child so the
-                    // prepaint callback always sees content bounds rather than
-                    // whichever image/layout child happens to be present.
+                    // Keep the terminal content as the first measured child:
+                    // prepaint uses bounds_list.first() to size the D3D grid,
+                    // while the gutter fills below only cover the inset edges.
+                    .child(
+                        div()
+                            .absolute()
+                            .left(px(TERMINAL_PADDING_X_PX))
+                            .right(px(TERMINAL_PADDING_X_PX))
+                            .top(px(TERMINAL_PADDING_Y_PX))
+                            .bottom(px(TERMINAL_PADDING_Y_PX))
+                            .overflow_hidden()
+                            .children(terminal_children)
+                            .child(
+                                canvas(
+                                    |_, _, _| {},
+                                    move |_, _, window, cx| {
+                                        window.handle_input(
+                                            &input_focus,
+                                            WindowsTerminalInputHandler::new(input_entity.clone()),
+                                            cx,
+                                        );
+                                    },
+                                )
+                                .absolute()
+                                .size_full(),
+                            ),
+                    )
                     .child(
                         div()
                             .absolute()
@@ -1757,30 +1781,6 @@ impl Render for GhosttyView {
                             .bottom(px(TERMINAL_PADDING_Y_PX))
                             .w(px(TERMINAL_PADDING_X_PX))
                             .bg(padding_background),
-                    )
-                    .child(
-                        div()
-                            .absolute()
-                            .left(px(TERMINAL_PADDING_X_PX))
-                            .right(px(TERMINAL_PADDING_X_PX))
-                            .top(px(TERMINAL_PADDING_Y_PX))
-                            .bottom(px(TERMINAL_PADDING_Y_PX))
-                            .overflow_hidden()
-                            .children(terminal_children)
-                            .child(
-                                canvas(
-                                    |_, _, _| {},
-                                    move |_, _, window, cx| {
-                                        window.handle_input(
-                                            &input_focus,
-                                            WindowsTerminalInputHandler::new(input_entity.clone()),
-                                            cx,
-                                        );
-                                    },
-                                )
-                                .absolute()
-                                .size_full(),
-                            ),
                     ),
             )
             .context_menu(move |menu, window, cx| {

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -63,6 +63,8 @@ use con_ghostty::windows::render::{FrameBgra, RenderOutcome};
 const SCROLLBAR_INSET_PX: f32 = 4.0;
 const SCROLLBAR_WIDTH_PX: f32 = 6.0;
 const SCROLLBAR_MIN_THUMB_PX: f32 = 28.0;
+const TERMINAL_PADDING_X_PX: f32 = 10.0;
+const TERMINAL_PADDING_Y_PX: f32 = 8.0;
 
 #[derive(Debug, Clone, Copy)]
 struct ScrollbarDrag {
@@ -1634,8 +1636,7 @@ impl Render for GhosttyView {
             }))
             .child(
                 div()
-                    .flex()
-                    .flex_col()
+                    .relative()
                     .size_full()
                     .min_w_0()
                     .min_h_0()
@@ -1654,12 +1655,15 @@ impl Render for GhosttyView {
                         }
                     })
                     // Measure a dedicated full-size wrapper child so the
-                    // prepaint callback always sees pane bounds rather than
+                    // prepaint callback always sees content bounds rather than
                     // whichever image/layout child happens to be present.
                     .child(
                         div()
-                            .relative()
-                            .size_full()
+                            .absolute()
+                            .left(px(TERMINAL_PADDING_X_PX))
+                            .right(px(TERMINAL_PADDING_X_PX))
+                            .top(px(TERMINAL_PADDING_Y_PX))
+                            .bottom(px(TERMINAL_PADDING_Y_PX))
                             .overflow_hidden()
                             .children(terminal_children)
                             .child(

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -1108,6 +1108,19 @@ impl GhosttyView {
             return false;
         }
 
+        // Plain Ctrl+C should copy terminal selection on Windows/Linux when
+        // text is selected; otherwise it must keep its shell meaning (^C).
+        if keystroke.modifiers.control
+            && !keystroke.modifiers.shift
+            && !keystroke.modifiers.alt
+            && !keystroke.modifiers.platform
+            && keystroke.key == "c"
+            && copy_selection_to_clipboard(terminal, cx)
+        {
+            cx.notify();
+            return true;
+        }
+
         // Ctrl+Shift+C / Ctrl+Shift+V → clipboard. These must run ahead
         // of the generic Ctrl-letter path below, which would otherwise
         // emit ^C / ^V to the shell.
@@ -1118,7 +1131,9 @@ impl GhosttyView {
         {
             match keystroke.key.as_str() {
                 "c" => {
-                    copy_selection_to_clipboard(terminal, cx);
+                    if copy_selection_to_clipboard(terminal, cx) {
+                        cx.notify();
+                    }
                     return true;
                 }
                 "v" => {
@@ -1517,7 +1532,9 @@ impl Render for GhosttyView {
             }))
             .on_action(cx.listener(|this, _: &crate::Copy, _window, cx| {
                 if let Some(terminal) = &this.terminal {
-                    copy_selection_to_clipboard(terminal, cx);
+                    if copy_selection_to_clipboard(terminal, cx) {
+                        cx.notify();
+                    }
                 }
             }))
             .on_action(cx.listener(|this, _: &crate::Paste, _window, cx| {

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -715,6 +715,13 @@ impl GhosttyView {
     /// session / bounds to project into.
     fn cell_from_event_position(&self, pos: Point<Pixels>) -> Option<(u16, u16)> {
         let bounds = self.pane_bounds?;
+        if pos.x < bounds.origin.x
+            || pos.y < bounds.origin.y
+            || pos.x >= bounds.origin.x + bounds.size.width
+            || pos.y >= bounds.origin.y + bounds.size.height
+        {
+            return None;
+        }
         let terminal = self.terminal.as_ref()?;
         let inner = terminal.inner();
         let guard = inner.lock();
@@ -723,8 +730,8 @@ impl GhosttyView {
         if metrics.cell_width_px == 0 || metrics.cell_height_px == 0 {
             return None;
         }
-        let local_x = (f32::from(pos.x) - f32::from(bounds.origin.x)).max(0.0);
-        let local_y = (f32::from(pos.y) - f32::from(bounds.origin.y)).max(0.0);
+        let local_x = f32::from(pos.x) - f32::from(bounds.origin.x);
+        let local_y = f32::from(pos.y) - f32::from(bounds.origin.y);
         let phys_x = (local_x * self.scale_factor) as u32;
         let phys_y = (local_y * self.scale_factor) as u32;
         let col = (phys_x / metrics.cell_width_px.max(1)) as u16;

--- a/crates/con-app/src/workspace/caption.rs
+++ b/crates/con-app/src/workspace/caption.rs
@@ -1,6 +1,5 @@
 use super::*;
 
-#[cfg(target_os = "macos")]
 pub(super) fn terminal_separator_over_backdrop(backdrop: Hsla, theme: &Theme) -> Hsla {
     let overlay_alpha = if theme.is_dark() { 0.14 } else { 0.11 };
     backdrop

--- a/crates/con-app/src/workspace/caption.rs
+++ b/crates/con-app/src/workspace/caption.rs
@@ -95,7 +95,12 @@ pub(super) fn caption_buttons(
     }
     .into();
     let fg = theme.muted_foreground.opacity(0.9);
-    let hover_bg = theme.muted.opacity(0.12);
+    let hover_bg = if theme.is_dark() {
+        theme.foreground.opacity(0.11)
+    } else {
+        theme.foreground.opacity(0.075)
+    };
+    let hover_fg = theme.foreground.opacity(0.96);
 
     let button = |id: &'static str, icon: &'static str, area: WindowControlArea, close: bool| {
         let hover = if close { close_red } else { hover_bg };
@@ -105,7 +110,7 @@ pub(super) fn caption_buttons(
         // matches Windows 11 convention. Parent div declares itself as
         // a `group(id)` so the svg's `.group_hover(id, ...)` fires when
         // the 36px hit-target is hovered, not just the 10px icon ink.
-        let hover_fg = if close { gpui::white() } else { fg };
+        let hover_fg = if close { gpui::white() } else { hover_fg };
         let el = div()
             .id(id)
             .group(id)

--- a/crates/con-app/src/workspace/caption.rs
+++ b/crates/con-app/src/workspace/caption.rs
@@ -95,7 +95,8 @@ pub(super) fn caption_buttons(
     }
     .into();
     let fg = theme.muted_foreground.opacity(0.9);
-    let hover_bg = if theme.is_dark() {
+    let is_dark = theme.background.l < 0.5;
+    let hover_bg = if is_dark {
         theme.foreground.opacity(0.11)
     } else {
         theme.foreground.opacity(0.075)

--- a/crates/con-app/src/workspace/control_requests.rs
+++ b/crates/con-app/src/workspace/control_requests.rs
@@ -867,7 +867,8 @@ impl ConWorkspace {
                                 )
                             {
                                 self.agent_panel_open = true;
-                                let duration = Self::terminal_adjacent_chrome_duration(true, 290, 220);
+                                let duration =
+                                    Self::terminal_adjacent_chrome_duration(true, 290, 220);
                                 self.agent_panel_motion.set_target(target, duration);
                                 cx.notify();
                             }

--- a/crates/con-app/src/workspace/mod.rs
+++ b/crates/con-app/src/workspace/mod.rs
@@ -8,10 +8,8 @@ use std::time::Duration;
 use std::time::Instant;
 
 use gpui::{prelude::FluentBuilder as _, *};
-#[cfg(target_os = "macos")]
-use gpui_component::Theme;
 use gpui_component::{
-    ActiveTheme, ElementExt, Sizable,
+    ActiveTheme, ElementExt, Sizable, Theme,
     input::{Escape as InputEscape, Input, InputEvent, InputState},
     tooltip::Tooltip,
 };
@@ -24,7 +22,6 @@ const TERMINAL_MIN_CONTENT_WIDTH: f32 = 360.0;
 const TOP_BAR_COMPACT_HEIGHT: f32 = 28.0;
 const TOP_BAR_TABS_HEIGHT: f32 = 36.0;
 const CHROME_TRANSITION_SEAM_COVER: f32 = 4.0;
-#[cfg(target_os = "macos")]
 const CHROME_MOTION_SEAM_OVERDRAW: f32 = 6.0;
 #[cfg(target_os = "macos")]
 const CHROME_SNAP_GUARD_MS: u64 = 160;

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -336,6 +336,8 @@ impl Render for ConWorkspace {
             a: 1.0,
         }
         .into();
+        let portable_terminal_backdrop_color =
+            terminal_surface_color.opacity(self.terminal_opacity);
         let chrome_transition_seam_color = terminal_surface_color;
         let chrome_static_seam_color =
             terminal_separator_over_backdrop(terminal_surface_color, theme);
@@ -431,6 +433,9 @@ impl Render for ConWorkspace {
             .min_h_0()
             .w_full()
             .overflow_hidden()
+            .when(cfg!(not(target_os = "macos")), |pane_content| {
+                pane_content.bg(portable_terminal_backdrop_color)
+            })
             .child(pane_tree_rendered)
             .on_children_prepainted(move |bounds_list, _, _| {
                 let Some(bounds) = bounds_list.first().copied() else {
@@ -610,7 +615,14 @@ impl Render for ConWorkspace {
             );
         }
 
-        let mut main_area = div().relative().flex().flex_1().min_h_0();
+        let mut main_area = div()
+            .relative()
+            .flex()
+            .flex_1()
+            .min_h_0()
+            .when(cfg!(not(target_os = "macos")), |main_area| {
+                main_area.bg(portable_terminal_backdrop_color)
+            });
 
         if self.vertical_tabs_active() {
             main_area = main_area.child(

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -153,19 +153,14 @@ impl Render for ConWorkspace {
         let agent_panel_transitioning = self.agent_panel_motion.is_animating();
         let input_bar_transitioning = self.input_bar_motion.is_animating();
         let tab_strip_transitioning = self.tab_strip_motion.is_animating();
-        #[cfg(target_os = "macos")]
         let (agent_panel_snap_guard_active, agent_panel_snap_guard_expired) =
             Self::snap_guard_state(&mut self.agent_panel_snap_guard_until, window);
-        #[cfg(target_os = "macos")]
         let (input_bar_snap_guard_active, input_bar_snap_guard_expired) =
             Self::snap_guard_state(&mut self.input_bar_snap_guard_until, window);
-        #[cfg(target_os = "macos")]
         let (top_chrome_snap_guard_active, top_chrome_snap_guard_expired) =
             Self::snap_guard_state(&mut self.top_chrome_snap_guard_until, window);
-        #[cfg(target_os = "macos")]
         let (sidebar_snap_guard_active, sidebar_snap_guard_expired) =
             Self::snap_guard_state(&mut self.sidebar_snap_guard_until, window);
-        #[cfg(target_os = "macos")]
         {
             let release_cover = Duration::from_millis(CHROME_RELEASE_COVER_MS);
             if agent_panel_snap_guard_expired && !self.agent_panel_open {
@@ -184,19 +179,14 @@ impl Render for ConWorkspace {
                 Self::extend_guard(&mut self.sidebar_release_cover_until, release_cover);
             }
         }
-        #[cfg(target_os = "macos")]
         let agent_panel_release_cover_active =
             Self::snap_guard_active(&mut self.agent_panel_release_cover_until, window);
-        #[cfg(target_os = "macos")]
         let input_bar_release_cover_active =
             Self::snap_guard_active(&mut self.input_bar_release_cover_until, window);
-        #[cfg(target_os = "macos")]
         let top_chrome_release_cover_active =
             Self::snap_guard_active(&mut self.top_chrome_release_cover_until, window);
-        #[cfg(target_os = "macos")]
         let sidebar_release_cover_active =
             Self::snap_guard_active(&mut self.sidebar_release_cover_until, window);
-        #[cfg(target_os = "macos")]
         if !sidebar_snap_guard_active && !sidebar_release_cover_active {
             self.sidebar_snap_guard_width = 0.0;
             self.sidebar_release_cover_width = 0.0;
@@ -241,7 +231,6 @@ impl Render for ConWorkspace {
             .min(max_agent_panel_width(window_width));
         #[cfg(not(target_os = "macos"))]
         let animated_panel_width = effective_agent_panel_width * agent_panel_progress;
-        #[cfg(target_os = "macos")]
         let agent_panel_reserved_for_layout =
             self.agent_panel_open || agent_panel_progress > 0.01 || agent_panel_snap_guard_active;
         #[cfg(target_os = "macos")]
@@ -253,6 +242,8 @@ impl Render for ConWorkspace {
         #[cfg(not(target_os = "macos"))]
         let agent_panel_outer_width = if agent_panel_progress > 0.01 {
             animated_panel_width + 1.0
+        } else if agent_panel_reserved_for_layout {
+            effective_agent_panel_width + 1.0
         } else {
             0.0
         };
@@ -263,16 +254,9 @@ impl Render for ConWorkspace {
                 sidebar.set_effective_panel_max_width(max_vertical_tabs_width);
                 sidebar.occupied_width_with_max(max_vertical_tabs_width)
             })
+        } else if sidebar_snap_guard_active {
+            self.sidebar_snap_guard_width
         } else {
-            #[cfg(target_os = "macos")]
-            {
-                if sidebar_snap_guard_active {
-                    self.sidebar_snap_guard_width
-                } else {
-                    0.0
-                }
-            }
-            #[cfg(not(target_os = "macos"))]
             0.0
         };
         let vertical_tabs_pinned = self.vertical_tabs_active() && self.sidebar.read(cx).is_pinned();
@@ -307,9 +291,7 @@ impl Render for ConWorkspace {
             .clamp(0.0, 1.0)
             .powf(0.92);
         let compact_titlebar_progress = 1.0 - tab_strip_progress;
-        #[cfg(target_os = "macos")]
         let terminal_background = self.terminal_theme.background;
-        #[cfg(target_os = "macos")]
         let terminal_surface_color: Hsla = Rgba {
             r: f32::from(terminal_background.r) / 255.0,
             g: f32::from(terminal_background.g) / 255.0,
@@ -321,18 +303,10 @@ impl Render for ConWorkspace {
             a: 1.0,
         }
         .into();
-        #[cfg(target_os = "macos")]
         let chrome_transition_seam_color = terminal_surface_color;
-        #[cfg(not(target_os = "macos"))]
-        let chrome_transition_seam_color = theme.background.opacity(elevated_ui_surface_opacity);
-        #[cfg(target_os = "macos")]
-        let chrome_static_seam_color = terminal_surface_color;
-        #[cfg(not(target_os = "macos"))]
-        let chrome_static_seam_color = theme.title_bar_border;
-        #[cfg(target_os = "macos")]
+        let chrome_static_seam_color =
+            terminal_separator_over_backdrop(terminal_surface_color, theme);
         let pane_divider_color = terminal_separator_over_backdrop(terminal_surface_color, theme);
-        #[cfg(not(target_os = "macos"))]
-        let pane_divider_color = theme.title_bar_border;
         #[cfg(target_os = "macos")]
         let top_bar_surface_color = theme.title_bar.opacity(ui_surface_opacity);
         #[cfg(not(target_os = "macos"))]
@@ -573,11 +547,8 @@ impl Render for ConWorkspace {
             );
         }
 
-        #[cfg(target_os = "macos")]
         let input_bar_reserved_for_layout =
             input_bar_progress > 0.01 || input_bar_snap_guard_active;
-        #[cfg(not(target_os = "macos"))]
-        let input_bar_reserved_for_layout = input_bar_progress > 0.01;
 
         if input_bar_reserved_for_layout {
             let input_bar_height = if input_bar_progress > 0.01 {
@@ -609,24 +580,15 @@ impl Render for ConWorkspace {
         let mut main_area = div().relative().flex().flex_1().min_h_0();
 
         if self.vertical_tabs_active() {
-            #[cfg(target_os = "macos")]
-            {
-                main_area = main_area.child(
-                    div()
-                        .h_full()
-                        .flex_shrink_0()
-                        .overflow_hidden()
-                        .bg(elevated_panel_surface_color)
-                        .child(self.sidebar.clone()),
-                );
-            }
-
-            #[cfg(not(target_os = "macos"))]
-            {
-                main_area = main_area.child(self.sidebar.clone());
-            }
+            main_area = main_area.child(
+                div()
+                    .h_full()
+                    .flex_shrink_0()
+                    .overflow_hidden()
+                    .bg(elevated_panel_surface_color)
+                    .child(self.sidebar.clone()),
+            );
         }
-        #[cfg(target_os = "macos")]
         if !self.vertical_tabs_active() && sidebar_snap_guard_active && vertical_tabs_width > 0.0 {
             main_area = main_area.child(
                 div()
@@ -651,16 +613,17 @@ impl Render for ConWorkspace {
             );
         }
 
-        #[cfg(target_os = "macos")]
         let render_agent_panel = agent_panel_reserved_for_layout;
-        #[cfg(not(target_os = "macos"))]
-        let render_agent_panel = agent_panel_progress > 0.01;
 
         if render_agent_panel {
             #[cfg(target_os = "macos")]
             let panel_width = effective_agent_panel_width + 1.0;
             #[cfg(not(target_os = "macos"))]
-            let panel_width = animated_panel_width + 1.0;
+            let panel_width = if agent_panel_progress > 0.01 {
+                animated_panel_width + 1.0
+            } else {
+                effective_agent_panel_width + 1.0
+            };
             #[cfg(target_os = "macos")]
             let agent_panel_content_opacity =
                 if self.agent_panel_open || agent_panel_progress > 0.01 {
@@ -753,14 +716,11 @@ impl Render for ConWorkspace {
         }
 
         // Top bar — compact titlebar for one tab, full strip for many
-        #[cfg(target_os = "macos")]
         let top_bar_height = if top_chrome_snap_guard_active {
             TOP_BAR_TABS_HEIGHT
         } else {
             self.current_top_bar_height()
         };
-        #[cfg(not(target_os = "macos"))]
-        let top_bar_height = self.current_top_bar_height();
         let top_bar_controls_offset = 1.0 + (3.0 * tab_strip_progress);
 
         let top_bar = self.render_top_bar(
@@ -1216,7 +1176,6 @@ impl Render for ConWorkspace {
             );
         }
 
-        #[cfg(target_os = "macos")]
         if top_chrome_release_cover_active {
             root = root.child(
                 div()
@@ -1229,7 +1188,6 @@ impl Render for ConWorkspace {
             );
         }
 
-        #[cfg(target_os = "macos")]
         if sidebar_snap_guard_active {
             if self.vertical_tabs_active() {
                 root = root.child(
@@ -1246,7 +1204,6 @@ impl Render for ConWorkspace {
             }
         }
 
-        #[cfg(target_os = "macos")]
         if sidebar_release_cover_active && self.sidebar_release_cover_width > 0.0 {
             root = root.child(
                 div()
@@ -1259,7 +1216,20 @@ impl Render for ConWorkspace {
             );
         }
 
-        #[cfg(target_os = "macos")]
+        if self.sidebar_drag.is_some() && vertical_tabs_width > 0.0 {
+            root = root.child(
+                div()
+                    .absolute()
+                    .top(px(top_bar_height))
+                    .bottom_0()
+                    .left(px(
+                        (vertical_tabs_width - CHROME_MOTION_SEAM_OVERDRAW).max(0.0)
+                    ))
+                    .w(px(CHROME_MOTION_SEAM_OVERDRAW))
+                    .bg(chrome_transition_seam_color),
+            );
+        }
+
         if input_bar_snap_guard_active {
             if self.input_bar_visible {
                 root = root.child(
@@ -1274,7 +1244,6 @@ impl Render for ConWorkspace {
             }
         }
 
-        #[cfg(target_os = "macos")]
         if input_bar_release_cover_active {
             root = root.child(
                 div()
@@ -1287,7 +1256,6 @@ impl Render for ConWorkspace {
             );
         }
 
-        #[cfg(target_os = "macos")]
         if agent_panel_snap_guard_active {
             if self.agent_panel_open {
                 let agent_panel_seam_right = (effective_agent_panel_width
@@ -1305,7 +1273,6 @@ impl Render for ConWorkspace {
             }
         }
 
-        #[cfg(target_os = "macos")]
         if agent_panel_release_cover_active {
             root = root.child(
                 div()
@@ -1314,6 +1281,21 @@ impl Render for ConWorkspace {
                     .bottom_0()
                     .right_0()
                     .w(px(effective_agent_panel_width + 1.0))
+                    .bg(chrome_transition_seam_color),
+            );
+        }
+
+        if self.agent_panel_drag.is_some() && self.agent_panel_open {
+            let agent_panel_seam_right = (effective_agent_panel_width
+                - (CHROME_MOTION_SEAM_OVERDRAW - CHROME_TRANSITION_SEAM_COVER))
+                .max(0.0);
+            root = root.child(
+                div()
+                    .absolute()
+                    .top(px(top_bar_height))
+                    .bottom_0()
+                    .right(px(agent_panel_seam_right))
+                    .w(px(CHROME_MOTION_SEAM_OVERDRAW))
                     .bg(chrome_transition_seam_color),
             );
         }

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -153,14 +153,27 @@ impl Render for ConWorkspace {
         let agent_panel_transitioning = self.agent_panel_motion.is_animating();
         let input_bar_transitioning = self.input_bar_motion.is_animating();
         let tab_strip_transitioning = self.tab_strip_motion.is_animating();
+        #[cfg(target_os = "macos")]
         let (agent_panel_snap_guard_active, agent_panel_snap_guard_expired) =
             Self::snap_guard_state(&mut self.agent_panel_snap_guard_until, window);
+        #[cfg(target_os = "macos")]
         let (input_bar_snap_guard_active, input_bar_snap_guard_expired) =
             Self::snap_guard_state(&mut self.input_bar_snap_guard_until, window);
+        #[cfg(target_os = "macos")]
         let (top_chrome_snap_guard_active, top_chrome_snap_guard_expired) =
             Self::snap_guard_state(&mut self.top_chrome_snap_guard_until, window);
+        #[cfg(target_os = "macos")]
         let (sidebar_snap_guard_active, sidebar_snap_guard_expired) =
             Self::snap_guard_state(&mut self.sidebar_snap_guard_until, window);
+        #[cfg(not(target_os = "macos"))]
+        let agent_panel_snap_guard_active = false;
+        #[cfg(not(target_os = "macos"))]
+        let input_bar_snap_guard_active = false;
+        #[cfg(not(target_os = "macos"))]
+        let top_chrome_snap_guard_active = false;
+        #[cfg(not(target_os = "macos"))]
+        let sidebar_snap_guard_active = false;
+        #[cfg(target_os = "macos")]
         {
             let release_cover = Duration::from_millis(CHROME_RELEASE_COVER_MS);
             if agent_panel_snap_guard_expired && !self.agent_panel_open {
@@ -179,14 +192,25 @@ impl Render for ConWorkspace {
                 Self::extend_guard(&mut self.sidebar_release_cover_until, release_cover);
             }
         }
+        #[cfg(target_os = "macos")]
         let agent_panel_release_cover_active =
             Self::snap_guard_active(&mut self.agent_panel_release_cover_until, window);
+        #[cfg(target_os = "macos")]
         let input_bar_release_cover_active =
             Self::snap_guard_active(&mut self.input_bar_release_cover_until, window);
+        #[cfg(target_os = "macos")]
         let top_chrome_release_cover_active =
             Self::snap_guard_active(&mut self.top_chrome_release_cover_until, window);
+        #[cfg(target_os = "macos")]
         let sidebar_release_cover_active =
             Self::snap_guard_active(&mut self.sidebar_release_cover_until, window);
+        #[cfg(not(target_os = "macos"))]
+        let agent_panel_release_cover_active = false;
+        #[cfg(not(target_os = "macos"))]
+        let input_bar_release_cover_active = false;
+        #[cfg(not(target_os = "macos"))]
+        let top_chrome_release_cover_active = false;
+        #[cfg(target_os = "macos")]
         if !sidebar_snap_guard_active && !sidebar_release_cover_active {
             self.sidebar_snap_guard_width = 0.0;
             self.sidebar_release_cover_width = 0.0;
@@ -254,10 +278,19 @@ impl Render for ConWorkspace {
                 sidebar.set_effective_panel_max_width(max_vertical_tabs_width);
                 sidebar.occupied_width_with_max(max_vertical_tabs_width)
             })
-        } else if sidebar_snap_guard_active {
-            self.sidebar_snap_guard_width
         } else {
-            0.0
+            #[cfg(target_os = "macos")]
+            {
+                if sidebar_snap_guard_active {
+                    self.sidebar_snap_guard_width
+                } else {
+                    0.0
+                }
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                0.0
+            }
         };
         let vertical_tabs_pinned = self.vertical_tabs_active() && self.sidebar.read(cx).is_pinned();
 
@@ -1204,16 +1237,19 @@ impl Render for ConWorkspace {
             }
         }
 
-        if sidebar_release_cover_active && self.sidebar_release_cover_width > 0.0 {
-            root = root.child(
-                div()
-                    .absolute()
-                    .top(px(top_bar_height))
-                    .bottom_0()
-                    .left_0()
-                    .w(px(self.sidebar_release_cover_width))
-                    .bg(chrome_transition_seam_color),
-            );
+        #[cfg(target_os = "macos")]
+        {
+            if sidebar_release_cover_active && self.sidebar_release_cover_width > 0.0 {
+                root = root.child(
+                    div()
+                        .absolute()
+                        .top(px(top_bar_height))
+                        .bottom_0()
+                        .left_0()
+                        .w(px(self.sidebar_release_cover_width))
+                        .bg(chrome_transition_seam_color),
+                );
+            }
         }
 
         if self.sidebar_drag.is_some() && vertical_tabs_width > 0.0 {

--- a/crates/con-app/src/workspace/render/top_bar.rs
+++ b/crates/con-app/src/workspace/render/top_bar.rs
@@ -31,13 +31,18 @@ impl ConWorkspace {
         // still work) and still lets macOS react to
         // `titlebar_double_click`.
         let leading_pad = if cfg!(target_os = "macos") { 78.0 } else { 8.0 };
+        let trailing_pad = if cfg!(target_os = "windows") {
+            0.0
+        } else {
+            6.0
+        };
         let mut top_bar = div()
             .id("tab-bar")
             .flex()
             .h(px(top_bar_height))
             .items_end()
             .pl(px(leading_pad))
-            .pr(px(6.0))
+            .pr(px(trailing_pad))
             .bg(top_bar_surface_color);
 
         #[cfg(target_os = "macos")]

--- a/crates/con-app/src/workspace/tests.rs
+++ b/crates/con-app/src/workspace/tests.rs
@@ -25,10 +25,7 @@ fn agent_request_opening_panel_drives_panel_motion_to_visible() {
         agent_panel_motion_target_for_agent_request(false),
         Some(1.0)
     );
-    assert_eq!(
-        agent_panel_motion_target_for_agent_request(true),
-        Some(1.0)
-    );
+    assert_eq!(agent_panel_motion_target_for_agent_request(true), Some(1.0));
 }
 
 #[test]

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -424,6 +424,8 @@ impl LinuxGhosttyTerminal {
         None
     }
 
+    pub fn clear_selection(&self) {}
+
     pub fn read_screen_text(&self, max_lines: usize) -> Vec<String> {
         self.inner
             .lock()

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -255,6 +255,7 @@ impl LinuxPtySession {
     }
 
     pub fn write_input(&self, data: &[u8]) -> Result<()> {
+        self.scroll_viewport_to_bottom();
         self.writer
             .lock()
             .write_all(data)
@@ -266,6 +267,12 @@ impl LinuxPtySession {
     pub fn clear_screen_and_scrollback(&self) {
         self.shared.screen.clear_screen_and_scrollback();
         self.mark_needs_render();
+    }
+
+    pub fn scroll_viewport_to_bottom(&self) {
+        if self.shared.screen.scroll_viewport_bottom() {
+            self.mark_needs_render();
+        }
     }
 
     pub fn title(&self) -> Option<String> {

--- a/crates/con-ghostty/src/transcript.rs
+++ b/crates/con-ghostty/src/transcript.rs
@@ -274,6 +274,7 @@ mod tests {
             cells,
             dirty_rows: vec![0, 1],
             cursor: Cursor::default(),
+            alternate_screen: false,
             title: None,
             generation: 1,
         };

--- a/crates/con-ghostty/src/transcript.rs
+++ b/crates/con-ghostty/src/transcript.rs
@@ -275,6 +275,7 @@ mod tests {
             dirty_rows: vec![0, 1],
             cursor: Cursor::default(),
             alternate_screen: false,
+            scrollbar: None,
             title: None,
             generation: 1,
         };

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -645,6 +645,7 @@ pub struct ScreenSnapshot {
     pub dirty_rows: Vec<u16>,
     pub cursor: Cursor,
     pub alternate_screen: bool,
+    pub scrollbar: Option<GhosttyScrollbar>,
     pub title: Option<String>,
     pub generation: u64,
 }
@@ -1156,6 +1157,7 @@ impl VtScreen {
                 dirty_rows: Vec::new(),
                 cursor: Cursor::default(),
                 alternate_screen: false,
+                scrollbar: None,
                 title: None,
                 generation: inner.generation,
             };
@@ -1403,6 +1405,7 @@ impl VtScreen {
             dirty_rows,
             cursor,
             alternate_screen,
+            scrollbar: read_scrollbar(inner.terminal),
             title: None,
             generation: inner.generation,
         };
@@ -1483,19 +1486,7 @@ impl VtScreen {
         if inner.terminal.is_null() {
             return None;
         }
-        let mut scrollbar = GhosttyTerminalScrollbar::default();
-        let rc = unsafe {
-            ghostty_terminal_get(
-                inner.terminal,
-                GhosttyTerminalData::Scrollbar,
-                &mut scrollbar as *mut _ as *mut c_void,
-            )
-        };
-        (rc == 0).then_some(GhosttyScrollbar {
-            total: scrollbar.total,
-            offset: scrollbar.offset,
-            len: scrollbar.len,
-        })
+        read_scrollbar(inner.terminal)
     }
 
     /// Current working directory reported by shell integration (OSC 7).
@@ -1714,9 +1705,29 @@ fn empty_snapshot(cols: u16, rows: u16, generation: u64) -> ScreenSnapshot {
         dirty_rows: Vec::new(),
         cursor: Cursor::default(),
         alternate_screen: false,
+        scrollbar: None,
         title: None,
         generation,
     }
+}
+
+fn read_scrollbar(terminal: GhosttyTerminal) -> Option<GhosttyScrollbar> {
+    if terminal.is_null() {
+        return None;
+    }
+    let mut scrollbar = GhosttyTerminalScrollbar::default();
+    let rc = unsafe {
+        ghostty_terminal_get(
+            terminal,
+            GhosttyTerminalData::Scrollbar,
+            &mut scrollbar as *mut _ as *mut c_void,
+        )
+    };
+    (rc == 0).then_some(GhosttyScrollbar {
+        total: scrollbar.total,
+        offset: scrollbar.offset,
+        len: scrollbar.len,
+    })
 }
 
 fn push_unique_row(rows: &mut Vec<u16>, row: u16) {

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -635,6 +635,7 @@ pub struct ScreenSnapshot {
     pub cells: Vec<Cell>,
     pub dirty_rows: Vec<u16>,
     pub cursor: Cursor,
+    pub alternate_screen: bool,
     pub title: Option<String>,
     pub generation: u64,
 }
@@ -952,6 +953,7 @@ impl VtScreen {
                 cells: Vec::new(),
                 dirty_rows: Vec::new(),
                 cursor: Cursor::default(),
+                alternate_screen: false,
                 title: None,
                 generation: inner.generation,
             };
@@ -1008,6 +1010,17 @@ impl VtScreen {
         }
         cols = cols.max(1);
         rows = rows.max(1);
+
+        let mut active_screen = GhosttyTerminalScreen::Primary;
+        let active_screen_rc = unsafe {
+            ghostty_terminal_get(
+                inner.terminal,
+                GhosttyTerminalData::ActiveScreen,
+                &mut active_screen as *mut _ as *mut c_void,
+            )
+        };
+        let alternate_screen =
+            active_screen_rc == 0 && active_screen == GhosttyTerminalScreen::Alternate;
 
         let mut force_all_dirty = inner.force_full_snapshot;
         let mut full_redraw = force_all_dirty;
@@ -1187,6 +1200,7 @@ impl VtScreen {
             cells,
             dirty_rows,
             cursor,
+            alternate_screen,
             title: None,
             generation: inner.generation,
         };
@@ -1479,6 +1493,7 @@ fn empty_snapshot(cols: u16, rows: u16, generation: u64) -> ScreenSnapshot {
         cells: Vec::new(),
         dirty_rows: Vec::new(),
         cursor: Cursor::default(),
+        alternate_screen: false,
         title: None,
         generation,
     }

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -140,6 +140,8 @@ pub enum GhosttyTerminalOption {
     Size = 6,
     ColorScheme = 7,
     DeviceAttributes = 8,
+    Title = 9,
+    Pwd = 10,
     ColorForeground = 11,
     ColorBackground = 12,
     ColorCursor = 13,
@@ -289,6 +291,13 @@ pub struct GhosttyColorRgb {
 pub struct GhosttyString {
     pub ptr: *const u8,
     pub len: usize,
+}
+
+fn ghostty_string_from_bytes(bytes: &[u8]) -> GhosttyString {
+    GhosttyString {
+        ptr: bytes.as_ptr(),
+        len: bytes.len(),
+    }
 }
 
 #[repr(C)]
@@ -673,9 +682,23 @@ struct VtInner {
     scratch_rows: u16,
     scratch: Vec<Cell>,
     last_cursor: Cursor,
+    osc_state: OscParseState,
+    osc_command: Vec<u8>,
+    osc7_buffer: Vec<u8>,
 }
 
 unsafe impl Send for VtInner {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OscParseState {
+    Ground,
+    Esc,
+    Command,
+    Ignore,
+    IgnoreEsc,
+    Osc7,
+    Osc7Esc,
+}
 
 fn default_device_attributes() -> GhosttyDeviceAttributes {
     let mut features = [0_u16; 64];
@@ -696,6 +719,181 @@ fn default_device_attributes() -> GhosttyDeviceAttributes {
             rom_cartridge: 0,
         },
         tertiary: GhosttyDeviceAttributesTertiary { unit_id: 0 },
+    }
+}
+
+fn ingest_osc7_cwd(inner: &mut VtInner, bytes: &[u8]) {
+    for &byte in bytes {
+        match inner.osc_state {
+            OscParseState::Ground => {
+                if byte == 0x1b {
+                    inner.osc_state = OscParseState::Esc;
+                }
+            }
+            OscParseState::Esc => {
+                if byte == b']' {
+                    inner.osc_command.clear();
+                    inner.osc_state = OscParseState::Command;
+                } else if byte != 0x1b {
+                    inner.osc_state = OscParseState::Ground;
+                }
+            }
+            OscParseState::Command => match byte {
+                b';' => {
+                    if inner.osc_command.as_slice() == b"7" {
+                        inner.osc7_buffer.clear();
+                        inner.osc_state = OscParseState::Osc7;
+                    } else {
+                        inner.osc_state = OscParseState::Ignore;
+                    }
+                }
+                0x07 => inner.osc_state = OscParseState::Ground,
+                0x1b => inner.osc_state = OscParseState::IgnoreEsc,
+                _ if inner.osc_command.len() < 16 => inner.osc_command.push(byte),
+                _ => inner.osc_state = OscParseState::Ignore,
+            },
+            OscParseState::Ignore => match byte {
+                0x07 => inner.osc_state = OscParseState::Ground,
+                0x1b => inner.osc_state = OscParseState::IgnoreEsc,
+                _ => {}
+            },
+            OscParseState::IgnoreEsc => {
+                inner.osc_state = OscParseState::Ground;
+                if byte == 0x1b {
+                    inner.osc_state = OscParseState::Esc;
+                } else if byte != b'\\' {
+                    // The ESC did not terminate the OSC. Resume ignoring
+                    // until the real BEL/ST terminator.
+                    inner.osc_state = OscParseState::Ignore;
+                }
+            }
+            OscParseState::Osc7 => match byte {
+                0x07 => finish_osc7_cwd(inner),
+                0x1b => inner.osc_state = OscParseState::Osc7Esc,
+                _ if inner.osc7_buffer.len() < 4096 => inner.osc7_buffer.push(byte),
+                _ => {
+                    inner.osc7_buffer.clear();
+                    inner.osc_state = OscParseState::Ignore;
+                }
+            },
+            OscParseState::Osc7Esc => {
+                if byte == b'\\' {
+                    finish_osc7_cwd(inner);
+                } else {
+                    if inner.osc7_buffer.len() + 2 <= 4096 {
+                        inner.osc7_buffer.push(0x1b);
+                        inner.osc7_buffer.push(byte);
+                        inner.osc_state = OscParseState::Osc7;
+                    } else {
+                        inner.osc7_buffer.clear();
+                        inner.osc_state = OscParseState::Ignore;
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn finish_osc7_cwd(inner: &mut VtInner) {
+    if let Ok(url) = std::str::from_utf8(&inner.osc7_buffer)
+        && let Some(cwd) = parse_osc7_cwd(url)
+    {
+        let pwd = ghostty_string_from_bytes(cwd.as_bytes());
+        // SAFETY: `ghostty_terminal_set(PWD)` copies the string during
+        // the call; `cwd` stays alive until the call returns.
+        let rc = unsafe {
+            ghostty_terminal_set(
+                inner.terminal,
+                GhosttyTerminalOption::Pwd,
+                &pwd as *const _ as *const c_void,
+            )
+        };
+        if rc != 0 {
+            log::warn!("ghostty_terminal_set(Pwd) failed: rc={rc}");
+        }
+    }
+
+    inner.osc7_buffer.clear();
+    inner.osc_state = OscParseState::Ground;
+}
+
+fn parse_osc7_cwd(url: &str) -> Option<String> {
+    let url = url.trim();
+    let path = url.strip_prefix("file://")?;
+    if path.is_empty() {
+        return None;
+    }
+
+    let decoded = percent_decode_lossy(path);
+    if decoded.is_empty() {
+        return None;
+    }
+
+    if let Some(without_slash) = decoded.strip_prefix('/')
+        && is_windows_drive_path(without_slash)
+    {
+        return Some(without_slash.replace('/', "\\"));
+    }
+
+    if !decoded.starts_with('/') {
+        let (host, rest) = decoded.split_once('/')?;
+        if host.is_empty() {
+            return Some(local_file_path_from_rest(rest));
+        }
+        if host.eq_ignore_ascii_case("localhost") {
+            return Some(local_file_path_from_rest(rest));
+        }
+        #[cfg(not(target_os = "windows"))]
+        {
+            return Some(format!("/{rest}"));
+        }
+        #[cfg(target_os = "windows")]
+        return Some(format!("\\\\{}\\{}", host, rest.replace('/', "\\")));
+    }
+
+    Some(decoded)
+}
+
+fn local_file_path_from_rest(rest: &str) -> String {
+    if is_windows_drive_path(rest) {
+        rest.replace('/', "\\")
+    } else {
+        format!("/{rest}")
+    }
+}
+
+fn is_windows_drive_path(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic()
+}
+
+fn percent_decode_lossy(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%'
+            && index + 2 < bytes.len()
+            && let (Some(high), Some(low)) =
+                (hex_value(bytes[index + 1]), hex_value(bytes[index + 2]))
+        {
+            out.push((high << 4) | low);
+            index += 3;
+            continue;
+        }
+        out.push(bytes[index]);
+        index += 1;
+    }
+
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
     }
 }
 
@@ -856,6 +1054,9 @@ impl VtScreen {
                 scratch_rows: rows,
                 scratch: Vec::with_capacity(cols as usize * rows as usize),
                 last_cursor: Cursor::default(),
+                osc_state: OscParseState::Ground,
+                osc_command: Vec::with_capacity(8),
+                osc7_buffer: Vec::with_capacity(256),
             })),
         })
     }
@@ -888,6 +1089,7 @@ impl VtScreen {
     /// upstream: do not call from inside a registered callback.
     pub fn feed(&self, bytes: &[u8]) {
         let mut inner = self.inner.lock();
+        ingest_osc7_cwd(&mut inner, bytes);
         // SAFETY: terminal valid; bytes live for the call.
         unsafe { ghostty_terminal_vt_write(inner.terminal, bytes.as_ptr(), bytes.len()) };
         inner.generation = inner.generation.wrapping_add(1);
@@ -1657,5 +1859,43 @@ mod tests {
         screen.feed(b"\x1b]7;file:///tmp/con-vt-cwd\x07");
 
         assert_eq!(screen.current_dir().as_deref(), Some("/tmp/con-vt-cwd"));
+    }
+
+    #[test]
+    fn vt_screen_reports_windows_osc7_current_dir() {
+        let screen = VtScreen::new(80, 24, None).expect("create vt screen");
+
+        screen.feed(b"\x1b]7;file:///C:/Users/WeyGu/dev/con-terminal\x07");
+
+        assert_eq!(
+            screen.current_dir().as_deref(),
+            Some("C:\\Users\\WeyGu\\dev\\con-terminal")
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn vt_screen_reports_localhost_windows_osc7_current_dir() {
+        let screen = VtScreen::new(80, 24, None).expect("create vt screen");
+
+        screen.feed(b"\x1b]7;file://localhost/C:/Users/WeyGu/dev/con-terminal\x07");
+
+        assert_eq!(
+            screen.current_dir().as_deref(),
+            Some("C:\\Users\\WeyGu\\dev\\con-terminal")
+        );
+    }
+
+    #[test]
+    fn vt_screen_reports_split_osc7_current_dir() {
+        let screen = VtScreen::new(80, 24, None).expect("create vt screen");
+
+        screen.feed(b"\x1b]7;file:///home/me/con");
+        screen.feed(b"%20terminal\x1b\\");
+
+        assert_eq!(
+            screen.current_dir().as_deref(),
+            Some("/home/me/con terminal")
+        );
     }
 }

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -1560,6 +1560,24 @@ impl VtScreen {
         true
     }
 
+    /// Snap the visible viewport to the live tail. User input should
+    /// always return a scrolled-back terminal to the prompt before it
+    /// writes to the PTY, matching native terminal behavior.
+    pub fn scroll_viewport_bottom(&self) -> bool {
+        let mut inner = self.inner.lock();
+        if inner.terminal.is_null() {
+            return false;
+        }
+        let behavior = GhosttyTerminalScrollViewport {
+            tag: GhosttyTerminalScrollViewportTag::Bottom,
+            value: GhosttyTerminalScrollViewportValue { delta: 0 },
+        };
+        unsafe { ghostty_terminal_scroll_viewport(inner.terminal, behavior) };
+        inner.force_full_snapshot = true;
+        inner.generation = inner.generation.wrapping_add(1);
+        true
+    }
+
     /// Bracketed-paste mode (2004). When `true`, paste operations
     /// should wrap the payload in `ESC[200~ … ESC[201~` so the shell
     /// can treat it as a single paste.

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -1313,7 +1313,7 @@ impl VtScreen {
                 if col_idx >= cols {
                     break;
                 }
-                let cell = read_cell(inner.row_cells, default_fg, default_bg);
+                let cell = read_cell(inner.row_cells, default_fg, default_bg, alternate_screen);
                 let idx = row_start + col_idx as usize;
                 row_changed |= inner.scratch[idx] != cell;
                 inner.scratch[idx] = cell;
@@ -1740,6 +1740,7 @@ fn read_cell(
     cells: GhosttyRowCells,
     default_fg: GhosttyColorRgb,
     default_bg: GhosttyColorRgb,
+    alternate_screen: bool,
 ) -> Cell {
     // RAW here is an **opaque `GhosttyCell` u64 snapshot**, not a packed
     // codepoint. Decode fields via `ghostty_cell_get(cell, KEY, &out)`
@@ -1801,15 +1802,29 @@ fn read_cell(
     // reports no SGR override (tag == GHOSTTY_STYLE_COLOR_NONE). The
     // row_cells FG_COLOR / BG_COLOR accessors return (0,0,0) for
     // unstyled cells, so without this substitution default-bg cells
-    // would paint pure black. Keying off the style tag (not the RGB
-    // value) is the correct test: an explicit `SGR 40` or
-    // `48;2;0;0;0` sets tag = PALETTE(0) / RGB(0,0,0) while still
-    // requesting solid black.
+    // would paint pure black. Key off the style tag, not the RGB value:
+    // explicit black may still resolve to the same RGB as the default.
     const STYLE_COLOR_TAG_NONE: u32 = 0;
+    const STYLE_COLOR_TAG_PALETTE: u32 = 1;
+    const PALETTE_BLACK: u8 = 0;
     let fg_was_default = style.fg_color.tag == STYLE_COLOR_TAG_NONE;
     let bg_was_default = style.bg_color.tag == STYLE_COLOR_TAG_NONE;
+    // Curses-style full-screen apps often paint their canvas with SGR
+    // 40 instead of default background. For themes whose ANSI black is
+    // a raised surface (Catppuccin, Nord, Everforest), that makes htop
+    // and similar TUIs look like a detached slab. Normalize only
+    // alternate-screen background palette index 0 to the terminal
+    // canvas; normal shell output, foreground black, RGB black, and
+    // xterm-cube black (palette index 16) remain untouched.
+    let bg_is_alt_canvas_black = alternate_screen
+        && style.bg_color.tag == STYLE_COLOR_TAG_PALETTE
+        && style.bg_color.value as u8 == PALETTE_BLACK;
     let fg = if fg_was_default { default_fg } else { fg };
-    let bg = if bg_was_default { default_bg } else { bg };
+    let bg = if bg_was_default || bg_is_alt_canvas_black {
+        default_bg
+    } else {
+        bg
+    };
 
     // Pack RGB into the 0xRRGGBBAA u32 our HLSL `unpackRGBA` expects
     // (high byte = R, low byte = A). Default-bg cells carry alpha=0
@@ -1818,7 +1833,11 @@ fn read_cell(
     let pack = |c: GhosttyColorRgb, a: u8| -> u32 {
         ((c.r as u32) << 24) | ((c.g as u32) << 16) | ((c.b as u32) << 8) | (a as u32)
     };
-    let bg_alpha: u8 = if bg_was_default { 0 } else { 0xFF };
+    let bg_alpha: u8 = if bg_was_default || bg_is_alt_canvas_black {
+        0
+    } else {
+        0xFF
+    };
 
     // Pack style flags into the attrs byte the renderer (and HLSL
     // pixel shader) interpret. Underline is an `int` upstream
@@ -1926,5 +1945,45 @@ mod tests {
             screen.current_dir().as_deref(),
             Some("/home/me/con terminal")
         );
+    }
+
+    #[test]
+    fn normal_screen_preserves_explicit_palette_black_background() {
+        let theme = catppuccin_like_theme();
+        let screen = VtScreen::new(4, 2, Some(&theme)).expect("create vt screen");
+
+        screen.feed(b"\x1b[40mX");
+        let snapshot = screen.snapshot();
+
+        assert!(!snapshot.alternate_screen);
+        let cell = snapshot.cells.first().expect("first cell");
+        assert_eq!(cell.codepoint, 'X' as u32);
+        assert_eq!(cell.bg, rgba([0x45, 0x47, 0x5A], 0xFF));
+    }
+
+    #[test]
+    fn alternate_screen_uses_default_canvas_for_palette_black_background() {
+        let theme = catppuccin_like_theme();
+        let screen = VtScreen::new(4, 2, Some(&theme)).expect("create vt screen");
+
+        screen.feed(b"\x1b[?1049h\x1b[H\x1b[40mX");
+        let snapshot = screen.snapshot();
+
+        assert!(snapshot.alternate_screen);
+        let cell = snapshot.cells.first().expect("first cell");
+        assert_eq!(cell.codepoint, 'X' as u32);
+        assert_eq!(cell.bg, rgba([0x1E, 0x1E, 0x2E], 0x00));
+    }
+
+    fn catppuccin_like_theme() -> ThemeColors {
+        let mut ansi = [[0u8; 3]; 16];
+        ansi[0] = [0x45, 0x47, 0x5A];
+        ansi[7] = [0xBA, 0xC2, 0xDE];
+        ansi[15] = [0xCD, 0xD6, 0xF4];
+        ThemeColors::from_ansi16([0xCD, 0xD6, 0xF4], [0x1E, 0x1E, 0x2E], ansi)
+    }
+
+    fn rgba(rgb: [u8; 3], alpha: u8) -> u32 {
+        ((rgb[0] as u32) << 24) | ((rgb[1] as u32) << 16) | ((rgb[2] as u32) << 8) | alpha as u32
     }
 }

--- a/crates/con-ghostty/src/windows/backend.rs
+++ b/crates/con-ghostty/src/windows/backend.rs
@@ -282,6 +282,11 @@ impl WindowsGhosttyTerminal {
     pub fn selection_text(&self) -> Option<String> {
         self.inner.lock().as_ref().and_then(|s| s.selection_text())
     }
+    pub fn clear_selection(&self) {
+        if let Some(session) = self.inner.lock().as_ref() {
+            session.clear_selection();
+        }
+    }
     pub fn read_screen_text(&self, max_lines: usize) -> Vec<String> {
         self.inner
             .lock()

--- a/crates/con-ghostty/src/windows/conpty.rs
+++ b/crates/con-ghostty/src/windows/conpty.rs
@@ -535,27 +535,185 @@ where
 /// important when comparing prompt latency: PowerShell profile scripts,
 /// prompt frameworks, and WSL startup can dominate the first 400-500ms.
 pub fn default_shell_command() -> String {
-    if let Some(cmd) = std::env::var("CON_SHELL")
+    let command = if let Some(cmd) = std::env::var("CON_SHELL")
         .ok()
         .filter(|s| !s.trim().is_empty())
     {
-        return cmd;
+        cmd
+    } else if let Some(cmd) = windows_terminal_default_shell_command() {
+        cmd
+    } else if let Some(candidate) = ["pwsh.exe", "powershell.exe"]
+        .into_iter()
+        .find(|candidate| path_lookup(candidate).is_some())
+    {
+        candidate.to_string()
+    } else if let Some(cmd) = std::env::var("COMSPEC")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+    {
+        cmd
+    } else {
+        "cmd.exe".to_string()
+    };
+
+    with_shell_integration(command)
+}
+
+fn with_shell_integration(command: String) -> String {
+    with_powershell_cwd_integration(&command).unwrap_or(command)
+}
+
+fn with_powershell_cwd_integration(command: &str) -> Option<String> {
+    let script_path = powershell_cwd_integration_script_path()?;
+    with_powershell_cwd_integration_script(command, &script_path)
+}
+
+fn with_powershell_cwd_integration_script(command: &str, script_path: &Path) -> Option<String> {
+    let (executable, rest) = split_command_head(command.trim())?;
+    let basename = command_basename(executable);
+    if !matches_ignore_ascii_case_any(
+        basename,
+        &["pwsh", "pwsh.exe", "powershell", "powershell.exe"],
+    ) {
+        return None;
     }
-    if let Some(cmd) = windows_terminal_default_shell_command() {
-        return cmd;
+
+    let args = split_command_args(rest);
+    if args.iter().any(|arg| {
+        matches_ignore_ascii_case_any(
+            arg,
+            &[
+                "-command",
+                "/command",
+                "-c",
+                "/c",
+                "-encodedcommand",
+                "/encodedcommand",
+                "-ec",
+                "/ec",
+                "-file",
+                "/file",
+                "-f",
+                "/f",
+            ],
+        )
+    }) {
+        return None;
     }
-    for candidate in ["pwsh.exe", "powershell.exe"] {
-        if path_lookup(candidate).is_some() {
-            return candidate.to_string();
+
+    let mut integrated = command.trim().to_string();
+    if !args
+        .iter()
+        .any(|arg| matches_ignore_ascii_case_any(arg, &["-noexit", "/noexit"]))
+    {
+        integrated.push_str(" -NoExit");
+    }
+    integrated.push_str(" -ExecutionPolicy Bypass -File ");
+    integrated.push_str(&quote_path_for_command(script_path));
+    Some(integrated)
+}
+
+fn powershell_cwd_integration_script_path() -> Option<PathBuf> {
+    let dir = std::env::temp_dir().join("con-terminal");
+    if let Err(err) = fs::create_dir_all(&dir) {
+        log::warn!(
+            "could not create PowerShell cwd integration directory {}: {err}",
+            dir.display()
+        );
+        return None;
+    }
+
+    let path = dir.join("con-powershell-cwd-integration.ps1");
+    if let Err(err) = fs::write(&path, POWERSHELL_CWD_INTEGRATION_SCRIPT) {
+        log::warn!(
+            "could not write PowerShell cwd integration script {}: {err}",
+            path.display()
+        );
+        return None;
+    }
+    Some(path)
+}
+
+const POWERSHELL_CWD_INTEGRATION_SCRIPT: &str = r#"
+function global:__ConTerminalEmitOsc7 {
+    try {
+        $providerPath = (Get-Location).ProviderPath
+        if ([string]::IsNullOrWhiteSpace($providerPath)) {
+            return
+        }
+        $uri = ([System.Uri]::new($providerPath)).AbsoluteUri
+        [Console]::Write("$([char]0x1b)]7;$uri$([char]0x07)")
+    } catch {
+    }
+}
+
+if (-not $global:__ConTerminalPromptHookInstalled) {
+    $global:__ConTerminalPromptHookInstalled = $true
+    $global:__ConTerminalOriginalPrompt = (Get-Command prompt -CommandType Function -ErrorAction SilentlyContinue).ScriptBlock
+    function global:prompt {
+        global:__ConTerminalEmitOsc7
+        if ($global:__ConTerminalOriginalPrompt) {
+            & $global:__ConTerminalOriginalPrompt
+        } else {
+            "PS $($executionContext.SessionState.Path.CurrentLocation)$('>' * ($nestedPromptLevel + 1)) "
         }
     }
-    if let Some(cmd) = std::env::var("COMSPEC")
-        .ok()
-        .filter(|s| !s.trim().is_empty())
-    {
-        return cmd;
+}
+
+global:__ConTerminalEmitOsc7
+"#;
+
+fn split_command_head(command: &str) -> Option<(&str, &str)> {
+    let command = command.trim();
+    if command.is_empty() {
+        return None;
     }
-    "cmd.exe".to_string()
+
+    if let Some(stripped) = command.strip_prefix('"') {
+        let end = stripped.find('"')?;
+        let executable = &stripped[..end];
+        let rest = stripped[end + 1..].trim_start();
+        Some((executable, rest))
+    } else {
+        let split = command.find(char::is_whitespace).unwrap_or(command.len());
+        let executable = &command[..split];
+        let rest = command[split..].trim_start();
+        Some((executable, rest))
+    }
+}
+
+fn command_basename(path: &str) -> &str {
+    path.rsplit(['\\', '/']).next().unwrap_or(path)
+}
+
+fn split_command_args(input: &str) -> Vec<String> {
+    let mut args = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+
+    for ch in input.chars() {
+        match ch {
+            '"' => in_quotes = !in_quotes,
+            ch if ch.is_whitespace() && !in_quotes => {
+                if !current.is_empty() {
+                    args.push(std::mem::take(&mut current));
+                }
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    if !current.is_empty() {
+        args.push(current);
+    }
+
+    args
+}
+
+fn matches_ignore_ascii_case_any(input: &str, candidates: &[&str]) -> bool {
+    candidates
+        .iter()
+        .any(|candidate| input.eq_ignore_ascii_case(candidate))
 }
 
 fn windows_terminal_default_shell_command() -> Option<String> {
@@ -902,5 +1060,53 @@ mod tests {
             windows_terminal_profile_command_from_settings(settings).as_deref(),
             Some("powershell.exe")
         );
+    }
+
+    #[test]
+    fn wraps_powershell_shells_with_cwd_integration() {
+        let script = Path::new(r"C:\Users\me\AppData\Local\Temp\Con Terminal\con-cwd.ps1");
+
+        let wrapped = with_powershell_cwd_integration_script("pwsh.exe -NoLogo", script)
+            .expect("pwsh should be integrated");
+
+        assert!(wrapped.starts_with("pwsh.exe -NoLogo -NoExit "));
+        assert!(wrapped.contains("-ExecutionPolicy Bypass -File "));
+        assert!(wrapped.contains(r#""C:\Users\me\AppData\Local\Temp\Con Terminal\con-cwd.ps1""#));
+    }
+
+    #[test]
+    fn preserves_existing_noexit_when_wrapping_powershell() {
+        let script = Path::new(r"C:\Temp\con-cwd.ps1");
+
+        let wrapped = with_powershell_cwd_integration_script(
+            r#""C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoExit"#,
+            script,
+        )
+        .expect("quoted pwsh path should be integrated");
+
+        assert_eq!(wrapped.matches("-NoExit").count(), 1);
+        assert!(wrapped.contains("-ExecutionPolicy Bypass -File "));
+    }
+
+    #[test]
+    fn leaves_command_mode_powershell_commands_unchanged() {
+        let script = Path::new(r"C:\Temp\con-cwd.ps1");
+
+        assert!(
+            with_powershell_cwd_integration_script("pwsh.exe -Command Get-Location", script)
+                .is_none()
+        );
+        assert!(
+            with_powershell_cwd_integration_script("powershell.exe -File init.ps1", script)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn does_not_wrap_non_powershell_shells() {
+        let script = Path::new(r"C:\Temp\con-cwd.ps1");
+
+        assert!(with_powershell_cwd_integration_script("cmd.exe", script).is_none());
+        assert!(with_powershell_cwd_integration_script("wsl.exe", script).is_none());
     }
 }

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -42,6 +42,7 @@ pub struct RenderSession {
     vt: Arc<VtScreen>,
     transcript: Arc<Mutex<TranscriptBuffer>>,
     conpty: Arc<ConPty>,
+    shell_cwd: Option<PathBuf>,
     config: Mutex<RendererConfig>,
     base_font_size_px: f32,
     dpi: AtomicU32,
@@ -202,6 +203,7 @@ impl RenderSession {
             vt,
             transcript,
             conpty,
+            shell_cwd,
             config: Mutex::new(renderer_config),
             base_font_size_px,
             dpi: AtomicU32::new(current_dpi),
@@ -647,7 +649,11 @@ impl RenderSession {
     }
 
     pub fn current_dir(&self) -> Option<String> {
-        self.vt.current_dir()
+        self.vt.current_dir().or_else(|| {
+            self.shell_cwd
+                .as_ref()
+                .map(|cwd| cwd.to_string_lossy().to_string())
+        })
     }
 
     pub fn read_recent_lines(&self, max_lines: usize) -> Vec<String> {

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -66,7 +66,7 @@ pub struct RenderSession {
     /// so fractional deltas accumulate here instead of turning every
     /// tiny touchpad event into a full-row jump.
     scroll_remainder: Mutex<ScrollRemainder>,
-    drag_anchor: Mutex<Option<(u16, u16)>>,
+    drag_anchor: Mutex<Option<(u16, u64)>>,
 }
 
 unsafe impl Send for RenderSession {}
@@ -430,20 +430,21 @@ impl RenderSession {
             return;
         }
         self.request_low_latency_present();
+        let point = self.selection_point(col, row);
         if mods.shift {
             let renderer = self.renderer.lock();
-            let existing_anchor = renderer.selection().map(|s| s.anchor).unwrap_or((col, row));
+            let existing_anchor = renderer.selection().map(|s| s.anchor).unwrap_or(point);
             *self.drag_anchor.lock() = Some(existing_anchor);
             renderer.set_selection(Some(Selection {
                 anchor: existing_anchor,
-                extent: (col, row),
+                extent: point,
             }));
             return;
         }
-        *self.drag_anchor.lock() = Some((col, row));
+        *self.drag_anchor.lock() = Some(point);
         self.renderer.lock().set_selection(Some(Selection {
-            anchor: (col, row),
-            extent: (col, row),
+            anchor: point,
+            extent: point,
         }));
     }
 
@@ -464,7 +465,7 @@ impl RenderSession {
         if let Some(anchor) = anchor {
             self.renderer.lock().set_selection(Some(Selection {
                 anchor,
-                extent: (col, row),
+                extent: self.selection_point(col, row),
             }));
         }
     }
@@ -484,10 +485,15 @@ impl RenderSession {
         self.request_low_latency_present();
         let anchor = self.drag_anchor.lock().take();
         if let Some(anchor) = anchor
-            && anchor == (col, row)
+            && anchor == self.selection_point(col, row)
         {
             self.renderer.lock().set_selection(None);
         }
+    }
+
+    fn selection_point(&self, col: u16, row: u16) -> (u16, u64) {
+        let viewport_offset = self.vt.scrollbar().map_or(0, |scrollbar| scrollbar.offset);
+        (col, viewport_offset.saturating_add(row as u64))
     }
 
     fn report_sgr_button(
@@ -769,6 +775,7 @@ fn extract_selection_text(snapshot: &ScreenSnapshot, sel: Selection) -> String {
     if cols == 0 || snapshot.cells.is_empty() {
         return String::new();
     }
+    let viewport_offset = snapshot.scrollbar.map_or(0, |scrollbar| scrollbar.offset);
     let mut out = String::new();
     let rows = snapshot.rows;
     for row in 0..rows {
@@ -776,7 +783,7 @@ fn extract_selection_text(snapshot: &ScreenSnapshot, sel: Selection) -> String {
         let mut row_has_cell = false;
         let mut last_non_blank: i32 = -1;
         for col in 0..cols {
-            if !sel.contains(col, row, cols) {
+            if !sel.contains(col, row, cols, viewport_offset) {
                 continue;
             }
             row_has_cell = true;

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -392,6 +392,7 @@ impl RenderSession {
     /// Send UTF-8 text to the child shell. Handles the ConPTY Enter
     /// quirk (shell expects CR, not LF).
     pub fn write_input(&self, text: &str) {
+        self.scroll_viewport_to_bottom();
         self.request_low_latency_after_next_generation();
         let bytes: std::borrow::Cow<[u8]> = if text.as_bytes().contains(&b'\n') {
             std::borrow::Cow::Owned(text.replace('\n', "\r").into_bytes())
@@ -404,6 +405,7 @@ impl RenderSession {
     /// Raw PTY write — no CR/LF normalization. Used for bracketed-paste
     /// wrappers (ESC [200~ / ESC [201~) whose bytes mustn't be touched.
     pub fn write_pty_raw(&self, data: &[u8]) {
+        self.scroll_viewport_to_bottom();
         self.request_low_latency_after_next_generation();
         let _ = self.conpty.write(data);
     }
@@ -592,6 +594,14 @@ impl RenderSession {
     pub fn scroll_viewport_rows(&self, rows: isize) {
         self.scroll_remainder.lock().reset();
         if self.vt.scroll_viewport_delta(rows) {
+            self.request_low_latency_present();
+        }
+    }
+
+    /// Return the viewport to the prompt before writing user input.
+    pub fn scroll_viewport_to_bottom(&self) {
+        self.scroll_remainder.lock().reset();
+        if self.vt.scroll_viewport_bottom() {
             self.request_low_latency_present();
         }
     }

--- a/crates/con-ghostty/src/windows/render/atlas.rs
+++ b/crates/con-ghostty/src/windows/render/atlas.rs
@@ -84,6 +84,44 @@ pub struct CellMetrics {
     pub baseline_px: u32,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct TextFormatBaselines {
+    regular: f32,
+    bold: f32,
+    italic: f32,
+    bold_italic: f32,
+}
+
+impl TextFormatBaselines {
+    fn measure(
+        dwrite: &IDWriteFactory,
+        fallback_baseline: f32,
+        regular: &IDWriteTextFormat,
+        bold: &IDWriteTextFormat,
+        italic: &IDWriteTextFormat,
+        bold_italic: &IDWriteTextFormat,
+    ) -> Self {
+        let baseline = |format: &IDWriteTextFormat| {
+            text_layout_baseline(dwrite, format, &[b'M' as u16]).unwrap_or(fallback_baseline)
+        };
+        Self {
+            regular: baseline(regular),
+            bold: baseline(bold),
+            italic: baseline(italic),
+            bold_italic: baseline(bold_italic),
+        }
+    }
+
+    fn for_style(self, bold: bool, italic: bool) -> f32 {
+        match (bold, italic) {
+            (true, true) => self.bold_italic,
+            (true, false) => self.bold,
+            (false, true) => self.italic,
+            (false, false) => self.regular,
+        }
+    }
+}
+
 pub struct GlyphCache {
     device: ID3D11Device,
     _context: ID3D11DeviceContext,
@@ -132,6 +170,7 @@ pub struct GlyphCache {
     primary_upm: f32,
 
     metrics: CellMetrics,
+    layout_baselines: TextFormatBaselines,
     font_size_px: f32,
     font_family: String,
 }
@@ -200,6 +239,14 @@ impl GlyphCache {
         )?;
 
         let metrics = measure_cell(dwrite, text_collection, &resolved_family, font_size_px)?;
+        let layout_baselines = TextFormatBaselines::measure(
+            dwrite,
+            metrics.baseline_px as f32,
+            &text_format_regular,
+            &text_format_bold,
+            &text_format_italic,
+            &text_format_bold_italic,
+        );
 
         // Resolve a face for per-glyph design-metrics lookups. The face
         // comes from the same collection `measure_cell` walked, so
@@ -391,6 +438,7 @@ impl GlyphCache {
             primary_face,
             primary_upm,
             metrics,
+            layout_baselines,
             font_size_px,
             // Store the RESOLVED family and collection — downstream
             // rebuilds must use the same source to keep metrics and
@@ -501,6 +549,7 @@ impl GlyphCache {
             (false, true) => &self.text_format_italic,
             (false, false) => &self.text_format_regular,
         };
+        let target_baseline = self.layout_baselines.for_style(key.bold, key.italic);
 
         let slot_rect = D2D_RECT_F {
             left: rect.min.x as f32,
@@ -619,7 +668,12 @@ impl GlyphCache {
                 // lets glyphs drift vertically between characters and
                 // fallback faces. Anchor the isolated layout's baseline back
                 // to the terminal cell baseline before clipping to the slot.
-                let layout = self.baseline_aligned_layout_rect(slot_rect, format, utf16_slice);
+                let layout = self.baseline_aligned_layout_rect(
+                    slot_rect,
+                    format,
+                    utf16_slice,
+                    target_baseline,
+                );
                 self.d2d_rt.DrawText(
                     utf16_slice,
                     format,
@@ -659,11 +713,11 @@ impl GlyphCache {
         slot_rect: D2D_RECT_F,
         format: &IDWriteTextFormat,
         utf16: &[u16],
+        target_baseline: f32,
     ) -> D2D_RECT_F {
-        let Some(layout_baseline) = self.text_layout_baseline(format, utf16) else {
+        let Some(layout_baseline) = text_layout_baseline(&self.dwrite, format, utf16) else {
             return slot_rect;
         };
-        let target_baseline = self.metrics.baseline_px as f32;
         let shift = target_baseline - layout_baseline;
         D2D_RECT_F {
             left: slot_rect.left,
@@ -671,30 +725,6 @@ impl GlyphCache {
             right: slot_rect.right,
             bottom: slot_rect.bottom + shift,
         }
-    }
-
-    fn text_layout_baseline(&self, format: &IDWriteTextFormat, utf16: &[u16]) -> Option<f32> {
-        if utf16.is_empty() {
-            return None;
-        }
-        // SAFETY: `utf16` lives for the call; DirectWrite copies the text into
-        // the layout object. Infinite bounds mirror GPUI/Zed's Windows text
-        // layout path and avoid wrapping a single glyph.
-        let layout = unsafe {
-            self.dwrite
-                .CreateTextLayout(utf16, format, f32::INFINITY, f32::INFINITY)
-                .ok()?
-        };
-        let mut line_metrics = [DWRITE_LINE_METRICS::default(); 1];
-        let mut line_count = 0u32;
-        // SAFETY: output buffer contains one slot; a one-glyph layout has at
-        // most one line. If DirectWrite reports no line, leave the old rect.
-        unsafe {
-            layout
-                .GetLineMetrics(Some(&mut line_metrics), &mut line_count)
-                .ok()?;
-        }
-        (line_count > 0).then_some(line_metrics[0].baseline)
     }
 
     /// Glyph metrics in physical pixels for `codepoint` in the primary
@@ -804,6 +834,14 @@ impl GlyphCache {
             &self.font_family,
             font_size_px,
         )?;
+        self.layout_baselines = TextFormatBaselines::measure(
+            &self.dwrite,
+            self.metrics.baseline_px as f32,
+            &self.text_format_regular,
+            &self.text_format_bold,
+            &self.text_format_italic,
+            &self.text_format_bold_italic,
+        );
         // Refresh the primary face + upm so per-glyph scale-to-fit
         // works after a font-size change (the face itself doesn't
         // depend on size, but re-resolving keeps the field in lockstep
@@ -914,6 +952,34 @@ fn make_text_format(
     }
 
     Ok(format)
+}
+
+fn text_layout_baseline(
+    dwrite: &IDWriteFactory,
+    format: &IDWriteTextFormat,
+    utf16: &[u16],
+) -> Option<f32> {
+    if utf16.is_empty() {
+        return None;
+    }
+    // SAFETY: `utf16` lives for the call; DirectWrite copies the text into
+    // the layout object. Infinite bounds mirror GPUI/Zed's Windows text
+    // layout path and avoid wrapping a single glyph.
+    let layout = unsafe {
+        dwrite
+            .CreateTextLayout(utf16, format, f32::INFINITY, f32::INFINITY)
+            .ok()?
+    };
+    let mut line_metrics = [DWRITE_LINE_METRICS::default(); 1];
+    let mut line_count = 0u32;
+    // SAFETY: output buffer contains one slot; a one-glyph layout has at
+    // most one line. If DirectWrite reports no line, caller falls back.
+    unsafe {
+        layout
+            .GetLineMetrics(Some(&mut line_metrics), &mut line_count)
+            .ok()?;
+    }
+    (line_count > 0).then_some(line_metrics[0].baseline)
 }
 
 fn measure_cell(

--- a/crates/con-ghostty/src/windows/render/atlas.rs
+++ b/crates/con-ghostty/src/windows/render/atlas.rs
@@ -43,6 +43,9 @@ use windows::Win32::Graphics::Dxgi::IDXGISurface;
 use windows::core::Interface;
 use windows_numerics::Matrix3x2;
 
+const TEXT_ENHANCED_CONTRAST: f32 = 1.15;
+const CJK_TEXT_ENHANCED_CONTRAST: f32 = 1.85;
+
 #[derive(Debug, Clone, Copy)]
 #[allow(dead_code)] // offset_x/offset_y are wired in Phase 3b-2 (glyph bearing).
 pub struct GlyphRect {
@@ -142,6 +145,8 @@ pub struct GlyphCache {
     _atlas_texture: ID3D11Texture2D,
     atlas_srv: ID3D11ShaderResourceView,
     d2d_rt: ID2D1RenderTarget,
+    text_rendering_params: Option<IDWriteRenderingParams>,
+    cjk_text_rendering_params: Option<IDWriteRenderingParams>,
     white_brush: ID2D1SolidColorBrush,
     /// Opaque-black brush. Used to clear each slot before `DrawText` so
     /// any stale pixels — from a neighbouring scaled-PUA glyph that bled
@@ -352,26 +357,25 @@ impl GlyphCache {
         // coverage in our offscreen atlas. A mild contrast bump offsets
         // the perceived weight loss from dropping ClearType.
         //
+        // CJK fallback glyphs need a separate, stronger grayscale
+        // contrast. The user-visible complaint in #78 was not Latin
+        // weight after the RGB-fringe fix; it was CJK strokes looking
+        // too thin. Keep Latin / PUA conservative and only switch to
+        // the heavier params for wide fallback glyph rasterization.
+        //
         // If CreateCustomRenderingParams fails (very rare — it's a pure
         // parameter validator) we leave the default params in place.
-        // SAFETY: constants are valid for IDWriteFactory.
-        let custom_params: Option<IDWriteRenderingParams> = unsafe {
-            dwrite
-                .CreateCustomRenderingParams(
-                    1.8,  // gamma
-                    1.15, // enhanced contrast; offsets grayscale/ClearType weight loss
-                    0.0,  // ClearType level; zero means no RGB subpixel coverage
-                    DWRITE_PIXEL_GEOMETRY_FLAT,
-                    DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC,
-                )
-                .ok()
-        };
+        let text_rendering_params = custom_text_rendering_params(dwrite, TEXT_ENHANCED_CONTRAST);
+        let cjk_text_rendering_params = text_rendering_params
+            .is_some()
+            .then(|| custom_text_rendering_params(dwrite, CJK_TEXT_ENHANCED_CONTRAST))
+            .flatten();
         // SAFETY: grayscale AA. Setting the mode is cheap; if a driver
         // clamps it, the shader still collapses coverage to one scalar
         // so colored subpixel fringe cannot escape to the final frame.
         unsafe {
             d2d_rt.SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE_GRAYSCALE);
-            if let Some(params) = custom_params.as_ref() {
+            if let Some(params) = text_rendering_params.as_ref() {
                 d2d_rt.SetTextRenderingParams(params);
             }
         }
@@ -427,6 +431,8 @@ impl GlyphCache {
             _atlas_texture: atlas_texture,
             atlas_srv,
             d2d_rt,
+            text_rendering_params,
+            cjk_text_rendering_params,
             white_brush,
             black_brush,
             allocator,
@@ -674,6 +680,9 @@ impl GlyphCache {
                     utf16_slice,
                     target_baseline,
                 );
+                if let Some(params) = self.cjk_text_rendering_params.as_ref() {
+                    self.d2d_rt.SetTextRenderingParams(params);
+                }
                 self.d2d_rt.DrawText(
                     utf16_slice,
                     format,
@@ -682,6 +691,9 @@ impl GlyphCache {
                     D2D1_DRAW_TEXT_OPTIONS_NONE,
                     DWRITE_MEASURING_MODE_NATURAL,
                 );
+                if let Some(params) = self.text_rendering_params.as_ref() {
+                    self.d2d_rt.SetTextRenderingParams(params);
+                }
             } else {
                 self.d2d_rt.DrawText(
                     utf16_slice,
@@ -952,6 +964,27 @@ fn make_text_format(
     }
 
     Ok(format)
+}
+
+fn custom_text_rendering_params(
+    dwrite: &IDWriteFactory,
+    enhanced_contrast: f32,
+) -> Option<IDWriteRenderingParams> {
+    // SAFETY: constants are valid for IDWriteFactory. ClearType level
+    // stays zero because this atlas is sampled and composited by our
+    // own shader; RGB subpixel coverage would survive screenshots and
+    // remote displays as colored fringe.
+    unsafe {
+        dwrite
+            .CreateCustomRenderingParams(
+                1.8,
+                enhanced_contrast,
+                0.0,
+                DWRITE_PIXEL_GEOMETRY_FLAT,
+                DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC,
+            )
+            .ok()
+    }
 }
 
 fn text_layout_baseline(

--- a/crates/con-ghostty/src/windows/render/atlas.rs
+++ b/crates/con-ghostty/src/windows/render/atlas.rs
@@ -32,11 +32,12 @@ use windows::Win32::Graphics::Direct3D11::{
 };
 use windows::Win32::Graphics::DirectWrite::{
     DWRITE_FONT_METRICS, DWRITE_FONT_STRETCH_NORMAL, DWRITE_FONT_STYLE_ITALIC,
-    DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_WEIGHT_BOLD, DWRITE_FONT_WEIGHT_NORMAL,
-    DWRITE_GLYPH_METRICS, DWRITE_LINE_METRICS, DWRITE_MEASURING_MODE_NATURAL,
-    DWRITE_PIXEL_GEOMETRY_FLAT, DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC, IDWriteFactory,
-    IDWriteFontCollection, IDWriteFontFace, IDWriteFontFallback, IDWriteRenderingParams,
-    IDWriteTextFormat, IDWriteTextFormat1,
+    DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_WEIGHT, DWRITE_FONT_WEIGHT_BOLD,
+    DWRITE_FONT_WEIGHT_MEDIUM, DWRITE_FONT_WEIGHT_NORMAL, DWRITE_GLYPH_METRICS,
+    DWRITE_LINE_METRICS, DWRITE_MEASURING_MODE_NATURAL, DWRITE_PIXEL_GEOMETRY_FLAT,
+    DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC, IDWriteFactory, IDWriteFontCollection,
+    IDWriteFontFace, IDWriteFontFallback, IDWriteRenderingParams, IDWriteTextFormat,
+    IDWriteTextFormat1,
 };
 use windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT_B8G8R8A8_UNORM, DXGI_SAMPLE_DESC};
 use windows::Win32::Graphics::Dxgi::IDXGISurface;
@@ -44,7 +45,7 @@ use windows::core::Interface;
 use windows_numerics::Matrix3x2;
 
 const TEXT_ENHANCED_CONTRAST: f32 = 1.15;
-const CJK_TEXT_ENHANCED_CONTRAST: f32 = 1.85;
+const CJK_TEXT_ENHANCED_CONTRAST: f32 = 1.45;
 
 #[derive(Debug, Clone, Copy)]
 #[allow(dead_code)] // offset_x/offset_y are wired in Phase 3b-2 (glyph bearing).
@@ -162,6 +163,8 @@ pub struct GlyphCache {
     text_format_bold: IDWriteTextFormat,
     text_format_italic: IDWriteTextFormat,
     text_format_bold_italic: IDWriteTextFormat,
+    text_format_cjk_regular: IDWriteTextFormat,
+    text_format_cjk_italic: IDWriteTextFormat,
 
     /// Regular-weight face of the primary family, kept around so we can
     /// query per-glyph design metrics at rasterize time and scale wide
@@ -240,6 +243,24 @@ impl GlyphCache {
             &resolved_family,
             font_size_px,
             true,
+            true,
+        )?;
+        let text_format_cjk_regular = make_text_format_with_weight(
+            dwrite,
+            text_collection,
+            font_fallback.as_ref(),
+            &resolved_family,
+            font_size_px,
+            DWRITE_FONT_WEIGHT_MEDIUM,
+            false,
+        )?;
+        let text_format_cjk_italic = make_text_format_with_weight(
+            dwrite,
+            text_collection,
+            font_fallback.as_ref(),
+            &resolved_family,
+            font_size_px,
+            DWRITE_FONT_WEIGHT_MEDIUM,
             true,
         )?;
 
@@ -441,6 +462,8 @@ impl GlyphCache {
             text_format_bold,
             text_format_italic,
             text_format_bold_italic,
+            text_format_cjk_regular,
+            text_format_cjk_italic,
             primary_face,
             primary_upm,
             metrics,
@@ -501,6 +524,7 @@ impl GlyphCache {
         let is_scalable_pua =
             matches!(codepoint, 0xE000..=0xF8FF) && !matches!(codepoint, 0xE0A0..=0xE0D4);
         let is_wide_text = is_wide_codepoint(codepoint);
+        let is_cjk_text = is_cjk_codepoint(codepoint);
         let metrics = if is_scalable_pua {
             self.primary_glyph_metrics_px(codepoint)
         } else {
@@ -549,11 +573,20 @@ impl GlyphCache {
         let mut utf16 = [0u16; 2];
         let utf16_slice = ch.encode_utf16(&mut utf16);
 
-        let format = match (key.bold, key.italic) {
+        let base_format = match (key.bold, key.italic) {
             (true, true) => &self.text_format_bold_italic,
             (true, false) => &self.text_format_bold,
             (false, true) => &self.text_format_italic,
             (false, false) => &self.text_format_regular,
+        };
+        let format = if is_cjk_text && !key.bold {
+            if key.italic {
+                &self.text_format_cjk_italic
+            } else {
+                &self.text_format_cjk_regular
+            }
+        } else {
+            base_format
         };
         let target_baseline = self.layout_baselines.for_style(key.bold, key.italic);
 
@@ -680,7 +713,7 @@ impl GlyphCache {
                     utf16_slice,
                     target_baseline,
                 );
-                if let Some(params) = self.cjk_text_rendering_params.as_ref() {
+                if is_cjk_text && let Some(params) = self.cjk_text_rendering_params.as_ref() {
                     self.d2d_rt.SetTextRenderingParams(params);
                 }
                 self.d2d_rt.DrawText(
@@ -691,7 +724,7 @@ impl GlyphCache {
                     D2D1_DRAW_TEXT_OPTIONS_NONE,
                     DWRITE_MEASURING_MODE_NATURAL,
                 );
-                if let Some(params) = self.text_rendering_params.as_ref() {
+                if is_cjk_text && let Some(params) = self.text_rendering_params.as_ref() {
                     self.d2d_rt.SetTextRenderingParams(params);
                 }
             } else {
@@ -840,6 +873,24 @@ impl GlyphCache {
             true,
             true,
         )?;
+        self.text_format_cjk_regular = make_text_format_with_weight(
+            &self.dwrite,
+            self.font_collection.as_ref(),
+            self.font_fallback.as_ref(),
+            &self.font_family,
+            font_size_px,
+            DWRITE_FONT_WEIGHT_MEDIUM,
+            false,
+        )?;
+        self.text_format_cjk_italic = make_text_format_with_weight(
+            &self.dwrite,
+            self.font_collection.as_ref(),
+            self.font_fallback.as_ref(),
+            &self.font_family,
+            font_size_px,
+            DWRITE_FONT_WEIGHT_MEDIUM,
+            true,
+        )?;
         self.metrics = measure_cell(
             &self.dwrite,
             self.font_collection.as_ref(),
@@ -915,14 +966,28 @@ fn make_text_format(
     bold: bool,
     italic: bool,
 ) -> Result<IDWriteTextFormat> {
-    let family_w: Vec<u16> = family.encode_utf16().chain(std::iter::once(0)).collect();
-    let locale_w: Vec<u16> = "en-us".encode_utf16().chain(std::iter::once(0)).collect();
-
     let weight = if bold {
         DWRITE_FONT_WEIGHT_BOLD
     } else {
         DWRITE_FONT_WEIGHT_NORMAL
     };
+    make_text_format_with_weight(
+        dwrite, collection, fallback, family, size_px, weight, italic,
+    )
+}
+
+fn make_text_format_with_weight(
+    dwrite: &IDWriteFactory,
+    collection: Option<&IDWriteFontCollection>,
+    fallback: Option<&IDWriteFontFallback>,
+    family: &str,
+    size_px: f32,
+    weight: DWRITE_FONT_WEIGHT,
+    italic: bool,
+) -> Result<IDWriteTextFormat> {
+    let family_w: Vec<u16> = family.encode_utf16().chain(std::iter::once(0)).collect();
+    let locale_w: Vec<u16> = "en-us".encode_utf16().chain(std::iter::once(0)).collect();
+
     let style = if italic {
         DWRITE_FONT_STYLE_ITALIC
     } else {
@@ -1298,9 +1363,35 @@ fn is_wide_codepoint(codepoint: u32) -> bool {
         .is_some_and(|width| width >= 2)
 }
 
+fn is_cjk_codepoint(codepoint: u32) -> bool {
+    matches!(
+        codepoint,
+        // Hangul Jamo.
+        0x1100..=0x11FF
+            // CJK radicals, Kangxi radicals, ideographic description chars.
+            | 0x2E80..=0x2FFF
+            // CJK punctuation, Hiragana, Katakana, Bopomofo, Hangul compatibility.
+            | 0x3000..=0x318F
+            // CJK strokes, Katakana extensions, enclosed CJK.
+            | 0x31C0..=0x32FF
+            // CJK Unified Ideographs Extension A + Unified Ideographs.
+            | 0x3400..=0x9FFF
+            // Hangul syllables.
+            | 0xAC00..=0xD7AF
+            // CJK compatibility ideographs.
+            | 0xF900..=0xFAFF
+            // Kana Supplement / Extended, Small Kana, Nushu.
+            | 0x1AFF0..=0x1B16F
+            // Ideographic symbols and Tangut/Nushu-era East Asian wide scripts.
+            | 0x16FE0..=0x18D8F
+            // CJK Extension B and later assigned extension planes.
+            | 0x20000..=0x323AF
+    )
+}
+
 #[cfg(test)]
 mod tests {
-    use super::is_wide_codepoint;
+    use super::{is_cjk_codepoint, is_wide_codepoint};
 
     #[test]
     fn wide_codepoint_uses_unicode_width_instead_of_local_ranges() {
@@ -1323,5 +1414,23 @@ mod tests {
         // Ambiguous-width punctuation should stay one cell unless the
         // terminal layer explicitly gains a CJK-ambiguous-width mode.
         assert!(!is_wide_codepoint(0x00B7));
+    }
+
+    #[test]
+    fn cjk_codepoint_detection_is_limited_to_east_asian_text() {
+        for codepoint in [
+            0x4E00,  // CJK Unified Ideograph
+            0x3002,  // Ideographic full stop
+            0x3042,  // Hiragana
+            0x30A2,  // Katakana
+            0x3105,  // Bopomofo
+            0xAC00,  // Hangul syllable
+            0x20000, // CJK Unified Ideographs Extension B
+        ] {
+            assert!(is_cjk_codepoint(codepoint), "U+{codepoint:04X}");
+        }
+
+        assert!(!is_cjk_codepoint('A' as u32));
+        assert!(!is_cjk_codepoint(0xE0B0)); // Powerline glyph; keep prompt icons untouched.
     }
 }

--- a/crates/con-ghostty/src/windows/render/atlas.rs
+++ b/crates/con-ghostty/src/windows/render/atlas.rs
@@ -33,10 +33,10 @@ use windows::Win32::Graphics::Direct3D11::{
 use windows::Win32::Graphics::DirectWrite::{
     DWRITE_FONT_METRICS, DWRITE_FONT_STRETCH_NORMAL, DWRITE_FONT_STYLE_ITALIC,
     DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_WEIGHT_BOLD, DWRITE_FONT_WEIGHT_NORMAL,
-    DWRITE_GLYPH_METRICS, DWRITE_MEASURING_MODE_NATURAL, DWRITE_PIXEL_GEOMETRY_FLAT,
-    DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC, IDWriteFactory, IDWriteFontCollection,
-    IDWriteFontFace, IDWriteFontFallback, IDWriteRenderingParams, IDWriteTextFormat,
-    IDWriteTextFormat1,
+    DWRITE_GLYPH_METRICS, DWRITE_LINE_METRICS, DWRITE_MEASURING_MODE_NATURAL,
+    DWRITE_PIXEL_GEOMETRY_FLAT, DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC, IDWriteFactory,
+    IDWriteFontCollection, IDWriteFontFace, IDWriteFontFallback, IDWriteRenderingParams,
+    IDWriteTextFormat, IDWriteTextFormat1,
 };
 use windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT_B8G8R8A8_UNORM, DXGI_SAMPLE_DESC};
 use windows::Win32::Graphics::Dxgi::IDXGISurface;
@@ -311,9 +311,9 @@ impl GlyphCache {
         let custom_params: Option<IDWriteRenderingParams> = unsafe {
             dwrite
                 .CreateCustomRenderingParams(
-                    1.8, // gamma
-                    0.8, // enhanced contrast
-                    0.0, // ClearType level; zero means no RGB subpixel coverage
+                    1.8,  // gamma
+                    1.15, // enhanced contrast; offsets grayscale/ClearType weight loss
+                    0.0,  // ClearType level; zero means no RGB subpixel coverage
                     DWRITE_PIXEL_GEOMETRY_FLAT,
                     DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC,
                 )
@@ -612,10 +612,18 @@ impl GlyphCache {
                 // clips or visually narrows the fallback font, then the
                 // second spacer cell makes the text look like it has
                 // inserted spaces.
+                //
+                // DrawText lays this one codepoint as an isolated line.
+                // Fallback CJK fonts do not necessarily share the primary
+                // terminal face's baseline, so top-aligning the layout rect
+                // lets glyphs drift vertically between characters and
+                // fallback faces. Anchor the isolated layout's baseline back
+                // to the terminal cell baseline before clipping to the slot.
+                let layout = self.baseline_aligned_layout_rect(slot_rect, format, utf16_slice);
                 self.d2d_rt.DrawText(
                     utf16_slice,
                     format,
-                    &slot_rect,
+                    &layout,
                     &self.white_brush,
                     D2D1_DRAW_TEXT_OPTIONS_NONE,
                     DWRITE_MEASURING_MODE_NATURAL,
@@ -644,6 +652,49 @@ impl GlyphCache {
         };
         self.entries.insert(key, (alloc.id, glyph_rect));
         Some(glyph_rect)
+    }
+
+    fn baseline_aligned_layout_rect(
+        &self,
+        slot_rect: D2D_RECT_F,
+        format: &IDWriteTextFormat,
+        utf16: &[u16],
+    ) -> D2D_RECT_F {
+        let Some(layout_baseline) = self.text_layout_baseline(format, utf16) else {
+            return slot_rect;
+        };
+        let target_baseline = self.metrics.baseline_px as f32;
+        let shift = target_baseline - layout_baseline;
+        D2D_RECT_F {
+            left: slot_rect.left,
+            top: slot_rect.top + shift,
+            right: slot_rect.right,
+            bottom: slot_rect.bottom + shift,
+        }
+    }
+
+    fn text_layout_baseline(&self, format: &IDWriteTextFormat, utf16: &[u16]) -> Option<f32> {
+        if utf16.is_empty() {
+            return None;
+        }
+        // SAFETY: `utf16` lives for the call; DirectWrite copies the text into
+        // the layout object. Infinite bounds mirror GPUI/Zed's Windows text
+        // layout path and avoid wrapping a single glyph.
+        let layout = unsafe {
+            self.dwrite
+                .CreateTextLayout(utf16, format, f32::INFINITY, f32::INFINITY)
+                .ok()?
+        };
+        let mut line_metrics = [DWRITE_LINE_METRICS::default(); 1];
+        let mut line_count = 0u32;
+        // SAFETY: output buffer contains one slot; a one-glyph layout has at
+        // most one line. If DirectWrite reports no line, leave the old rect.
+        unsafe {
+            layout
+                .GetLineMetrics(Some(&mut line_metrics), &mut line_count)
+                .ok()?;
+        }
+        (line_count > 0).then_some(line_metrics[0].baseline)
     }
 
     /// Glyph metrics in physical pixels for `codepoint` in the primary

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -57,6 +57,7 @@ pub use super::vt::ThemeColors;
 pub use atlas::CellMetrics;
 
 const ATLAS_SIZE_PX: u32 = 2048;
+const ALTERNATE_SCREEN_BACKGROUND_OPACITY_FLOOR: f32 = 0.94;
 /// Initial instance-buffer capacity. 16 384 covers a 200×80 grid
 /// without reallocation; panes larger than that grow via
 /// `Pipeline::ensure_instance_capacity` in the hot path.
@@ -520,7 +521,7 @@ impl Renderer {
             // under GPUI's premultiplied-alpha blend (otherwise
             // translucent pixels look washed out / haloed against the
             // visual beneath).
-            let opacity = config.background_opacity.clamp(0.0, 1.0);
+            let opacity = effective_background_opacity(snapshot, config);
             let clear = [
                 config.clear_color[0] * opacity,
                 config.clear_color[1] * opacity,
@@ -894,7 +895,8 @@ impl Renderer {
         // path injects an `0x......00` value into cell.bg without
         // meaning the sentinel, it would be silently rewritten — keep
         // the producers honest.
-        let opacity_byte: u8 = (config.background_opacity.clamp(0.0, 1.0) * 255.0).round() as u8;
+        let background_opacity = effective_background_opacity(snapshot, config);
+        let opacity_byte: u8 = (background_opacity * 255.0).round() as u8;
         let apply_opacity = |bg: u32| -> u32 {
             if (bg & 0xFF) == 0 {
                 (bg & 0xFFFFFF00) | opacity_byte as u32
@@ -943,7 +945,9 @@ impl Renderer {
             // cells when it would be pixel-identical to the clear. This
             // preserves explicit SGR backgrounds, selection / inverse,
             // and underline / strike decorations on spaces.
-            if !is_cursor_cell && is_default_blank_cell(cell, effective_attrs, config) {
+            if !is_cursor_cell
+                && is_default_blank_cell(cell, effective_attrs, config, background_opacity)
+            {
                 continue;
             }
 
@@ -1165,7 +1169,27 @@ fn log_render_profile(
     );
 }
 
-fn is_default_blank_cell(cell: &Cell, effective_attrs: u8, config: &RendererConfig) -> bool {
+fn effective_background_opacity(snapshot: &ScreenSnapshot, config: &RendererConfig) -> f32 {
+    let opacity = config.background_opacity.clamp(0.0, 1.0);
+    // Full-screen TUIs use the terminal default background as their
+    // application canvas. At Con's default glass level, Windows Mica /
+    // DComp backdrops can wash that canvas out compared with Windows
+    // Terminal. Keep ordinary shells fully user-configurable, but give
+    // alternate-screen apps a readable floor. If the user explicitly
+    // sets the terminal to fully transparent, respect that.
+    if snapshot.alternate_screen && opacity > f32::EPSILON {
+        opacity.max(ALTERNATE_SCREEN_BACKGROUND_OPACITY_FLOOR)
+    } else {
+        opacity
+    }
+}
+
+fn is_default_blank_cell(
+    cell: &Cell,
+    effective_attrs: u8,
+    config: &RendererConfig,
+    background_opacity: f32,
+) -> bool {
     let is_blank = cell.codepoint == 0 || cell.codepoint == 0x20;
     if !is_blank {
         return false;
@@ -1184,8 +1208,7 @@ fn is_default_blank_cell(cell: &Cell, effective_attrs: u8, config: &RendererConf
         return false;
     }
 
-    let opacity = config.background_opacity.clamp(0.0, 1.0);
-    if opacity <= f32::EPSILON {
+    if background_opacity <= f32::EPSILON {
         return true;
     }
 

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -57,7 +57,7 @@ pub use super::vt::ThemeColors;
 pub use atlas::CellMetrics;
 
 const ATLAS_SIZE_PX: u32 = 2048;
-const ALTERNATE_SCREEN_BACKGROUND_OPACITY_FLOOR: f32 = 0.94;
+const ALTERNATE_SCREEN_BACKGROUND_OPACITY_FLOOR: f32 = 1.0;
 /// Initial instance-buffer capacity. 16 384 covers a 200×80 grid
 /// without reallocation; panes larger than that grow via
 /// `Pipeline::ensure_instance_capacity` in the hot path.
@@ -188,24 +188,32 @@ pub enum RenderOutcome {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Selection {
-    pub anchor: (u16, u16),
-    pub extent: (u16, u16),
+    pub anchor: (u16, u64),
+    pub extent: (u16, u64),
 }
 
 impl Selection {
-    pub fn contains(&self, col: u16, row: u16, cols: u16) -> bool {
-        let to_lin = |p: (u16, u16)| (p.1 as u32) * (cols as u32) + (p.0 as u32);
+    pub fn contains(&self, col: u16, row: u16, cols: u16, viewport_offset: u64) -> bool {
+        let to_lin = |p: (u16, u64)| (p.1 as u128) * (cols as u128) + (p.0 as u128);
         let a = to_lin(self.anchor);
         let b = to_lin(self.extent);
         let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
-        let here = to_lin((col, row));
+        let here = to_lin((col, viewport_offset.saturating_add(row as u64)));
         here >= lo && here <= hi
     }
 
     pub fn hash_u64(&self) -> u64 {
-        let a = ((self.anchor.0 as u64) << 16) | (self.anchor.1 as u64);
-        let b = ((self.extent.0 as u64) << 16) | (self.extent.1 as u64);
-        (a << 32) | b
+        let mut hash = 0x9E37_79B9_7F4A_7C15u64;
+        for value in [
+            self.anchor.0 as u64,
+            self.anchor.1,
+            self.extent.0 as u64,
+            self.extent.1,
+        ] {
+            hash ^= value;
+            hash = hash.rotate_left(13).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        }
+        hash
     }
 }
 
@@ -922,6 +930,7 @@ impl Renderer {
         } else {
             None
         };
+        let viewport_offset = snapshot.scrollbar.map_or(0, |scrollbar| scrollbar.offset);
         let mut cursor_source: Option<Instance> = None;
         let mut has_wide_glyph = false;
 
@@ -930,7 +939,7 @@ impl Renderer {
             let row = (i / snapshot.cols as usize) as u16;
 
             let in_sel = selection
-                .map(|s| s.contains(col, row, snapshot.cols))
+                .map(|s| s.contains(col, row, snapshot.cols, viewport_offset))
                 .unwrap_or(false);
             let effective_attrs = if in_sel {
                 cell.attrs ^ 0x10
@@ -1172,11 +1181,10 @@ fn log_render_profile(
 fn effective_background_opacity(snapshot: &ScreenSnapshot, config: &RendererConfig) -> f32 {
     let opacity = config.background_opacity.clamp(0.0, 1.0);
     // Full-screen TUIs use the terminal default background as their
-    // application canvas. At Con's default glass level, Windows Mica /
-    // DComp backdrops can wash that canvas out compared with Windows
-    // Terminal. Keep ordinary shells fully user-configurable, but give
-    // alternate-screen apps a readable floor. If the user explicitly
-    // sets the terminal to fully transparent, respect that.
+    // application canvas. Match Windows Terminal/Ghostty behavior
+    // here: ordinary shells keep the configured glass level, but
+    // alternate-screen apps paint a solid canvas. If the user
+    // explicitly sets the terminal to fully transparent, respect that.
     if snapshot.alternate_screen && opacity > f32::EPSILON {
         opacity.max(ALTERNATE_SCREEN_BACKGROUND_OPACITY_FLOOR)
     } else {

--- a/docs/impl/linux-port.md
+++ b/docs/impl/linux-port.md
@@ -14,7 +14,7 @@ the recommended architecture, and the staged path from today's
 preview pane to a fully shippable Linux terminal backend (the
 remaining work is the long-term GPUI-owned glyph-atlas grid
 renderer matching the D3D11/DirectWrite path Windows uses, plus
-mouse selection / reporting and packaging).
+mouse reporting and packaging).
 
 This is a planning document, not an implementation log. The live issue
 tracker is GitHub issue #18. The deeper architecture notes live in
@@ -52,6 +52,9 @@ What that gives you:
   per styled span: SGR colors, bold (`FontWeight::BOLD`), italic
   (`FontStyle::Italic`), underline, strikethrough, inverse, and a
   block cursor (fg/bg swap on the cursor cell) all survive
+- terminal text selection with left-drag, `Ctrl+C` copy-and-clear
+  semantics, and `Ctrl+Shift+C` clipboard copy. Plain `Ctrl+C` still
+  sends interrupt when no text is selected.
 - terminal-local Tab / Shift+Tab capture, so shell completion and TUI
   focus/navigation keys reach the Linux pane instead of being swallowed
   by GPUI focus traversal
@@ -93,7 +96,7 @@ What it still does **not** give you:
   a block cursor correctly, but per-cell metrics still come from
   layout-time text shaping rather than a fixed cell grid the way
   the Windows D3D11/DirectWrite path does)
-- validated mouse selection / reporting
+- mouse reporting for terminal apps that request it
 - native packaging artifacts (`.deb`, AppImage, Flatpak, …); the
   current release pipeline already ships a tarball, one-line installer,
   `co.nowledge.con.desktop` launcher identity, icon install, appcast,
@@ -282,7 +285,7 @@ can ship.
 | 2c | Architecture decision | pick Linux backend lane | one recommended implementation path, no split-brain plan | ✅ landed |
 | 3 | Linux backend scaffold | `con-ghostty/src/linux/` plus `con-app/src/linux_view.rs` (or equivalent) with real lifecycle types | Linux no longer routes through the generic stub path conceptually | ✅ landed |
 | 4 | First real terminal surface | PTY spawn, resize, exit, `libghostty-vt` state, GPUI-owned pane paint, real product chrome (no native WM titlebar), embedded mono font, transparent + rounded window with compositor-gated blur | VT-backed Linux pane compiles and displays live shell state with SGR colors / bold / italic / underline / strikethrough / inverse, cursor block, theme palette synced from settings, IoskeleyMono shaping, client-side titlebar with min/max/close caption cluster, transparent ARGB window with rounded corners and per-pane / per-surface opacity, real KWin Wayland blur where available, fast paint pipeline (16 ms keystroke-echo round-trip), no placeholder flash on alt-screen TUIs | ✅ landed (preview) |
-| 5 | Input + selection + glyph-atlas grid renderer | keyboard, mouse, clipboard, bracketed paste, DECCKM, CJK IME text/preedit input, selection, plus the long-term GPUI-owned glyph-atlas grid renderer matching the D3D11/DirectWrite path Windows uses | vim/tmux/fzf/less usable on Linux at full speed | 🚧 in progress (DECCKM, bracketed paste, CJK IME text/preedit input, and terminal-local Tab / Shift+Tab capture are wired; mouse reporting, selection, desktop IME validation matrix, and the glyph-atlas renderer remain) |
+| 5 | Input + selection + glyph-atlas grid renderer | keyboard, mouse, clipboard, bracketed paste, DECCKM, CJK IME text/preedit input, selection, plus the long-term GPUI-owned glyph-atlas grid renderer matching the D3D11/DirectWrite path Windows uses | vim/tmux/fzf/less usable on Linux at full speed | 🚧 in progress (DECCKM, bracketed paste, CJK IME text/preedit input, terminal-local Tab / Shift+Tab capture, and basic left-drag text selection are wired; mouse reporting, scrollback gestures, desktop IME validation matrix, and the glyph-atlas renderer remain) |
 | 6 | Packaging | one-line installer, tarball release, desktop entry, icon integration, appcast / notify-only updater, plus native artifact strategy (`.deb`, AppImage, Flatpak, etc.) | tarball installer exists; runtime Linux app id, desktop-file basename, and `StartupWMClass` are aligned as `co.nowledge.con`; native package format decision remains | 🚧 partially landed |
 
 ## Immediate next work
@@ -303,10 +306,10 @@ With phase 4 landed (preview), the remaining Linux tasks are:
    stay on huge panes (the gap shows up first on `top -d 0.1`-class
    workloads and large command-start redraws).
 2. Finish Linux input correctness: mouse reporting (button + wheel),
-   selection (mouse drag → SGR 1006 / X10 reports + clipboard
-   integration), scrollback gestures, and a real desktop/IME validation
-   matrix across Wayland and X11. DECCKM, bracketed paste, and CJK
-   IME commit/preedit input are already wired through `libghostty-vt`
+   scrollback gestures, drag-to-scroll selection polish, and a real
+   desktop/IME validation matrix across Wayland and X11. DECCKM,
+   bracketed paste, basic left-drag text selection, and CJK IME
+   commit/preedit input are already wired through `libghostty-vt`
    mode tracking plus GPUI's text-input path; Tab / Shift+Tab now use
    a terminal-local key context so shell completion and reverse focus
    traversal are not intercepted by GPUI's app-level focus navigation.

--- a/docs/impl/linux-port.md
+++ b/docs/impl/linux-port.md
@@ -70,6 +70,9 @@ What that gives you:
 - the user's `TerminalColors` (foreground / background / 16-color
   ANSI palette) plumbed into `VtScreen::set_theme` at session spawn
   and live whenever the user picks a theme in settings
+- OSC 7 cwd updates are captured by Con's Rust VT wrapper instead of
+  relying on libghostty-vt's terminal-only stream handler, so Linux
+  pane/session state can follow shell-reported directory changes
 - transparent ARGB window with rounded corners (14 px on Linux, no
   corners from `NSWindow` or DWM here so we clip the GPUI root
   ourselves) and per-pane / per-surface opacity that composites

--- a/docs/impl/windows-port.md
+++ b/docs/impl/windows-port.md
@@ -381,8 +381,10 @@ Phase 3c details now covered by the beta baseline:
   stdout/stderr handles, starts from a valid absolute cwd when provided, then
   falls back to the user's home directory and finally `%TEMP%`.
   PowerShell/pwsh shells are launched with a lightweight prompt hook that emits
-  OSC 7 cwd updates, so restored sessions and new panes can follow `cd`
-  changes instead of only remembering the process launch directory.
+  OSC 7 cwd updates, and Con's Rust VT wrapper captures OSC 7 directly because
+  libghostty-vt's terminal-only handler does not mutate pwd for that report.
+  Restored sessions and new panes can therefore follow `cd` changes instead of
+  only remembering the process launch directory.
 - Profiling uses `CON_LOG_FILE` instead of shell redirection so the child shell never sees redirected log handles.
 
 Phases 0-3e are **substantially complete** for the current Windows beta

--- a/docs/impl/windows-port.md
+++ b/docs/impl/windows-port.md
@@ -366,6 +366,10 @@ Phase 3c details now covered by the beta baseline:
 - CJK fallback glyphs are baseline-aligned inside the glyph atlas instead of
   being top-aligned as one-character `DrawText` lines. This keeps fallback
   CJK runs anchored to the same terminal-cell baseline as the primary face.
+- Normal-weight East Asian text uses a medium-weight DirectWrite text format
+  with a CJK-only grayscale contrast profile. That keeps Chinese strokes closer
+  to browser/native text weight without reintroducing ClearType RGB fringe or
+  changing Latin / Nerd-Font prompt glyphs.
 - OSC 52 and ordinary clipboard operations are wired through the Win32 clipboard.
 - CJK IME commit/preedit input is wired through GPUI's platform
   `InputHandler`. The terminal still owns control, alt/meta, and

--- a/docs/impl/windows-port.md
+++ b/docs/impl/windows-port.md
@@ -376,7 +376,13 @@ Phase 3c details now covered by the beta baseline:
   special-key encoding, while printable text and IME commits enter the
   PTY as text. Composition ranges report cursor-relative bounds so
   candidate windows anchor to the terminal cursor.
-- ConPTY child launch passes the pseudo-console with `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE`, avoids inheriting con's unrelated stdout/stderr handles, starts from a valid absolute cwd when provided, then falls back to the user's home directory and finally `%TEMP%`.
+- ConPTY child launch passes the pseudo-console with
+  `PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE`, avoids inheriting con's unrelated
+  stdout/stderr handles, starts from a valid absolute cwd when provided, then
+  falls back to the user's home directory and finally `%TEMP%`.
+  PowerShell/pwsh shells are launched with a lightweight prompt hook that emits
+  OSC 7 cwd updates, so restored sessions and new panes can follow `cd`
+  changes instead of only remembering the process launch directory.
 - Profiling uses `CON_LOG_FILE` instead of shell redirection so the child shell never sees redirected log handles.
 
 Phases 0-3e are **substantially complete** for the current Windows beta
@@ -471,7 +477,10 @@ Caveats:
 - The shell is `CON_SHELL` if set, else the configured Windows Terminal
   default profile command when `%LOCALAPPDATA%` settings are readable,
   else `pwsh.exe`/`powershell.exe` if on `PATH`, else `$env:COMSPEC`,
-  else `cmd.exe`. A first-class config field is still Phase 4 work.
+  else `cmd.exe`. PowerShell/pwsh profiles without an explicit
+  `-Command`/`-File` get Con's OSC 7 cwd hook automatically; custom
+  command/file profiles are left untouched. A first-class config field is
+  still Phase 4 work.
 - The terminal still pays a GPU→CPU readback and GPUI image upload on
   dirty frames. Recent fixes made small updates row-local and removed
   avoidable extra-frame latency plus several backlog stalls, but Windows
@@ -488,9 +497,11 @@ remaining decisions are narrower:
    that lets con present a Windows composition swap chain directly in the
    GPUI tree, then remove the D3D readback + `RenderImage` re-upload
    bridge.
-2. **Shell integration scope.** Decide whether OSC 133 / OSC 7 and
-   related shell-integration features belong in the shared VT layer or in
-   per-platform shell adapters.
+2. **Shell integration scope.** Decide whether OSC 133 and non-PowerShell
+   OSC 7 support belong in the shared VT layer or in per-platform shell
+   adapters. PowerShell/pwsh cwd tracking is currently handled as a
+   Windows launch-time adapter because those shells do not emit OSC 7 by
+   default.
 3. **Windows hardening.** Broaden IME/dead-key/international-keyboard
    validation, drag-to-scroll selection polish, column selection,
    CJK font-weight tuning, extreme resize behavior, ligatures, and

--- a/docs/impl/windows-port.md
+++ b/docs/impl/windows-port.md
@@ -357,7 +357,9 @@ Phase 3c details now covered by the beta baseline:
 - The Windows terminal view insets the measured renderer surface from the pane
   edge. Mouse hit testing, IME candidate bounds, link hover, scrollbar, and
   render dimensions all use the inset content bounds, so the visual padding is
-  not a cosmetic overlay that desynchronizes terminal coordinates.
+  not a cosmetic overlay that desynchronizes terminal coordinates. The gutter is
+  painted with the same terminal clear color and opacity as the renderer image
+  rather than falling through to transparent window content.
 - CJK fallback glyphs are baseline-aligned inside the glyph atlas instead of
   being top-aligned as one-character `DrawText` lines. This keeps fallback
   CJK runs anchored to the same terminal-cell baseline as the primary face.

--- a/docs/impl/windows-port.md
+++ b/docs/impl/windows-port.md
@@ -354,6 +354,13 @@ Phase 3c details now covered by the beta baseline:
   reserved for app tab switching on Windows.
 - Wheel and touchpad input scroll libghostty-vt viewport state when mouse tracking is inactive. Alternate-screen mode-1007 wheel gestures translate into cursor keys with the same fractional row accumulator used by primary scrollback.
 - The Windows pane has a visible GPUI scrollback scrollbar backed by cached libghostty-vt scrollbar state, so render no longer polls the expensive scrollbar query on every paint.
+- The Windows terminal view insets the measured renderer surface from the pane
+  edge. Mouse hit testing, IME candidate bounds, link hover, scrollbar, and
+  render dimensions all use the inset content bounds, so the visual padding is
+  not a cosmetic overlay that desynchronizes terminal coordinates.
+- CJK fallback glyphs are baseline-aligned inside the glyph atlas instead of
+  being top-aligned as one-character `DrawText` lines. This keeps fallback
+  CJK runs anchored to the same terminal-cell baseline as the primary face.
 - OSC 52 and ordinary clipboard operations are wired through the Win32 clipboard.
 - CJK IME commit/preedit input is wired through GPUI's platform
   `InputHandler`. The terminal still owns control, alt/meta, and
@@ -439,9 +446,10 @@ right column, Tab / Shift+Tab reach shells and TUIs, wheel gestures
 respect the platform scroll intent, and normal-shell scrollback is
 reachable through both the mouse wheel and the visible scrollbar.
 Resize works. Window close kills the shell. The remaining Windows work
-is now direct-composition presentation, IME edge-case validation /
-resize / advanced selection polish, and distribution hardening rather than basic
-input/selection bring-up.
+is now direct-composition presentation, IME edge-case validation,
+maximize/resize feel (#125), CJK font-weight polish, advanced selection
+polish, and distribution hardening rather than basic input/selection
+bring-up.
 
 Caveats:
 - You must have **Zig 0.15.2 exactly** on `PATH` for `cargo build` to
@@ -476,8 +484,8 @@ remaining decisions are narrower:
    per-platform shell adapters.
 3. **Windows hardening.** Broaden IME/dead-key/international-keyboard
    validation, drag-to-scroll selection polish, column selection,
-   extreme resize behavior, ligatures, and remaining multi-monitor/GPU
-   edge cases.
+   CJK font-weight tuning, extreme resize behavior, ligatures, and
+   remaining multi-monitor/GPU edge cases.
 4. **Distribution.** Choose the installer/signing path (MSIX/MSI/cargo
    dist/winget), code-sign the binary, and harden the existing beta
    in-place update flow with artifact signature verification.

--- a/docs/impl/windows-port.md
+++ b/docs/impl/windows-port.md
@@ -360,6 +360,9 @@ Phase 3c details now covered by the beta baseline:
   not a cosmetic overlay that desynchronizes terminal coordinates. The gutter is
   painted with the same terminal clear color and opacity as the renderer image
   rather than falling through to transparent window content.
+- Alternate-screen TUIs keep a higher default-background opacity floor than the
+  ordinary shell. That preserves Con's glass effect for prompts while keeping
+  htop/vim-style application canvases readable on Windows.
 - CJK fallback glyphs are baseline-aligned inside the glyph atlas instead of
   being top-aligned as one-character `DrawText` lines. This keeps fallback
   CJK runs anchored to the same terminal-cell baseline as the primary face.

--- a/postmortem/2026-05-07-windows-cjk-baseline-rendering.md
+++ b/postmortem/2026-05-07-windows-cjk-baseline-rendering.md
@@ -27,16 +27,19 @@ result was visible per-glyph vertical drift.
 
 The thin-stroke report came from the same rendering pipeline after we disabled
 ClearType subpixel color coverage. Grayscale text avoids RGB fringe in our
-offscreen BGRA atlas, but it needs slightly more contrast to match ClearType's
-perceived weight.
+offscreen BGRA atlas, but CJK fallback glyphs lost more perceived weight than
+Latin text. A single global contrast value was too blunt: pushing it high enough
+for CJK would also over-darken Latin and Nerd-Font prompt glyphs.
 
 ## Fix Applied
 
 - CJK/wide glyph rasterization now creates a tiny DirectWrite text layout for
   the glyph, reads the layout line baseline, and shifts the atlas layout rect so
   the fallback glyph baseline matches the primary terminal cell baseline.
-- The atlas keeps grayscale antialiasing but uses a modestly stronger
-  DirectWrite enhanced-contrast value to offset perceived weight loss.
+- The atlas keeps grayscale antialiasing. Latin and Nerd-Font glyphs use the
+  conservative contrast path; CJK/wide fallback glyphs temporarily switch to a
+  stronger DirectWrite enhanced-contrast profile during rasterization, then the
+  render target is restored before the next glyph.
 - The Windows terminal view now measures and renders an inset content surface
   instead of painting cells flush against the pane edge. Hit testing, link hover,
   IME cursor bounds, scrollbar placement, and renderer dimensions all use the

--- a/postmortem/2026-05-07-windows-cjk-baseline-rendering.md
+++ b/postmortem/2026-05-07-windows-cjk-baseline-rendering.md
@@ -40,7 +40,9 @@ perceived weight.
 - The Windows terminal view now measures and renders an inset content surface
   instead of painting cells flush against the pane edge. Hit testing, link hover,
   IME cursor bounds, scrollbar placement, and renderer dimensions all use the
-  same inset content bounds.
+  same inset content bounds. The inset gutter is painted with the terminal
+  renderer's clear color and opacity so it stays visually attached to the
+  terminal instead of showing transparent window content.
 
 ## What We Learned
 
@@ -53,4 +55,3 @@ perceived weight.
 - Windows font-quality bugs need reporter-facing dev builds and profile logs.
   The tracker should keep #78 open until users confirm the perceived weight is
   comfortable on real Windows displays.
-

--- a/postmortem/2026-05-07-windows-cjk-baseline-rendering.md
+++ b/postmortem/2026-05-07-windows-cjk-baseline-rendering.md
@@ -30,6 +30,10 @@ ClearType subpixel color coverage. Grayscale text avoids RGB fringe in our
 offscreen BGRA atlas, but CJK fallback glyphs lost more perceived weight than
 Latin text. A single global contrast value was too blunt: pushing it high enough
 for CJK would also over-darken Latin and Nerd-Font prompt glyphs.
+The right typography fix is to ask DirectWrite for a more appropriate East
+Asian text weight first, then apply a moderate raster contrast adjustment only
+to CJK text. Contrast alone is a last-mile rasterization tweak, not a substitute
+for glyph weight.
 
 ## Fix Applied
 
@@ -37,9 +41,10 @@ for CJK would also over-darken Latin and Nerd-Font prompt glyphs.
   the glyph, reads the layout line baseline, and shifts the atlas layout rect so
   the fallback glyph baseline matches the primary terminal cell baseline.
 - The atlas keeps grayscale antialiasing. Latin and Nerd-Font glyphs use the
-  conservative contrast path; CJK/wide fallback glyphs temporarily switch to a
-  stronger DirectWrite enhanced-contrast profile during rasterization, then the
-  render target is restored before the next glyph.
+  conservative contrast path; normal-weight CJK glyphs use a medium-weight
+  DirectWrite text format and temporarily switch to a moderate CJK-only
+  enhanced-contrast profile during rasterization, then the render target is
+  restored before the next glyph.
 - The Windows terminal view now measures and renders an inset content surface
   instead of painting cells flush against the pane edge. Hit testing, link hover,
   IME cursor bounds, scrollbar placement, and renderer dimensions all use the
@@ -58,3 +63,5 @@ for CJK would also over-darken Latin and Nerd-Font prompt glyphs.
 - Windows font-quality bugs need reporter-facing dev builds and profile logs.
   The tracker should keep #78 open until users confirm the perceived weight is
   comfortable on real Windows displays.
+- Glyph weight and raster contrast are separate controls. We should prefer
+  semantically correct font selection before tuning DirectWrite contrast values.

--- a/postmortem/2026-05-07-windows-cjk-baseline-rendering.md
+++ b/postmortem/2026-05-07-windows-cjk-baseline-rendering.md
@@ -1,0 +1,56 @@
+# 2026-05-07 — Windows CJK baseline rendering
+
+## What Happened
+
+Windows users reported two related rendering problems:
+
+- CJK characters in the same terminal row could sit at slightly different
+  vertical positions (#124).
+- After the earlier ClearType RGB-fringing fix, CJK glyphs no longer showed
+  colored edges but still felt too thin (#78).
+
+The reports were hard to verify locally because no Windows test machine was
+available in this pass, so the fix had to be grounded in the renderer code and
+validated through CI plus a Windows dev build.
+
+## Root Cause
+
+The Windows terminal renderer rasterizes one terminal glyph at a time into a
+DirectWrite/Direct2D glyph atlas. For glyphs missing from the primary terminal
+font, DirectWrite selects fallback fonts during `DrawText`.
+
+That is safe for coverage, but the old code top-aligned each one-character
+fallback layout rectangle to the atlas slot. CJK fallback fonts do not all share
+the primary terminal face's baseline metrics, and a one-character `DrawText`
+call does not have surrounding run context to normalize the line baseline. The
+result was visible per-glyph vertical drift.
+
+The thin-stroke report came from the same rendering pipeline after we disabled
+ClearType subpixel color coverage. Grayscale text avoids RGB fringe in our
+offscreen BGRA atlas, but it needs slightly more contrast to match ClearType's
+perceived weight.
+
+## Fix Applied
+
+- CJK/wide glyph rasterization now creates a tiny DirectWrite text layout for
+  the glyph, reads the layout line baseline, and shifts the atlas layout rect so
+  the fallback glyph baseline matches the primary terminal cell baseline.
+- The atlas keeps grayscale antialiasing but uses a modestly stronger
+  DirectWrite enhanced-contrast value to offset perceived weight loss.
+- The Windows terminal view now measures and renders an inset content surface
+  instead of painting cells flush against the pane edge. Hit testing, link hover,
+  IME cursor bounds, scrollbar placement, and renderer dimensions all use the
+  same inset content bounds.
+
+## What We Learned
+
+- Per-glyph atlas renderers cannot treat DirectWrite fallback as purely a
+  coverage problem. Baseline metrics are part of the glyph contract.
+- `DrawText` is acceptable for a cached glyph atlas only if fallback glyphs are
+  baseline-corrected. A full Zed-style glyph-run renderer remains the higher
+  ceiling, but this fix addresses the concrete drift without replacing the
+  renderer.
+- Windows font-quality bugs need reporter-facing dev builds and profile logs.
+  The tracker should keep #78 open until users confirm the perceived weight is
+  comfortable on real Windows displays.
+

--- a/postmortem/2026-05-11-windows-pane-resize-stale-frame.md
+++ b/postmortem/2026-05-11-windows-pane-resize-stale-frame.md
@@ -29,6 +29,12 @@ The cwd fallback also only covered the launch directory. It could not learn
 `cd` changes in default Windows PowerShell/pwsh sessions because those shells
 do not emit OSC 7 cwd updates by default.
 
+One more layer was missed in the first fix: even after Con injected OSC 7 into
+PowerShell/pwsh, `libghostty-vt`'s terminal-only stream handler ignores
+`report_pwd`. That is correct for upstream's low-level VT helper, but it means
+the Rust wrapper must capture OSC 7 itself if portable backends want live cwd
+state.
+
 ## Fix Applied
 
 The Windows terminal view now keeps stale cached readback images at their
@@ -43,7 +49,14 @@ The Windows `RenderSession` now mirrors the Linux fallback model: it stores the
 resolved shell cwd and returns it from `current_dir()` until the VT layer reports
 a newer directory. PowerShell/pwsh launches also get a lightweight prompt hook
 that emits OSC 7 on every prompt, so cwd snapshots follow real `cd` changes
-instead of freezing at the launch directory.
+instead of freezing at the launch directory. The shared Rust `VtScreen` wrapper
+now parses OSC 7 and sets `GHOSTTY_TERMINAL_OPT_PWD` manually, which makes the
+cwd path work on both Windows and Linux.
+
+The pane divider and chrome transition path now uses terminal-colored seam
+covers across portable backends too. Divider hit areas are absolute overlays
+around a 1px visible divider instead of 5px transparent layout strips, so drag
+targets stay usable without exposing the window backdrop between panes.
 
 ## What We Learned
 

--- a/postmortem/2026-05-11-windows-pane-resize-stale-frame.md
+++ b/postmortem/2026-05-11-windows-pane-resize-stale-frame.md
@@ -20,16 +20,30 @@ resolved ConPTY launch directory as a current-directory fallback. If shell
 integration had not yet reported a newer path, session snapshots could lose the
 restored cwd even though scrollback text was present.
 
+After the stretch was fixed, deleting the right pane exposed a second artifact:
+the old frame stayed correctly sized, but the newly revealed area to its right
+had no terminal-colored filler until the resized D3D frame arrived. That showed
+the transparent window backing for a few frames.
+
+The cwd fallback also only covered the launch directory. It could not learn
+`cd` changes in default Windows PowerShell/pwsh sessions because those shells
+do not emit OSC 7 cwd updates by default.
+
 ## Fix Applied
 
 The Windows terminal view now keeps stale cached readback images at their
 original logical size while the pane is resizing. The parent terminal surface
 clips overflow and paints its normal background until the renderer publishes the
-next frame, avoiding the visibly stretched text.
+next frame, avoiding the visibly stretched text. When the pane grows before the
+next frame arrives, only the uncovered stale-frame gutters are filled with the
+terminal background so glass opacity is preserved without double-compositing
+behind the old image.
 
 The Windows `RenderSession` now mirrors the Linux fallback model: it stores the
 resolved shell cwd and returns it from `current_dir()` until the VT layer reports
-a newer directory.
+a newer directory. PowerShell/pwsh launches also get a lightweight prompt hook
+that emits OSC 7 on every prompt, so cwd snapshots follow real `cd` changes
+instead of freezing at the launch directory.
 
 ## What We Learned
 
@@ -39,4 +53,7 @@ stable and letting the terminal background cover new space is less visually
 wrong than resampling text.
 
 For session continuity, every platform backend needs a reliable cwd fallback
-that survives the gap between process launch and shell-integration events.
+that survives the gap between process launch and shell-integration events. On
+Windows that fallback is not enough by itself: shells that do not emit OSC 7
+need integration at process launch, otherwise the app has no grounded way to
+know the user's current directory after `cd`.

--- a/postmortem/2026-05-11-windows-pane-resize-stale-frame.md
+++ b/postmortem/2026-05-11-windows-pane-resize-stale-frame.md
@@ -1,0 +1,42 @@
+# Windows Pane Resize Stale Frame
+
+## What Happened
+
+On Windows, closing or splitting panes could briefly show the surviving
+terminal content stretched to the new pane size before the terminal renderer
+published the resized frame. The artifact looked like old text being zoomed or
+reshaped for a few frames during pane layout changes.
+
+## Root Cause
+
+The Windows backend paints terminal content through a cached D3D11 readback
+image inside a GPUI image element. During a pane layout change, GPUI resized the
+image element immediately, but the D3D renderer had not yet produced a frame at
+the new physical size. Because the cached image used `ObjectFit::Fill` with
+`size_full`, the old readback texture was stretched to the new pane bounds.
+
+The same pass also found that Windows restored sessions did not retain the
+resolved ConPTY launch directory as a current-directory fallback. If shell
+integration had not yet reported a newer path, session snapshots could lose the
+restored cwd even though scrollback text was present.
+
+## Fix Applied
+
+The Windows terminal view now keeps stale cached readback images at their
+original logical size while the pane is resizing. The parent terminal surface
+clips overflow and paints its normal background until the renderer publishes the
+next frame, avoiding the visibly stretched text.
+
+The Windows `RenderSession` now mirrors the Linux fallback model: it stores the
+resolved shell cwd and returns it from `current_dir()` until the VT layer reports
+a newer directory.
+
+## What We Learned
+
+Cached terminal frames must be treated as size-stamped render artifacts, not
+stretchable UI imagery. When a terminal surface changes size, keeping old pixels
+stable and letting the terminal background cover new space is less visually
+wrong than resampling text.
+
+For session continuity, every platform backend needs a reliable cwd fallback
+that survives the gap between process launch and shell-integration events.


### PR DESCRIPTION
## Summary

This pass addresses the Windows rendering polish reports we can ground from the code and manual Windows feedback, while keeping the portable Linux selection work in the same branch because the input/copy semantics are shared release work.

- inset the Windows terminal content surface so the prompt no longer sits flush against the pane edge, while keeping hit testing, IME cursor bounds, link hover, scrollbar placement, and renderer dimensions on the same measured bounds
- align Windows caption buttons to the native right edge and restore visible hover feedback for minimize/maximize/close on Windows and Linux
- baseline-align fallback CJK/wide glyphs in the DirectWrite atlas and tune grayscale contrast so CJK text is less thin without reintroducing ClearType RGB fringing
- improve full-screen TUI readability on Windows by raising the alternate-screen default-background opacity floor
- keep stale D3D readback frames at their original logical size during pane close/split/resize so old terminal text no longer appears briefly zoomed before the next renderer frame arrives
- keep the resolved ConPTY launch cwd as the Windows current-directory fallback so restored sessions preserve the saved path until shell integration reports a newer one
- tighten portable selection behavior: Ctrl+C copies and clears selected text, padding-originated Windows drags are not forwarded to ConPTY, Linux selection clears when fresh terminal output replaces the grid, and the copy-selection decision is unit-tested
- document the current Windows/Linux state and keep the remaining maximize/live-resize smoothness work tracked in #34

## Issues

Addresses part of #131.

Targets the rendering issues reported in #124 and #78.

Improves the Windows track in #34, including restored cwd fallback and pane resize artifacts.

Keeps the remaining #125 resize/maximize smoothness issue tracked in #34 rather than claiming it fixed here; the current architecture still pays the D3D readback + GPUI image upload bridge until the direct-composition path lands.

## Validation

- `cargo fmt --check`
- `cargo check -p con`
- `cargo wcheck -p con`
- `cargo test -p con --bin con`
- `cargo test -p con-core --lib`
- `cargo test -p con-ghostty --lib`
- `python3 scripts/docs/validate-manifest.py`
- `git diff --check`

I also attempted `cargo check -p con --target x86_64-pc-windows-msvc --no-default-features --features con/bin-con-app` from macOS. It cannot reach our Windows Rust code on this machine because the local environment lacks the MSVC/Windows SDK toolchain (`lib.exe`, `windows.h`, CRT headers). Windows CI is the real compile gate for the platform-specific code in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added terminal text selection on Linux with Ctrl+C/Ctrl+Shift+C clipboard shortcuts

* **Bug Fixes**
  * Fixed CJK character baseline alignment and visual rendering
  * Fixed alternate-screen TUI background readability
  * Improved Windows caption button hover feedback
  * Fixed terminal frame artifacts during pane resize operations
  * Fixed Windows session restoration directory tracking with PowerShell integration
  * Improved cross-platform terminal selection and interrupt behavior

* **Changed**
  * Adjusted Windows terminal pane padding and caption alignment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->