### PR TITLE
Fix cwd inheritance for new panes and tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## `v0.1.0-beta.67` - Unreleased
+
+### Fixed
+
+**Tabs and Panes**
+
+- New panes created by Con's agent/control plane now inherit the focused pane's
+  working directory, and new tabs inherit the active terminal's restored working
+  directory instead of dropping back to the shell default. _(Issue
+  [#171](https://github.com/nowledge-co/con-terminal/issues/171), PR
+  [#172](https://github.com/nowledge-co/con-terminal/pull/172) by
+  [@wey-gu](https://github.com/wey-gu))_
+
 ## `v0.1.0-beta.66` - 2026-05-08
 
 ### Changed

--- a/crates/con-app/src/workspace/control_agent_tools.rs
+++ b/crates/con-app/src/workspace/control_agent_tools.rs
@@ -973,8 +973,13 @@ impl ConWorkspace {
             PaneQuery::CreatePane { command, location } => {
                 // Creating a terminal requires a Window, so defer into an explicit
                 // window-aware callback instead of depending on a later render.
+                let cwd = self.tabs[tab_idx]
+                    .pane_tree
+                    .focused_terminal()
+                    .current_dir(cx);
                 self.pending_create_pane_requests.push(PendingCreatePane {
                     command,
+                    cwd,
                     tab_idx,
                     location,
                     response_tx: req.response_tx,

--- a/crates/con-app/src/workspace/control_surfaces.rs
+++ b/crates/con-app/src/workspace/control_surfaces.rs
@@ -68,8 +68,17 @@ impl ConWorkspace {
             return;
         }
 
+        let mut created_any = false;
         for req in pending {
-            let terminal = self.create_terminal(None, window, cx);
+            if req.tab_idx >= self.tabs.len() {
+                let _ = req.response_tx.send(con_agent::PaneResponse::Error(format!(
+                    "Tab {} is no longer available.",
+                    req.tab_idx + 1
+                )));
+                continue;
+            }
+
+            let terminal = self.create_terminal(req.cwd.as_deref(), window, cx);
             let direction = match req.location {
                 con_agent::tools::PaneCreateLocation::Right => SplitDirection::Horizontal,
                 con_agent::tools::PaneCreateLocation::Down => SplitDirection::Vertical,
@@ -129,8 +138,12 @@ impl ConWorkspace {
                 is_alive: terminal.is_alive(cx),
                 has_shell_integration: terminal.has_shell_integration(cx),
             });
+            created_any = true;
         }
 
+        if created_any {
+            self.save_session(cx);
+        }
         cx.notify();
         window.refresh();
     }

--- a/crates/con-app/src/workspace/types.rs
+++ b/crates/con-app/src/workspace/types.rs
@@ -275,6 +275,7 @@ pub(super) struct ResolvedSurfaceTarget {
 /// A deferred create-pane request waiting for a window-aware context.
 pub(super) struct PendingCreatePane {
     pub(super) command: Option<String>,
+    pub(super) cwd: Option<String>,
     pub(super) tab_idx: usize,
     pub(super) location: con_agent::tools::PaneCreateLocation,
     pub(super) response_tx: crossbeam_channel::Sender<con_agent::PaneResponse>,

--- a/crates/con-app/src/workspace/window_actions.rs
+++ b/crates/con-app/src/workspace/window_actions.rs
@@ -279,7 +279,11 @@ impl ConWorkspace {
     }
 
     pub(super) fn new_tab(&mut self, _: &NewTab, window: &mut Window, cx: &mut Context<Self>) {
-        let terminal = self.create_terminal(None, window, cx);
+        let cwd = self
+            .has_active_tab()
+            .then(|| self.active_terminal().current_dir(cx))
+            .flatten();
+        let terminal = self.create_terminal(cwd.as_deref(), window, cx);
         let tab_number = self.tabs.len() + 1;
         let summary_id = self.next_tab_summary_id;
         self.next_tab_summary_id += 1;

--- a/postmortem/2026-05-08-agent-created-pane-cwd.md
+++ b/postmortem/2026-05-08-agent-created-pane-cwd.md
@@ -1,0 +1,27 @@
+# Agent-created panes lost working directory
+
+## What happened
+
+Panes created through the control plane or the built-in agent opened from the
+default shell directory instead of inheriting the focused pane's working
+directory.
+
+## Root cause
+
+The immediate split actions already passed the focused terminal cwd into
+`create_terminal`, but `panes.create` deferred creation until a `Window` was
+available. That deferred request only kept the command, tab, and split
+direction, so the eventual window-aware flush always called
+`create_terminal(None, ...)`.
+
+## Fix applied
+
+The create-pane request now captures the focused pane cwd before deferring and
+passes it through the window-aware flush. The flush also fails stale tab
+requests cleanly and saves the session after successful agent-created panes.
+
+## What we learned
+
+Window-aware deferred work must carry the same semantic inputs as the direct UI
+path. If a future pane creation path needs a `Window`, capture cwd, target, and
+user intent before queueing instead of recomputing from defaults later.

--- a/postmortem/2026-05-08-agent-created-pane-cwd.md
+++ b/postmortem/2026-05-08-agent-created-pane-cwd.md
@@ -1,10 +1,12 @@
-# Agent-created panes lost working directory
+# New panes and tabs lost working directory
 
 ## What happened
 
 Panes created through the control plane or the built-in agent opened from the
 default shell directory instead of inheriting the focused pane's working
-directory.
+directory. New tabs had the same user-visible problem after restoring a
+session: the restored active pane knew its cwd, but the new-tab path ignored it
+and launched from the shell default.
 
 ## Root cause
 
@@ -12,16 +14,20 @@ The immediate split actions already passed the focused terminal cwd into
 `create_terminal`, but `panes.create` deferred creation until a `Window` was
 available. That deferred request only kept the command, tab, and split
 direction, so the eventual window-aware flush always called
-`create_terminal(None, ...)`.
+`create_terminal(None, ...)`. Separately, `new_tab` always passed `None`
+instead of using the active terminal cwd, so restored workspaces could still
+produce home-directory tabs.
 
 ## Fix applied
 
 The create-pane request now captures the focused pane cwd before deferring and
-passes it through the window-aware flush. The flush also fails stale tab
-requests cleanly and saves the session after successful agent-created panes.
+passes it through the window-aware flush. New tabs inherit the active terminal
+cwd as well. The flush also fails stale tab requests cleanly and saves the
+session after successful agent-created panes.
 
 ## What we learned
 
-Window-aware deferred work must carry the same semantic inputs as the direct UI
-path. If a future pane creation path needs a `Window`, capture cwd, target, and
-user intent before queueing instead of recomputing from defaults later.
+Window-aware deferred work and top-level creation actions must carry the same
+semantic inputs as the direct split path. If a future pane or tab creation path
+needs a `Window`, capture cwd, target, and user intent before queueing instead
+of recomputing from defaults later.


### PR DESCRIPTION
## Summary
- Carry the focused pane working directory through deferred agent/control-plane pane creation.
- Make new tabs inherit the active terminal cwd, including restored-session cwd, instead of dropping back to the shell default.
- Return a clean control-plane error if the requested tab disappears before deferred pane creation, and save the session after agent-created panes.
- Document the root cause in a postmortem and add the beta.67 changelog entry.

Fixes #171.

## Validation
- cargo fmt --check
- cargo check -p con --no-default-features --features con/bin-con-app
- cargo test -p con-core --lib
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pane/tab creation and session persistence paths; mistakes could lead to incorrect cwd on spawn or unintended session-save behavior, but changes are localized and additive.
> 
> **Overview**
> Fixes cwd inheritance when creating panes via the agent/control-plane by capturing the focused terminal’s cwd at request time and passing it through the deferred window-aware flush.
> 
> New tabs now inherit the active terminal’s current directory (including restored-session cwd) instead of always starting from the shell default. The deferred pane flush also returns a clean error if the target tab disappeared and saves the session after successfully creating any panes.
> 
> Adds a `v0.1.0-beta.67` changelog entry and a postmortem documenting the incident and fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f430f2cb482ce0db02469064e9d21fed09c01c6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->