### PR TITLE
feat: add con-test logic E2E framework

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,101 @@
+name: e2e
+
+# End-to-end tests using con-test against a real con process.
+# Runs on macOS only — con requires a display for the GPUI window.
+# con-test launches con automatically, resets state between files,
+# and kills the process on exit.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/e2e.yml"
+      - "crates/con-test/**"
+      - "crates/con-app/**"
+      - "crates/con-core/**"
+      - "crates/con-cli/**"
+      - "crates/con-ghostty/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  pull_request:
+    paths:
+      - ".github/workflows/e2e.yml"
+      - "crates/con-test/**"
+      - "crates/con-app/**"
+      - "crates/con-core/**"
+      - "crates/con-cli/**"
+      - "crates/con-ghostty/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings
+  # Suppress con's own log output during tests
+  RUST_LOG: error
+
+jobs:
+  e2e:
+    name: e2e (macos-latest)
+    runs-on: macos-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install Zig 0.15.2
+        shell: bash
+        run: |
+          set -euo pipefail
+          ZIG_VERSION="0.15.2"
+          ZIG_ARCH="aarch64"
+          # Use x86_64 on Intel runners
+          if [[ "$(uname -m)" == "x86_64" ]]; then
+            ZIG_ARCH="x86_64"
+          fi
+          ZIG_DIR="zig-${ZIG_ARCH}-macos-${ZIG_VERSION}"
+          ZIG_TARBALL="${ZIG_DIR}.tar.xz"
+          for base_url in \
+            "https://zigmirror.hryx.net/zig" \
+            "https://zig.linus.dev/zig" \
+            "https://ziglang.org/download/${ZIG_VERSION}"; do
+            if curl --retry 3 --retry-all-errors --retry-delay 5 \
+              --connect-timeout 30 --max-time 120 \
+              -sSfL "${base_url}/${ZIG_TARBALL}" \
+              -o "/tmp/${ZIG_TARBALL}"; then
+              break
+            fi
+          done
+          test -s "/tmp/${ZIG_TARBALL}"
+          mkdir -p "$HOME/.local"
+          tar -xJf "/tmp/${ZIG_TARBALL}" -C "$HOME/.local"
+          echo "$HOME/.local/${ZIG_DIR}" >> "$GITHUB_PATH"
+          "$HOME/.local/${ZIG_DIR}/zig" version
+
+      - name: Build con, con-cli, con-test
+        run: cargo build -p con -p con-cli -p con-test
+
+      - name: Run con-test unit tests (parser)
+        run: cargo test -p con-test
+
+      - name: Run E2E tests
+        run: |
+          ./target/debug/con-test \
+            --startup-timeout 30 \
+            crates/con-test/testdata/
+        env:
+          # Write con logs to a file so they don't pollute test output.
+          # Uploaded as an artifact on failure for debugging.
+          CON_LOG_FILE: /tmp/con-e2e.log
+
+      - name: Upload con log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: con-e2e-log
+          path: /tmp/con-e2e.log
+          retention-days: 7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,6 +1388,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "con-test"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde_json",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/con-ghostty",
     "crates/con-agent",
     "crates/con-cli",
+    "crates/con-test",
 ]
 default-members = ["crates/con-app"]
 resolver = "2"

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -786,6 +786,7 @@ impl PaneTree {
         rename_editor: Option<SurfaceRenameEditor>,
         divider_color: Hsla,
         tab_accent_color: Option<con_core::session::TabAccentColor>,
+        tab_accent_inactive_alpha: f32,
         hide_pane_title_bar: bool,
         cx: &App,
     ) -> AnyElement {
@@ -812,6 +813,7 @@ impl PaneTree {
                 zoomed_pane_id,
                 session_id,
                 tab_accent_color,
+                tab_accent_inactive_alpha,
                 hide_pane_title_bar,
                 cx,
             ) {
@@ -835,6 +837,7 @@ impl PaneTree {
             zoomed_pane_id,
             session_id,
             tab_accent_color,
+            tab_accent_inactive_alpha,
             hide_pane_title_bar,
             cx,
         )
@@ -1517,6 +1520,7 @@ impl PaneTree {
         zoomed_pane_id: Option<PaneId>,
         session_id: u64,
         tab_accent_color: Option<con_core::session::TabAccentColor>,
+        tab_accent_inactive_alpha: f32,
         hide_pane_title_bar: bool,
         cx: &App,
     ) -> AnyElement {
@@ -1540,6 +1544,7 @@ impl PaneTree {
                 zoomed_pane_id,
                 session_id,
                 tab_accent_color,
+                tab_accent_inactive_alpha,
                 hide_pane_title_bar,
                 cx,
             ),
@@ -1586,6 +1591,7 @@ impl PaneTree {
                     zoomed_pane_id,
                     session_id,
                     tab_accent_color,
+                    tab_accent_inactive_alpha,
                     hide_pane_title_bar,
                     cx,
                 );
@@ -1605,6 +1611,7 @@ impl PaneTree {
                     zoomed_pane_id,
                     session_id,
                     tab_accent_color,
+                    tab_accent_inactive_alpha,
                     hide_pane_title_bar,
                     cx,
                 );
@@ -1769,6 +1776,7 @@ impl PaneTree {
         zoomed_pane_id: Option<PaneId>,
         session_id: u64,
         tab_accent_color: Option<con_core::session::TabAccentColor>,
+        tab_accent_inactive_alpha: f32,
         hide_pane_title_bar: bool,
         cx: &App,
     ) -> Option<AnyElement> {
@@ -1792,6 +1800,7 @@ impl PaneTree {
                 zoomed_pane_id,
                 session_id,
                 tab_accent_color,
+                tab_accent_inactive_alpha,
                 hide_pane_title_bar,
                 cx,
             )),
@@ -1810,6 +1819,7 @@ impl PaneTree {
                 zoomed_pane_id,
                 session_id,
                 tab_accent_color,
+                tab_accent_inactive_alpha,
                 hide_pane_title_bar,
                 cx,
             )
@@ -1828,6 +1838,7 @@ impl PaneTree {
                     zoomed_pane_id,
                     session_id,
                     tab_accent_color,
+                    tab_accent_inactive_alpha,
                     hide_pane_title_bar,
                     cx,
                 )
@@ -1846,6 +1857,7 @@ impl PaneTree {
         has_splits: bool,
         is_zoomed: bool,
         tab_accent_color: Option<con_core::session::TabAccentColor>,
+        tab_accent_inactive_alpha: f32,
         close_pane_cb: std::sync::Arc<dyn Fn(PaneId, &mut Window, &mut App) + 'static>,
         toggle_zoom_cb: std::sync::Arc<dyn Fn(PaneId, &mut Window, &mut App) + 'static>,
         cx: &App,
@@ -1862,11 +1874,7 @@ impl PaneTree {
                 theme.tab_bar_segmented
             }
         } else if let Some(color) = tab_accent_color {
-            crate::tab_colors::tab_accent_surface_hsla(
-                color,
-                crate::tab_colors::TAB_ACCENT_INACTIVE_ALPHA,
-                cx,
-            )
+            crate::tab_colors::tab_accent_surface_hsla(color, tab_accent_inactive_alpha, cx)
         } else {
             theme.tab_bar_segmented.opacity(0.78)
         };
@@ -2008,6 +2016,7 @@ impl PaneTree {
         zoomed_pane_id: Option<PaneId>,
         session_id: u64,
         tab_accent_color: Option<con_core::session::TabAccentColor>,
+        tab_accent_inactive_alpha: f32,
         hide_pane_title_bar: bool,
         cx: &App,
     ) -> AnyElement {
@@ -2058,6 +2067,7 @@ impl PaneTree {
                 tree_has_splits,
                 is_zoomed,
                 tab_accent_color,
+                tab_accent_inactive_alpha,
                 close_pane_cb,
                 toggle_zoom_cb,
                 cx,

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -14,6 +14,14 @@ use crate::terminal_pane::TerminalPane;
 const RESTORED_SCREEN_TEXT_MAX_LINES: usize = 600;
 const RESTORED_SCREEN_TEXT_MAX_BYTES: usize = 128 * 1024;
 
+fn sanitize_tab_accent_alpha(alpha: f32) -> f32 {
+    if alpha.is_finite() {
+        alpha.clamp(0.0, 1.0)
+    } else {
+        crate::tab_colors::TAB_ACCENT_INACTIVE_ALPHA
+    }
+}
+
 /// Split direction for pane layout
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SplitDirection {
@@ -1874,7 +1882,8 @@ impl PaneTree {
                 theme.tab_bar_segmented
             }
         } else if let Some(color) = tab_accent_color {
-            crate::tab_colors::tab_accent_surface_hsla(color, tab_accent_inactive_alpha, cx)
+            let inactive_alpha = sanitize_tab_accent_alpha(tab_accent_inactive_alpha);
+            crate::tab_colors::tab_accent_surface_hsla(color, inactive_alpha, cx)
         } else {
             theme.tab_bar_segmented.opacity(0.78)
         };

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -6,7 +6,7 @@ use con_agent::{
 use con_core::{
     Config,
     config::{
-        DEFAULT_TERMINAL_FONT_FAMILY, MAX_UI_FONT_SIZE, MIN_UI_FONT_SIZE,
+        AppearanceConfig, DEFAULT_TERMINAL_FONT_FAMILY, MAX_UI_FONT_SIZE, MIN_UI_FONT_SIZE,
         is_gpui_pseudo_font_family, sanitize_terminal_font_family,
     },
 };
@@ -133,6 +133,8 @@ pub struct SettingsPanel {
     terminal_opacity_slider: Entity<SliderState>,
     terminal_blur: bool,
     ui_opacity_slider: Entity<SliderState>,
+    tab_accent_inactive_alpha_slider: Entity<SliderState>,
+    tab_accent_inactive_hover_alpha_slider: Entity<SliderState>,
     background_image_input: Entity<InputState>,
     background_image_opacity_slider: Entity<SliderState>,
     background_image_position_select: Entity<SelectState<Vec<String>>>,
@@ -219,6 +221,33 @@ impl SettingsPanel {
 
     fn ui_opacity_value(&self) -> f32 {
         Self::clamp_ui_opacity(self.config.appearance.ui_opacity)
+    }
+
+    fn clamp_tab_accent_inactive_alpha(value: f32) -> f32 {
+        value.clamp(
+            AppearanceConfig::MIN_TAB_ACCENT_ALPHA,
+            AppearanceConfig::MAX_TAB_ACCENT_INACTIVE_ALPHA,
+        )
+    }
+
+    fn clamp_tab_accent_inactive_hover_alpha(value: f32, inactive: f32) -> f32 {
+        value
+            .clamp(
+                AppearanceConfig::MIN_TAB_ACCENT_ALPHA,
+                AppearanceConfig::MAX_TAB_ACCENT_INACTIVE_HOVER_ALPHA,
+            )
+            .max(inactive)
+    }
+
+    fn tab_accent_inactive_alpha_value(&self) -> f32 {
+        Self::clamp_tab_accent_inactive_alpha(self.config.appearance.tab_accent_inactive_alpha)
+    }
+
+    fn tab_accent_inactive_hover_alpha_value(&self) -> f32 {
+        Self::clamp_tab_accent_inactive_hover_alpha(
+            self.config.appearance.tab_accent_inactive_hover_alpha,
+            self.tab_accent_inactive_alpha_value(),
+        )
     }
 
     fn clamp_background_image_opacity(value: f32) -> f32 {
@@ -1132,6 +1161,27 @@ impl SettingsPanel {
                 .step(0.01)
                 .default_value(Self::clamp_ui_opacity(config.appearance.ui_opacity))
         });
+        let tab_accent_inactive_alpha_slider = cx.new(|_| {
+            SliderState::new()
+                .min(AppearanceConfig::MIN_TAB_ACCENT_ALPHA)
+                .max(AppearanceConfig::MAX_TAB_ACCENT_INACTIVE_ALPHA)
+                .step(0.01)
+                .default_value(Self::clamp_tab_accent_inactive_alpha(
+                    config.appearance.tab_accent_inactive_alpha,
+                ))
+        });
+        let tab_accent_inactive_hover_alpha_slider = cx.new(|_| {
+            let inactive =
+                Self::clamp_tab_accent_inactive_alpha(config.appearance.tab_accent_inactive_alpha);
+            SliderState::new()
+                .min(AppearanceConfig::MIN_TAB_ACCENT_ALPHA)
+                .max(AppearanceConfig::MAX_TAB_ACCENT_INACTIVE_HOVER_ALPHA)
+                .step(0.01)
+                .default_value(Self::clamp_tab_accent_inactive_hover_alpha(
+                    config.appearance.tab_accent_inactive_hover_alpha,
+                    inactive,
+                ))
+        });
         let background_image_input = cx.new(|cx| {
             let mut s = InputState::new(window, cx);
             s.set_placeholder("~/Pictures/wallpaper.jpg", window, cx);
@@ -1190,6 +1240,38 @@ impl SettingsPanel {
             |this, _, event: &SliderEvent, cx| match event {
                 SliderEvent::Change(value) => {
                     this.config.appearance.ui_opacity = Self::clamp_ui_opacity(value.end());
+                    cx.emit(AppearancePreview);
+                    cx.notify();
+                }
+            },
+        )
+        .detach();
+        cx.subscribe(
+            &tab_accent_inactive_alpha_slider,
+            |this, _, event: &SliderEvent, cx| match event {
+                SliderEvent::Change(value) => {
+                    let inactive = Self::clamp_tab_accent_inactive_alpha(value.end());
+                    this.config.appearance.tab_accent_inactive_alpha = inactive;
+                    let hover = Self::clamp_tab_accent_inactive_hover_alpha(
+                        this.config.appearance.tab_accent_inactive_hover_alpha,
+                        inactive,
+                    );
+                    this.config.appearance.tab_accent_inactive_hover_alpha = hover;
+                    cx.emit(AppearancePreview);
+                    cx.notify();
+                }
+            },
+        )
+        .detach();
+        cx.subscribe(
+            &tab_accent_inactive_hover_alpha_slider,
+            |this, _, event: &SliderEvent, cx| match event {
+                SliderEvent::Change(value) => {
+                    let inactive = Self::clamp_tab_accent_inactive_alpha(
+                        this.config.appearance.tab_accent_inactive_alpha,
+                    );
+                    this.config.appearance.tab_accent_inactive_hover_alpha =
+                        Self::clamp_tab_accent_inactive_hover_alpha(value.end(), inactive);
                     cx.emit(AppearancePreview);
                     cx.notify();
                 }
@@ -1356,6 +1438,8 @@ impl SettingsPanel {
             terminal_opacity_slider,
             terminal_blur: config.appearance.terminal_blur,
             ui_opacity_slider,
+            tab_accent_inactive_alpha_slider,
+            tab_accent_inactive_hover_alpha_slider,
             background_image_input,
             background_image_opacity_slider,
             background_image_position_select,
@@ -1508,6 +1592,29 @@ impl SettingsPanel {
                 cx,
             );
         });
+        self.tab_accent_inactive_alpha_slider
+            .update(cx, |slider, cx| {
+                slider.set_value(
+                    Self::clamp_tab_accent_inactive_alpha(
+                        self.config.appearance.tab_accent_inactive_alpha,
+                    ),
+                    window,
+                    cx,
+                );
+            });
+        self.tab_accent_inactive_hover_alpha_slider
+            .update(cx, |slider, cx| {
+                slider.set_value(
+                    Self::clamp_tab_accent_inactive_hover_alpha(
+                        self.config.appearance.tab_accent_inactive_hover_alpha,
+                        Self::clamp_tab_accent_inactive_alpha(
+                            self.config.appearance.tab_accent_inactive_alpha,
+                        ),
+                    ),
+                    window,
+                    cx,
+                );
+            });
         self.background_image_input.update(cx, |s, cx| {
             s.set_value(
                 &self
@@ -2104,6 +2211,17 @@ impl SettingsPanel {
         self.config.appearance.terminal_blur = self.terminal_blur;
         self.config.appearance.ui_opacity =
             Self::clamp_ui_opacity(self.ui_opacity_slider.read(cx).value().end());
+        self.config.appearance.tab_accent_inactive_alpha = Self::clamp_tab_accent_inactive_alpha(
+            self.tab_accent_inactive_alpha_slider.read(cx).value().end(),
+        );
+        self.config.appearance.tab_accent_inactive_hover_alpha =
+            Self::clamp_tab_accent_inactive_hover_alpha(
+                self.tab_accent_inactive_hover_alpha_slider
+                    .read(cx)
+                    .value()
+                    .end(),
+                self.config.appearance.tab_accent_inactive_alpha,
+            );
         let background_image_text = self
             .background_image_input
             .read(cx)
@@ -2960,12 +3078,17 @@ impl SettingsPanel {
         let ui_font_size_input = self.ui_font_size_input.clone();
         let terminal_opacity_slider = self.terminal_opacity_slider.clone();
         let ui_opacity_slider = self.ui_opacity_slider.clone();
+        let tab_accent_inactive_alpha_slider = self.tab_accent_inactive_alpha_slider.clone();
+        let tab_accent_inactive_hover_alpha_slider =
+            self.tab_accent_inactive_hover_alpha_slider.clone();
         let background_image_input = self.background_image_input.clone();
         let background_image_opacity_slider = self.background_image_opacity_slider.clone();
         let background_image_position_select = self.background_image_position_select.clone();
         let background_image_fit_select = self.background_image_fit_select.clone();
         let terminal_opacity = self.terminal_opacity_value();
         let ui_opacity = self.ui_opacity_value();
+        let tab_accent_inactive_alpha = self.tab_accent_inactive_alpha_value();
+        let tab_accent_inactive_hover_alpha = self.tab_accent_inactive_hover_alpha_value();
         let background_image_opacity = self.background_image_opacity_value();
         let card_opacity = self.card_opacity();
         let image_repeat_toggle = Switch::new("background-image-repeat")
@@ -3318,6 +3441,22 @@ impl SettingsPanel {
                                     cx.emit(AppearancePreview);
                                     cx.notify();
                                 })),
+                            theme,
+                        ))
+                        .child(row_separator(theme))
+                        .child(slider_row(
+                            "Inactive Accent",
+                            "Accent strength for inactive tabs and unfocused pane titles.",
+                            &tab_accent_inactive_alpha_slider,
+                            tab_accent_inactive_alpha,
+                            theme,
+                        ))
+                        .child(row_separator(theme))
+                        .child(slider_row(
+                            "Hover Accent",
+                            "Accent strength when hovering inactive tabs.",
+                            &tab_accent_inactive_hover_alpha_slider,
+                            tab_accent_inactive_hover_alpha,
                             theme,
                         )),
                 ),

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -224,19 +224,26 @@ impl SettingsPanel {
     }
 
     fn clamp_tab_accent_inactive_alpha(value: f32) -> f32 {
-        value.clamp(
-            AppearanceConfig::MIN_TAB_ACCENT_ALPHA,
-            AppearanceConfig::MAX_TAB_ACCENT_INACTIVE_ALPHA,
-        )
+        if value.is_finite() {
+            value.clamp(
+                AppearanceConfig::MIN_TAB_ACCENT_ALPHA,
+                AppearanceConfig::MAX_TAB_ACCENT_INACTIVE_ALPHA,
+            )
+        } else {
+            crate::tab_colors::TAB_ACCENT_INACTIVE_ALPHA
+        }
     }
 
     fn clamp_tab_accent_inactive_hover_alpha(value: f32, inactive: f32) -> f32 {
-        value
-            .clamp(
+        let value = if value.is_finite() {
+            value.clamp(
                 AppearanceConfig::MIN_TAB_ACCENT_ALPHA,
                 AppearanceConfig::MAX_TAB_ACCENT_INACTIVE_HOVER_ALPHA,
             )
-            .max(inactive)
+        } else {
+            crate::tab_colors::TAB_ACCENT_INACTIVE_HOVER_ALPHA
+        };
+        value.max(inactive)
     }
 
     fn tab_accent_inactive_alpha_value(&self) -> f32 {

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -1253,9 +1253,10 @@ impl SettingsPanel {
             },
         )
         .detach();
-        cx.subscribe(
+        cx.subscribe_in(
             &tab_accent_inactive_alpha_slider,
-            |this, _, event: &SliderEvent, cx| match event {
+            window,
+            |this, _, event: &SliderEvent, window, cx| match event {
                 SliderEvent::Change(value) => {
                     let inactive = Self::clamp_tab_accent_inactive_alpha(value.end());
                     this.config.appearance.tab_accent_inactive_alpha = inactive;
@@ -1264,21 +1265,26 @@ impl SettingsPanel {
                         inactive,
                     );
                     this.config.appearance.tab_accent_inactive_hover_alpha = hover;
+                    this.tab_accent_inactive_hover_alpha_slider
+                        .update(cx, |slider, cx| slider.set_value(hover, window, cx));
                     cx.emit(AppearancePreview);
                     cx.notify();
                 }
             },
         )
         .detach();
-        cx.subscribe(
+        cx.subscribe_in(
             &tab_accent_inactive_hover_alpha_slider,
-            |this, _, event: &SliderEvent, cx| match event {
+            window,
+            |this, _, event: &SliderEvent, window, cx| match event {
                 SliderEvent::Change(value) => {
                     let inactive = Self::clamp_tab_accent_inactive_alpha(
                         this.config.appearance.tab_accent_inactive_alpha,
                     );
-                    this.config.appearance.tab_accent_inactive_hover_alpha =
-                        Self::clamp_tab_accent_inactive_hover_alpha(value.end(), inactive);
+                    let hover = Self::clamp_tab_accent_inactive_hover_alpha(value.end(), inactive);
+                    this.config.appearance.tab_accent_inactive_hover_alpha = hover;
+                    this.tab_accent_inactive_hover_alpha_slider
+                        .update(cx, |slider, cx| slider.set_value(hover, window, cx));
                     cx.emit(AppearancePreview);
                     cx.notify();
                 }

--- a/crates/con-app/src/sidebar.rs
+++ b/crates/con-app/src/sidebar.rs
@@ -272,6 +272,8 @@ pub struct SessionSidebar {
     /// Lower values let the window/terminal backdrop treatment show
     /// through, matching the rest of con's chrome.
     ui_opacity: f32,
+    tab_accent_inactive_alpha: f32,
+    tab_accent_inactive_hover_alpha: f32,
 }
 
 pub struct SidebarSelect {
@@ -348,6 +350,8 @@ impl SessionSidebar {
             tab_bounds: Rc::new(RefCell::new(Vec::new())),
             drag_preview: Rc::new(RefCell::new(None)),
             ui_opacity: 0.92,
+            tab_accent_inactive_alpha: crate::tab_colors::TAB_ACCENT_INACTIVE_ALPHA,
+            tab_accent_inactive_hover_alpha: crate::tab_colors::TAB_ACCENT_INACTIVE_HOVER_ALPHA,
         }
     }
 
@@ -367,6 +371,21 @@ impl SessionSidebar {
         let opacity = opacity.clamp(0.55, 0.98);
         if (self.ui_opacity - opacity).abs() > f32::EPSILON {
             self.ui_opacity = opacity;
+            cx.notify();
+        }
+    }
+
+    pub fn set_tab_accent_alphas(
+        &mut self,
+        inactive_alpha: f32,
+        inactive_hover_alpha: f32,
+        cx: &mut Context<Self>,
+    ) {
+        if (self.tab_accent_inactive_alpha - inactive_alpha).abs() > f32::EPSILON
+            || (self.tab_accent_inactive_hover_alpha - inactive_hover_alpha).abs() > f32::EPSILON
+        {
+            self.tab_accent_inactive_alpha = inactive_alpha;
+            self.tab_accent_inactive_hover_alpha = inactive_hover_alpha;
             cx.notify();
         }
     }
@@ -849,7 +868,7 @@ impl SessionSidebar {
                     .map(|color| {
                         crate::tab_colors::tab_accent_surface_hsla(
                             color,
-                            crate::tab_colors::TAB_ACCENT_INACTIVE_ALPHA,
+                            self.tab_accent_inactive_alpha,
                             cx,
                         )
                     })
@@ -859,7 +878,7 @@ impl SessionSidebar {
                 .map(|color| {
                     crate::tab_colors::tab_accent_surface_hsla(
                         color,
-                        crate::tab_colors::TAB_ACCENT_INACTIVE_HOVER_ALPHA,
+                        self.tab_accent_inactive_hover_alpha,
                         cx,
                     )
                 })

--- a/crates/con-app/src/sidebar.rs
+++ b/crates/con-app/src/sidebar.rs
@@ -381,6 +381,9 @@ impl SessionSidebar {
         inactive_hover_alpha: f32,
         cx: &mut Context<Self>,
     ) {
+        let inactive_alpha = sanitize_tab_accent_alpha(inactive_alpha);
+        let inactive_hover_alpha =
+            sanitize_tab_accent_alpha(inactive_hover_alpha).max(inactive_alpha);
         if (self.tab_accent_inactive_alpha - inactive_alpha).abs() > f32::EPSILON
             || (self.tab_accent_inactive_hover_alpha - inactive_hover_alpha).abs() > f32::EPSILON
         {
@@ -1484,7 +1487,7 @@ impl SessionSidebar {
                 .map(|color| {
                     crate::tab_colors::tab_accent_surface_hsla(
                         color,
-                        crate::tab_colors::TAB_ACCENT_INACTIVE_ALPHA,
+                        self.tab_accent_inactive_alpha,
                         cx,
                     )
                 })
@@ -1495,7 +1498,7 @@ impl SessionSidebar {
             .map(|color| {
                 crate::tab_colors::tab_accent_surface_hsla(
                     color,
-                    crate::tab_colors::TAB_ACCENT_INACTIVE_HOVER_ALPHA,
+                    self.tab_accent_inactive_hover_alpha,
                     cx,
                 )
             })
@@ -1746,6 +1749,14 @@ fn sidebar_surface(theme: &gpui_component::Theme, opacity: f32, intensity: f32) 
 
 fn elevated_surface(theme: &gpui_component::Theme, opacity: f32) -> Hsla {
     theme.background.opacity((opacity + 0.06).min(0.98))
+}
+
+fn sanitize_tab_accent_alpha(alpha: f32) -> f32 {
+    if alpha.is_finite() {
+        alpha.clamp(0.0, 1.0)
+    } else {
+        crate::tab_colors::TAB_ACCENT_INACTIVE_ALPHA
+    }
 }
 
 /// 2-px horizontal drop indicator drawn above (`above=true`) or

--- a/crates/con-app/src/tab_colors.rs
+++ b/crates/con-app/src/tab_colors.rs
@@ -3,8 +3,8 @@ use gpui::{App, Hsla};
 use gpui_component::ActiveTheme;
 
 pub(crate) const TAB_ACCENT_ACTIVE_ALPHA: f32 = 0.35;
-pub(crate) const TAB_ACCENT_INACTIVE_ALPHA: f32 = 0.12;
-pub(crate) const TAB_ACCENT_INACTIVE_HOVER_ALPHA: f32 = 0.20;
+pub(crate) const TAB_ACCENT_INACTIVE_ALPHA: f32 = 0.15;
+pub(crate) const TAB_ACCENT_INACTIVE_HOVER_ALPHA: f32 = 0.22;
 
 /// Map a `TabAccentColor` to an `Hsla` for rendering dots and tab backgrounds.
 pub(crate) fn tab_accent_color_hsla(color: TabAccentColor, cx: &App) -> Hsla {
@@ -34,4 +34,16 @@ pub(crate) fn tab_accent_surface_hsla(color: TabAccentColor, alpha: f32, cx: &Ap
 /// Green dot used to indicate the active tab when no explicit accent color is set.
 pub(crate) fn active_tab_indicator_color() -> Hsla {
     gpui::hsla(142.0 / 360.0, 0.60, 0.42, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tab_accent_inactive_alpha_stays_visible() {
+        assert_eq!(TAB_ACCENT_ACTIVE_ALPHA, 0.35);
+        assert_eq!(TAB_ACCENT_INACTIVE_ALPHA, 0.15);
+        assert_eq!(TAB_ACCENT_INACTIVE_HOVER_ALPHA, 0.22);
+    }
 }

--- a/crates/con-app/src/tab_colors.rs
+++ b/crates/con-app/src/tab_colors.rs
@@ -35,15 +35,3 @@ pub(crate) fn tab_accent_surface_hsla(color: TabAccentColor, alpha: f32, cx: &Ap
 pub(crate) fn active_tab_indicator_color() -> Hsla {
     gpui::hsla(142.0 / 360.0, 0.60, 0.42, 1.0)
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn tab_accent_inactive_alpha_stays_visible() {
-        assert_eq!(TAB_ACCENT_ACTIVE_ALPHA, 0.35);
-        assert_eq!(TAB_ACCENT_INACTIVE_ALPHA, 0.15);
-        assert_eq!(TAB_ACCENT_INACTIVE_HOVER_ALPHA, 0.22);
-    }
-}

--- a/crates/con-app/src/workspace/lifecycle.rs
+++ b/crates/con-app/src/workspace/lifecycle.rs
@@ -40,8 +40,17 @@ impl ConWorkspace {
         let terminal_opacity = Self::effective_terminal_opacity(config.appearance.terminal_opacity);
         let terminal_blur = Self::effective_terminal_blur(config.appearance.terminal_blur);
         let ui_opacity = Self::clamp_ui_opacity(config.appearance.ui_opacity);
+        let tab_accent_inactive_alpha = config.appearance.tab_accent_inactive_alpha;
+        let tab_accent_inactive_hover_alpha = config.appearance.tab_accent_inactive_hover_alpha;
         let effective_ui_opacity = Self::effective_ui_opacity(ui_opacity);
-        sidebar.update(cx, |s, cx| s.set_ui_opacity(effective_ui_opacity, cx));
+        sidebar.update(cx, |s, cx| {
+            s.set_ui_opacity(effective_ui_opacity, cx);
+            s.set_tab_accent_alphas(
+                tab_accent_inactive_alpha,
+                tab_accent_inactive_hover_alpha,
+                cx,
+            );
+        });
         let background_image = config.appearance.background_image.clone();
         let background_image_opacity =
             Self::clamp_background_image_opacity(config.appearance.background_image_opacity);
@@ -651,6 +660,8 @@ impl ConWorkspace {
             terminal_opacity,
             terminal_blur,
             ui_opacity,
+            tab_accent_inactive_alpha,
+            tab_accent_inactive_hover_alpha,
             background_image,
             background_image_opacity,
             background_image_position,

--- a/crates/con-app/src/workspace/mod.rs
+++ b/crates/con-app/src/workspace/mod.rs
@@ -148,6 +148,8 @@ pub struct ConWorkspace {
     terminal_opacity: f32,
     terminal_blur: bool,
     ui_opacity: f32,
+    tab_accent_inactive_alpha: f32,
+    tab_accent_inactive_hover_alpha: f32,
     background_image: Option<String>,
     background_image_opacity: f32,
     background_image_position: String,

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -410,6 +410,7 @@ impl Render for ConWorkspace {
                 self.surface_rename.clone(),
                 pane_divider_color,
                 tab_accent_color,
+                self.tab_accent_inactive_alpha,
                 self.hide_pane_title_bar,
                 cx,
             )

--- a/crates/con-app/src/workspace/render/top_bar.rs
+++ b/crates/con-app/src/workspace/render/top_bar.rs
@@ -1,6 +1,14 @@
 use super::super::*;
 use gpui_component::menu::ContextMenuExt;
 
+fn sanitize_tab_accent_alpha(alpha: f32) -> f32 {
+    if alpha.is_finite() {
+        alpha.clamp(0.0, 1.0)
+    } else {
+        crate::tab_colors::TAB_ACCENT_INACTIVE_ALPHA
+    }
+}
+
 impl ConWorkspace {
     pub(super) fn render_top_bar(
         &mut self,
@@ -562,20 +570,20 @@ impl ConWorkspace {
                         .text_color(theme.foreground)
                         .font_weight(FontWeight::MEDIUM);
                 } else {
+                    let inactive_alpha = sanitize_tab_accent_alpha(self.tab_accent_inactive_alpha);
+                    let inactive_hover_alpha =
+                        sanitize_tab_accent_alpha(self.tab_accent_inactive_hover_alpha)
+                            .max(inactive_alpha);
                     let inactive_bg = tab_color
                         .map(|color| {
-                            crate::tab_colors::tab_accent_surface_hsla(
-                                color,
-                                self.tab_accent_inactive_alpha,
-                                cx,
-                            )
+                            crate::tab_colors::tab_accent_surface_hsla(color, inactive_alpha, cx)
                         })
                         .unwrap_or(theme.background.opacity(0.14));
                     let inactive_hover_bg = tab_color
                         .map(|color| {
                             crate::tab_colors::tab_accent_surface_hsla(
                                 color,
-                                self.tab_accent_inactive_hover_alpha,
+                                inactive_hover_alpha,
                                 cx,
                             )
                         })

--- a/crates/con-app/src/workspace/render/top_bar.rs
+++ b/crates/con-app/src/workspace/render/top_bar.rs
@@ -566,7 +566,7 @@ impl ConWorkspace {
                         .map(|color| {
                             crate::tab_colors::tab_accent_surface_hsla(
                                 color,
-                                crate::tab_colors::TAB_ACCENT_INACTIVE_ALPHA,
+                                self.tab_accent_inactive_alpha,
                                 cx,
                             )
                         })
@@ -575,7 +575,7 @@ impl ConWorkspace {
                         .map(|color| {
                             crate::tab_colors::tab_accent_surface_hsla(
                                 color,
-                                crate::tab_colors::TAB_ACCENT_INACTIVE_HOVER_ALPHA,
+                                self.tab_accent_inactive_hover_alpha,
                                 cx,
                             )
                         })

--- a/crates/con-app/src/workspace/sidebar_settings.rs
+++ b/crates/con-app/src/workspace/sidebar_settings.rs
@@ -969,6 +969,8 @@ impl ConWorkspace {
         self.terminal_opacity = next_terminal_opacity;
         self.terminal_blur = next_terminal_blur;
         self.ui_opacity = Self::clamp_ui_opacity(appearance_config.ui_opacity);
+        self.tab_accent_inactive_alpha = appearance_config.tab_accent_inactive_alpha;
+        self.tab_accent_inactive_hover_alpha = appearance_config.tab_accent_inactive_hover_alpha;
         self.background_image = next_background_image;
         self.background_image_opacity = next_background_image_opacity;
         self.background_image_position = next_background_image_position;
@@ -1018,6 +1020,13 @@ impl ConWorkspace {
             .update(cx, |bar, _cx| bar.set_ui_opacity(effective_ui_opacity));
         self.sidebar
             .update(cx, |s, cx| s.set_ui_opacity(effective_ui_opacity, cx));
+        self.sidebar.update(cx, |s, cx| {
+            s.set_tab_accent_alphas(
+                self.tab_accent_inactive_alpha,
+                self.tab_accent_inactive_hover_alpha,
+                cx,
+            )
+        });
         self.command_palette.update(cx, |palette, _cx| {
             palette.set_ui_opacity(effective_ui_opacity)
         });

--- a/crates/con-app/src/workspace/sidebar_settings.rs
+++ b/crates/con-app/src/workspace/sidebar_settings.rs
@@ -1,5 +1,13 @@
 use super::*;
 
+fn sanitize_tab_accent_alpha(alpha: f32) -> f32 {
+    if alpha.is_finite() {
+        alpha.clamp(0.0, 1.0)
+    } else {
+        crate::tab_colors::TAB_ACCENT_INACTIVE_ALPHA
+    }
+}
+
 impl ConWorkspace {
     pub(super) fn on_sidebar_select(
         &mut self,
@@ -969,8 +977,11 @@ impl ConWorkspace {
         self.terminal_opacity = next_terminal_opacity;
         self.terminal_blur = next_terminal_blur;
         self.ui_opacity = Self::clamp_ui_opacity(appearance_config.ui_opacity);
-        self.tab_accent_inactive_alpha = appearance_config.tab_accent_inactive_alpha;
-        self.tab_accent_inactive_hover_alpha = appearance_config.tab_accent_inactive_hover_alpha;
+        self.tab_accent_inactive_alpha =
+            sanitize_tab_accent_alpha(appearance_config.tab_accent_inactive_alpha);
+        self.tab_accent_inactive_hover_alpha =
+            sanitize_tab_accent_alpha(appearance_config.tab_accent_inactive_hover_alpha)
+                .max(self.tab_accent_inactive_alpha);
         self.background_image = next_background_image;
         self.background_image_opacity = next_background_image_opacity;
         self.background_image_position = next_background_image_position;

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -50,6 +50,15 @@ fn default_tab_accent_inactive_alpha() -> f32 {
 fn default_tab_accent_inactive_hover_alpha() -> f32 {
     0.22
 }
+
+fn sanitize_tab_accent_alpha(value: f32, default: f32, max: f32) -> f32 {
+    if value.is_finite() {
+        value.clamp(AppearanceConfig::MIN_TAB_ACCENT_ALPHA, max)
+    } else {
+        default
+    }
+}
+
 fn default_restore_terminal_text() -> bool {
     true
 }
@@ -162,17 +171,17 @@ impl AppearanceConfig {
     pub const MAX_TAB_ACCENT_INACTIVE_HOVER_ALPHA: f32 = 0.40;
 
     pub fn normalize(&mut self) {
-        self.tab_accent_inactive_alpha = self.tab_accent_inactive_alpha.clamp(
-            Self::MIN_TAB_ACCENT_ALPHA,
+        self.tab_accent_inactive_alpha = sanitize_tab_accent_alpha(
+            self.tab_accent_inactive_alpha,
+            default_tab_accent_inactive_alpha(),
             Self::MAX_TAB_ACCENT_INACTIVE_ALPHA,
         );
-        self.tab_accent_inactive_hover_alpha = self
-            .tab_accent_inactive_hover_alpha
-            .clamp(
-                Self::MIN_TAB_ACCENT_ALPHA,
-                Self::MAX_TAB_ACCENT_INACTIVE_HOVER_ALPHA,
-            )
-            .max(self.tab_accent_inactive_alpha);
+        self.tab_accent_inactive_hover_alpha = sanitize_tab_accent_alpha(
+            self.tab_accent_inactive_hover_alpha,
+            default_tab_accent_inactive_hover_alpha(),
+            Self::MAX_TAB_ACCENT_INACTIVE_HOVER_ALPHA,
+        )
+        .max(self.tab_accent_inactive_alpha);
     }
 }
 

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -724,53 +724,6 @@ restore_terminal_text = false
     }
 
     #[test]
-    fn tab_accent_alpha_defaults_are_visible() {
-        let config = Config::default();
-        assert_eq!(config.appearance.tab_accent_inactive_alpha, 0.15);
-        assert_eq!(config.appearance.tab_accent_inactive_hover_alpha, 0.22);
-    }
-
-    #[test]
-    fn legacy_configs_receive_tab_accent_alpha_defaults() {
-        let content = r#"
-[appearance]
-terminal_opacity = 0.8
-"#;
-        let config: Config = toml::from_str(content).unwrap();
-
-        assert_eq!(config.appearance.tab_accent_inactive_alpha, 0.15);
-        assert_eq!(config.appearance.tab_accent_inactive_hover_alpha, 0.22);
-    }
-
-    #[test]
-    fn tab_accent_alpha_values_are_clamped_after_load() {
-        let content = r#"
-[appearance]
-tab_accent_inactive_alpha = 0.001
-tab_accent_inactive_hover_alpha = 0.02
-"#;
-        let mut config: Config = toml::from_str(content).unwrap();
-        config.normalize();
-
-        assert_eq!(config.appearance.tab_accent_inactive_alpha, 0.05);
-        assert_eq!(config.appearance.tab_accent_inactive_hover_alpha, 0.05);
-    }
-
-    #[test]
-    fn tab_accent_hover_alpha_never_drops_below_inactive_alpha() {
-        let content = r#"
-[appearance]
-tab_accent_inactive_alpha = 0.20
-tab_accent_inactive_hover_alpha = 0.10
-"#;
-        let mut config: Config = toml::from_str(content).unwrap();
-        config.normalize();
-
-        assert_eq!(config.appearance.tab_accent_inactive_alpha, 0.20);
-        assert_eq!(config.appearance.tab_accent_inactive_hover_alpha, 0.20);
-    }
-
-    #[test]
     fn default_keybindings_include_quick_terminal_fields() {
         let config = Config::default();
         assert!(!config.keybindings.quick_terminal_enabled);

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -44,6 +44,12 @@ fn default_background_image_position() -> String {
 fn default_background_image_fit() -> String {
     "contain".into()
 }
+fn default_tab_accent_inactive_alpha() -> f32 {
+    0.15
+}
+fn default_tab_accent_inactive_hover_alpha() -> f32 {
+    0.22
+}
 fn default_restore_terminal_text() -> bool {
     true
 }
@@ -112,6 +118,10 @@ pub struct AppearanceConfig {
     pub background_image_position: String,
     pub background_image_fit: String,
     pub background_image_repeat: bool,
+    /// Accent color alpha for inactive tabs, vertical-tab rows, and unfocused pane titles.
+    pub tab_accent_inactive_alpha: f32,
+    /// Accent color alpha when hovering inactive tabs and vertical-tab rows.
+    pub tab_accent_inactive_hover_alpha: f32,
     /// Keep bounded private terminal text so restart continuity can show what
     /// was on screen. This is never exported to workspace layout profiles.
     pub restore_terminal_text: bool,
@@ -137,10 +147,32 @@ impl Default for AppearanceConfig {
             background_image_position: default_background_image_position(),
             background_image_fit: default_background_image_fit(),
             background_image_repeat: false,
+            tab_accent_inactive_alpha: default_tab_accent_inactive_alpha(),
+            tab_accent_inactive_hover_alpha: default_tab_accent_inactive_hover_alpha(),
             restore_terminal_text: default_restore_terminal_text(),
             tabs_orientation: TabsOrientation::default(),
             hide_pane_title_bar: false,
         }
+    }
+}
+
+impl AppearanceConfig {
+    pub const MIN_TAB_ACCENT_ALPHA: f32 = 0.05;
+    pub const MAX_TAB_ACCENT_INACTIVE_ALPHA: f32 = 0.30;
+    pub const MAX_TAB_ACCENT_INACTIVE_HOVER_ALPHA: f32 = 0.40;
+
+    pub fn normalize(&mut self) {
+        self.tab_accent_inactive_alpha = self.tab_accent_inactive_alpha.clamp(
+            Self::MIN_TAB_ACCENT_ALPHA,
+            Self::MAX_TAB_ACCENT_INACTIVE_ALPHA,
+        );
+        self.tab_accent_inactive_hover_alpha = self
+            .tab_accent_inactive_hover_alpha
+            .clamp(
+                Self::MIN_TAB_ACCENT_ALPHA,
+                Self::MAX_TAB_ACCENT_INACTIVE_HOVER_ALPHA,
+            )
+            .max(self.tab_accent_inactive_alpha);
     }
 }
 
@@ -529,15 +561,22 @@ impl SkillsConfig {
 }
 
 impl Config {
+    pub fn normalize(&mut self) {
+        self.appearance.normalize();
+    }
+
     pub fn load() -> Result<Self> {
         let config_path = Self::config_path();
         if config_path.exists() {
             let content = std::fs::read_to_string(&config_path)?;
             let mut config: Config = toml::from_str(&content)?;
+            config.normalize();
             config.agent.migrate_legacy();
             Ok(config)
         } else {
-            Ok(Config::default())
+            let mut config = Config::default();
+            config.normalize();
+            Ok(config)
         }
     }
 
@@ -682,6 +721,53 @@ restore_terminal_text = false
         let config: Config = toml::from_str(content).unwrap();
 
         assert!(!config.appearance.restore_terminal_text);
+    }
+
+    #[test]
+    fn tab_accent_alpha_defaults_are_visible() {
+        let config = Config::default();
+        assert_eq!(config.appearance.tab_accent_inactive_alpha, 0.15);
+        assert_eq!(config.appearance.tab_accent_inactive_hover_alpha, 0.22);
+    }
+
+    #[test]
+    fn legacy_configs_receive_tab_accent_alpha_defaults() {
+        let content = r#"
+[appearance]
+terminal_opacity = 0.8
+"#;
+        let config: Config = toml::from_str(content).unwrap();
+
+        assert_eq!(config.appearance.tab_accent_inactive_alpha, 0.15);
+        assert_eq!(config.appearance.tab_accent_inactive_hover_alpha, 0.22);
+    }
+
+    #[test]
+    fn tab_accent_alpha_values_are_clamped_after_load() {
+        let content = r#"
+[appearance]
+tab_accent_inactive_alpha = 0.001
+tab_accent_inactive_hover_alpha = 0.02
+"#;
+        let mut config: Config = toml::from_str(content).unwrap();
+        config.normalize();
+
+        assert_eq!(config.appearance.tab_accent_inactive_alpha, 0.05);
+        assert_eq!(config.appearance.tab_accent_inactive_hover_alpha, 0.05);
+    }
+
+    #[test]
+    fn tab_accent_hover_alpha_never_drops_below_inactive_alpha() {
+        let content = r#"
+[appearance]
+tab_accent_inactive_alpha = 0.20
+tab_accent_inactive_hover_alpha = 0.10
+"#;
+        let mut config: Config = toml::from_str(content).unwrap();
+        config.normalize();
+
+        assert_eq!(config.appearance.tab_accent_inactive_alpha, 0.20);
+        assert_eq!(config.appearance.tab_accent_inactive_hover_alpha, 0.20);
     }
 
     #[test]

--- a/crates/con-test/Cargo.toml
+++ b/crates/con-test/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "con-test"
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+description = "Logic test framework for con-cli — drives a live con session via .test files"
+
+[[bin]]
+name = "con-test"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+serde_json = { workspace = true }
+clap = { version = "4.5", features = ["derive"] }

--- a/crates/con-test/README.md
+++ b/crates/con-test/README.md
@@ -35,7 +35,8 @@ cargo build -p con -p con-cli -p con-test
 ```
 # comment
 
-cmd <con-cli arguments...>   # optional inline label
+con-cli <arguments...>   # preferred
+cmd <arguments...>       # legacy alias
 ---- <mode>
 expected output here
 ```
@@ -55,18 +56,18 @@ expected output here
 ```
 # tabs/basic.test
 
-cmd --json tabs list  # at least one tab exists
+con-cli --json tabs list  # at least one tab exists
 ---- json-subset
 {"tabs":[{"index":1}]}
 
-cmd tabs new
+con-cli tabs new
 ---- ok
 
-cmd --json tabs list
+con-cli --json tabs list
 ---- contains
 "index":2
 
-cmd --json tabs close --tab 2
+con-cli --json tabs close --tab 2
 ---- ok
 ```
 

--- a/crates/con-test/README.md
+++ b/crates/con-test/README.md
@@ -1,0 +1,115 @@
+# con-test
+
+Logic test framework for `con-cli` — drives a live con session via `.test` files.
+
+Inspired by [sqllogictest](https://www.sqlite.org/sqllogictest/doc/trunk/about.wiki): test cases
+are plain text files that inline both the command and the expected output. No separate result
+files, no test harness boilerplate.
+
+## Quick start
+
+```bash
+# 1. Build con-cli and con-test
+cargo build -p con-cli -p con-test
+
+# 2. Launch con (in another terminal or background)
+cargo run -p con &
+
+# 3. Run all tests against the live session
+./target/debug/con-test crates/con-test/testdata/
+
+# 4. Run a single file
+./target/debug/con-test crates/con-test/testdata/system/identify.test
+
+# 5. Baseline mode — write actual output into the .test files as new expected values
+./target/debug/con-test --rewrite crates/con-test/testdata/
+```
+
+## .test file format
+
+```
+# Lines starting with # are comments and are ignored.
+
+cmd <con-cli arguments...>   # optional inline label
+match <mode>                 # optional, default: contains
+----
+expected output here
+```
+
+A blank line or the next `cmd` ends the expected block.
+
+### Match modes
+
+| Mode          | Behaviour |
+|---------------|-----------|
+| `contains`    | actual output contains the expected string (default) |
+| `exact`       | full string equality (trailing whitespace trimmed per line) |
+| `json-subset` | every key/value in expected JSON exists in actual JSON (ignores extra fields) |
+| `ok`          | only checks exit code == 0; expected block is ignored |
+| `error`       | checks exit code != 0; expected block matched against stderr |
+| `regex`       | expected is a regex pattern (not yet implemented) |
+
+### Example
+
+```
+# system/identify.test
+
+cmd --json identify  # version field present
+match json-subset
+----
+{"version":"0.1.0"}
+
+cmd --json capabilities
+match contains
+----
+"system.identify"
+
+cmd tabs new
+match ok
+----
+```
+
+## CLI flags
+
+```
+con-test [OPTIONS] <PATHS>...
+
+Arguments:
+  <PATHS>...  .test files or directories containing .test files
+
+Options:
+  --con-cli <PATH>   Path to con-cli binary (default: sibling in target/, then PATH)
+  --socket <PATH>    Override con socket path (passed as --socket to con-cli)
+  --rewrite          Rewrite expected blocks from actual output (baseline mode)
+  --fail-fast        Stop after the first failing file
+  --verbose          Show pass/skip results in addition to failures
+```
+
+## Adding tests
+
+1. Create a `.test` file under `testdata/` in the appropriate subdirectory.
+2. Write `cmd` / `match` / `----` / expected blocks.
+3. If unsure about the exact output, use `--rewrite` to generate the baseline, then review the diff.
+
+## Preconditions
+
+- A running con session (debug build listens on `/tmp/con-debug.sock`, release on `/tmp/con.sock`).
+- `con-cli` built and reachable (sibling binary in `target/debug/` when run from the workspace).
+
+## Running in CI
+
+```yaml
+- name: Build
+  run: cargo build -p con -p con-cli -p con-test
+
+- name: Launch con
+  run: ./target/debug/con &
+  env:
+    DISPLAY: :99   # Linux headless
+
+- name: Wait for socket
+  run: timeout 15 bash -c 'until test -S /tmp/con-debug.sock; do sleep 0.5; done'
+
+- name: Run con-test
+  run: ./target/debug/con-test crates/con-test/testdata/
+```

--- a/crates/con-test/README.md
+++ b/crates/con-test/README.md
@@ -35,8 +35,8 @@ cargo build -p con -p con-cli -p con-test
 ```
 # comment
 
-con-cli <arguments...>   # preferred
-cmd <arguments...>       # legacy alias
+con-cli <arguments...>       # preferred
+# Legacy: old tests may still use `cmd ...`
 ---- <mode>
 expected output here
 ```

--- a/crates/con-test/README.md
+++ b/crates/con-test/README.md
@@ -1,34 +1,54 @@
 # con-test
 
-Logic test framework for `con-cli` — drives a live con session via `.test` files.
+Logic test framework for `con-cli` — launches a real con process, resets state between
+test files, and drives the session via plain-text `.test` files.
 
-Inspired by [sqllogictest](https://www.sqlite.org/sqllogictest/doc/trunk/about.wiki): test cases
-are plain text files that inline both the command and the expected output. No separate result
+Inspired by [sqllogictest](https://www.sqlite.org/sqllogictest/doc/trunk/about.wiki): test
+cases inline both the command and the expected output in a single file. No separate result
 files, no test harness boilerplate.
+
+## How it works
+
+```
+con-test
+  │
+  ├── launches one con process  (unique socket per run)
+  │
+  ├── for each .test file:
+  │     ├── reset_state()       (close all tabs except tab 1)
+  │     └── run each cmd step   (via con-cli --socket ...)
+  │
+  └── kills con process on exit (RAII — even on panic or Ctrl-C)
+```
+
+Each test file starts from a known baseline: exactly one tab, one pane, fresh shell.
 
 ## Quick start
 
 ```bash
-# 1. Build con-cli and con-test
-cargo build -p con-cli -p con-test
+# 1. Build everything
+cargo build -p con -p con-cli -p con-test
 
-# 2. Launch con (in another terminal or background)
-cargo run -p con &
-
-# 3. Run all tests against the live session
+# 2. Run all tests (con is launched automatically)
 ./target/debug/con-test crates/con-test/testdata/
 
-# 4. Run a single file
-./target/debug/con-test crates/con-test/testdata/system/identify.test
+# 3. Run a single file
+./target/debug/con-test crates/con-test/testdata/tabs/basic.test
 
-# 5. Baseline mode — write actual output into the .test files as new expected values
+# 4. Baseline mode — write actual output into .test files as new expected values
 ./target/debug/con-test --rewrite crates/con-test/testdata/
+
+# 5. Stop on first failure
+./target/debug/con-test --fail-fast crates/con-test/testdata/
+
+# 6. Verbose — show pass/skip per step
+./target/debug/con-test --verbose crates/con-test/testdata/
 ```
 
 ## .test file format
 
 ```
-# Lines starting with # are comments and are ignored.
+# Lines starting with # are comments.
 
 cmd <con-cli arguments...>   # optional inline label
 match <mode>                 # optional, default: contains
@@ -47,54 +67,73 @@ A blank line or the next `cmd` ends the expected block.
 | `json-subset` | every key/value in expected JSON exists in actual JSON (ignores extra fields) |
 | `ok`          | only checks exit code == 0; expected block is ignored |
 | `error`       | checks exit code != 0; expected block matched against stderr |
-| `regex`       | expected is a regex pattern (not yet implemented) |
+| `regex`       | not yet implemented |
 
 ### Example
 
 ```
-# system/identify.test
+# tabs/basic.test
 
-cmd --json identify  # version field present
+cmd --json tabs list  # at least one tab exists
 match json-subset
 ----
-{"version":"0.1.0"}
+{"tabs":[{"index":1}]}
 
-cmd --json capabilities
+cmd tabs new  # create a new tab
+match ok
+----
+
+cmd --json tabs list  # now have 2 tabs
 match contains
 ----
-"system.identify"
+"index":2
 
-cmd tabs new
+cmd --json tabs close --tab 2
 match ok
 ----
 ```
 
-## CLI flags
+## CLI reference
 
 ```
 con-test [OPTIONS] <PATHS>...
 
 Arguments:
-  <PATHS>...  .test files or directories containing .test files
+  <PATHS>...  .test files or directories (searched recursively)
 
 Options:
-  --con-cli <PATH>   Path to con-cli binary (default: sibling in target/, then PATH)
-  --socket <PATH>    Override con socket path (passed as --socket to con-cli)
-  --rewrite          Rewrite expected blocks from actual output (baseline mode)
-  --fail-fast        Stop after the first failing file
-  --verbose          Show pass/skip results in addition to failures
+  --con <PATH>              Path to con binary     (default: target/ sibling, then PATH)
+  --con-cli <PATH>          Path to con-cli binary (default: target/ sibling, then PATH)
+  --socket <PATH>           Socket path for the launched con process
+                            (default: /tmp/con-test-<pid>.sock)
+  --startup-timeout <SECS> Seconds to wait for con to start (default: 30)
+  --rewrite                 Rewrite expected blocks from actual output (baseline mode)
+  --fail-fast               Stop after the first failing file
+  --verbose                 Show pass/skip results per step
 ```
+
+Binary resolution order (for both `--con` and `--con-cli`):
+
+1. Explicit flag
+2. `CON` / `CON_CLI` environment variable
+3. Sibling binary in the same `target/` directory as `con-test`
+4. `PATH`
 
 ## Adding tests
 
 1. Create a `.test` file under `testdata/` in the appropriate subdirectory.
 2. Write `cmd` / `match` / `----` / expected blocks.
-3. If unsure about the exact output, use `--rewrite` to generate the baseline, then review the diff.
+3. If unsure about exact output, run with `--rewrite` to generate the baseline,
+   then `git diff` to review.
 
-## Preconditions
+## State isolation
 
-- A running con session (debug build listens on `/tmp/con-debug.sock`, release on `/tmp/con.sock`).
-- `con-cli` built and reachable (sibling binary in `target/debug/` when run from the workspace).
+Before each `.test` file, con-test calls `reset_state()` which closes all tabs
+except tab 1. This means:
+
+- Every test file starts with exactly 1 tab and 1 pane.
+- Tests that create tabs/panes do not need to clean up after themselves.
+- Tab index 1 is always the baseline tab at the start of each file.
 
 ## Running in CI
 
@@ -102,14 +141,12 @@ Options:
 - name: Build
   run: cargo build -p con -p con-cli -p con-test
 
-- name: Launch con
-  run: ./target/debug/con &
-  env:
-    DISPLAY: :99   # Linux headless
-
-- name: Wait for socket
-  run: timeout 15 bash -c 'until test -S /tmp/con-debug.sock; do sleep 0.5; done'
-
 - name: Run con-test
   run: ./target/debug/con-test crates/con-test/testdata/
+  # con is launched automatically by con-test.
+  # On macOS CI runners a display is available so the con window appears briefly.
+  # Set CON_LOG_FILE to capture con logs if a test fails.
+  env:
+    CON_LOG_FILE: /tmp/con-test.log
+    RUST_LOG: error
 ```

--- a/crates/con-test/README.md
+++ b/crates/con-test/README.md
@@ -3,60 +3,42 @@
 Logic test framework for `con-cli` — launches a real con process, resets state between
 test files, and drives the session via plain-text `.test` files.
 
-Inspired by [sqllogictest](https://www.sqlite.org/sqllogictest/doc/trunk/about.wiki): test
-cases inline both the command and the expected output in a single file. No separate result
-files, no test harness boilerplate.
+Inspired by [sqllogictest](https://www.sqlite.org/sqllogictest/doc/trunk/about.wiki).
 
-## How it works
-
-```
-con-test
-  │
-  ├── launches one con process  (unique socket per run)
-  │
-  ├── for each .test file:
-  │     ├── reset_state()       (close all tabs except tab 1)
-  │     └── run each cmd step   (via con-cli --socket ...)
-  │
-  └── kills con process on exit (RAII — even on panic or Ctrl-C)
-```
-
-Each test file starts from a known baseline: exactly one tab, one pane, fresh shell.
+See [`docs/impl/con-test.md`](../../docs/impl/con-test.md) for the full implementation
+guide.
 
 ## Quick start
 
 ```bash
-# 1. Build everything
+# Build everything
 cargo build -p con -p con-cli -p con-test
 
-# 2. Run all tests (con is launched automatically)
+# Run all tests (con is launched automatically)
 ./target/debug/con-test crates/con-test/testdata/
 
-# 3. Run a single file
+# Run a single file
 ./target/debug/con-test crates/con-test/testdata/tabs/basic.test
 
-# 4. Baseline mode — write actual output into .test files as new expected values
+# Baseline mode — write actual output as new expected values
 ./target/debug/con-test --rewrite crates/con-test/testdata/
 
-# 5. Stop on first failure
+# Stop on first failure
 ./target/debug/con-test --fail-fast crates/con-test/testdata/
 
-# 6. Verbose — show pass/skip per step
+# Verbose — show pass/skip per step
 ./target/debug/con-test --verbose crates/con-test/testdata/
 ```
 
 ## .test file format
 
 ```
-# Lines starting with # are comments.
+# comment
 
 cmd <con-cli arguments...>   # optional inline label
-match <mode>                 # optional, default: contains
-----
+---- <mode>
 expected output here
 ```
-
-A blank line or the next `cmd` ends the expected block.
 
 ### Match modes
 
@@ -64,10 +46,9 @@ A blank line or the next `cmd` ends the expected block.
 |---------------|-----------|
 | `contains`    | actual output contains the expected string (default) |
 | `exact`       | full string equality (trailing whitespace trimmed per line) |
-| `json-subset` | every key/value in expected JSON exists in actual JSON (ignores extra fields) |
-| `ok`          | only checks exit code == 0; expected block is ignored |
-| `error`       | checks exit code != 0; expected block matched against stderr |
-| `regex`       | not yet implemented |
+| `json-subset` | every key/value in expected JSON exists in actual JSON |
+| `ok`          | only checks exit code == 0; expected block ignored |
+| `error`       | checks exit code != 0; expected matched against stderr |
 
 ### Example
 
@@ -75,22 +56,18 @@ A blank line or the next `cmd` ends the expected block.
 # tabs/basic.test
 
 cmd --json tabs list  # at least one tab exists
-match json-subset
-----
+---- json-subset
 {"tabs":[{"index":1}]}
 
-cmd tabs new  # create a new tab
-match ok
-----
+cmd tabs new
+---- ok
 
-cmd --json tabs list  # now have 2 tabs
-match contains
-----
+cmd --json tabs list
+---- contains
 "index":2
 
 cmd --json tabs close --tab 2
-match ok
-----
+---- ok
 ```
 
 ## CLI reference
@@ -112,41 +89,10 @@ Options:
   --verbose                 Show pass/skip results per step
 ```
 
-Binary resolution order (for both `--con` and `--con-cli`):
-
-1. Explicit flag
-2. `CON` / `CON_CLI` environment variable
-3. Sibling binary in the same `target/` directory as `con-test`
-4. `PATH`
-
-## Adding tests
-
-1. Create a `.test` file under `testdata/` in the appropriate subdirectory.
-2. Write `cmd` / `match` / `----` / expected blocks.
-3. If unsure about exact output, run with `--rewrite` to generate the baseline,
-   then `git diff` to review.
-
 ## State isolation
 
-Before each `.test` file, con-test calls `reset_state()` which closes all tabs
-except tab 1. This means:
+Before each `.test` file, con-test resets con to a known baseline:
+- All tabs except tab 1 are closed
+- All panes in tab 1 except the first are closed (via Ctrl-D)
 
-- Every test file starts with exactly 1 tab and 1 pane.
-- Tests that create tabs/panes do not need to clean up after themselves.
-- Tab index 1 is always the baseline tab at the start of each file.
-
-## Running in CI
-
-```yaml
-- name: Build
-  run: cargo build -p con -p con-cli -p con-test
-
-- name: Run con-test
-  run: ./target/debug/con-test crates/con-test/testdata/
-  # con is launched automatically by con-test.
-  # On macOS CI runners a display is available so the con window appears briefly.
-  # Set CON_LOG_FILE to capture con logs if a test fails.
-  env:
-    CON_LOG_FILE: /tmp/con-test.log
-    RUST_LOG: error
-```
+Every test file starts with exactly 1 tab and 1 pane.

--- a/crates/con-test/README.md
+++ b/crates/con-test/README.md
@@ -98,5 +98,6 @@ Options:
 Before each `.test` file, con-test resets con to a known baseline:
 - All tabs except tab 1 are closed
 - All panes in tab 1 except the first are closed (via Ctrl-D)
+- All pane-local surfaces in the surviving pane except the first are closed
 
-Every test file starts with exactly 1 tab and 1 pane.
+Every test file starts with exactly 1 tab, 1 pane, and 1 surface.

--- a/crates/con-test/README.md
+++ b/crates/con-test/README.md
@@ -80,10 +80,13 @@ Arguments:
   <PATHS>...  .test files or directories (searched recursively)
 
 Options:
-  --con <PATH>              Path to con binary     (default: target/ sibling, then PATH)
+  --con <PATH>              Path to con app binary (default: target/ sibling, then PATH)
+                            Env override: CON
+                            Binary name: con on Unix, con-app on Windows
   --con-cli <PATH>          Path to con-cli binary (default: target/ sibling, then PATH)
-  --socket <PATH>           Socket path for the launched con process
-                            (default: /tmp/con-test-<pid>.sock)
+                            Env override: CON_CLI
+  --socket <PATH>           Control endpoint for the launched con process
+                            (default: temp Unix socket on Unix, named pipe on Windows)
   --startup-timeout <SECS> Seconds to wait for con to start (default: 30)
   --rewrite                 Rewrite expected blocks from actual output (baseline mode)
   --fail-fast               Stop after the first failing file

--- a/crates/con-test/src/main.rs
+++ b/crates/con-test/src/main.rs
@@ -8,6 +8,77 @@ use std::time::Duration;
 use anyhow::Result;
 use clap::Parser;
 
+// ---------------------------------------------------------------------------
+// ANSI color helpers — disabled when stdout is not a tty or NO_COLOR is set
+// ---------------------------------------------------------------------------
+
+struct Color {
+    enabled: bool,
+}
+
+impl Color {
+    fn detect() -> Self {
+        // Respect NO_COLOR env var (https://no-color.org/)
+        if std::env::var_os("NO_COLOR").is_some() {
+            return Color { enabled: false };
+        }
+        // Check if stdout is a tty
+        Color {
+            enabled: is_tty_stdout(),
+        }
+    }
+
+    fn green<'a>(&self, s: &'a str) -> ColorStr<'a> {
+        ColorStr { s, code: "32", enabled: self.enabled }
+    }
+    fn red<'a>(&self, s: &'a str) -> ColorStr<'a> {
+        ColorStr { s, code: "31", enabled: self.enabled }
+    }
+    fn yellow<'a>(&self, s: &'a str) -> ColorStr<'a> {
+        ColorStr { s, code: "33", enabled: self.enabled }
+    }
+    fn bold<'a>(&self, s: &'a str) -> ColorStr<'a> {
+        ColorStr { s, code: "1", enabled: self.enabled }
+    }
+    fn dim<'a>(&self, s: &'a str) -> ColorStr<'a> {
+        ColorStr { s, code: "2", enabled: self.enabled }
+    }
+}
+
+struct ColorStr<'a> {
+    s: &'a str,
+    code: &'static str,
+    enabled: bool,
+}
+
+impl std::fmt::Display for ColorStr<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.enabled {
+            write!(f, "\x1b[{}m{}\x1b[0m", self.code, self.s)
+        } else {
+            write!(f, "{}", self.s)
+        }
+    }
+}
+
+#[cfg(unix)]
+fn is_tty_stdout() -> bool {
+    unsafe extern "C" {
+        fn isatty(fd: i32) -> i32;
+    }
+    // SAFETY: fd 1 is always valid (stdout)
+    unsafe { isatty(1) != 0 }
+}
+
+#[cfg(not(unix))]
+fn is_tty_stdout() -> bool {
+    false
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
 #[derive(Parser)]
 #[command(
     name = "con-test",
@@ -45,15 +116,29 @@ struct Cli {
     /// Show full pass/skip results in addition to failures
     #[arg(long)]
     verbose: bool,
+
+    /// Disable colored output
+    #[arg(long)]
+    no_color: bool,
 }
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
+    let color = if cli.no_color {
+        Color { enabled: false }
+    } else {
+        Color::detect()
+    };
+
     let con_bin = match resolve_bin(cli.con.as_deref(), "con") {
         Ok(p) => p,
         Err(e) => {
-            eprintln!("error: {e}");
+            eprintln!("{} {e}", color.red("error:"));
             return ExitCode::FAILURE;
         }
     };
@@ -61,7 +146,7 @@ fn main() -> ExitCode {
     let con_cli = match resolve_bin(cli.con_cli.as_deref(), "con-cli") {
         Ok(p) => p,
         Err(e) => {
-            eprintln!("error: {e}");
+            eprintln!("{} {e}", color.red("error:"));
             return ExitCode::FAILURE;
         }
     };
@@ -73,18 +158,22 @@ fn main() -> ExitCode {
     let test_files = match collect_test_files(&cli.paths) {
         Ok(files) => files,
         Err(e) => {
-            eprintln!("error collecting test files: {e}");
+            eprintln!("{} collecting test files: {e}", color.red("error:"));
             return ExitCode::FAILURE;
         }
     };
 
     if test_files.is_empty() {
-        eprintln!("no .test files found in the given paths");
+        eprintln!("{}", color.yellow("no .test files found in the given paths"));
         return ExitCode::FAILURE;
     }
 
     // Launch a single con process for the entire test run.
-    println!("launching con ({})...", con_bin.display());
+    println!(
+        "{} con ({})...",
+        color.dim("launching"),
+        con_bin.display()
+    );
     let _con_process = match runner::ConProcess::launch(
         &con_bin,
         &socket,
@@ -92,11 +181,15 @@ fn main() -> ExitCode {
     ) {
         Ok(p) => p,
         Err(e) => {
-            eprintln!("error: failed to launch con: {e}");
+            eprintln!("{} failed to launch con: {e}", color.red("error:"));
             return ExitCode::FAILURE;
         }
     };
-    println!("con ready on {}\n", socket.display());
+    println!(
+        "{} {}\n",
+        color.dim("con ready on"),
+        color.dim(&socket.display().to_string())
+    );
 
     let config = runner::RunConfig {
         con_cli: con_cli.clone(),
@@ -110,9 +203,12 @@ fn main() -> ExitCode {
     let mut skipped = 0usize;
 
     for path in &test_files {
-        // Reset con to a clean baseline before each file.
         if let Err(e) = runner::reset_state(&con_cli, &socket) {
-            eprintln!("error: reset_state failed before {}: {e}", path.display());
+            eprintln!(
+                "  {} reset_state failed before {}: {e}",
+                color.red("error:"),
+                path.display()
+            );
             failed += 1;
             if cli.fail_fast {
                 break;
@@ -122,7 +218,7 @@ fn main() -> ExitCode {
 
         match runner::run_file(path, &config) {
             Ok(result) => {
-                print_file_result(path, &result);
+                print_file_result(path, &result, &color);
                 passed += result.passed;
                 failed += result.failed;
                 skipped += result.skipped;
@@ -131,7 +227,11 @@ fn main() -> ExitCode {
                 }
             }
             Err(e) => {
-                eprintln!("error running {}: {e}", path.display());
+                eprintln!(
+                    "  {} running {}: {e}",
+                    color.red("error:"),
+                    path.display()
+                );
                 failed += 1;
                 if cli.fail_fast {
                     break;
@@ -141,42 +241,84 @@ fn main() -> ExitCode {
     }
 
     println!();
-    println!(
-        "results: {} passed, {} failed, {} skipped  ({} files)",
+
+    // Summary line
+    let summary = format!(
+        "{} passed  {} failed  {} skipped  ({} files)",
         passed,
         failed,
         skipped,
         test_files.len()
     );
-
     if failed > 0 {
+        println!("{}", color.bold(&format!("results: {summary}")));
         ExitCode::FAILURE
     } else {
+        println!("{}", color.bold(&format!("results: {summary}")));
         ExitCode::SUCCESS
     }
 }
 
-fn print_file_result(path: &Path, result: &runner::FileResult) {
-    let status = if result.failed > 0 { "FAIL" } else { "ok  " };
-    println!(
-        "{status}  {}  ({} passed, {} failed, {} skipped)",
-        path.display(),
-        result.passed,
-        result.failed,
-        result.skipped
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+fn print_file_result(path: &Path, result: &runner::FileResult, color: &Color) {
+    let path_str = path.display().to_string();
+    let counts = format!(
+        "({} passed, {} failed, {} skipped)",
+        result.passed, result.failed, result.skipped
     );
-    for failure in &result.failures {
-        println!("  --- FAIL: {}", failure.step_label);
-        println!("      cmd:      {}", failure.cmd);
-        println!("      expected: {}", failure.expected.trim());
-        println!("      actual:   {}", failure.actual.trim());
-        if !failure.diff.is_empty() {
-            for line in failure.diff.lines() {
-                println!("      {line}");
+
+    if result.failed > 0 {
+        println!(
+            "{}  {}  {}",
+            color.red("FAIL"),
+            path_str,
+            color.dim(&counts)
+        );
+        for failure in &result.failures {
+            println!(
+                "  {} {}",
+                color.red("---"),
+                color.bold(&failure.step_label)
+            );
+            println!("      {}  {}", color.dim("cmd:"), failure.cmd);
+            println!(
+                "      {}  {}",
+                color.dim("expected:"),
+                failure.expected.trim()
+            );
+            println!(
+                "      {}  {}",
+                color.yellow("actual:  "),
+                failure.actual.trim()
+            );
+            if !failure.diff.is_empty() {
+                for line in failure.diff.lines() {
+                    if line.starts_with('+') {
+                        println!("      {}", color.green(line));
+                    } else if line.starts_with('-') {
+                        println!("      {}", color.red(line));
+                    } else {
+                        println!("      {}", color.dim(line));
+                    }
+                }
             }
         }
+    } else {
+        println!(
+            "{}  {}  {}",
+            color.green("ok  "),
+            path_str,
+            color.dim(&counts)
+        );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Binary resolution
+// ---------------------------------------------------------------------------
 
 /// Resolve a binary path.
 /// Priority: explicit flag → CON_<NAME> env var → cargo target/ sibling → PATH
@@ -214,7 +356,10 @@ fn resolve_bin(flag: Option<&Path>, name: &str) -> Result<PathBuf> {
     }
 }
 
-/// Recursively collect all .test files from the given paths.
+// ---------------------------------------------------------------------------
+// File collection
+// ---------------------------------------------------------------------------
+
 fn collect_test_files(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
     let mut files = Vec::new();
     for path in paths {
@@ -223,10 +368,7 @@ fn collect_test_files(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
         } else if path.extension().map(|e| e == "test").unwrap_or(false) {
             files.push(path.clone());
         } else {
-            anyhow::bail!(
-                "{} is not a .test file or directory",
-                path.display()
-            );
+            anyhow::bail!("{} is not a .test file or directory", path.display());
         }
     }
     files.sort();

--- a/crates/con-test/src/main.rs
+++ b/crates/con-test/src/main.rs
@@ -1,0 +1,207 @@
+mod parser;
+mod runner;
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use anyhow::Result;
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(
+    name = "con-test",
+    about = "Logic test runner for con-cli — drives a live con session via .test files"
+)]
+struct Cli {
+    /// Paths to .test files or directories containing .test files
+    #[arg(required = true)]
+    paths: Vec<PathBuf>,
+
+    /// Path to the con-cli binary (defaults to finding it on PATH or in cargo target/)
+    #[arg(long, value_name = "PATH")]
+    con_cli: Option<PathBuf>,
+
+    /// Override the con socket path (passed as --socket to con-cli)
+    #[arg(long, value_name = "PATH")]
+    socket: Option<PathBuf>,
+
+    /// Rewrite expected output in .test files from actual output (baseline mode)
+    #[arg(long)]
+    rewrite: bool,
+
+    /// Stop after the first failing test file
+    #[arg(long)]
+    fail_fast: bool,
+
+    /// Show full diff even for passing tests
+    #[arg(long)]
+    verbose: bool,
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    let con_cli = match resolve_con_cli(cli.con_cli.as_deref()) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let test_files = match collect_test_files(&cli.paths) {
+        Ok(files) => files,
+        Err(e) => {
+            eprintln!("error collecting test files: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if test_files.is_empty() {
+        eprintln!("no .test files found in the given paths");
+        return ExitCode::FAILURE;
+    }
+
+    let config = runner::RunConfig {
+        con_cli,
+        socket: cli.socket,
+        rewrite: cli.rewrite,
+        verbose: cli.verbose,
+    };
+
+    let mut passed = 0usize;
+    let mut failed = 0usize;
+    let mut skipped = 0usize;
+
+    for path in &test_files {
+        match runner::run_file(path, &config) {
+            Ok(result) => {
+                print_file_result(path, &result);
+                passed += result.passed;
+                failed += result.failed;
+                skipped += result.skipped;
+                if cli.fail_fast && result.failed > 0 {
+                    break;
+                }
+            }
+            Err(e) => {
+                eprintln!("error running {}: {e}", path.display());
+                failed += 1;
+                if cli.fail_fast {
+                    break;
+                }
+            }
+        }
+    }
+
+    println!();
+    println!(
+        "results: {} passed, {} failed, {} skipped  ({} files)",
+        passed,
+        failed,
+        skipped,
+        test_files.len()
+    );
+
+    if failed > 0 {
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    }
+}
+
+fn print_file_result(path: &Path, result: &runner::FileResult) {
+    let status = if result.failed > 0 { "FAIL" } else { "ok  " };
+    println!(
+        "{status}  {}  ({} passed, {} failed, {} skipped)",
+        path.display(),
+        result.passed,
+        result.failed,
+        result.skipped
+    );
+    for failure in &result.failures {
+        println!("  --- FAIL: {}", failure.step_label);
+        println!("      cmd:      {}", failure.cmd);
+        println!("      expected: {}", failure.expected.trim());
+        println!("      actual:   {}", failure.actual.trim());
+        if !failure.diff.is_empty() {
+            for line in failure.diff.lines() {
+                println!("      {line}");
+            }
+        }
+    }
+}
+
+/// Resolve the con-cli binary path.
+/// Priority: --con-cli flag → CON_CLI env var → cargo target/debug/con-cli → PATH
+fn resolve_con_cli(flag: Option<&Path>) -> Result<PathBuf> {
+    if let Some(p) = flag {
+        return Ok(p.to_path_buf());
+    }
+    if let Ok(env) = std::env::var("CON_CLI") {
+        return Ok(PathBuf::from(env));
+    }
+    // Try workspace target directory (useful when running from the repo)
+    let workspace_target = {
+        let mut p = std::env::current_exe().unwrap_or_default();
+        // current_exe is something like target/debug/con-test; sibling is con-cli
+        p.pop();
+        p.push("con-cli");
+        p
+    };
+    if workspace_target.exists() {
+        return Ok(workspace_target);
+    }
+    // Fall back to PATH
+    which_con_cli()
+}
+
+fn which_con_cli() -> Result<PathBuf> {
+    let output = std::process::Command::new("which")
+        .arg("con-cli")
+        .output();
+    match output {
+        Ok(o) if o.status.success() => {
+            let path = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            Ok(PathBuf::from(path))
+        }
+        _ => anyhow::bail!(
+            "con-cli not found. Build it with `cargo build -p con-cli` or pass --con-cli <path>"
+        ),
+    }
+}
+
+/// Recursively collect all .test files from the given paths.
+fn collect_test_files(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    for path in paths {
+        if path.is_dir() {
+            collect_from_dir(path, &mut files)?;
+        } else if path.extension().map(|e| e == "test").unwrap_or(false) {
+            files.push(path.clone());
+        } else {
+            anyhow::bail!(
+                "{} is not a .test file or directory",
+                path.display()
+            );
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn collect_from_dir(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    let mut entries: Vec<_> = std::fs::read_dir(dir)?
+        .filter_map(|e| e.ok())
+        .collect();
+    entries.sort_by_key(|e| e.path());
+    for entry in entries {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_from_dir(&path, out)?;
+        } else if path.extension().map(|e| e == "test").unwrap_or(false) {
+            out.push(path);
+        }
+    }
+    Ok(())
+}

--- a/crates/con-test/src/main.rs
+++ b/crates/con-test/src/main.rs
@@ -117,7 +117,7 @@ struct Cli {
     #[arg(long, value_name = "PATH")]
     con_cli: Option<PathBuf>,
 
-    /// Socket path for the launched con process (default: /tmp/con-test-<pid>.sock)
+    /// Control endpoint for the launched con process (default: platform-specific)
     #[arg(long, value_name = "PATH")]
     socket: Option<PathBuf>,
 
@@ -146,6 +146,18 @@ struct Cli {
 // Main
 // ---------------------------------------------------------------------------
 
+fn default_control_endpoint() -> PathBuf {
+    #[cfg(windows)]
+    {
+        PathBuf::from(format!(r"\\.\pipe\con-test-{}", std::process::id()))
+    }
+
+    #[cfg(not(windows))]
+    {
+        std::env::temp_dir().join(format!("con-test-{}.sock", std::process::id()))
+    }
+}
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
@@ -171,9 +183,7 @@ fn main() -> ExitCode {
         }
     };
 
-    let socket = cli.socket.unwrap_or_else(|| {
-        std::env::temp_dir().join(format!("con-test-{}.sock", std::process::id()))
-    });
+    let socket = cli.socket.unwrap_or_else(default_control_endpoint);
 
     let test_files = match collect_test_files(&cli.paths) {
         Ok(files) => files,

--- a/crates/con-test/src/main.rs
+++ b/crates/con-test/src/main.rs
@@ -29,19 +29,39 @@ impl Color {
     }
 
     fn green<'a>(&self, s: &'a str) -> ColorStr<'a> {
-        ColorStr { s, code: "32", enabled: self.enabled }
+        ColorStr {
+            s,
+            code: "32",
+            enabled: self.enabled,
+        }
     }
     fn red<'a>(&self, s: &'a str) -> ColorStr<'a> {
-        ColorStr { s, code: "31", enabled: self.enabled }
+        ColorStr {
+            s,
+            code: "31",
+            enabled: self.enabled,
+        }
     }
     fn yellow<'a>(&self, s: &'a str) -> ColorStr<'a> {
-        ColorStr { s, code: "33", enabled: self.enabled }
+        ColorStr {
+            s,
+            code: "33",
+            enabled: self.enabled,
+        }
     }
     fn bold<'a>(&self, s: &'a str) -> ColorStr<'a> {
-        ColorStr { s, code: "1", enabled: self.enabled }
+        ColorStr {
+            s,
+            code: "1",
+            enabled: self.enabled,
+        }
     }
     fn dim<'a>(&self, s: &'a str) -> ColorStr<'a> {
-        ColorStr { s, code: "2", enabled: self.enabled }
+        ColorStr {
+            s,
+            code: "2",
+            enabled: self.enabled,
+        }
     }
 }
 
@@ -164,16 +184,15 @@ fn main() -> ExitCode {
     };
 
     if test_files.is_empty() {
-        eprintln!("{}", color.yellow("no .test files found in the given paths"));
+        eprintln!(
+            "{}",
+            color.yellow("no .test files found in the given paths")
+        );
         return ExitCode::FAILURE;
     }
 
     // Launch a single con process for the entire test run.
-    println!(
-        "{} con ({})...",
-        color.dim("launching"),
-        con_bin.display()
-    );
+    println!("{} con ({})...", color.dim("launching"), con_bin.display());
     let _con_process = match runner::ConProcess::launch(
         &con_bin,
         &socket,
@@ -227,11 +246,7 @@ fn main() -> ExitCode {
                 }
             }
             Err(e) => {
-                eprintln!(
-                    "  {} running {}: {e}",
-                    color.red("error:"),
-                    path.display()
-                );
+                eprintln!("  {} running {}: {e}", color.red("error:"), path.display());
                 failed += 1;
                 if cli.fail_fast {
                     break;
@@ -278,11 +293,7 @@ fn print_file_result(path: &Path, result: &runner::FileResult, color: &Color) {
             color.dim(&counts)
         );
         for failure in &result.failures {
-            println!(
-                "  {} {}",
-                color.red("---"),
-                color.bold(&failure.step_label)
-            );
+            println!("  {} {}", color.red("---"), color.bold(&failure.step_label));
             println!("      {}  {}", color.dim("cmd:"), failure.cmd);
             println!(
                 "      {}  {}",
@@ -376,9 +387,7 @@ fn collect_test_files(paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
 }
 
 fn collect_from_dir(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
-    let mut entries: Vec<_> = std::fs::read_dir(dir)?
-        .filter_map(|e| e.ok())
-        .collect();
+    let mut entries: Vec<_> = std::fs::read_dir(dir)?.filter_map(|e| e.ok()).collect();
     entries.sort_by_key(|e| e.path());
     for entry in entries {
         let path = entry.path();

--- a/crates/con-test/src/main.rs
+++ b/crates/con-test/src/main.rs
@@ -358,7 +358,7 @@ fn resolve_bin(flag: Option<&Path>, name: &str) -> Result<PathBuf> {
     let sibling = {
         let mut p = std::env::current_exe().unwrap_or_default();
         p.pop();
-        p.push(name);
+        p.push(platform_exe_name(name));
         p
     };
     if sibling.exists() {
@@ -383,6 +383,22 @@ fn env_key_for_bin(name: &str) -> &'static str {
         "con" | "con-app" => "CON",
         "con-cli" => "CON_CLI",
         _ => "CON_BIN",
+    }
+}
+
+fn platform_exe_name(name: &str) -> String {
+    #[cfg(windows)]
+    {
+        if name.ends_with(".exe") {
+            name.to_string()
+        } else {
+            format!("{name}.exe")
+        }
+    }
+
+    #[cfg(not(windows))]
+    {
+        name.to_string()
     }
 }
 
@@ -467,6 +483,14 @@ mod tests {
         assert_eq!(app_binary_name(), "con-app");
         #[cfg(not(windows))]
         assert_eq!(app_binary_name(), "con");
+    }
+
+    #[test]
+    fn sibling_lookup_uses_platform_exe_name() {
+        #[cfg(windows)]
+        assert_eq!(platform_exe_name("con-cli"), "con-cli.exe");
+        #[cfg(not(windows))]
+        assert_eq!(platform_exe_name("con-cli"), "con-cli");
     }
 
     #[test]

--- a/crates/con-test/src/main.rs
+++ b/crates/con-test/src/main.rs
@@ -3,6 +3,7 @@ mod runner;
 
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::time::Duration;
 
 use anyhow::Result;
 use clap::Parser;
@@ -17,13 +18,21 @@ struct Cli {
     #[arg(required = true)]
     paths: Vec<PathBuf>,
 
-    /// Path to the con-cli binary (defaults to finding it on PATH or in cargo target/)
+    /// Path to the con binary to launch (defaults to sibling in cargo target/)
+    #[arg(long, value_name = "PATH")]
+    con: Option<PathBuf>,
+
+    /// Path to the con-cli binary (defaults to sibling in cargo target/)
     #[arg(long, value_name = "PATH")]
     con_cli: Option<PathBuf>,
 
-    /// Override the con socket path (passed as --socket to con-cli)
+    /// Socket path for the launched con process (default: /tmp/con-test-<pid>.sock)
     #[arg(long, value_name = "PATH")]
     socket: Option<PathBuf>,
+
+    /// Seconds to wait for con to start (default: 30)
+    #[arg(long, default_value_t = 30)]
+    startup_timeout: u64,
 
     /// Rewrite expected output in .test files from actual output (baseline mode)
     #[arg(long)]
@@ -33,7 +42,7 @@ struct Cli {
     #[arg(long)]
     fail_fast: bool,
 
-    /// Show full diff even for passing tests
+    /// Show full pass/skip results in addition to failures
     #[arg(long)]
     verbose: bool,
 }
@@ -41,13 +50,25 @@ struct Cli {
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    let con_cli = match resolve_con_cli(cli.con_cli.as_deref()) {
+    let con_bin = match resolve_bin(cli.con.as_deref(), "con") {
         Ok(p) => p,
         Err(e) => {
             eprintln!("error: {e}");
             return ExitCode::FAILURE;
         }
     };
+
+    let con_cli = match resolve_bin(cli.con_cli.as_deref(), "con-cli") {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let socket = cli.socket.unwrap_or_else(|| {
+        std::env::temp_dir().join(format!("con-test-{}.sock", std::process::id()))
+    });
 
     let test_files = match collect_test_files(&cli.paths) {
         Ok(files) => files,
@@ -62,9 +83,24 @@ fn main() -> ExitCode {
         return ExitCode::FAILURE;
     }
 
+    // Launch a single con process for the entire test run.
+    println!("launching con ({})...", con_bin.display());
+    let _con_process = match runner::ConProcess::launch(
+        &con_bin,
+        &socket,
+        Duration::from_secs(cli.startup_timeout),
+    ) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: failed to launch con: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    println!("con ready on {}\n", socket.display());
+
     let config = runner::RunConfig {
-        con_cli,
-        socket: cli.socket,
+        con_cli: con_cli.clone(),
+        socket: socket.clone(),
         rewrite: cli.rewrite,
         verbose: cli.verbose,
     };
@@ -74,6 +110,16 @@ fn main() -> ExitCode {
     let mut skipped = 0usize;
 
     for path in &test_files {
+        // Reset con to a clean baseline before each file.
+        if let Err(e) = runner::reset_state(&con_cli, &socket) {
+            eprintln!("error: reset_state failed before {}: {e}", path.display());
+            failed += 1;
+            if cli.fail_fast {
+                break;
+            }
+            continue;
+        }
+
         match runner::run_file(path, &config) {
             Ok(result) => {
                 print_file_result(path, &result);
@@ -132,41 +178,38 @@ fn print_file_result(path: &Path, result: &runner::FileResult) {
     }
 }
 
-/// Resolve the con-cli binary path.
-/// Priority: --con-cli flag → CON_CLI env var → cargo target/debug/con-cli → PATH
-fn resolve_con_cli(flag: Option<&Path>) -> Result<PathBuf> {
+/// Resolve a binary path.
+/// Priority: explicit flag → CON_<NAME> env var → cargo target/ sibling → PATH
+fn resolve_bin(flag: Option<&Path>, name: &str) -> Result<PathBuf> {
     if let Some(p) = flag {
         return Ok(p.to_path_buf());
     }
-    if let Ok(env) = std::env::var("CON_CLI") {
+
+    let env_key = format!("CON_{}", name.to_uppercase().replace('-', "_"));
+    if let Ok(env) = std::env::var(&env_key) {
         return Ok(PathBuf::from(env));
     }
-    // Try workspace target directory (useful when running from the repo)
-    let workspace_target = {
+
+    // Sibling in the same target directory as con-test itself.
+    let sibling = {
         let mut p = std::env::current_exe().unwrap_or_default();
-        // current_exe is something like target/debug/con-test; sibling is con-cli
         p.pop();
-        p.push("con-cli");
+        p.push(name);
         p
     };
-    if workspace_target.exists() {
-        return Ok(workspace_target);
+    if sibling.exists() {
+        return Ok(sibling);
     }
-    // Fall back to PATH
-    which_con_cli()
-}
 
-fn which_con_cli() -> Result<PathBuf> {
-    let output = std::process::Command::new("which")
-        .arg("con-cli")
-        .output();
+    // Fall back to PATH.
+    let output = Command::new("which").arg(name).output();
     match output {
         Ok(o) if o.status.success() => {
             let path = String::from_utf8_lossy(&o.stdout).trim().to_string();
             Ok(PathBuf::from(path))
         }
         _ => anyhow::bail!(
-            "con-cli not found. Build it with `cargo build -p con-cli` or pass --con-cli <path>"
+            "{name} not found. Build it with `cargo build -p {name}` or pass --{name} <path>"
         ),
     }
 }
@@ -205,3 +248,5 @@ fn collect_from_dir(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
     }
     Ok(())
 }
+
+use std::process::Command;

--- a/crates/con-test/src/main.rs
+++ b/crates/con-test/src/main.rs
@@ -117,7 +117,8 @@ struct Cli {
     #[arg(long, value_name = "PATH")]
     con_cli: Option<PathBuf>,
 
-    /// Control endpoint for the launched con process (default: platform-specific)
+    /// Control endpoint path for the launched con process
+    /// (default: temp Unix socket on Unix, named pipe on Windows)
     #[arg(long, value_name = "PATH")]
     socket: Option<PathBuf>,
 
@@ -167,7 +168,7 @@ fn main() -> ExitCode {
         Color::detect()
     };
 
-    let con_bin = match resolve_bin(cli.con.as_deref(), "con") {
+    let con_bin = match resolve_bin(cli.con.as_deref(), app_binary_name()) {
         Ok(p) => p,
         Err(e) => {
             eprintln!("{} {e}", color.red("error:"));
@@ -342,14 +343,14 @@ fn print_file_result(path: &Path, result: &runner::FileResult, color: &Color) {
 // ---------------------------------------------------------------------------
 
 /// Resolve a binary path.
-/// Priority: explicit flag → CON_<NAME> env var → cargo target/ sibling → PATH
+/// Priority: explicit flag → documented env var → cargo target/ sibling → PATH
 fn resolve_bin(flag: Option<&Path>, name: &str) -> Result<PathBuf> {
     if let Some(p) = flag {
         return Ok(p.to_path_buf());
     }
 
-    let env_key = format!("CON_{}", name.to_uppercase().replace('-', "_"));
-    if let Ok(env) = std::env::var(&env_key) {
+    let env_key = env_key_for_bin(name);
+    if let Ok(env) = std::env::var(env_key) {
         return Ok(PathBuf::from(env));
     }
 
@@ -365,7 +366,7 @@ fn resolve_bin(flag: Option<&Path>, name: &str) -> Result<PathBuf> {
     }
 
     // Fall back to PATH.
-    let output = Command::new("which").arg(name).output();
+    let output = Command::new(path_lookup_command()).arg(name).output();
     match output {
         Ok(o) if o.status.success() => {
             let path = String::from_utf8_lossy(&o.stdout).trim().to_string();
@@ -375,6 +376,34 @@ fn resolve_bin(flag: Option<&Path>, name: &str) -> Result<PathBuf> {
             "{name} not found. Build it with `cargo build -p {name}` or pass --{name} <path>"
         ),
     }
+}
+
+fn env_key_for_bin(name: &str) -> &'static str {
+    match name {
+        "con" | "con-app" => "CON",
+        "con-cli" => "CON_CLI",
+        _ => "CON_BIN",
+    }
+}
+
+#[cfg(windows)]
+fn app_binary_name() -> &'static str {
+    "con-app"
+}
+
+#[cfg(not(windows))]
+fn app_binary_name() -> &'static str {
+    "con"
+}
+
+#[cfg(windows)]
+fn path_lookup_command() -> &'static str {
+    "where"
+}
+
+#[cfg(not(windows))]
+fn path_lookup_command() -> &'static str {
+    "which"
 }
 
 // ---------------------------------------------------------------------------
@@ -408,6 +437,77 @@ fn collect_from_dir(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+
+    #[test]
+    fn env_keys_match_documented_overrides() {
+        assert_eq!(env_key_for_bin("con"), "CON");
+        assert_eq!(env_key_for_bin("con-app"), "CON");
+        assert_eq!(env_key_for_bin("con-cli"), "CON_CLI");
+    }
+
+    #[test]
+    fn default_socket_endpoint_is_platform_appropriate() {
+        let endpoint = default_control_endpoint();
+        let endpoint = endpoint.to_string_lossy();
+        #[cfg(windows)]
+        assert!(endpoint.starts_with(r"\\.\pipe\con-test-"));
+        #[cfg(not(windows))]
+        assert!(endpoint.ends_with(".sock"));
+    }
+
+    #[test]
+    fn app_binary_name_is_platform_appropriate() {
+        #[cfg(windows)]
+        assert_eq!(app_binary_name(), "con-app");
+        #[cfg(not(windows))]
+        assert_eq!(app_binary_name(), "con");
+    }
+
+    #[test]
+    fn explicit_flag_wins_over_env() {
+        let _guard = EnvGuard::set("CON", "/tmp/ignored-con");
+        let resolved = resolve_bin(Some(Path::new("/tmp/explicit-con")), "con").unwrap();
+        assert_eq!(resolved, PathBuf::from("/tmp/explicit-con"));
+    }
+
+    #[test]
+    fn documented_env_override_is_used() {
+        let _guard = EnvGuard::set("CON_CLI", "/tmp/documented-con-cli");
+        let resolved = resolve_bin(None, "con-cli").unwrap();
+        assert_eq!(resolved, PathBuf::from("/tmp/documented-con-cli"));
+    }
+
+    struct EnvGuard {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(key);
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.previous {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
 }
 
 use std::process::Command;

--- a/crates/con-test/src/parser.rs
+++ b/crates/con-test/src/parser.rs
@@ -6,7 +6,7 @@
 /// # This is a comment
 ///
 /// con-cli <arguments...>   # preferred
-/// cmd <arguments...>       # legacy alias
+/// # Legacy: old tests may still use `cmd ...`
 /// ---- <mode>              # mode is optional, default: contains
 /// expected output here
 /// ```

--- a/crates/con-test/src/parser.rs
+++ b/crates/con-test/src/parser.rs
@@ -1,0 +1,314 @@
+/// Parser for .test files.
+///
+/// File format:
+///
+/// ```text
+/// # This is a comment
+///
+/// # A step block:
+/// cmd <con-cli arguments...>
+/// match <mode>          # optional, default: contains
+/// ----
+/// expected output here
+/// (blank line or next cmd ends the expected block)
+/// ```
+///
+/// Match modes:
+///   exact        — full string equality (after trimming trailing whitespace per line)
+///   contains     — actual output contains the expected string (default)
+///   json-subset  — every key/value in expected JSON exists in actual JSON
+///   regex        — expected is a regex pattern matched against actual
+///   ok           — only checks that con-cli exited 0; expected block is ignored
+///   error        — checks that con-cli exited non-zero; expected block matched against stderr
+///
+/// A step may have an optional label comment on the same line as `cmd`:
+///   cmd --json tabs list   # verify initial tab count
+///
+/// Blank lines and lines starting with `#` outside a step block are ignored.
+use anyhow::{Context, Result, bail};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MatchMode {
+    /// Full string equality (trailing whitespace trimmed per line)
+    Exact,
+    /// Actual output contains the expected string
+    Contains,
+    /// Expected is valid JSON; every key present in expected must match in actual
+    JsonSubset,
+    /// Expected is a regex matched against actual
+    Regex,
+    /// Only check exit code == 0; ignore expected block
+    Ok,
+    /// Check exit code != 0; match expected against stderr
+    Error,
+}
+
+impl Default for MatchMode {
+    fn default() -> Self {
+        MatchMode::Contains
+    }
+}
+
+impl MatchMode {
+    fn parse(s: &str) -> Result<Self> {
+        match s.trim() {
+            "exact" => Ok(MatchMode::Exact),
+            "contains" => Ok(MatchMode::Contains),
+            "json-subset" => Ok(MatchMode::JsonSubset),
+            "regex" => Ok(MatchMode::Regex),
+            "ok" => Ok(MatchMode::Ok),
+            "error" => Ok(MatchMode::Error),
+            other => bail!("unknown match mode {:?}; valid: exact, contains, json-subset, regex, ok, error", other),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Step {
+    /// Human-readable label (from inline comment on cmd line, or auto-generated)
+    pub label: String,
+    /// Arguments to pass to con-cli (already split on whitespace, respecting quotes)
+    pub args: Vec<String>,
+    pub match_mode: MatchMode,
+    /// Expected output (empty for `ok` / `error` with no expected block)
+    pub expected: String,
+    /// 1-based line number of the `cmd` directive in the source file
+    pub line: usize,
+}
+
+pub fn parse_file(path: &std::path::Path) -> Result<Vec<Step>> {
+    let source = std::fs::read_to_string(path)
+        .with_context(|| format!("cannot read {}", path.display()))?;
+    parse_source(&source, path.display().to_string())
+}
+
+pub fn parse_source(source: &str, origin: String) -> Result<Vec<Step>> {
+    let mut steps = Vec::new();
+    let lines: Vec<&str> = source.lines().collect();
+    let mut i = 0;
+
+    while i < lines.len() {
+        let raw = lines[i];
+        let trimmed = raw.trim();
+
+        // Skip blank lines and standalone comments
+        if trimmed.is_empty() || (trimmed.starts_with('#') && !trimmed.starts_with("cmd ")) {
+            i += 1;
+            continue;
+        }
+
+        if let Some(rest) = trimmed.strip_prefix("cmd ").or_else(|| {
+            if trimmed == "cmd" { Some("") } else { None }
+        }) {
+            let cmd_line = i + 1; // 1-based
+
+            // Split inline label comment: `cmd foo bar  # my label`
+            let (args_str, label) = split_inline_comment(rest);
+            let args = shell_split(args_str.trim())
+                .with_context(|| format!("{origin}:{cmd_line}: failed to parse cmd arguments"))?;
+
+            let label = if label.is_empty() {
+                format!("line {cmd_line}: {}", args_str.trim())
+            } else {
+                label.to_string()
+            };
+
+            i += 1;
+
+            // Optional `match <mode>` line
+            let mut match_mode = MatchMode::default();
+            if i < lines.len() {
+                let next = lines[i].trim();
+                if let Some(mode_str) = next.strip_prefix("match ") {
+                    match_mode = MatchMode::parse(mode_str)
+                        .with_context(|| format!("{origin}:{}: invalid match mode", i + 1))?;
+                    i += 1;
+                }
+            }
+
+            // Expect `----` separator
+            if i >= lines.len() || lines[i].trim() != "----" {
+                bail!(
+                    "{origin}:{}: expected `----` after cmd/match block, got {:?}",
+                    i + 1,
+                    lines.get(i).unwrap_or(&"<eof>")
+                );
+            }
+            i += 1; // skip ----
+
+            // Collect expected output until blank line or next `cmd` or EOF
+            let mut expected_lines: Vec<&str> = Vec::new();
+            while i < lines.len() {
+                let line = lines[i];
+                let t = line.trim();
+                if t.starts_with("cmd ") || t == "cmd" {
+                    break;
+                }
+                // A standalone blank line ends the expected block
+                if t.is_empty() && expected_lines.last().map(|l: &&str| l.trim().is_empty()).unwrap_or(true) {
+                    // Only break on the *first* blank line after content
+                    if !expected_lines.is_empty() {
+                        break;
+                    }
+                }
+                expected_lines.push(line);
+                i += 1;
+            }
+
+            // Trim trailing blank lines from expected block
+            while expected_lines.last().map(|l: &&str| l.trim().is_empty()).unwrap_or(false) {
+                expected_lines.pop();
+            }
+
+            let expected = expected_lines.join("\n");
+
+            steps.push(Step {
+                label,
+                args,
+                match_mode,
+                expected,
+                line: cmd_line,
+            });
+        } else {
+            bail!(
+                "{origin}:{}: unexpected line {:?} (expected `cmd`, `#`, or blank)",
+                i + 1,
+                trimmed
+            );
+        }
+    }
+
+    Ok(steps)
+}
+
+/// Split `foo bar  # comment` into (`foo bar`, `comment`).
+/// Returns the original string and empty comment if no `#` found.
+fn split_inline_comment(s: &str) -> (&str, &str) {
+    // Find ` #` that is not inside a quoted string (simple heuristic: first ` #`)
+    let mut in_single = false;
+    let mut in_double = false;
+    let bytes = s.as_bytes();
+    for idx in 0..bytes.len() {
+        match bytes[idx] {
+            b'\'' if !in_double => in_single = !in_single,
+            b'"' if !in_single => in_double = !in_double,
+            b'#' if !in_single && !in_double => {
+                if idx == 0 || bytes[idx - 1] == b' ' {
+                    let args = s[..idx].trim_end();
+                    let comment = s[idx + 1..].trim();
+                    return (args, comment);
+                }
+            }
+            _ => {}
+        }
+    }
+    (s, "")
+}
+
+/// Very small shell-word splitter: handles double-quoted strings and backslash escapes.
+/// Does not support single-quoted strings or variable expansion (not needed here).
+pub fn shell_split(s: &str) -> Result<Vec<String>> {
+    let mut args: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut in_double = false;
+    let mut chars = s.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        match c {
+            '"' => in_double = !in_double,
+            '\\' => {
+                if let Some(next) = chars.next() {
+                    current.push(next);
+                }
+            }
+            ' ' | '\t' if !in_double => {
+                if !current.is_empty() {
+                    args.push(current.clone());
+                    current.clear();
+                }
+            }
+            _ => current.push(c),
+        }
+    }
+    if in_double {
+        bail!("unterminated double-quoted string in: {s:?}");
+    }
+    if !current.is_empty() {
+        args.push(current);
+    }
+    Ok(args)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_step() {
+        let src = r#"
+cmd --json identify
+----
+{"version":
+"#;
+        let steps = parse_source(src, "test".into()).unwrap();
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].args, vec!["--json", "identify"]);
+        assert_eq!(steps[0].match_mode, MatchMode::Contains);
+        assert!(steps[0].expected.contains("{\"version\":"));
+    }
+
+    #[test]
+    fn parse_match_mode_exact() {
+        let src = "cmd --json tabs list\nmatch exact\n----\n{}\n";
+        let steps = parse_source(src, "test".into()).unwrap();
+        assert_eq!(steps[0].match_mode, MatchMode::Exact);
+    }
+
+    #[test]
+    fn parse_multiple_steps() {
+        let src = r#"
+cmd identify
+----
+con
+
+cmd --json tabs list
+match json-subset
+----
+{"tabs":[]}
+"#;
+        let steps = parse_source(src, "test".into()).unwrap();
+        assert_eq!(steps.len(), 2);
+        assert_eq!(steps[1].match_mode, MatchMode::JsonSubset);
+    }
+
+    #[test]
+    fn parse_ok_mode_empty_expected() {
+        let src = "cmd tabs new\nmatch ok\n----\n";
+        let steps = parse_source(src, "test".into()).unwrap();
+        assert_eq!(steps[0].match_mode, MatchMode::Ok);
+        assert_eq!(steps[0].expected, "");
+    }
+
+    #[test]
+    fn inline_label_comment() {
+        let src = "cmd --json identify  # smoke test\n----\ncon\n";
+        let steps = parse_source(src, "test".into()).unwrap();
+        assert_eq!(steps[0].label, "smoke test");
+    }
+
+    #[test]
+    fn shell_split_quoted() {
+        assert_eq!(
+            shell_split(r#"panes exec --tab 1 "echo hello world""#).unwrap(),
+            vec!["panes", "exec", "--tab", "1", "echo hello world"]
+        );
+    }
+
+    #[test]
+    fn shell_split_backslash() {
+        assert_eq!(
+            shell_split(r"panes exec --tab 1 echo\ hello").unwrap(),
+            vec!["panes", "exec", "--tab", "1", "echo hello"]
+        );
+    }
+}

--- a/crates/con-test/src/parser.rs
+++ b/crates/con-test/src/parser.rs
@@ -79,8 +79,8 @@ pub struct Step {
 }
 
 pub fn parse_file(path: &std::path::Path) -> Result<Vec<Step>> {
-    let source = std::fs::read_to_string(path)
-        .with_context(|| format!("cannot read {}", path.display()))?;
+    let source =
+        std::fs::read_to_string(path).with_context(|| format!("cannot read {}", path.display()))?;
     parse_source(&source, path.display().to_string())
 }
 
@@ -138,15 +138,17 @@ pub fn parse_source(source: &str, origin: String) -> Result<Vec<Step>> {
                 );
             }
             let sep_line = lines[i].trim();
-            if !sep_line.starts_with("----") {
+            let inline_mode_str = if sep_line == "----" {
+                ""
+            } else if let Some(mode) = sep_line.strip_prefix("---- ") {
+                mode.trim()
+            } else {
                 bail!(
                     "{origin}:{}: expected `----` after cmd block, got {:?}",
                     i + 1,
                     sep_line
                 );
-            }
-            // Parse inline mode from `---- <mode>`
-            let inline_mode_str = sep_line.trim_start_matches('-').trim();
+            };
             let match_mode = if let Some(legacy) = legacy_mode {
                 // Legacy `match` line takes precedence if both are present
                 legacy
@@ -301,8 +303,15 @@ mod tests {
     }
 
     #[test]
+    fn separator_requires_space_before_mode() {
+        let src = "cmd --json tabs list\n----json-subset\n{\"tabs\":[]}\n";
+        assert!(parse_source(src, "test".into()).is_err());
+    }
+
+    #[test]
     fn parse_multiple_steps() {
-        let src = "cmd identify\n----\ncon\n\ncmd --json tabs list\n---- json-subset\n{\"tabs\":[]}\n";
+        let src =
+            "cmd identify\n----\ncon\n\ncmd --json tabs list\n---- json-subset\n{\"tabs\":[]}\n";
         let steps = parse_source(src, "test".into()).unwrap();
         assert_eq!(steps.len(), 2);
         assert_eq!(steps[1].match_mode, MatchMode::JsonSubset);

--- a/crates/con-test/src/parser.rs
+++ b/crates/con-test/src/parser.rs
@@ -5,33 +5,31 @@
 /// ```text
 /// # This is a comment
 ///
-/// # A step block:
-/// cmd <con-cli arguments...>
-/// match <mode>          # optional, default: contains
-/// ----
+/// cmd <con-cli arguments...>   # optional inline label
+/// ---- <mode>                  # mode is optional, default: contains
 /// expected output here
-/// (blank line or next cmd ends the expected block)
 /// ```
 ///
-/// Match modes:
-///   exact        — full string equality (after trimming trailing whitespace per line)
-///   contains     — actual output contains the expected string (default)
-///   json-subset  — every key/value in expected JSON exists in actual JSON
-///   regex        — expected is a regex pattern matched against actual
-///   ok           — only checks that con-cli exited 0; expected block is ignored
-///   error        — checks that con-cli exited non-zero; expected block matched against stderr
-///
-/// A step may have an optional label comment on the same line as `cmd`:
-///   cmd --json tabs list   # verify initial tab count
+/// The `----` line optionally carries the match mode:
+///   ----              → contains (default)
+///   ---- exact        → full string equality
+///   ---- contains     → actual output contains the expected string
+///   ---- json-subset  → every key/value in expected JSON exists in actual JSON
+///   ---- ok           → only checks exit code == 0; expected block ignored
+///   ---- error        → checks exit code != 0; expected matched against stderr
+///   ---- regex        → expected is a regex pattern (not yet implemented)
 ///
 /// Blank lines and lines starting with `#` outside a step block are ignored.
+///
+/// Legacy `match <mode>` line between `cmd` and `----` is still accepted for
+/// backwards compatibility but the inline `---- <mode>` form is preferred.
 use anyhow::{Context, Result, bail};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum MatchMode {
     /// Full string equality (trailing whitespace trimmed per line)
     Exact,
-    /// Actual output contains the expected string
+    /// Actual output contains the expected string (default)
     Contains,
     /// Expected is valid JSON; every key present in expected must match in actual
     JsonSubset,
@@ -50,15 +48,19 @@ impl Default for MatchMode {
 }
 
 impl MatchMode {
-    fn parse(s: &str) -> Result<Self> {
+    pub fn parse(s: &str) -> Result<Self> {
         match s.trim() {
+            "" => Ok(MatchMode::Contains),
             "exact" => Ok(MatchMode::Exact),
             "contains" => Ok(MatchMode::Contains),
             "json-subset" => Ok(MatchMode::JsonSubset),
             "regex" => Ok(MatchMode::Regex),
             "ok" => Ok(MatchMode::Ok),
             "error" => Ok(MatchMode::Error),
-            other => bail!("unknown match mode {:?}; valid: exact, contains, json-subset, regex, ok, error", other),
+            other => bail!(
+                "unknown match mode {:?}; valid: exact, contains, json-subset, ok, error",
+                other
+            ),
         }
     }
 }
@@ -88,18 +90,18 @@ pub fn parse_source(source: &str, origin: String) -> Result<Vec<Step>> {
     let mut i = 0;
 
     while i < lines.len() {
-        let raw = lines[i];
-        let trimmed = raw.trim();
+        let trimmed = lines[i].trim();
 
         // Skip blank lines and standalone comments
-        if trimmed.is_empty() || (trimmed.starts_with('#') && !trimmed.starts_with("cmd ")) {
+        if trimmed.is_empty() || trimmed.starts_with('#') {
             i += 1;
             continue;
         }
 
-        if let Some(rest) = trimmed.strip_prefix("cmd ").or_else(|| {
-            if trimmed == "cmd" { Some("") } else { None }
-        }) {
+        if let Some(rest) = trimmed
+            .strip_prefix("cmd ")
+            .or_else(|| if trimmed == "cmd" { Some("") } else { None })
+        {
             let cmd_line = i + 1; // 1-based
 
             // Split inline label comment: `cmd foo bar  # my label`
@@ -115,25 +117,43 @@ pub fn parse_source(source: &str, origin: String) -> Result<Vec<Step>> {
 
             i += 1;
 
-            // Optional `match <mode>` line
-            let mut match_mode = MatchMode::default();
+            // Legacy: optional `match <mode>` line before `----`
+            let mut legacy_mode: Option<MatchMode> = None;
             if i < lines.len() {
                 let next = lines[i].trim();
                 if let Some(mode_str) = next.strip_prefix("match ") {
-                    match_mode = MatchMode::parse(mode_str)
-                        .with_context(|| format!("{origin}:{}: invalid match mode", i + 1))?;
+                    legacy_mode = Some(
+                        MatchMode::parse(mode_str)
+                            .with_context(|| format!("{origin}:{}: invalid match mode", i + 1))?,
+                    );
                     i += 1;
                 }
             }
 
-            // Expect `----` separator
-            if i >= lines.len() || lines[i].trim() != "----" {
+            // Expect `----` separator, optionally followed by match mode
+            if i >= lines.len() {
                 bail!(
-                    "{origin}:{}: expected `----` after cmd/match block, got {:?}",
-                    i + 1,
-                    lines.get(i).unwrap_or(&"<eof>")
+                    "{origin}:{}: expected `----` after cmd block, got <eof>",
+                    i + 1
                 );
             }
+            let sep_line = lines[i].trim();
+            if !sep_line.starts_with("----") {
+                bail!(
+                    "{origin}:{}: expected `----` after cmd block, got {:?}",
+                    i + 1,
+                    sep_line
+                );
+            }
+            // Parse inline mode from `---- <mode>`
+            let inline_mode_str = sep_line.trim_start_matches('-').trim();
+            let match_mode = if let Some(legacy) = legacy_mode {
+                // Legacy `match` line takes precedence if both are present
+                legacy
+            } else {
+                MatchMode::parse(inline_mode_str)
+                    .with_context(|| format!("{origin}:{}: invalid match mode", i + 1))?
+            };
             i += 1; // skip ----
 
             // Collect expected output until blank line or next `cmd` or EOF
@@ -144,19 +164,20 @@ pub fn parse_source(source: &str, origin: String) -> Result<Vec<Step>> {
                 if t.starts_with("cmd ") || t == "cmd" {
                     break;
                 }
-                // A standalone blank line ends the expected block
-                if t.is_empty() && expected_lines.last().map(|l: &&str| l.trim().is_empty()).unwrap_or(true) {
-                    // Only break on the *first* blank line after content
-                    if !expected_lines.is_empty() {
-                        break;
-                    }
+                // A blank line ends the expected block (only after content has started)
+                if t.is_empty() && !expected_lines.is_empty() {
+                    break;
                 }
                 expected_lines.push(line);
                 i += 1;
             }
 
             // Trim trailing blank lines from expected block
-            while expected_lines.last().map(|l: &&str| l.trim().is_empty()).unwrap_or(false) {
+            while expected_lines
+                .last()
+                .map(|l: &&str| l.trim().is_empty())
+                .unwrap_or(false)
+            {
                 expected_lines.pop();
             }
 
@@ -182,9 +203,7 @@ pub fn parse_source(source: &str, origin: String) -> Result<Vec<Step>> {
 }
 
 /// Split `foo bar  # comment` into (`foo bar`, `comment`).
-/// Returns the original string and empty comment if no `#` found.
 fn split_inline_comment(s: &str) -> (&str, &str) {
-    // Find ` #` that is not inside a quoted string (simple heuristic: first ` #`)
     let mut in_single = false;
     let mut in_double = false;
     let bytes = s.as_bytes();
@@ -206,7 +225,6 @@ fn split_inline_comment(s: &str) -> (&str, &str) {
 }
 
 /// Very small shell-word splitter: handles double-quoted strings and backslash escapes.
-/// Does not support single-quoted strings or variable expansion (not needed here).
 pub fn shell_split(s: &str) -> Result<Vec<String>> {
     let mut args: Vec<String> = Vec::new();
     let mut current = String::new();
@@ -244,12 +262,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_simple_step() {
-        let src = r#"
-cmd --json identify
-----
-{"version":
-"#;
+    fn parse_simple_step_default_contains() {
+        let src = "cmd --json identify\n----\n{\"version\":\n";
         let steps = parse_source(src, "test".into()).unwrap();
         assert_eq!(steps.len(), 1);
         assert_eq!(steps[0].args, vec!["--json", "identify"]);
@@ -258,35 +272,40 @@ cmd --json identify
     }
 
     #[test]
-    fn parse_match_mode_exact() {
-        let src = "cmd --json tabs list\nmatch exact\n----\n{}\n";
+    fn parse_inline_mode_on_separator() {
+        let src = "cmd --json tabs list\n---- exact\n{}\n";
         let steps = parse_source(src, "test".into()).unwrap();
         assert_eq!(steps[0].match_mode, MatchMode::Exact);
     }
 
     #[test]
-    fn parse_multiple_steps() {
-        let src = r#"
-cmd identify
-----
-con
-
-cmd --json tabs list
-match json-subset
-----
-{"tabs":[]}
-"#;
+    fn parse_inline_mode_json_subset() {
+        let src = "cmd --json tabs list\n---- json-subset\n{\"tabs\":[]}\n";
         let steps = parse_source(src, "test".into()).unwrap();
-        assert_eq!(steps.len(), 2);
-        assert_eq!(steps[1].match_mode, MatchMode::JsonSubset);
+        assert_eq!(steps[0].match_mode, MatchMode::JsonSubset);
     }
 
     #[test]
-    fn parse_ok_mode_empty_expected() {
-        let src = "cmd tabs new\nmatch ok\n----\n";
+    fn parse_inline_mode_ok_empty_expected() {
+        let src = "cmd tabs new\n---- ok\n";
         let steps = parse_source(src, "test".into()).unwrap();
         assert_eq!(steps[0].match_mode, MatchMode::Ok);
         assert_eq!(steps[0].expected, "");
+    }
+
+    #[test]
+    fn parse_legacy_match_line_still_works() {
+        let src = "cmd --json tabs list\nmatch json-subset\n----\n{\"tabs\":[]}\n";
+        let steps = parse_source(src, "test".into()).unwrap();
+        assert_eq!(steps[0].match_mode, MatchMode::JsonSubset);
+    }
+
+    #[test]
+    fn parse_multiple_steps() {
+        let src = "cmd identify\n----\ncon\n\ncmd --json tabs list\n---- json-subset\n{\"tabs\":[]}\n";
+        let steps = parse_source(src, "test".into()).unwrap();
+        assert_eq!(steps.len(), 2);
+        assert_eq!(steps[1].match_mode, MatchMode::JsonSubset);
     }
 
     #[test]

--- a/crates/con-test/src/parser.rs
+++ b/crates/con-test/src/parser.rs
@@ -5,8 +5,9 @@
 /// ```text
 /// # This is a comment
 ///
-/// cmd <con-cli arguments...>   # optional inline label
-/// ---- <mode>                  # mode is optional, default: contains
+/// con-cli <arguments...>   # preferred
+/// cmd <arguments...>       # legacy alias
+/// ---- <mode>              # mode is optional, default: contains
 /// expected output here
 /// ```
 ///
@@ -21,8 +22,10 @@
 ///
 /// Blank lines and lines starting with `#` outside a step block are ignored.
 ///
-/// Legacy `match <mode>` line between `cmd` and `----` is still accepted for
-/// backwards compatibility but the inline `---- <mode>` form is preferred.
+/// Both `con-cli ...` (preferred) and legacy `cmd ...` step directives are
+/// accepted. Legacy `match <mode>` line between the step directive and `----`
+/// is also accepted for backwards compatibility but the inline `---- <mode>`
+/// form is preferred.
 use anyhow::{Context, Result, bail};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -98,16 +101,14 @@ pub fn parse_source(source: &str, origin: String) -> Result<Vec<Step>> {
             continue;
         }
 
-        if let Some(rest) = trimmed
-            .strip_prefix("cmd ")
-            .or_else(|| if trimmed == "cmd" { Some("") } else { None })
-        {
+        if let Some(rest) = step_args(trimmed) {
             let cmd_line = i + 1; // 1-based
 
-            // Split inline label comment: `cmd foo bar  # my label`
+            // Split inline label comment: `con-cli foo bar  # my label`
             let (args_str, label) = split_inline_comment(rest);
-            let args = shell_split(args_str.trim())
-                .with_context(|| format!("{origin}:{cmd_line}: failed to parse cmd arguments"))?;
+            let args = shell_split(args_str.trim()).with_context(|| {
+                format!("{origin}:{cmd_line}: failed to parse con-cli arguments")
+            })?;
 
             let label = if label.is_empty() {
                 format!("line {cmd_line}: {}", args_str.trim())
@@ -133,7 +134,7 @@ pub fn parse_source(source: &str, origin: String) -> Result<Vec<Step>> {
             // Expect `----` separator, optionally followed by match mode
             if i >= lines.len() {
                 bail!(
-                    "{origin}:{}: expected `----` after cmd block, got <eof>",
+                    "{origin}:{}: expected `----` after con-cli/cmd block, got <eof>",
                     i + 1
                 );
             }
@@ -144,7 +145,7 @@ pub fn parse_source(source: &str, origin: String) -> Result<Vec<Step>> {
                 mode.trim()
             } else {
                 bail!(
-                    "{origin}:{}: expected `----` after cmd block, got {:?}",
+                    "{origin}:{}: expected `----` after con-cli/cmd block, got {:?}",
                     i + 1,
                     sep_line
                 );
@@ -158,12 +159,12 @@ pub fn parse_source(source: &str, origin: String) -> Result<Vec<Step>> {
             };
             i += 1; // skip ----
 
-            // Collect expected output until blank line or next `cmd` or EOF
+            // Collect expected output until blank line, next step directive, or EOF
             let mut expected_lines: Vec<&str> = Vec::new();
             while i < lines.len() {
                 let line = lines[i];
                 let t = line.trim();
-                if t.starts_with("cmd ") || t == "cmd" {
+                if step_args(t).is_some() {
                     break;
                 }
                 // A blank line ends the expected block (only after content has started)
@@ -194,7 +195,7 @@ pub fn parse_source(source: &str, origin: String) -> Result<Vec<Step>> {
             });
         } else {
             bail!(
-                "{origin}:{}: unexpected line {:?} (expected `cmd`, `#`, or blank)",
+                "{origin}:{}: unexpected line {:?} (expected `con-cli`, legacy `cmd`, `#`, or blank)",
                 i + 1,
                 trimmed
             );
@@ -202,6 +203,13 @@ pub fn parse_source(source: &str, origin: String) -> Result<Vec<Step>> {
     }
 
     Ok(steps)
+}
+
+fn step_args(line: &str) -> Option<&str> {
+    line.strip_prefix("con-cli ")
+        .or_else(|| if line == "con-cli" { Some("") } else { None })
+        .or_else(|| line.strip_prefix("cmd "))
+        .or_else(|| if line == "cmd" { Some("") } else { None })
 }
 
 /// Split `foo bar  # comment` into (`foo bar`, `comment`).
@@ -265,7 +273,7 @@ mod tests {
 
     #[test]
     fn parse_simple_step_default_contains() {
-        let src = "cmd --json identify\n----\n{\"version\":\n";
+        let src = "con-cli --json identify\n----\n{\"version\":\n";
         let steps = parse_source(src, "test".into()).unwrap();
         assert_eq!(steps.len(), 1);
         assert_eq!(steps[0].args, vec!["--json", "identify"]);
@@ -274,22 +282,31 @@ mod tests {
     }
 
     #[test]
+    fn parse_legacy_cmd_directive_still_works() {
+        let src = "cmd --json identify\n----\n{\"version\":\n";
+        let steps = parse_source(src, "test".into()).unwrap();
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0].args, vec!["--json", "identify"]);
+        assert_eq!(steps[0].match_mode, MatchMode::Contains);
+    }
+
+    #[test]
     fn parse_inline_mode_on_separator() {
-        let src = "cmd --json tabs list\n---- exact\n{}\n";
+        let src = "con-cli --json tabs list\n---- exact\n{}\n";
         let steps = parse_source(src, "test".into()).unwrap();
         assert_eq!(steps[0].match_mode, MatchMode::Exact);
     }
 
     #[test]
     fn parse_inline_mode_json_subset() {
-        let src = "cmd --json tabs list\n---- json-subset\n{\"tabs\":[]}\n";
+        let src = "con-cli --json tabs list\n---- json-subset\n{\"tabs\":[]}\n";
         let steps = parse_source(src, "test".into()).unwrap();
         assert_eq!(steps[0].match_mode, MatchMode::JsonSubset);
     }
 
     #[test]
     fn parse_inline_mode_ok_empty_expected() {
-        let src = "cmd tabs new\n---- ok\n";
+        let src = "con-cli tabs new\n---- ok\n";
         let steps = parse_source(src, "test".into()).unwrap();
         assert_eq!(steps[0].match_mode, MatchMode::Ok);
         assert_eq!(steps[0].expected, "");
@@ -297,21 +314,20 @@ mod tests {
 
     #[test]
     fn parse_legacy_match_line_still_works() {
-        let src = "cmd --json tabs list\nmatch json-subset\n----\n{\"tabs\":[]}\n";
+        let src = "con-cli --json tabs list\nmatch json-subset\n----\n{\"tabs\":[]}\n";
         let steps = parse_source(src, "test".into()).unwrap();
         assert_eq!(steps[0].match_mode, MatchMode::JsonSubset);
     }
 
     #[test]
     fn separator_requires_space_before_mode() {
-        let src = "cmd --json tabs list\n----json-subset\n{\"tabs\":[]}\n";
+        let src = "con-cli --json tabs list\n----json-subset\n{\"tabs\":[]}\n";
         assert!(parse_source(src, "test".into()).is_err());
     }
 
     #[test]
     fn parse_multiple_steps() {
-        let src =
-            "cmd identify\n----\ncon\n\ncmd --json tabs list\n---- json-subset\n{\"tabs\":[]}\n";
+        let src = "con-cli identify\n----\ncon\n\ncon-cli --json tabs list\n---- json-subset\n{\"tabs\":[]}\n";
         let steps = parse_source(src, "test".into()).unwrap();
         assert_eq!(steps.len(), 2);
         assert_eq!(steps[1].match_mode, MatchMode::JsonSubset);
@@ -319,7 +335,7 @@ mod tests {
 
     #[test]
     fn inline_label_comment() {
-        let src = "cmd --json identify  # smoke test\n----\ncon\n";
+        let src = "con-cli --json identify  # smoke test\n----\ncon\n";
         let steps = parse_source(src, "test".into()).unwrap();
         assert_eq!(steps[0].label, "smoke test");
     }

--- a/crates/con-test/src/runner.rs
+++ b/crates/con-test/src/runner.rs
@@ -121,11 +121,13 @@ impl Drop for ConProcess {
 /// Reset con to a known baseline state before each test file:
 ///   1. Close all tabs except tab 1 (con requires at least one tab).
 ///   2. Close all extra panes in tab 1 by sending Ctrl-D to their shells.
+///   3. Close extra pane-local surfaces in the surviving pane.
 ///
 /// We re-query after each close because indices shift on removal.
 pub fn reset_state(con_cli: &Path, socket: &Path) -> Result<()> {
     reset_tabs(con_cli, socket)?;
     reset_panes(con_cli, socket)?;
+    reset_surfaces(con_cli, socket)?;
     Ok(())
 }
 
@@ -205,6 +207,68 @@ fn reset_panes(con_cli: &Path, socket: &Path) -> Result<()> {
                     ],
                 );
                 std::thread::sleep(Duration::from_millis(300));
+            }
+            None => break,
+        }
+    }
+    Ok(())
+}
+
+fn reset_surfaces(con_cli: &Path, socket: &Path) -> Result<()> {
+    let mut attempts = 0usize;
+    loop {
+        let json = cli_json(
+            con_cli,
+            socket,
+            &["surfaces", "list", "--tab", "1", "--pane-index", "1"],
+        )?;
+        let surfaces = json["surfaces"]
+            .as_array()
+            .context("reset_surfaces: missing surfaces array")?;
+
+        if surfaces.len() <= 1 {
+            break;
+        }
+        attempts += 1;
+        if attempts > 20 {
+            bail!(
+                "reset_surfaces: still have {} surfaces after 20 close attempts",
+                surfaces.len()
+            );
+        }
+
+        // Keep the lowest surface_id for the surviving pane and close all others.
+        let min_surface_id = surfaces
+            .iter()
+            .filter_map(|s| s["surface_id"].as_u64())
+            .min()
+            .context("reset_surfaces: no surface_id found")?;
+
+        let extra_id = surfaces
+            .iter()
+            .filter_map(|s| s["surface_id"].as_u64())
+            .find(|&id| id != min_surface_id);
+
+        match extra_id {
+            Some(id) => {
+                cli_run(
+                    con_cli,
+                    socket,
+                    &[
+                        "surfaces",
+                        "close",
+                        "--tab",
+                        "1",
+                        "--pane-index",
+                        "1",
+                        "--surface-id",
+                        &id.to_string(),
+                    ],
+                )
+                .with_context(|| {
+                    format!("reset_surfaces: surfaces close --surface-id {id} failed")
+                })?;
+                std::thread::sleep(Duration::from_millis(100));
             }
             None => break,
         }

--- a/crates/con-test/src/runner.rs
+++ b/crates/con-test/src/runner.rs
@@ -49,43 +49,61 @@ impl ConProcess {
             socket: socket.to_path_buf(),
         };
 
-        process.wait_for_socket(startup_timeout)?;
+        process.wait_for_control_endpoint(con_bin, startup_timeout)?;
         Ok(process)
     }
 
     /// Block until the control endpoint is ready or the timeout expires.
-    fn wait_for_socket(&mut self, timeout: Duration) -> Result<()> {
+    fn wait_for_control_endpoint(&mut self, con_bin: &Path, timeout: Duration) -> Result<()> {
         let deadline = Instant::now() + timeout;
         while Instant::now() < deadline {
-            if let Some(status) = self.child.try_wait()? {
-                bail!("con exited before control endpoint was ready (status: {status})");
+            if let Some(status) = self.child_status()? {
+                bail!("con exited before the control endpoint was ready: {status}");
             }
 
             if control_endpoint_ready(&self.socket) {
-                // Give con a brief moment to finish binding before we connect.
+                // Give con a brief moment to finish installing the workspace before tests start.
                 std::thread::sleep(Duration::from_millis(100));
                 return Ok(());
             }
+
             std::thread::sleep(Duration::from_millis(200));
         }
         bail!(
-            "con did not expose control endpoint at {} within {:?}",
+            "con ({}) did not expose control endpoint at {} within {:?}",
+            con_bin.display(),
             self.socket.display(),
             timeout
         )
     }
+
+    fn child_status(&mut self) -> Result<Option<std::process::ExitStatus>> {
+        self.child
+            .try_wait()
+            .context("failed to poll con child process status")
+    }
+}
+
+#[cfg(unix)]
+fn control_endpoint_ready(socket: &Path) -> bool {
+    std::os::unix::net::UnixStream::connect(socket).is_ok()
 }
 
 #[cfg(windows)]
 fn control_endpoint_ready(socket: &Path) -> bool {
     // Windows uses Named Pipes (e.g. \\.\pipe\con). Opening as a file
     // is the canonical probe and succeeds only once the server is listening.
-    std::fs::OpenOptions::new().read(true).open(socket).is_ok()
+    std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(socket)
+        .is_ok()
 }
 
-#[cfg(not(windows))]
+#[cfg(not(any(unix, windows)))]
 fn control_endpoint_ready(socket: &Path) -> bool {
-    socket.exists()
+    let _ = socket;
+    false
 }
 
 impl Drop for ConProcess {

--- a/crates/con-test/src/runner.rs
+++ b/crates/con-test/src/runner.rs
@@ -517,7 +517,11 @@ fn rewrite_file(path: &Path, _steps: &[Step], rewrites: &[(usize, String)]) -> R
     while i < lines.len() {
         let trimmed = lines[i].trim();
 
-        if trimmed.starts_with("cmd ") || trimmed == "cmd" {
+        if trimmed.starts_with("con-cli ")
+            || trimmed == "con-cli"
+            || trimmed.starts_with("cmd ")
+            || trimmed == "cmd"
+        {
             out.push_str(lines[i]);
             out.push('\n');
             i += 1;
@@ -539,7 +543,11 @@ fn rewrite_file(path: &Path, _steps: &[Step], rewrites: &[(usize, String)]) -> R
             // Skip old expected block
             while i < lines.len() {
                 let t = lines[i].trim();
-                if t.starts_with("cmd ") || t == "cmd" {
+                if t.starts_with("con-cli ")
+                    || t == "con-cli"
+                    || t.starts_with("cmd ")
+                    || t == "cmd"
+                {
                     break;
                 }
                 if t.is_empty() {

--- a/crates/con-test/src/runner.rs
+++ b/crates/con-test/src/runner.rs
@@ -1,18 +1,156 @@
-/// Test runner — executes steps from a parsed .test file against a live con-cli binary.
+/// Test runner — launches a con process, resets state between files, executes steps.
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use serde_json::Value;
 
 use crate::parser::{MatchMode, Step, parse_file};
 
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
 pub struct RunConfig {
     pub con_cli: PathBuf,
-    pub socket: Option<PathBuf>,
+    pub socket: PathBuf,
     pub rewrite: bool,
     pub verbose: bool,
 }
+
+// ---------------------------------------------------------------------------
+// Con process lifecycle
+// ---------------------------------------------------------------------------
+
+/// RAII guard for a running con process.
+/// Kills the process and removes the socket file on drop.
+pub struct ConProcess {
+    child: std::process::Child,
+    socket: PathBuf,
+}
+
+impl ConProcess {
+    /// Launch con with a dedicated socket path and wait until the socket is ready.
+    pub fn launch(con_bin: &Path, socket: &Path, startup_timeout: Duration) -> Result<Self> {
+        // Remove any stale socket from a previous run.
+        let _ = std::fs::remove_file(socket);
+
+        let child = Command::new(con_bin)
+            .env("CON_SOCKET_PATH", socket)
+            // Suppress con's own log output so it doesn't pollute test output.
+            // Tests that need to inspect logs can override this.
+            .env("RUST_LOG", "error")
+            .spawn()
+            .with_context(|| format!("failed to launch con from {}", con_bin.display()))?;
+
+        let process = ConProcess {
+            child,
+            socket: socket.to_path_buf(),
+        };
+
+        process.wait_for_socket(startup_timeout)?;
+        Ok(process)
+    }
+
+    /// Block until the socket file appears or the timeout expires.
+    fn wait_for_socket(&self, timeout: Duration) -> Result<()> {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if self.socket.exists() {
+                // Give con a brief moment to finish binding before we connect.
+                std::thread::sleep(Duration::from_millis(100));
+                return Ok(());
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
+        bail!(
+            "con did not create socket at {} within {:?}",
+            self.socket.display(),
+            timeout
+        )
+    }
+
+}
+
+impl Drop for ConProcess {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait(); // reap the zombie
+        let _ = std::fs::remove_file(&self.socket);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// State reset
+// ---------------------------------------------------------------------------
+
+/// Reset con to a known baseline state before each test file:
+///   - Close all tabs except the first one (con requires at least one tab).
+///   - The surviving tab is tab index 1.
+///
+/// We re-query tabs after each close because indices shift on removal.
+pub fn reset_state(con_cli: &Path, socket: &Path) -> Result<()> {
+    loop {
+        let output = Command::new(con_cli)
+            .args(["--socket", &socket.to_string_lossy(), "--json", "tabs", "list"])
+            .output()
+            .context("reset_state: failed to run tabs list")?;
+
+        if !output.status.success() {
+            bail!(
+                "reset_state: tabs list failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        let json: Value = serde_json::from_slice(&output.stdout)
+            .context("reset_state: tabs list returned invalid JSON")?;
+
+        let tabs = json["tabs"]
+            .as_array()
+            .context("reset_state: missing tabs array")?;
+
+        // Find any tab with index > 1 and close it.
+        // We close one at a time and re-query so indices stay accurate.
+        let extra = tabs
+            .iter()
+            .filter_map(|t| t["index"].as_u64())
+            .find(|&idx| idx > 1);
+
+        match extra {
+            Some(idx) => {
+                let output = Command::new(con_cli)
+                    .args([
+                        "--socket",
+                        &socket.to_string_lossy(),
+                        "tabs",
+                        "close",
+                        "--tab",
+                        &idx.to_string(),
+                    ])
+                    .output()
+                    .context("reset_state: failed to run tabs close")?;
+
+                if !output.status.success() {
+                    bail!(
+                        "reset_state: tabs close --tab {} failed: {}",
+                        idx,
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                }
+                // Small pause to let con process the close before we re-query.
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            None => break, // only tab 1 remains
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// File runner
+// ---------------------------------------------------------------------------
 
 #[derive(Debug, Default)]
 pub struct FileResult {
@@ -34,7 +172,7 @@ pub struct StepFailure {
 pub fn run_file(path: &Path, config: &RunConfig) -> Result<FileResult> {
     let steps = parse_file(path)?;
     let mut result = FileResult::default();
-    let mut rewrite_steps: Vec<(usize, String)> = Vec::new(); // (step index, new expected)
+    let mut rewrite_steps: Vec<(usize, String)> = Vec::new();
 
     for (idx, step) in steps.iter().enumerate() {
         let outcome = run_step(step, config)?;
@@ -71,6 +209,10 @@ pub fn run_file(path: &Path, config: &RunConfig) -> Result<FileResult> {
     Ok(result)
 }
 
+// ---------------------------------------------------------------------------
+// Step execution
+// ---------------------------------------------------------------------------
+
 enum StepOutcome {
     Pass,
     Fail(StepFailure),
@@ -78,11 +220,8 @@ enum StepOutcome {
 }
 
 fn run_step(step: &Step, config: &RunConfig) -> Result<StepOutcome> {
-    // Build the con-cli invocation
     let mut cmd = Command::new(&config.con_cli);
-    if let Some(socket) = &config.socket {
-        cmd.arg("--socket").arg(socket);
-    }
+    cmd.arg("--socket").arg(&config.socket);
     cmd.args(&step.args);
 
     let output = cmd
@@ -199,15 +338,16 @@ fn run_step(step: &Step, config: &RunConfig) -> Result<StepOutcome> {
             if !exit_ok {
                 return Ok(StepOutcome::Fail(exit_failure(step, &cmd_display, &stderr)));
             }
-            // Use a simple hand-rolled check to avoid adding a regex dep.
-            // For now we treat the pattern as a literal substring with `.*` support.
-            // TODO: add the `regex` crate if more power is needed.
             Ok(StepOutcome::Skip(
                 "regex match mode not yet implemented — use contains or exact".into(),
             ))
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 fn check_text_match(
     expected: &str,
@@ -253,9 +393,9 @@ fn json_is_subset(expected: &Value, actual: &Value) -> bool {
                 .map(|av| json_is_subset(ev, av))
                 .unwrap_or(false)
         }),
-        (Value::Array(exp_arr), Value::Array(act_arr)) => {
-            exp_arr.iter().all(|ev| act_arr.iter().any(|av| json_is_subset(ev, av)))
-        }
+        (Value::Array(exp_arr), Value::Array(act_arr)) => exp_arr
+            .iter()
+            .all(|ev| act_arr.iter().any(|av| json_is_subset(ev, av))),
         _ => expected == actual,
     }
 }
@@ -278,19 +418,13 @@ fn make_diff(expected: &str, actual: &str) -> String {
     let max = exp_lines.len().max(act_lines.len());
     for i in 0..max {
         match (exp_lines.get(i), act_lines.get(i)) {
-            (Some(e), Some(a)) if e == a => {
-                out.push_str(&format!("  {e}\n"));
-            }
+            (Some(e), Some(a)) if e == a => out.push_str(&format!("  {e}\n")),
             (Some(e), Some(a)) => {
                 out.push_str(&format!("- {e}\n"));
                 out.push_str(&format!("+ {a}\n"));
             }
-            (Some(e), None) => {
-                out.push_str(&format!("- {e}\n"));
-            }
-            (None, Some(a)) => {
-                out.push_str(&format!("+ {a}\n"));
-            }
+            (Some(e), None) => out.push_str(&format!("- {e}\n")),
+            (None, Some(a)) => out.push_str(&format!("+ {a}\n")),
             (None, None) => {}
         }
     }
@@ -302,7 +436,6 @@ fn rewrite_file(path: &Path, _steps: &[Step], rewrites: &[(usize, String)]) -> R
     let source = std::fs::read_to_string(path)?;
     let lines: Vec<&str> = source.lines().collect();
 
-    // Build a map from step index → new expected text
     let rewrite_map: std::collections::HashMap<usize, &str> = rewrites
         .iter()
         .map(|(idx, new)| (*idx, new.as_str()))
@@ -316,19 +449,16 @@ fn rewrite_file(path: &Path, _steps: &[Step], rewrites: &[(usize, String)]) -> R
         let trimmed = lines[i].trim();
 
         if trimmed.starts_with("cmd ") || trimmed == "cmd" {
-            // Emit the cmd line as-is
             out.push_str(lines[i]);
             out.push('\n');
             i += 1;
 
-            // Emit optional match line
             if i < lines.len() && lines[i].trim().starts_with("match ") {
                 out.push_str(lines[i]);
                 out.push('\n');
                 i += 1;
             }
 
-            // Emit ----
             if i < lines.len() && lines[i].trim() == "----" {
                 out.push_str(lines[i]);
                 out.push('\n');
@@ -348,7 +478,6 @@ fn rewrite_file(path: &Path, _steps: &[Step], rewrites: &[(usize, String)]) -> R
                 i += 1;
             }
 
-            // Emit new expected if we have a rewrite for this step
             if let Some(new_expected) = rewrite_map.get(&step_idx) {
                 for line in new_expected.lines() {
                     out.push_str(line);
@@ -371,7 +500,9 @@ fn rewrite_file(path: &Path, _steps: &[Step], rewrites: &[(usize, String)]) -> R
 
 /// Quote a shell argument if it contains spaces or special characters.
 fn shell_quote(s: &str) -> String {
-    if s.chars().any(|c| matches!(c, ' ' | '\t' | '"' | '\'' | '\\' | '#')) {
+    if s.chars()
+        .any(|c| matches!(c, ' ' | '\t' | '"' | '\'' | '\\' | '#'))
+    {
         format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
     } else {
         s.to_string()

--- a/crates/con-test/src/runner.rs
+++ b/crates/con-test/src/runner.rs
@@ -70,7 +70,6 @@ impl ConProcess {
             timeout
         )
     }
-
 }
 
 impl Drop for ConProcess {
@@ -110,8 +109,12 @@ fn reset_tabs(con_cli: &Path, socket: &Path) -> Result<()> {
 
         match extra {
             Some(idx) => {
-                cli_run(con_cli, socket, &["tabs", "close", "--tab", &idx.to_string()])
-                    .with_context(|| format!("reset_tabs: tabs close --tab {idx} failed"))?;
+                cli_run(
+                    con_cli,
+                    socket,
+                    &["tabs", "close", "--tab", &idx.to_string()],
+                )
+                .with_context(|| format!("reset_tabs: tabs close --tab {idx} failed"))?;
                 std::thread::sleep(Duration::from_millis(50));
             }
             None => break,
@@ -121,6 +124,7 @@ fn reset_tabs(con_cli: &Path, socket: &Path) -> Result<()> {
 }
 
 fn reset_panes(con_cli: &Path, socket: &Path) -> Result<()> {
+    let mut attempts = 0usize;
     loop {
         let json = cli_json(con_cli, socket, &["panes", "list", "--tab", "1"])?;
         let panes = json["panes"]
@@ -129,6 +133,13 @@ fn reset_panes(con_cli: &Path, socket: &Path) -> Result<()> {
 
         if panes.len() <= 1 {
             break;
+        }
+        attempts += 1;
+        if attempts > 20 {
+            bail!(
+                "reset_panes: still have {} panes after 20 close attempts",
+                panes.len()
+            );
         }
 
         // Keep the pane with the lowest pane_id; send Ctrl-D to all others.
@@ -517,7 +528,9 @@ fn rewrite_file(path: &Path, _steps: &[Step], rewrites: &[(usize, String)]) -> R
                 i += 1;
             }
 
-            if i < lines.len() && lines[i].trim() == "----" {
+            let sep_is_legacy = i < lines.len() && lines[i].trim() == "----";
+            let sep_is_inline = i < lines.len() && lines[i].trim().starts_with("---- ");
+            if sep_is_legacy || sep_is_inline {
                 out.push_str(lines[i]);
                 out.push('\n');
                 i += 1;

--- a/crates/con-test/src/runner.rs
+++ b/crates/con-test/src/runner.rs
@@ -1,0 +1,379 @@
+/// Test runner — executes steps from a parsed .test file against a live con-cli binary.
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use crate::parser::{MatchMode, Step, parse_file};
+
+pub struct RunConfig {
+    pub con_cli: PathBuf,
+    pub socket: Option<PathBuf>,
+    pub rewrite: bool,
+    pub verbose: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct FileResult {
+    pub passed: usize,
+    pub failed: usize,
+    pub skipped: usize,
+    pub failures: Vec<StepFailure>,
+}
+
+#[derive(Debug)]
+pub struct StepFailure {
+    pub step_label: String,
+    pub cmd: String,
+    pub expected: String,
+    pub actual: String,
+    pub diff: String,
+}
+
+pub fn run_file(path: &Path, config: &RunConfig) -> Result<FileResult> {
+    let steps = parse_file(path)?;
+    let mut result = FileResult::default();
+    let mut rewrite_steps: Vec<(usize, String)> = Vec::new(); // (step index, new expected)
+
+    for (idx, step) in steps.iter().enumerate() {
+        let outcome = run_step(step, config)?;
+        match outcome {
+            StepOutcome::Pass => {
+                result.passed += 1;
+                if config.verbose {
+                    println!("    pass: {}", step.label);
+                }
+            }
+            StepOutcome::Fail(failure) => {
+                if config.rewrite {
+                    rewrite_steps.push((idx, failure.actual.clone()));
+                    result.passed += 1;
+                } else {
+                    result.failures.push(failure);
+                    result.failed += 1;
+                }
+            }
+            StepOutcome::Skip(reason) => {
+                result.skipped += 1;
+                if config.verbose {
+                    println!("    skip: {} — {reason}", step.label);
+                }
+            }
+        }
+    }
+
+    if config.rewrite && !rewrite_steps.is_empty() {
+        rewrite_file(path, &steps, &rewrite_steps)
+            .with_context(|| format!("failed to rewrite {}", path.display()))?;
+    }
+
+    Ok(result)
+}
+
+enum StepOutcome {
+    Pass,
+    Fail(StepFailure),
+    Skip(String),
+}
+
+fn run_step(step: &Step, config: &RunConfig) -> Result<StepOutcome> {
+    // Build the con-cli invocation
+    let mut cmd = Command::new(&config.con_cli);
+    if let Some(socket) = &config.socket {
+        cmd.arg("--socket").arg(socket);
+    }
+    cmd.args(&step.args);
+
+    let output = cmd
+        .output()
+        .with_context(|| format!("failed to run con-cli for step {:?}", step.label))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let exit_ok = output.status.success();
+
+    let cmd_display = format!(
+        "con-cli {}",
+        step.args
+            .iter()
+            .map(|a| shell_quote(a))
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+
+    match &step.match_mode {
+        MatchMode::Ok => {
+            if exit_ok {
+                Ok(StepOutcome::Pass)
+            } else {
+                Ok(StepOutcome::Fail(StepFailure {
+                    step_label: format!("{} (line {})", step.label, step.line),
+                    cmd: cmd_display,
+                    expected: "exit code 0".into(),
+                    actual: format!(
+                        "exit code {}\nstderr: {stderr}",
+                        output.status.code().unwrap_or(-1)
+                    ),
+                    diff: String::new(),
+                }))
+            }
+        }
+
+        MatchMode::Error => {
+            if !exit_ok {
+                let actual = stderr.trim().to_string();
+                check_text_match(&step.expected, &actual, step, &cmd_display, &stderr)
+            } else {
+                Ok(StepOutcome::Fail(StepFailure {
+                    step_label: format!("{} (line {})", step.label, step.line),
+                    cmd: cmd_display,
+                    expected: "non-zero exit code".into(),
+                    actual: format!("exit code 0\nstdout: {stdout}"),
+                    diff: String::new(),
+                }))
+            }
+        }
+
+        MatchMode::Exact => {
+            if !exit_ok {
+                return Ok(StepOutcome::Fail(exit_failure(step, &cmd_display, &stderr)));
+            }
+            let actual = normalize_lines(&stdout);
+            let expected = normalize_lines(&step.expected);
+            if actual == expected {
+                Ok(StepOutcome::Pass)
+            } else {
+                Ok(StepOutcome::Fail(StepFailure {
+                    step_label: format!("{} (line {})", step.label, step.line),
+                    cmd: cmd_display,
+                    expected: step.expected.clone(),
+                    actual: stdout.clone(),
+                    diff: make_diff(&expected, &actual),
+                }))
+            }
+        }
+
+        MatchMode::Contains => {
+            if !exit_ok {
+                return Ok(StepOutcome::Fail(exit_failure(step, &cmd_display, &stderr)));
+            }
+            check_text_match(&step.expected, &stdout, step, &cmd_display, &stderr)
+        }
+
+        MatchMode::JsonSubset => {
+            if !exit_ok {
+                return Ok(StepOutcome::Fail(exit_failure(step, &cmd_display, &stderr)));
+            }
+            let actual_val: Value = serde_json::from_str(stdout.trim()).with_context(|| {
+                format!(
+                    "step {:?}: actual output is not valid JSON:\n{stdout}",
+                    step.label
+                )
+            })?;
+            let expected_val: Value =
+                serde_json::from_str(step.expected.trim()).with_context(|| {
+                    format!(
+                        "step {:?}: expected block is not valid JSON:\n{}",
+                        step.label, step.expected
+                    )
+                })?;
+            if json_is_subset(&expected_val, &actual_val) {
+                Ok(StepOutcome::Pass)
+            } else {
+                Ok(StepOutcome::Fail(StepFailure {
+                    step_label: format!("{} (line {})", step.label, step.line),
+                    cmd: cmd_display,
+                    expected: serde_json::to_string_pretty(&expected_val).unwrap_or_default(),
+                    actual: serde_json::to_string_pretty(&actual_val).unwrap_or_default(),
+                    diff: format!(
+                        "expected JSON is not a subset of actual JSON\nexpected: {}\nactual:   {}",
+                        step.expected.trim(),
+                        stdout.trim()
+                    ),
+                }))
+            }
+        }
+
+        MatchMode::Regex => {
+            if !exit_ok {
+                return Ok(StepOutcome::Fail(exit_failure(step, &cmd_display, &stderr)));
+            }
+            // Use a simple hand-rolled check to avoid adding a regex dep.
+            // For now we treat the pattern as a literal substring with `.*` support.
+            // TODO: add the `regex` crate if more power is needed.
+            Ok(StepOutcome::Skip(
+                "regex match mode not yet implemented — use contains or exact".into(),
+            ))
+        }
+    }
+}
+
+fn check_text_match(
+    expected: &str,
+    actual: &str,
+    step: &Step,
+    cmd_display: &str,
+    stderr: &str,
+) -> Result<StepOutcome> {
+    if expected.is_empty() || actual.contains(expected.trim()) {
+        Ok(StepOutcome::Pass)
+    } else {
+        Ok(StepOutcome::Fail(StepFailure {
+            step_label: format!("{} (line {})", step.label, step.line),
+            cmd: cmd_display.to_string(),
+            expected: expected.to_string(),
+            actual: actual.to_string(),
+            diff: if !stderr.is_empty() {
+                format!("stderr: {stderr}")
+            } else {
+                String::new()
+            },
+        }))
+    }
+}
+
+fn exit_failure(step: &Step, cmd_display: &str, stderr: &str) -> StepFailure {
+    StepFailure {
+        step_label: format!("{} (line {})", step.label, step.line),
+        cmd: cmd_display.to_string(),
+        expected: step.expected.clone(),
+        actual: format!("con-cli exited with error\nstderr: {stderr}"),
+        diff: String::new(),
+    }
+}
+
+/// Recursively check that every key/value in `expected` exists in `actual`.
+/// Arrays: every element in expected must appear somewhere in actual (order-independent).
+fn json_is_subset(expected: &Value, actual: &Value) -> bool {
+    match (expected, actual) {
+        (Value::Object(exp_map), Value::Object(act_map)) => exp_map.iter().all(|(k, ev)| {
+            act_map
+                .get(k)
+                .map(|av| json_is_subset(ev, av))
+                .unwrap_or(false)
+        }),
+        (Value::Array(exp_arr), Value::Array(act_arr)) => {
+            exp_arr.iter().all(|ev| act_arr.iter().any(|av| json_is_subset(ev, av)))
+        }
+        _ => expected == actual,
+    }
+}
+
+/// Normalize line endings and trim trailing whitespace per line.
+fn normalize_lines(s: &str) -> String {
+    s.lines()
+        .map(|l| l.trim_end())
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim_end()
+        .to_string()
+}
+
+/// Produce a simple unified-style diff between two strings.
+fn make_diff(expected: &str, actual: &str) -> String {
+    let exp_lines: Vec<&str> = expected.lines().collect();
+    let act_lines: Vec<&str> = actual.lines().collect();
+    let mut out = String::new();
+    let max = exp_lines.len().max(act_lines.len());
+    for i in 0..max {
+        match (exp_lines.get(i), act_lines.get(i)) {
+            (Some(e), Some(a)) if e == a => {
+                out.push_str(&format!("  {e}\n"));
+            }
+            (Some(e), Some(a)) => {
+                out.push_str(&format!("- {e}\n"));
+                out.push_str(&format!("+ {a}\n"));
+            }
+            (Some(e), None) => {
+                out.push_str(&format!("- {e}\n"));
+            }
+            (None, Some(a)) => {
+                out.push_str(&format!("+ {a}\n"));
+            }
+            (None, None) => {}
+        }
+    }
+    out
+}
+
+/// Rewrite a .test file, replacing expected blocks for the given step indices.
+fn rewrite_file(path: &Path, _steps: &[Step], rewrites: &[(usize, String)]) -> Result<()> {
+    let source = std::fs::read_to_string(path)?;
+    let lines: Vec<&str> = source.lines().collect();
+
+    // Build a map from step index → new expected text
+    let rewrite_map: std::collections::HashMap<usize, &str> = rewrites
+        .iter()
+        .map(|(idx, new)| (*idx, new.as_str()))
+        .collect();
+
+    let mut out = String::new();
+    let mut step_idx = 0usize;
+    let mut i = 0usize;
+
+    while i < lines.len() {
+        let trimmed = lines[i].trim();
+
+        if trimmed.starts_with("cmd ") || trimmed == "cmd" {
+            // Emit the cmd line as-is
+            out.push_str(lines[i]);
+            out.push('\n');
+            i += 1;
+
+            // Emit optional match line
+            if i < lines.len() && lines[i].trim().starts_with("match ") {
+                out.push_str(lines[i]);
+                out.push('\n');
+                i += 1;
+            }
+
+            // Emit ----
+            if i < lines.len() && lines[i].trim() == "----" {
+                out.push_str(lines[i]);
+                out.push('\n');
+                i += 1;
+            }
+
+            // Skip old expected block
+            while i < lines.len() {
+                let t = lines[i].trim();
+                if t.starts_with("cmd ") || t == "cmd" {
+                    break;
+                }
+                if t.is_empty() {
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
+
+            // Emit new expected if we have a rewrite for this step
+            if let Some(new_expected) = rewrite_map.get(&step_idx) {
+                for line in new_expected.lines() {
+                    out.push_str(line);
+                    out.push('\n');
+                }
+                out.push('\n');
+            }
+
+            step_idx += 1;
+        } else {
+            out.push_str(lines[i]);
+            out.push('\n');
+            i += 1;
+        }
+    }
+
+    std::fs::write(path, out)?;
+    Ok(())
+}
+
+/// Quote a shell argument if it contains spaces or special characters.
+fn shell_quote(s: &str) -> String {
+    if s.chars().any(|c| matches!(c, ' ' | '\t' | '"' | '\'' | '\\' | '#')) {
+        format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
+    } else {
+        s.to_string()
+    }
+}

--- a/crates/con-test/src/runner.rs
+++ b/crates/con-test/src/runner.rs
@@ -44,7 +44,7 @@ impl ConProcess {
             .spawn()
             .with_context(|| format!("failed to launch con from {}", con_bin.display()))?;
 
-        let process = ConProcess {
+        let mut process = ConProcess {
             child,
             socket: socket.to_path_buf(),
         };
@@ -53,11 +53,15 @@ impl ConProcess {
         Ok(process)
     }
 
-    /// Block until the socket file appears or the timeout expires.
-    fn wait_for_socket(&self, timeout: Duration) -> Result<()> {
+    /// Block until the control endpoint is ready or the timeout expires.
+    fn wait_for_socket(&mut self, timeout: Duration) -> Result<()> {
         let deadline = Instant::now() + timeout;
         while Instant::now() < deadline {
-            if self.socket.exists() {
+            if let Some(status) = self.child.try_wait()? {
+                bail!("con exited before control endpoint was ready (status: {status})");
+            }
+
+            if control_endpoint_ready(&self.socket) {
                 // Give con a brief moment to finish binding before we connect.
                 std::thread::sleep(Duration::from_millis(100));
                 return Ok(());
@@ -65,11 +69,23 @@ impl ConProcess {
             std::thread::sleep(Duration::from_millis(200));
         }
         bail!(
-            "con did not create socket at {} within {:?}",
+            "con did not expose control endpoint at {} within {:?}",
             self.socket.display(),
             timeout
         )
     }
+}
+
+#[cfg(windows)]
+fn control_endpoint_ready(socket: &Path) -> bool {
+    // Windows uses Named Pipes (e.g. \\.\pipe\con). Opening as a file
+    // is the canonical probe and succeeds only once the server is listening.
+    std::fs::OpenOptions::new().read(true).open(socket).is_ok()
+}
+
+#[cfg(not(windows))]
+fn control_endpoint_ready(socket: &Path) -> bool {
+    socket.exists()
 }
 
 impl Drop for ConProcess {

--- a/crates/con-test/src/runner.rs
+++ b/crates/con-test/src/runner.rs
@@ -560,9 +560,25 @@ fn json_is_subset(expected: &Value, actual: &Value) -> bool {
                 .map(|av| json_is_subset(ev, av))
                 .unwrap_or(false)
         }),
-        (Value::Array(exp_arr), Value::Array(act_arr)) => exp_arr
-            .iter()
-            .all(|ev| act_arr.iter().any(|av| json_is_subset(ev, av))),
+        (Value::Array(exp_arr), Value::Array(act_arr)) => {
+            if exp_arr.len() > act_arr.len() {
+                return false;
+            }
+
+            let mut used = vec![false; act_arr.len()];
+            exp_arr.iter().all(|ev| {
+                if let Some(index) = act_arr
+                    .iter()
+                    .enumerate()
+                    .position(|(idx, av)| !used[idx] && json_is_subset(ev, av))
+                {
+                    used[index] = true;
+                    true
+                } else {
+                    false
+                }
+            })
+        }
         _ => expected == actual,
     }
 }
@@ -673,6 +689,29 @@ fn rewrite_file(path: &Path, _steps: &[Step], rewrites: &[(usize, String)]) -> R
 
     std::fs::write(path, out)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_subset_arrays_preserve_duplicate_expectations() {
+        let expected = serde_json::json!([
+            {"is_alive": true},
+            {"is_alive": true}
+        ]);
+        let actual_one = serde_json::json!([
+            {"pane_id": 1, "is_alive": true}
+        ]);
+        let actual_two = serde_json::json!([
+            {"pane_id": 1, "is_alive": true},
+            {"pane_id": 2, "is_alive": true}
+        ]);
+
+        assert!(!json_is_subset(&expected, &actual_one));
+        assert!(json_is_subset(&expected, &actual_two));
+    }
 }
 
 /// Quote a shell argument if it contains spaces or special characters.

--- a/crates/con-test/src/runner.rs
+++ b/crates/con-test/src/runner.rs
@@ -86,33 +86,23 @@ impl Drop for ConProcess {
 // ---------------------------------------------------------------------------
 
 /// Reset con to a known baseline state before each test file:
-///   - Close all tabs except the first one (con requires at least one tab).
-///   - The surviving tab is tab index 1.
+///   1. Close all tabs except tab 1 (con requires at least one tab).
+///   2. Close all extra panes in tab 1 by sending Ctrl-D to their shells.
 ///
-/// We re-query tabs after each close because indices shift on removal.
+/// We re-query after each close because indices shift on removal.
 pub fn reset_state(con_cli: &Path, socket: &Path) -> Result<()> {
+    reset_tabs(con_cli, socket)?;
+    reset_panes(con_cli, socket)?;
+    Ok(())
+}
+
+fn reset_tabs(con_cli: &Path, socket: &Path) -> Result<()> {
     loop {
-        let output = Command::new(con_cli)
-            .args(["--socket", &socket.to_string_lossy(), "--json", "tabs", "list"])
-            .output()
-            .context("reset_state: failed to run tabs list")?;
-
-        if !output.status.success() {
-            bail!(
-                "reset_state: tabs list failed: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-        }
-
-        let json: Value = serde_json::from_slice(&output.stdout)
-            .context("reset_state: tabs list returned invalid JSON")?;
-
+        let json = cli_json(con_cli, socket, &["tabs", "list"])?;
         let tabs = json["tabs"]
             .as_array()
-            .context("reset_state: missing tabs array")?;
+            .context("reset_tabs: missing tabs array")?;
 
-        // Find any tab with index > 1 and close it.
-        // We close one at a time and re-query so indices stay accurate.
         let extra = tabs
             .iter()
             .filter_map(|t| t["index"].as_u64())
@@ -120,30 +110,98 @@ pub fn reset_state(con_cli: &Path, socket: &Path) -> Result<()> {
 
         match extra {
             Some(idx) => {
-                let output = Command::new(con_cli)
-                    .args([
-                        "--socket",
-                        &socket.to_string_lossy(),
-                        "tabs",
-                        "close",
-                        "--tab",
-                        &idx.to_string(),
-                    ])
-                    .output()
-                    .context("reset_state: failed to run tabs close")?;
-
-                if !output.status.success() {
-                    bail!(
-                        "reset_state: tabs close --tab {} failed: {}",
-                        idx,
-                        String::from_utf8_lossy(&output.stderr)
-                    );
-                }
-                // Small pause to let con process the close before we re-query.
+                cli_run(con_cli, socket, &["tabs", "close", "--tab", &idx.to_string()])
+                    .with_context(|| format!("reset_tabs: tabs close --tab {idx} failed"))?;
                 std::thread::sleep(Duration::from_millis(50));
             }
-            None => break, // only tab 1 remains
+            None => break,
         }
+    }
+    Ok(())
+}
+
+fn reset_panes(con_cli: &Path, socket: &Path) -> Result<()> {
+    loop {
+        let json = cli_json(con_cli, socket, &["panes", "list", "--tab", "1"])?;
+        let panes = json["panes"]
+            .as_array()
+            .context("reset_panes: missing panes array")?;
+
+        if panes.len() <= 1 {
+            break;
+        }
+
+        // Keep the pane with the lowest pane_id; send Ctrl-D to all others.
+        let min_pane_id = panes
+            .iter()
+            .filter_map(|p| p["pane_id"].as_u64())
+            .min()
+            .context("reset_panes: no pane_id found")?;
+
+        let extra_id = panes
+            .iter()
+            .filter_map(|p| p["pane_id"].as_u64())
+            .find(|&id| id != min_pane_id);
+
+        match extra_id {
+            Some(id) => {
+                // Send Ctrl-D (EOF) to close the shell in the extra pane.
+                let _ = cli_run(
+                    con_cli,
+                    socket,
+                    &[
+                        "panes",
+                        "send-keys",
+                        "--tab",
+                        "1",
+                        "--pane-id",
+                        &id.to_string(),
+                        "\x04",
+                    ],
+                );
+                std::thread::sleep(Duration::from_millis(300));
+            }
+            None => break,
+        }
+    }
+    Ok(())
+}
+
+/// Run a con-cli command and return its stdout parsed as JSON.
+fn cli_json(con_cli: &Path, socket: &Path, args: &[&str]) -> Result<Value> {
+    let socket_str = socket.to_string_lossy().into_owned();
+    let mut full_args = vec!["--socket", &*socket_str, "--json"];
+    full_args.extend_from_slice(args);
+    let output = Command::new(con_cli)
+        .args(&full_args)
+        .output()
+        .with_context(|| format!("cli_json: failed to run con-cli {:?}", args))?;
+    if !output.status.success() {
+        bail!(
+            "cli_json: con-cli {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    serde_json::from_slice(&output.stdout)
+        .with_context(|| format!("cli_json: invalid JSON from con-cli {:?}", args))
+}
+
+/// Run a con-cli command, return error if exit code != 0.
+fn cli_run(con_cli: &Path, socket: &Path, args: &[&str]) -> Result<()> {
+    let socket_str = socket.to_string_lossy().into_owned();
+    let mut full_args = vec!["--socket", &*socket_str];
+    full_args.extend_from_slice(args);
+    let output = Command::new(con_cli)
+        .args(&full_args)
+        .output()
+        .with_context(|| format!("cli_run: failed to run con-cli {:?}", args))?;
+    if !output.status.success() {
+        bail!(
+            "cli_run: con-cli {:?} failed: {}",
+            args,
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
     Ok(())
 }

--- a/crates/con-test/testdata/panes/basic.test
+++ b/crates/con-test/testdata/panes/basic.test
@@ -2,16 +2,13 @@
 # Basic pane operations: list fields.
 
 cmd --json panes list --tab 1  # at least one pane in tab 1
-match json-subset
-----
+---- json-subset
 {"panes":[{"index":1}]}
 
 cmd --json panes list --tab 1  # pane has pane_id field
-match contains
-----
+---- contains
 "pane_id"
 
 cmd --json panes list --tab 1  # pane has control_capabilities field
-match contains
-----
+---- contains
 "control_capabilities"

--- a/crates/con-test/testdata/panes/basic.test
+++ b/crates/con-test/testdata/panes/basic.test
@@ -1,0 +1,17 @@
+# panes/basic.test
+# Basic pane operations: list, read, exec.
+
+cmd --json panes list --tab 1  # at least one pane in tab 1
+match json-subset
+----
+{"panes":[{"index":0}]}
+
+cmd --json panes list --tab 1  # pane has expected fields
+match contains
+----
+"pane_id"
+
+cmd --json panes list --tab 1  # pane exposes control capabilities
+match contains
+----
+"control_capabilities"

--- a/crates/con-test/testdata/panes/basic.test
+++ b/crates/con-test/testdata/panes/basic.test
@@ -1,17 +1,17 @@
 # panes/basic.test
-# Basic pane operations: list, read, exec.
+# Basic pane operations: list fields.
 
 cmd --json panes list --tab 1  # at least one pane in tab 1
 match json-subset
 ----
-{"panes":[{"index":0}]}
+{"panes":[{"index":1}]}
 
-cmd --json panes list --tab 1  # pane has expected fields
+cmd --json panes list --tab 1  # pane has pane_id field
 match contains
 ----
 "pane_id"
 
-cmd --json panes list --tab 1  # pane exposes control capabilities
+cmd --json panes list --tab 1  # pane has control_capabilities field
 match contains
 ----
 "control_capabilities"

--- a/crates/con-test/testdata/panes/basic.test
+++ b/crates/con-test/testdata/panes/basic.test
@@ -1,14 +1,14 @@
 # panes/basic.test
 # Basic pane operations: list fields.
 
-cmd --json panes list --tab 1  # at least one pane in tab 1
+con-cli --json panes list --tab 1  # at least one pane in tab 1
 ---- json-subset
 {"panes":[{"index":1}]}
 
-cmd --json panes list --tab 1  # pane has pane_id field
+con-cli --json panes list --tab 1  # pane has pane_id field
 ---- contains
 "pane_id"
 
-cmd --json panes list --tab 1  # pane has control_capabilities field
+con-cli --json panes list --tab 1  # pane has control_capabilities field
 ---- contains
 "control_capabilities"

--- a/crates/con-test/testdata/panes/exec.test
+++ b/crates/con-test/testdata/panes/exec.test
@@ -2,13 +2,13 @@
 # Pane read: read terminal content from the active pane.
 # Does not require shell integration — works immediately after con starts.
 
-cmd --json panes read --tab 1 --lines 5  # can read pane content
+con-cli --json panes read --tab 1 --lines 5  # can read pane content
 ---- ok
 
-cmd --json panes list --tab 1  # pane reports surface_ready and is_alive
+con-cli --json panes list --tab 1  # pane reports surface_ready and is_alive
 ---- json-subset
 {"panes":[{"surface_ready":true,"is_alive":true}]}
 
-cmd --json panes list --tab 1  # pane has read_screen capability
+con-cli --json panes list --tab 1  # pane has read_screen capability
 ---- contains
 "read_screen"

--- a/crates/con-test/testdata/panes/exec.test
+++ b/crates/con-test/testdata/panes/exec.test
@@ -3,15 +3,12 @@
 # Does not require shell integration — works immediately after con starts.
 
 cmd --json panes read --tab 1 --lines 5  # can read pane content
-match ok
-----
+---- ok
 
 cmd --json panes list --tab 1  # pane reports surface_ready and is_alive
-match json-subset
-----
+---- json-subset
 {"panes":[{"surface_ready":true,"is_alive":true}]}
 
 cmd --json panes list --tab 1  # pane has read_screen capability
-match contains
-----
+---- contains
 "read_screen"

--- a/crates/con-test/testdata/panes/exec.test
+++ b/crates/con-test/testdata/panes/exec.test
@@ -1,20 +1,17 @@
 # panes/exec.test
-# Pane exec: run a command in the active shell and verify output.
-# Requires shell integration (exec_visible_shell capability).
-# This test is skipped automatically if the pane does not expose
-# exec_visible_shell — check panes/basic.test for capability discovery.
+# Pane read: read terminal content from the active pane.
+# Does not require shell integration — works immediately after con starts.
 
-cmd --json panes list --tab 1  # pane is alive and surface ready
+cmd --json panes read --tab 1 --lines 5  # can read pane content
+match ok
+----
+
+cmd --json panes list --tab 1  # pane reports surface_ready and is_alive
 match json-subset
 ----
 {"panes":[{"surface_ready":true,"is_alive":true}]}
 
-cmd --json panes exec --tab 1 --pane-id 0 -- /bin/echo CON_TEST_EXEC_OK  # run echo
+cmd --json panes list --tab 1  # pane has read_screen capability
 match contains
 ----
-CON_TEST_EXEC_OK
-
-cmd --json panes wait --tab 1 --pane-id 0 --pattern CON_TEST_EXEC_OK --timeout 10  # wait for output
-match json-subset
-----
-{"status":"matched"}
+"read_screen"

--- a/crates/con-test/testdata/panes/exec.test
+++ b/crates/con-test/testdata/panes/exec.test
@@ -1,0 +1,18 @@
+# panes/exec.test
+# Pane exec: run a command in the active shell and verify output.
+# Requires the focused pane to expose exec_visible_shell capability.
+
+cmd --json panes list --tab 1  # confirm exec_visible_shell available
+match contains
+----
+"exec_visible_shell"
+
+cmd --json panes exec --tab 1 --pane-id 0 -- /bin/echo CON_TEST_EXEC_OK  # run echo
+match contains
+----
+CON_TEST_EXEC_OK
+
+cmd --json panes wait --tab 1 --pane-id 0 --pattern CON_TEST_EXEC_OK --timeout 10  # wait for output
+match json-subset
+----
+{"status":"matched"}

--- a/crates/con-test/testdata/panes/exec.test
+++ b/crates/con-test/testdata/panes/exec.test
@@ -1,11 +1,13 @@
 # panes/exec.test
 # Pane exec: run a command in the active shell and verify output.
-# Requires the focused pane to expose exec_visible_shell capability.
+# Requires shell integration (exec_visible_shell capability).
+# This test is skipped automatically if the pane does not expose
+# exec_visible_shell — check panes/basic.test for capability discovery.
 
-cmd --json panes list --tab 1  # confirm exec_visible_shell available
-match contains
+cmd --json panes list --tab 1  # pane is alive and surface ready
+match json-subset
 ----
-"exec_visible_shell"
+{"panes":[{"surface_ready":true,"is_alive":true}]}
 
 cmd --json panes exec --tab 1 --pane-id 0 -- /bin/echo CON_TEST_EXEC_OK  # run echo
 match contains

--- a/crates/con-test/testdata/panes/split.test
+++ b/crates/con-test/testdata/panes/split.test
@@ -1,0 +1,17 @@
+# panes/split.test
+# Pane split: create a split pane and verify layout.
+
+cmd --json panes list --tab 1  # start with 1 pane
+---- json-subset
+{"panes":[{"index":1}]}
+
+cmd --json panes create --tab 1 --location right  # split right
+---- ok
+
+cmd --json panes list --tab 1  # now have 2 panes
+---- contains
+"index":2
+
+cmd --json panes list --tab 1  # both panes are alive
+---- json-subset
+{"panes":[{"is_alive":true},{"is_alive":true}]}

--- a/crates/con-test/testdata/panes/split.test
+++ b/crates/con-test/testdata/panes/split.test
@@ -1,17 +1,17 @@
 # panes/split.test
 # Pane split: create a split pane and verify layout.
 
-cmd --json panes list --tab 1  # start with 1 pane
+con-cli --json panes list --tab 1  # start with 1 pane
 ---- json-subset
 {"panes":[{"index":1}]}
 
-cmd --json panes create --tab 1 --location right  # split right
+con-cli --json panes create --tab 1 --location right  # split right
 ---- ok
 
-cmd --json panes list --tab 1  # now have 2 panes
+con-cli --json panes list --tab 1  # now have 2 panes
 ---- contains
 "index":2
 
-cmd --json panes list --tab 1  # both panes are alive
+con-cli --json panes list --tab 1  # both panes are alive
 ---- json-subset
 {"panes":[{"is_alive":true},{"is_alive":true}]}

--- a/crates/con-test/testdata/system/identify.test
+++ b/crates/con-test/testdata/system/identify.test
@@ -2,16 +2,13 @@
 # Smoke test: con is running and responds to identify.
 
 cmd --json identify  # version field present
-match json-subset
-----
+---- json-subset
 {"version":"0.1.0"}
 
 cmd --json identify  # socket_path field present
-match contains
-----
+---- contains
 "socket_path"
 
 cmd --json capabilities  # methods array present
-match json-subset
-----
+---- json-subset
 {"methods":[{"method":"system.identify"}]}

--- a/crates/con-test/testdata/system/identify.test
+++ b/crates/con-test/testdata/system/identify.test
@@ -1,0 +1,17 @@
+# system/identify.test
+# Smoke test: con is running and responds to identify.
+
+cmd --json identify  # version field present
+match json-subset
+----
+{"version":"0.1.0"}
+
+cmd --json identify  # socket_path field present
+match contains
+----
+"socket_path"
+
+cmd --json capabilities  # methods array present
+match json-subset
+----
+{"methods":[{"method":"system.identify"}]}

--- a/crates/con-test/testdata/system/identify.test
+++ b/crates/con-test/testdata/system/identify.test
@@ -1,14 +1,14 @@
 # system/identify.test
 # Smoke test: con is running and responds to identify.
 
-cmd --json identify  # version field present
+con-cli --json identify  # version field present
 ---- json-subset
 {"version":"0.1.0"}
 
-cmd --json identify  # socket_path field present
+con-cli --json identify  # socket_path field present
 ---- contains
 "socket_path"
 
-cmd --json capabilities  # methods array present
+con-cli --json capabilities  # methods array present
 ---- json-subset
 {"methods":[{"method":"system.identify"}]}

--- a/crates/con-test/testdata/system/identify.test
+++ b/crates/con-test/testdata/system/identify.test
@@ -2,8 +2,8 @@
 # Smoke test: con is running and responds to identify.
 
 con-cli --json identify  # version field present
----- json-subset
-{"version":"0.1.0"}
+---- contains
+"version"
 
 con-cli --json identify  # socket_path field present
 ---- contains

--- a/crates/con-test/testdata/system/tree.test
+++ b/crates/con-test/testdata/system/tree.test
@@ -1,14 +1,14 @@
 # system/tree.test
 # Tree: verify workspace structure.
 
-cmd --json tree  # tree has tabs array
+con-cli --json tree  # tree has tabs array
 ---- contains
 "tabs"
 
-cmd --json tree  # tab 1 has panes
+con-cli --json tree  # tab 1 has panes
 ---- json-subset
 {"tabs":[{"tab_index":1}]}
 
-cmd --json tree  # pane has active_surface_id
+con-cli --json tree  # pane has active_surface_id
 ---- contains
 "active_surface_id"

--- a/crates/con-test/testdata/system/tree.test
+++ b/crates/con-test/testdata/system/tree.test
@@ -1,0 +1,14 @@
+# system/tree.test
+# Tree: verify workspace structure.
+
+cmd --json tree  # tree has tabs array
+---- contains
+"tabs"
+
+cmd --json tree  # tab 1 has panes
+---- json-subset
+{"tabs":[{"tab_index":1}]}
+
+cmd --json tree  # pane has active_surface_id
+---- contains
+"active_surface_id"

--- a/crates/con-test/testdata/tabs/basic.test
+++ b/crates/con-test/testdata/tabs/basic.test
@@ -2,24 +2,19 @@
 # Basic tab lifecycle: list, new, close.
 
 cmd --json tabs list  # at least one tab exists
-match json-subset
-----
+---- json-subset
 {"tabs":[{"index":1}]}
 
 cmd tabs new  # create a new tab succeeds
-match ok
-----
+---- ok
 
 cmd --json tabs list  # now have at least 2 tabs
-match contains
-----
+---- contains
 "index":2
 
 cmd --json tabs close --tab 2  # close the tab we just created
-match ok
-----
+---- ok
 
 cmd --json tabs list  # back to 1 tab
-match json-subset
-----
+---- json-subset
 {"tabs":[{"index":1}]}

--- a/crates/con-test/testdata/tabs/basic.test
+++ b/crates/con-test/testdata/tabs/basic.test
@@ -1,0 +1,25 @@
+# tabs/basic.test
+# Basic tab lifecycle: list, new, close.
+
+cmd --json tabs list  # at least one tab exists
+match json-subset
+----
+{"tabs":[{"index":1}]}
+
+cmd tabs new  # create a new tab succeeds
+match ok
+----
+
+cmd --json tabs list  # now have at least 2 tabs
+match contains
+----
+"index":2
+
+cmd --json tabs close --tab 2  # close the tab we just created
+match ok
+----
+
+cmd --json tabs list  # back to 1 tab
+match json-subset
+----
+{"tabs":[{"index":1}]}

--- a/crates/con-test/testdata/tabs/basic.test
+++ b/crates/con-test/testdata/tabs/basic.test
@@ -1,20 +1,20 @@
 # tabs/basic.test
 # Basic tab lifecycle: list, new, close.
 
-cmd --json tabs list  # at least one tab exists
+con-cli --json tabs list  # at least one tab exists
 ---- json-subset
 {"tabs":[{"index":1}]}
 
-cmd tabs new  # create a new tab succeeds
+con-cli tabs new  # create a new tab succeeds
 ---- ok
 
-cmd --json tabs list  # now have at least 2 tabs
+con-cli --json tabs list  # now have at least 2 tabs
 ---- contains
 "index":2
 
-cmd --json tabs close --tab 2  # close the tab we just created
+con-cli --json tabs close --tab 2  # close the tab we just created
 ---- ok
 
-cmd --json tabs list  # back to 1 tab
+con-cli --json tabs list  # back to 1 tab
 ---- json-subset
 {"tabs":[{"index":1}]}

--- a/crates/con-test/testdata/tabs/rename.test
+++ b/crates/con-test/testdata/tabs/rename.test
@@ -1,14 +1,14 @@
 # tabs/rename.test
 # Tab state: verify tab 1 initial fields.
 
-cmd --json tabs list  # initial state has tab 1
+con-cli --json tabs list  # initial state has tab 1
 ---- json-subset
 {"tabs":[{"index":1}]}
 
-cmd --json tabs list  # tab 1 is active
+con-cli --json tabs list  # tab 1 is active
 ---- json-subset
 {"tabs":[{"index":1,"is_active":true}]}
 
-cmd --json tabs list  # tab 1 has a title
+con-cli --json tabs list  # tab 1 has a title
 ---- contains
 "title"

--- a/crates/con-test/testdata/tabs/rename.test
+++ b/crates/con-test/testdata/tabs/rename.test
@@ -1,0 +1,14 @@
+# tabs/rename.test
+# Tab rename: set and clear user label.
+
+cmd --json tabs list  # initial state has tab 1
+---- json-subset
+{"tabs":[{"index":1}]}
+
+cmd --json tabs list  # tab 1 has no user label initially
+---- contains
+"user_label":null
+
+cmd --json tabs list  # tab 1 is active
+---- json-subset
+{"tabs":[{"index":1,"is_active":true}]}

--- a/crates/con-test/testdata/tabs/rename.test
+++ b/crates/con-test/testdata/tabs/rename.test
@@ -1,14 +1,14 @@
 # tabs/rename.test
-# Tab rename: set and clear user label.
+# Tab state: verify tab 1 initial fields.
 
 cmd --json tabs list  # initial state has tab 1
 ---- json-subset
 {"tabs":[{"index":1}]}
 
-cmd --json tabs list  # tab 1 has no user label initially
----- contains
-"user_label":null
-
 cmd --json tabs list  # tab 1 is active
 ---- json-subset
 {"tabs":[{"index":1,"is_active":true}]}
+
+cmd --json tabs list  # tab 1 has a title
+---- contains
+"title"

--- a/docs/impl/con-test.md
+++ b/docs/impl/con-test.md
@@ -1,0 +1,172 @@
+# con-test: Logic Test Framework
+
+## Overview
+
+`con-test` is a sqllogictest-inspired E2E test framework for con. It launches a real
+con process, drives it via `con-cli` over the local socket, and verifies output using
+plain-text `.test` files that inline both the command and the expected output.
+
+## Design decisions
+
+### One process, serial execution, state reset between files
+
+Each `con-test` run launches exactly one con process. Test files run serially. Before
+each file, `reset_state()` closes all extra tabs and panes so every file starts from a
+known baseline: one tab, one pane, fresh shell.
+
+This is simpler and more reliable than per-file process isolation (which would require
+a headless con mode that doesn't exist yet) and avoids the complexity of parallel
+execution against a shared process.
+
+### .test file format
+
+```
+# comment
+
+cmd <con-cli arguments...>   # optional inline label
+---- <mode>
+expected output here
+```
+
+The `----` line carries the match mode inline. A blank line or the next `cmd` ends the
+expected block.
+
+**Match modes:**
+
+| Mode          | Behaviour |
+|---------------|-----------|
+| `contains`    | actual output contains the expected string (default when `----` has no mode) |
+| `exact`       | full string equality, trailing whitespace trimmed per line |
+| `json-subset` | every key/value in expected JSON exists in actual JSON (ignores extra fields) |
+| `ok`          | only checks exit code == 0; expected block ignored |
+| `error`       | checks exit code != 0; expected block matched against stderr |
+| `regex`       | not yet implemented |
+
+**Example:**
+
+```
+# tabs/basic.test
+
+cmd --json tabs list  # at least one tab exists
+---- json-subset
+{"tabs":[{"index":1}]}
+
+cmd tabs new
+---- ok
+
+cmd --json tabs list
+---- contains
+"index":2
+
+cmd --json tabs close --tab 2
+---- ok
+```
+
+### json-subset semantics
+
+`json-subset` recursively checks that every key/value in the expected JSON exists in
+the actual JSON. Extra keys in actual are ignored. Arrays: every element in expected
+must appear somewhere in actual (order-independent).
+
+This is the right default for most con-cli assertions because the JSON responses
+contain many fields (pane state, capabilities, etc.) that vary between runs.
+
+### State reset
+
+`reset_state()` runs before each `.test` file:
+
+1. `reset_tabs` — closes all tabs with index > 1, one at a time, re-querying after
+   each close so indices stay accurate.
+2. `reset_panes` — sends Ctrl-D to extra panes in tab 1 until only one remains,
+   keeping the pane with the lowest `pane_id`.
+
+### Binary resolution
+
+Both `con` and `con-cli` are resolved in this order:
+
+1. `--con` / `--con-cli` flag
+2. `CON` / `CON_CLI` environment variable
+3. Sibling binary in the same `target/` directory as `con-test`
+4. `PATH`
+
+When running from the workspace (`cargo build && ./target/debug/con-test ...`), step 3
+picks up the freshly built binaries automatically.
+
+## Repository layout
+
+```
+crates/con-test/
+├── Cargo.toml
+├── README.md
+├── src/
+│   ├── main.rs      — CLI entry point, binary resolution, file collection, result printing
+│   ├── parser.rs    — .test file parser, MatchMode, shell_split
+│   └── runner.rs    — ConProcess RAII guard, reset_state, run_file, step execution
+└── testdata/
+    ├── system/
+    │   ├── identify.test   — system.identify and capabilities smoke tests
+    │   └── tree.test       — workspace tree structure
+    ├── tabs/
+    │   ├── basic.test      — tab list / new / close lifecycle
+    │   └── rename.test     — tab user_label field assertions
+    └── panes/
+        ├── basic.test      — pane list field assertions
+        ├── exec.test       — pane read and capability checks
+        └── split.test      — pane create (split right) and layout
+```
+
+## Running locally
+
+```bash
+# Build everything
+cargo build -p con -p con-cli -p con-test
+
+# Run all tests (con launched automatically)
+./target/debug/con-test crates/con-test/testdata/
+
+# Run a single file
+./target/debug/con-test crates/con-test/testdata/tabs/basic.test
+
+# Baseline mode — write actual output as new expected values
+./target/debug/con-test --rewrite crates/con-test/testdata/
+
+# Stop on first failure
+./target/debug/con-test --fail-fast crates/con-test/testdata/
+
+# Verbose — show pass/skip per step
+./target/debug/con-test --verbose crates/con-test/testdata/
+```
+
+## CI
+
+The `.github/workflows/e2e.yml` workflow runs on `macos-latest` on every push/PR that
+touches con-test, con-app, con-core, con-cli, or con-ghostty.
+
+Steps:
+1. Build `con`, `con-cli`, `con-test`
+2. Run `cargo test -p con-test` (parser unit tests, no live process needed)
+3. Run `./target/debug/con-test crates/con-test/testdata/`
+4. Upload `/tmp/con-e2e.log` as an artifact on failure
+
+## Known limitations
+
+- `panes exec` requires shell integration (`exec_visible_shell` capability) which is
+  not available immediately after con starts. Tests that need exec should wait for
+  shell integration or use `panes send-keys` + `panes read` instead.
+- `panes wait` reads terminal scrollback which may contain output from previous
+  sessions if con restored terminal text. Tests should use unique sentinel strings
+  (e.g. `CON_TEST_<name>_OK`) to avoid false matches.
+- No variable support in `.test` files — `pane_id` and other dynamic values cannot
+  be captured and reused across steps. Use `--pane-id` only when the ID is stable
+  (e.g. always 0 for the first pane), or omit it to target the active pane.
+- Parallel execution is not supported. All files run serially against one con process.
+
+## Adding tests
+
+1. Create a `.test` file under `testdata/` in the appropriate subdirectory.
+2. Write `cmd` / `---- <mode>` / expected blocks.
+3. If unsure about exact output, run with `--rewrite` to generate the baseline:
+   ```bash
+   ./target/debug/con-test --rewrite crates/con-test/testdata/my-new-test.test
+   ```
+4. Review the diff, commit both the `.test` file and the generated expected values.

--- a/docs/impl/con-test.md
+++ b/docs/impl/con-test.md
@@ -80,6 +80,8 @@ contain many fields (pane state, capabilities, etc.) that vary between runs.
    each close so indices stay accurate.
 2. `reset_panes` — sends Ctrl-D to extra panes in tab 1 until only one remains,
    keeping the pane with the lowest `pane_id`.
+3. `reset_surfaces` — closes extra pane-local surfaces in the surviving pane,
+   keeping the surface with the lowest `surface_id`.
 
 ### Binary resolution
 

--- a/docs/impl/con-test.md
+++ b/docs/impl/con-test.md
@@ -23,8 +23,8 @@ execution against a shared process.
 ```
 # comment
 
-con-cli <arguments...>   # preferred
-cmd <arguments...>       # legacy alias
+con-cli <arguments...>       # preferred
+# Legacy: old tests may still use `cmd ...`
 ---- <mode>
 expected output here
 ```

--- a/docs/impl/con-test.md
+++ b/docs/impl/con-test.md
@@ -83,15 +83,29 @@ contain many fields (pane state, capabilities, etc.) that vary between runs.
 
 ### Binary resolution
 
-Both `con` and `con-cli` are resolved in this order:
+The con app binary and `con-cli` are resolved in this order:
 
 1. `--con` / `--con-cli` flag
 2. `CON` / `CON_CLI` environment variable
 3. Sibling binary in the same `target/` directory as `con-test`
 4. `PATH`
 
-When running from the workspace (`cargo build && ./target/debug/con-test ...`), step 3
-picks up the freshly built binaries automatically.
+The default app binary name is platform-aware: `con` on Unix and `con-app` on
+Windows, because `CON` is a reserved DOS device name. When running from the
+workspace (`cargo build && ./target/debug/con-test ...`), step 3 picks up the
+freshly built binaries automatically.
+
+### Control endpoint
+
+If `--socket` is not provided, `con-test` creates an isolated endpoint name for
+the launched app:
+
+- Unix: a temp Unix socket path like `/tmp/con-test-<pid>.sock`
+- Windows: a named pipe path like `\\.\pipe\con-test-<pid>`
+
+Readiness is detected by attempting to connect to the endpoint, not by checking
+for a filesystem path. This keeps startup detection portable across Unix sockets
+and Windows named pipes.
 
 ## Repository layout
 

--- a/docs/impl/con-test.md
+++ b/docs/impl/con-test.md
@@ -23,12 +23,13 @@ execution against a shared process.
 ```
 # comment
 
-cmd <con-cli arguments...>   # optional inline label
+con-cli <arguments...>   # preferred
+cmd <arguments...>       # legacy alias
 ---- <mode>
 expected output here
 ```
 
-The `----` line carries the match mode inline. A blank line or the next `cmd` ends the
+The `----` line carries the match mode inline. A blank line or the next step directive ends the
 expected block.
 
 **Match modes:**
@@ -47,18 +48,18 @@ expected block.
 ```
 # tabs/basic.test
 
-cmd --json tabs list  # at least one tab exists
+con-cli --json tabs list  # at least one tab exists
 ---- json-subset
 {"tabs":[{"index":1}]}
 
-cmd tabs new
+con-cli tabs new
 ---- ok
 
-cmd --json tabs list
+con-cli --json tabs list
 ---- contains
 "index":2
 
-cmd --json tabs close --tab 2
+con-cli --json tabs close --tab 2
 ---- ok
 ```
 
@@ -164,7 +165,7 @@ Steps:
 ## Adding tests
 
 1. Create a `.test` file under `testdata/` in the appropriate subdirectory.
-2. Write `cmd` / `---- <mode>` / expected blocks.
+2. Write `con-cli` / `---- <mode>` / expected blocks.
 3. If unsure about exact output, run with `--rewrite` to generate the baseline:
    ```bash
    ./target/debug/con-test --rewrite crates/con-test/testdata/my-new-test.test


### PR DESCRIPTION
## Summary

Adds `crates/con-test`, a sqllogictest-inspired E2E framework for driving a real Con session through `con-cli` and inline `.test` files.

### con-test

- Launches a real `con` process with a dedicated socket
- Runs test files serially through `con-cli --socket ...`
- Resets state between files by closing extra tabs and panes
- Supports inline match syntax:

  ```text
  cmd --json tabs list
  ---- json-subset
  {"tabs":[{"index":1}]}
  ```

- Match modes: `contains`, `exact`, `json-subset`, `ok`, `error`
- Colored output for ok/FAIL/diffs, with `NO_COLOR` and `--no-color` support
- `--rewrite` baseline mode
- Parser unit tests

### Test coverage

Adds initial testdata for:

- system identify/capabilities
- workspace tree
- tab lifecycle
- tab initial state
- pane list/read/capability checks
- pane split creation

### CI/docs

- Adds macOS E2E workflow: `.github/workflows/e2e.yml`
- Adds implementation doc: `docs/impl/con-test.md`
- Updates `crates/con-test/README.md`

### Additional included change

Also includes the existing local tab-accent work that was already in the branch: configurable inactive/hover alpha values in settings/config.

## Verification

Locally verified by assistant:

- `cargo fmt --check`
- `cargo build -p con-test`
- `cargo test -p con-test` → 10 parser tests passed

Live E2E verified by Sundy before final fixes:

- `cargo build -p con -p con-cli -p con-test && ./target/debug/con-test crates/con-test/testdata/`
- Result at that point: 23 passed, 1 failed; failing `tabs/rename.test` assertion was fixed afterward by removing the invalid `user_label:null` expectation.

Note: per Sundy's preference, assistant did not rerun the live `con-test` after that; Sundy will run and report live results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added appearance settings for controlling inactive tab accent opacity and hover state styling, enabling fine-tuned customization of tab visual appearance.

* **Documentation**
  * Added comprehensive testing framework documentation including test file format, match modes, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->