### PR TITLE
feat: agent panel state commands, pane title dot, proxy config, con-test fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,15 +87,15 @@ Windows-named binary requires.
 
 - `con-cli` is a real client for Con's local control socket, not a stub.
 - Implementation details live in `docs/impl/socket-api.md`.
-- The current live E2E workflow lives in `docs/impl/con-cli-e2e.md`.
+- The current live E2E workflow lives in `docs/impl/con-cli-e2e.md` and `docs/impl/con-test.md`.
 
 ## Local Skills
 
 - `skills/con-cli-e2e/SKILL.md` — use when validating the control plane from
-  an external agent or when writing eval automation against a real running Con
-  session. Prefer `con-cli --json`, verify pane capabilities before acting, and
-  treat `panes create` as provisional until the new pane reports as alive and
-  shell-ready.
+  an external agent, writing eval automation against a real running Con session,
+  or writing/fixing integration tests in `crates/con-test/testdata/`. Covers
+  both manual `con-cli` E2E and the `con-test` runner (test file format,
+  assertion types, common failure patterns).
 - `skills/gpui-cache-aware/SKILL.md` — use when reviewing or changing UI
   performance, especially markdown/chat rendering, terminal-adjacent UI, or
   resize/animation paths.
@@ -171,6 +171,14 @@ Read the component's source in `3pp/gpui-component/crates/ui/src/` to understand
 
 - `main` — stable
 - Feature branches: `wey-gu/<short-name>`
+
+## Testing Strategy
+
+After implementing a PR, write tests following this priority order:
+
+- **Unit tests first** — test functions and logic directly in the same crate using `#[cfg(test)]` modules. Cover non-trivial logic, edge cases, and error paths.
+- **con-test for integration** — use `con-test` only for integration and interactive behavior that requires a running session (e.g., pane lifecycle, socket API, agent interactions).
+- **No low-value tests** — don't write tests just to hit coverage. Skip tests for trivial getters, one-liner wrappers, or behavior already covered by the type system. Every test should catch a real bug or document a real contract.
 
 ## Postmortems
 

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -1428,30 +1428,17 @@ fn install_seh_filter() {
 }
 
 /// On macOS and Linux, GUI apps launched from the Dock / Spotlight / a
-/// desktop launcher do not inherit the user's shell environment, so proxy
-/// variables like `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` (and their
-/// lowercase equivalents) are absent from the process environment.
+/// desktop launcher do not inherit the user's shell environment. Variables
+/// like `PATH`, `GOPATH`, `NVM_DIR`, `HTTP_PROXY`, etc. that are set in
+/// shell rc files are absent from the process environment.
 ///
-/// Runs `<login-shell> -l -c 'env'` and parses the `KEY=VALUE` output.
-/// Only proxy-related variables not already set in the process environment
-/// are injected, so an explicit env-var or a `[network]` config value wins.
+/// Runs `<login-shell> -l -c 'env'` and injects every variable that is not
+/// already present in the current process environment, so explicit env-vars
+/// and `[network]` config values always win.
 #[cfg(any(target_os = "macos", target_os = "linux"))]
-fn inherit_shell_proxy_env() {
+fn inherit_shell_env() {
     use std::process::Command;
 
-    // Proxy-related variable names we want to forward (both cases).
-    const PROXY_VARS: &[&str] = &[
-        "HTTP_PROXY",
-        "http_proxy",
-        "HTTPS_PROXY",
-        "https_proxy",
-        "ALL_PROXY",
-        "all_proxy",
-        "NO_PROXY",
-        "no_proxy",
-    ];
-
-    // Determine the user's login shell from $SHELL, falling back to /bin/sh.
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
 
     // Run `<shell> -l -c 'env'`.
@@ -1468,7 +1455,7 @@ fn inherit_shell_proxy_env() {
     {
         Ok(c) => c,
         Err(e) => {
-            log::debug!("inherit_shell_proxy_env: could not run {shell}: {e}");
+            log::debug!("inherit_shell_env: could not run {shell}: {e}");
             return;
         }
     };
@@ -1481,7 +1468,7 @@ fn inherit_shell_proxy_env() {
             Ok(None) => {
                 if std::time::Instant::now() >= deadline {
                     log::debug!(
-                        "inherit_shell_proxy_env: shell timed out after {}s, killing",
+                        "inherit_shell_env: shell timed out after {}s, killing",
                         TIMEOUT.as_secs()
                     );
                     let _ = child.kill();
@@ -1491,7 +1478,7 @@ fn inherit_shell_proxy_env() {
                 std::thread::sleep(std::time::Duration::from_millis(50));
             }
             Err(e) => {
-                log::debug!("inherit_shell_proxy_env: try_wait error: {e}");
+                log::debug!("inherit_shell_env: try_wait error: {e}");
                 return;
             }
         }
@@ -1500,7 +1487,7 @@ fn inherit_shell_proxy_env() {
     let output = match child.wait_with_output() {
         Ok(o) => o,
         Err(e) => {
-            log::debug!("inherit_shell_proxy_env: wait_with_output error: {e}");
+            log::debug!("inherit_shell_env: wait_with_output error: {e}");
             return;
         }
     };
@@ -1511,29 +1498,28 @@ fn inherit_shell_proxy_env() {
     };
 
     // Parse KEY=VALUE lines. Values may contain `=` so split on the first `=` only.
+    // Inject every variable not already present — existing values win.
     let mut inherited = 0usize;
     for line in stdout.lines() {
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
-        if PROXY_VARS.contains(&key) && std::env::var_os(key).is_none() {
+        if std::env::var_os(key).is_none() {
             // SAFETY: single-threaded at this point in startup; no other
             // threads have been spawned yet.
             unsafe { std::env::set_var(key, value) };
             inherited += 1;
-            log::info!("inherit_shell_proxy_env: inherited {key} from login shell");
         }
     }
 
-    if inherited == 0 {
-        log::debug!("inherit_shell_proxy_env: no proxy vars found in login shell env");
+    if inherited > 0 {
+        log::info!("inherit_shell_env: inherited {inherited} variables from login shell");
+    } else {
+        log::debug!("inherit_shell_env: no new variables found in login shell env");
     }
 }
 
 fn main() {
-    // `--printenv`: emit the current process environment as JSON and exit.
-    // This is invoked by `inherit_shell_proxy_env` via the login shell so we
-    // can capture the full shell environment robustly (Zed-style).
     // Install a panic hook before anything else so every panic —
     // including ones from background threads that would otherwise be
     // invisible — gets written to both stderr and a dated log file.
@@ -1555,7 +1541,7 @@ fn main() {
         unsafe { std::env::set_var("RUST_BACKTRACE", "full") };
     }
 
-    // Init the logger before inherit_shell_proxy_env so its log::info!/debug!
+    // Init the logger before inherit_shell_env so its log::info!/debug!
     // calls are visible when debugging proxy issues.
     let mut builder = env_logger::Builder::from_default_env();
     if std::env::var_os("RUST_LOG").is_none() {
@@ -1579,12 +1565,11 @@ fn main() {
     }
     builder.init();
 
-    // Inherit proxy env vars from the login shell before any network
-    // client is constructed.  GUI apps on macOS/Linux don't get the
-    // shell environment, so HTTP_PROXY / HTTPS_PROXY etc. are missing
-    // unless we source them explicitly.
+    // Inherit the full login shell environment before any network client is
+    // constructed. GUI apps on macOS/Linux launched from Dock/Spotlight don't
+    // get PATH, GOPATH, HTTP_PROXY, etc. from shell rc files.
     #[cfg(any(target_os = "macos", target_os = "linux"))]
-    inherit_shell_proxy_env();
+    inherit_shell_env();
 
     log::info!("con starting (pid {})", std::process::id());
     if let Some(path) = log_file_path.as_ref() {

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -1427,34 +1427,14 @@ fn install_seh_filter() {
     }
 }
 
-/// Print the current process environment as a JSON object to stdout.
-///
-/// This is the `--printenv` mode: the login shell runs
-/// `con --printenv` and we emit JSON so the parent process can parse it
-/// robustly even when the shell rc files produce noisy output on other fds.
-fn cmd_printenv() {
-    let map: std::collections::HashMap<String, String> = std::env::vars().collect();
-    match serde_json::to_string(&map) {
-        Ok(json) => {
-            println!("{json}");
-        }
-        Err(e) => {
-            eprintln!("con --printenv: failed to serialize env: {e}");
-            std::process::exit(1);
-        }
-    }
-}
-
 /// On macOS and Linux, GUI apps launched from the Dock / Spotlight / a
 /// desktop launcher do not inherit the user's shell environment, so proxy
 /// variables like `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` (and their
 /// lowercase equivalents) are absent from the process environment.
 ///
-/// This function runs the user's login shell with `-l -i -c "con --printenv"`
-/// (Zed-style) so the shell fully initialises its rc files before we capture
-/// the environment as JSON.  Only proxy-related variables that are not already
-/// set in the process environment are injected, so an explicit env-var or a
-/// `[network]` config value always wins.
+/// Runs `<login-shell> -l -c 'env'` and parses the `KEY=VALUE` output.
+/// Only proxy-related variables not already set in the process environment
+/// are injected, so an explicit env-var or a `[network]` config value wins.
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 fn inherit_shell_proxy_env() {
     use std::process::Command;
@@ -1471,37 +1451,19 @@ fn inherit_shell_proxy_env() {
         "no_proxy",
     ];
 
-    // Path to the running binary — we re-invoke ourselves with --printenv.
-    let self_exe = match std::env::current_exe() {
-        Ok(p) => p,
-        Err(e) => {
-            log::debug!("inherit_shell_proxy_env: current_exe: {e}");
-            return;
-        }
-    };
-
     // Determine the user's login shell from $SHELL, falling back to /bin/sh.
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
 
-    // Run `<shell> -l -i -c "<self> --printenv"`.
-    // -l  : login shell (sources /etc/profile, ~/.zprofile, ~/.bash_profile …)
-    // -i  : interactive (sources ~/.zshrc, ~/.bashrc … where proxy vars often live)
-    // The shell may print noise to stdout from rc files; we parse the JSON
-    // object by scanning for the first `{` in the output, matching Zed's
-    // parse_env_map_from_noisy_output strategy.
-    // Single-quote the exe path so spaces / metacharacters in bundle paths
-    // (e.g. `/Applications/Con Terminal.app/...`) don't get word-split by sh.
-    let exe_str = self_exe.display().to_string();
-    let quoted = exe_str.replace('\'', r"'\''");
-    let cmd_str = format!("'{}' --printenv", quoted);
-
-    // Spawn with a 5 s timeout — shell rc files can hang on slow NFS mounts,
-    // SSH agent prompts, etc.  We must not block the GUI from appearing.
+    // Run `<shell> -l -c 'env'`.
+    // -l : login shell — sources /etc/profile, ~/.zprofile, ~/.bash_profile …
+    //      (no -i: avoids interactive-only rc noise and TTY hangs)
+    // env outputs KEY=VALUE\n lines; no JSON, no self-invocation needed.
     const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
     let mut child = match Command::new(&shell)
-        .args(["-l", "-i", "-c", &cmd_str])
+        .args(["-l", "-c", "env"])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null())
+        .stdin(std::process::Stdio::null())
         .spawn()
     {
         Ok(c) => c,
@@ -1511,10 +1473,11 @@ fn inherit_shell_proxy_env() {
         }
     };
 
+    // Poll with a deadline so a hanging rc file doesn't block the GUI.
     let deadline = std::time::Instant::now() + TIMEOUT;
     loop {
         match child.try_wait() {
-            Ok(Some(_)) => break, // exited
+            Ok(Some(_)) => break,
             Ok(None) => {
                 if std::time::Instant::now() >= deadline {
                     log::debug!(
@@ -1547,38 +1510,18 @@ fn inherit_shell_proxy_env() {
         Err(_) => return,
     };
 
-    // Scan for the first `{` and try to parse a JSON object from there,
-    // tolerating any shell startup noise that precedes it.
-    let env_map: std::collections::HashMap<String, String> = {
-        let mut parsed = None;
-        for (pos, _) in stdout.match_indices('{') {
-            if let Ok(map) =
-                serde_json::from_str::<std::collections::HashMap<String, String>>(&stdout[pos..])
-            {
-                parsed = Some(map);
-                break;
-            }
-        }
-        match parsed {
-            Some(m) => m,
-            None => {
-                log::debug!("inherit_shell_proxy_env: no JSON env found in shell output");
-                return;
-            }
-        }
-    };
-
+    // Parse KEY=VALUE lines. Values may contain `=` so split on the first `=` only.
     let mut inherited = 0usize;
-    for key in PROXY_VARS {
-        if let Some(value) = env_map.get(*key) {
-            // Only set if not already present in the process environment.
-            if std::env::var_os(key).is_none() {
-                // SAFETY: single-threaded at this point in startup; no other
-                // threads have been spawned yet.
-                unsafe { std::env::set_var(key, value) };
-                inherited += 1;
-                log::info!("inherit_shell_proxy_env: inherited {key} from login shell");
-            }
+    for line in stdout.lines() {
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if PROXY_VARS.contains(&key) && std::env::var_os(key).is_none() {
+            // SAFETY: single-threaded at this point in startup; no other
+            // threads have been spawned yet.
+            unsafe { std::env::set_var(key, value) };
+            inherited += 1;
+            log::info!("inherit_shell_proxy_env: inherited {key} from login shell");
         }
     }
 
@@ -1591,11 +1534,6 @@ fn main() {
     // `--printenv`: emit the current process environment as JSON and exit.
     // This is invoked by `inherit_shell_proxy_env` via the login shell so we
     // can capture the full shell environment robustly (Zed-style).
-    if std::env::args().any(|a| a == "--printenv") {
-        cmd_printenv();
-        return;
-    }
-
     // Install a panic hook before anything else so every panic —
     // including ones from background threads that would otherwise be
     // invisible — gets written to both stderr and a dated log file.

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -1460,10 +1460,10 @@ fn inherit_shell_env() {
         }
     };
 
-    // Drain stdout on a background thread so the pipe never fills up and
-    // deadlocks the child. We use a channel so we can abandon the reader
-    // if the deadline is reached (e.g. a background process inherits stdout
-    // and keeps the pipe open after the shell exits).
+    // Read stdout incrementally on a background thread, sending chunks as they
+    // arrive. The main thread signals "child exited" via a second channel so
+    // the reader can stop without waiting for EOF (which may never come if a
+    // background process inherited stdout).
     let mut stdout_pipe = match child.stdout.take() {
         Some(p) => p,
         None => {
@@ -1471,11 +1471,50 @@ fn inherit_shell_env() {
             return;
         }
     };
-    let (tx, rx) = std::sync::mpsc::channel::<Vec<u8>>();
+
+    // Set the pipe to non-blocking so the reader thread can poll and check
+    // the stop signal without blocking forever on a single read call.
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::AsRawFd;
+        unsafe extern "C" {
+            fn fcntl(fd: i32, cmd: i32, ...) -> i32;
+        }
+        #[cfg(target_os = "macos")]
+        const O_NONBLOCK: i32 = 0x0004;
+        #[cfg(target_os = "linux")]
+        const O_NONBLOCK: i32 = 0x0800;
+        const F_GETFL: i32 = 3;
+        const F_SETFL: i32 = 4;
+        let fd = stdout_pipe.as_raw_fd();
+        unsafe {
+            let flags = fcntl(fd, F_GETFL);
+            if flags >= 0 {
+                fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+            }
+        }
+    }
+
+    let (data_tx, data_rx) = std::sync::mpsc::channel::<Vec<u8>>();
+    let (stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
     let reader_handle = std::thread::spawn(move || {
         let mut buf = Vec::new();
-        stdout_pipe.read_to_end(&mut buf).ok();
-        let _ = tx.send(buf);
+        let mut tmp = [0u8; 4096];
+        loop {
+            // Check if the main thread signalled stop.
+            if stop_rx.try_recv().is_ok() {
+                break;
+            }
+            match stdout_pipe.read(&mut tmp) {
+                Ok(0) => break, // EOF
+                Ok(n) => buf.extend_from_slice(&tmp[..n]),
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(std::time::Duration::from_millis(10));
+                }
+                Err(_) => break,
+            }
+        }
+        let _ = data_tx.send(buf);
     });
 
     // Wait for the child with a deadline.
@@ -1491,9 +1530,7 @@ fn inherit_shell_env() {
                     );
                     let _ = child.kill();
                     let _ = child.wait();
-                    // Killing the child closes the write end of the pipe, so
-                    // the reader thread gets EOF and exits. Join it to ensure
-                    // no thread is running before apply_to_env calls set_var.
+                    let _ = stop_tx.send(());
                     let _ = reader_handle.join();
                     return;
                 }
@@ -1501,18 +1538,19 @@ fn inherit_shell_env() {
             }
             Err(e) => {
                 log::debug!("inherit_shell_env: try_wait error: {e}");
+                let _ = stop_tx.send(());
                 let _ = reader_handle.join();
                 return;
             }
         }
     }
 
-    // Collect stdout with the remaining deadline — if a background process
-    // inherited the pipe and keeps it open, use whatever was buffered so far
-    // (empty on timeout). unwrap_or_default() means we always proceed on this
-    // thread and never call set_var from a concurrent context.
+    // Child exited — signal the reader to stop (it may still be draining
+    // buffered bytes) and collect whatever was read so far.
+    let _ = stop_tx.send(());
     let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-    let raw = rx.recv_timeout(remaining).unwrap_or_default();
+    let raw = data_rx.recv_timeout(remaining).unwrap_or_default();
+    let _ = reader_handle.join();
     let stdout = match std::str::from_utf8(&raw) {
         Ok(s) => s,
         Err(_) => return,

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -1427,7 +1427,134 @@ fn install_seh_filter() {
     }
 }
 
+/// Print the current process environment as a JSON object to stdout.
+///
+/// This is the `--printenv` mode: the login shell runs
+/// `con --printenv` and we emit JSON so the parent process can parse it
+/// robustly even when the shell rc files produce noisy output on other fds.
+fn cmd_printenv() {
+    let map: std::collections::HashMap<String, String> = std::env::vars().collect();
+    match serde_json::to_string(&map) {
+        Ok(json) => {
+            println!("{json}");
+        }
+        Err(e) => {
+            eprintln!("con --printenv: failed to serialize env: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+/// On macOS and Linux, GUI apps launched from the Dock / Spotlight / a
+/// desktop launcher do not inherit the user's shell environment, so proxy
+/// variables like `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` (and their
+/// lowercase equivalents) are absent from the process environment.
+///
+/// This function runs the user's login shell with `-l -i -c "con --printenv"`
+/// (Zed-style) so the shell fully initialises its rc files before we capture
+/// the environment as JSON.  Only proxy-related variables that are not already
+/// set in the process environment are injected, so an explicit env-var or a
+/// `[network]` config value always wins.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn inherit_shell_proxy_env() {
+    use std::process::Command;
+
+    // Proxy-related variable names we want to forward (both cases).
+    const PROXY_VARS: &[&str] = &[
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+        "NO_PROXY",
+        "no_proxy",
+    ];
+
+    // Path to the running binary — we re-invoke ourselves with --printenv.
+    let self_exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => {
+            log::debug!("inherit_shell_proxy_env: current_exe: {e}");
+            return;
+        }
+    };
+
+    // Determine the user's login shell from $SHELL, falling back to /bin/sh.
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
+
+    // Run `<shell> -l -i -c "<self> --printenv"`.
+    // -l  : login shell (sources /etc/profile, ~/.zprofile, ~/.bash_profile …)
+    // -i  : interactive (sources ~/.zshrc, ~/.bashrc … where proxy vars often live)
+    // The shell may print noise to stdout from rc files; we parse the JSON
+    // object by scanning for the first `{` in the output, matching Zed's
+    // parse_env_map_from_noisy_output strategy.
+    let cmd_str = format!("{} --printenv", self_exe.display());
+    let output = match Command::new(&shell)
+        .args(["-l", "-i", "-c", &cmd_str])
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => {
+            log::debug!("inherit_shell_proxy_env: could not run {shell}: {e}");
+            return;
+        }
+    };
+
+    let stdout = match std::str::from_utf8(&output.stdout) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    // Scan for the first `{` and try to parse a JSON object from there,
+    // tolerating any shell startup noise that precedes it.
+    let env_map: std::collections::HashMap<String, String> = {
+        let mut parsed = None;
+        for (pos, _) in stdout.match_indices('{') {
+            if let Ok(map) =
+                serde_json::from_str::<std::collections::HashMap<String, String>>(&stdout[pos..])
+            {
+                parsed = Some(map);
+                break;
+            }
+        }
+        match parsed {
+            Some(m) => m,
+            None => {
+                log::debug!("inherit_shell_proxy_env: no JSON env found in shell output");
+                return;
+            }
+        }
+    };
+
+    let mut inherited = 0usize;
+    for key in PROXY_VARS {
+        if let Some(value) = env_map.get(*key) {
+            // Only set if not already present in the process environment.
+            if std::env::var_os(key).is_none() {
+                // SAFETY: single-threaded at this point in startup; no other
+                // threads have been spawned yet.
+                unsafe { std::env::set_var(key, value) };
+                inherited += 1;
+                log::info!("inherit_shell_proxy_env: inherited {key} from login shell");
+            }
+        }
+    }
+
+    if inherited == 0 {
+        log::debug!("inherit_shell_proxy_env: no proxy vars found in login shell env");
+    }
+}
+
 fn main() {
+    // `--printenv`: emit the current process environment as JSON and exit.
+    // This is invoked by `inherit_shell_proxy_env` via the login shell so we
+    // can capture the full shell environment robustly (Zed-style).
+    if std::env::args().any(|a| a == "--printenv") {
+        cmd_printenv();
+        return;
+    }
+
     // Install a panic hook before anything else so every panic —
     // including ones from background threads that would otherwise be
     // invisible — gets written to both stderr and a dated log file.
@@ -1440,6 +1567,13 @@ fn main() {
     // Rust's panic infrastructure entirely.
     #[cfg(target_os = "windows")]
     install_seh_filter();
+
+    // Inherit proxy env vars from the login shell before any network
+    // client is constructed.  GUI apps on macOS/Linux don't get the
+    // shell environment, so HTTP_PROXY / HTTPS_PROXY etc. are missing
+    // unless we source them explicitly.
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    inherit_shell_proxy_env();
 
     // Always capture backtraces unless the user already set a
     // preference. `full` prints symbols + line numbers when debug info
@@ -1483,6 +1617,8 @@ fn main() {
 
     let config = con_core::Config::load().unwrap_or_default();
     log::info!("config loaded");
+    // Apply [network] proxy config — overrides any shell-inherited env vars.
+    config.network.apply_to_env();
 
     let app = gpui_platform::application()
         .with_quit_mode(QuitMode::Explicit)

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -1472,7 +1472,7 @@ fn inherit_shell_env() {
         }
     };
     let (tx, rx) = std::sync::mpsc::channel::<Vec<u8>>();
-    std::thread::spawn(move || {
+    let reader_handle = std::thread::spawn(move || {
         let mut buf = Vec::new();
         stdout_pipe.read_to_end(&mut buf).ok();
         let _ = tx.send(buf);
@@ -1491,12 +1491,17 @@ fn inherit_shell_env() {
                     );
                     let _ = child.kill();
                     let _ = child.wait();
+                    // Killing the child closes the write end of the pipe, so
+                    // the reader thread gets EOF and exits. Join it to ensure
+                    // no thread is running before apply_to_env calls set_var.
+                    let _ = reader_handle.join();
                     return;
                 }
                 std::thread::sleep(std::time::Duration::from_millis(50));
             }
             Err(e) => {
                 log::debug!("inherit_shell_env: try_wait error: {e}");
+                let _ = reader_handle.join();
                 return;
             }
         }
@@ -1509,6 +1514,10 @@ fn inherit_shell_env() {
         Ok(b) => b,
         Err(_) => {
             log::debug!("inherit_shell_env: stdout reader timed out (background process holding pipe open)");
+            // The reader thread may still be blocked; it will eventually get
+            // EOF when the background process exits. We cannot join here
+            // without blocking, so we detach — but we must not call set_var
+            // after this point (we return immediately).
             return;
         }
     };

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -1489,14 +1489,55 @@ fn inherit_shell_proxy_env() {
     // The shell may print noise to stdout from rc files; we parse the JSON
     // object by scanning for the first `{` in the output, matching Zed's
     // parse_env_map_from_noisy_output strategy.
-    let cmd_str = format!("{} --printenv", self_exe.display());
-    let output = match Command::new(&shell)
+    // Single-quote the exe path so spaces / metacharacters in bundle paths
+    // (e.g. `/Applications/Con Terminal.app/...`) don't get word-split by sh.
+    let exe_str = self_exe.display().to_string();
+    let quoted = exe_str.replace('\'', r"'\''");
+    let cmd_str = format!("'{}' --printenv", quoted);
+
+    // Spawn with a 5 s timeout — shell rc files can hang on slow NFS mounts,
+    // SSH agent prompts, etc.  We must not block the GUI from appearing.
+    const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+    let mut child = match Command::new(&shell)
         .args(["-l", "-i", "-c", &cmd_str])
-        .output()
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
     {
-        Ok(o) => o,
+        Ok(c) => c,
         Err(e) => {
             log::debug!("inherit_shell_proxy_env: could not run {shell}: {e}");
+            return;
+        }
+    };
+
+    let deadline = std::time::Instant::now() + TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break, // exited
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    log::debug!(
+                        "inherit_shell_proxy_env: shell timed out after {}s, killing",
+                        TIMEOUT.as_secs()
+                    );
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            Err(e) => {
+                log::debug!("inherit_shell_proxy_env: try_wait error: {e}");
+                return;
+            }
+        }
+    }
+
+    let output = match child.wait_with_output() {
+        Ok(o) => o,
+        Err(e) => {
+            log::debug!("inherit_shell_proxy_env: wait_with_output error: {e}");
             return;
         }
     };
@@ -1568,13 +1609,6 @@ fn main() {
     #[cfg(target_os = "windows")]
     install_seh_filter();
 
-    // Inherit proxy env vars from the login shell before any network
-    // client is constructed.  GUI apps on macOS/Linux don't get the
-    // shell environment, so HTTP_PROXY / HTTPS_PROXY etc. are missing
-    // unless we source them explicitly.
-    #[cfg(any(target_os = "macos", target_os = "linux"))]
-    inherit_shell_proxy_env();
-
     // Always capture backtraces unless the user already set a
     // preference. `full` prints symbols + line numbers when debug info
     // is present; harmless in release.
@@ -1583,8 +1617,8 @@ fn main() {
         unsafe { std::env::set_var("RUST_BACKTRACE", "full") };
     }
 
-    // Default to `info` for our crates if the user didn't set RUST_LOG,
-    // so early-init traces are visible without an explicit opt-in.
+    // Init the logger before inherit_shell_proxy_env so its log::info!/debug!
+    // calls are visible when debugging proxy issues.
     let mut builder = env_logger::Builder::from_default_env();
     if std::env::var_os("RUST_LOG").is_none() {
         builder.filter_level(log::LevelFilter::Info);
@@ -1607,6 +1641,13 @@ fn main() {
     }
     builder.init();
 
+    // Inherit proxy env vars from the login shell before any network
+    // client is constructed.  GUI apps on macOS/Linux don't get the
+    // shell environment, so HTTP_PROXY / HTTPS_PROXY etc. are missing
+    // unless we source them explicitly.
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    inherit_shell_proxy_env();
+
     log::info!("con starting (pid {})", std::process::id());
     if let Some(path) = log_file_path.as_ref() {
         log::info!("logging to {}", path.display());
@@ -1618,7 +1659,8 @@ fn main() {
     let config = con_core::Config::load().unwrap_or_default();
     log::info!("config loaded");
     // Apply [network] proxy config — overrides any shell-inherited env vars.
-    config.network.apply_to_env();
+    // SAFETY: single-threaded at this point in startup; no other threads spawned yet.
+    unsafe { config.network.apply_to_env() };
 
     let app = gpui_platform::application()
         .with_quit_mode(QuitMode::Explicit)

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -1498,18 +1498,21 @@ fn inherit_shell_env() {
     };
 
     // Parse KEY=VALUE lines. Values may contain `=` so split on the first `=` only.
-    // Inject every variable not already present — existing values win.
+    // Full override — shell values win, matching Zed's load_login_shell_environment.
+    // Skip SHLVL: the login shell increments it, and terminals spawned by con
+    // would inherit it and increment again (starting at 2 instead of 1).
     let mut inherited = 0usize;
     for line in stdout.lines() {
         let Some((key, value)) = line.split_once('=') else {
             continue;
         };
-        if std::env::var_os(key).is_none() {
-            // SAFETY: single-threaded at this point in startup; no other
-            // threads have been spawned yet.
-            unsafe { std::env::set_var(key, value) };
-            inherited += 1;
+        if key == "SHLVL" {
+            continue;
         }
+        // SAFETY: single-threaded at this point in startup; no other
+        // threads have been spawned yet.
+        unsafe { std::env::set_var(key, value) };
+        inherited += 1;
     }
 
     if inherited > 0 {

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -1461,7 +1461,9 @@ fn inherit_shell_env() {
     };
 
     // Drain stdout on a background thread so the pipe never fills up and
-    // deadlocks the child. The child can then exit, and we join with a timeout.
+    // deadlocks the child. We use a channel so we can abandon the reader
+    // if the deadline is reached (e.g. a background process inherits stdout
+    // and keeps the pipe open after the shell exits).
     let mut stdout_pipe = match child.stdout.take() {
         Some(p) => p,
         None => {
@@ -1469,10 +1471,11 @@ fn inherit_shell_env() {
             return;
         }
     };
-    let reader_thread = std::thread::spawn(move || {
+    let (tx, rx) = std::sync::mpsc::channel::<Vec<u8>>();
+    std::thread::spawn(move || {
         let mut buf = Vec::new();
         stdout_pipe.read_to_end(&mut buf).ok();
-        buf
+        let _ = tx.send(buf);
     });
 
     // Wait for the child with a deadline.
@@ -1499,9 +1502,15 @@ fn inherit_shell_env() {
         }
     }
 
-    let raw = match reader_thread.join() {
+    // Collect stdout with the remaining deadline — if a background process
+    // inherited the pipe and keeps it open, we abandon after the timeout.
+    let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+    let raw = match rx.recv_timeout(remaining) {
         Ok(b) => b,
-        Err(_) => return,
+        Err(_) => {
+            log::debug!("inherit_shell_env: stdout reader timed out (background process holding pipe open)");
+            return;
+        }
     };
     let stdout = match std::str::from_utf8(&raw) {
         Ok(s) => s,

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -1432,11 +1432,12 @@ fn install_seh_filter() {
 /// like `PATH`, `GOPATH`, `NVM_DIR`, `HTTP_PROXY`, etc. that are set in
 /// shell rc files are absent from the process environment.
 ///
-/// Runs `<login-shell> -l -c 'env'` and injects every variable that is not
-/// already present in the current process environment, so explicit env-vars
-/// and `[network]` config values always win.
+/// Runs `<login-shell> -l -c 'env'` and full-overrides the process env with
+/// the shell's values, matching Zed's `load_login_shell_environment` strategy.
+/// `SHLVL` is skipped so terminal children start at level 1.
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 fn inherit_shell_env() {
+    use std::io::Read;
     use std::process::Command;
 
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".to_string());
@@ -1444,7 +1445,6 @@ fn inherit_shell_env() {
     // Run `<shell> -l -c 'env'`.
     // -l : login shell — sources /etc/profile, ~/.zprofile, ~/.bash_profile …
     //      (no -i: avoids interactive-only rc noise and TTY hangs)
-    // env outputs KEY=VALUE\n lines; no JSON, no self-invocation needed.
     const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
     let mut child = match Command::new(&shell)
         .args(["-l", "-c", "env"])
@@ -1460,7 +1460,22 @@ fn inherit_shell_env() {
         }
     };
 
-    // Poll with a deadline so a hanging rc file doesn't block the GUI.
+    // Drain stdout on a background thread so the pipe never fills up and
+    // deadlocks the child. The child can then exit, and we join with a timeout.
+    let mut stdout_pipe = match child.stdout.take() {
+        Some(p) => p,
+        None => {
+            log::debug!("inherit_shell_env: no stdout pipe");
+            return;
+        }
+    };
+    let reader_thread = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        stdout_pipe.read_to_end(&mut buf).ok();
+        buf
+    });
+
+    // Wait for the child with a deadline.
     let deadline = std::time::Instant::now() + TIMEOUT;
     loop {
         match child.try_wait() {
@@ -1484,15 +1499,11 @@ fn inherit_shell_env() {
         }
     }
 
-    let output = match child.wait_with_output() {
-        Ok(o) => o,
-        Err(e) => {
-            log::debug!("inherit_shell_env: wait_with_output error: {e}");
-            return;
-        }
+    let raw = match reader_thread.join() {
+        Ok(b) => b,
+        Err(_) => return,
     };
-
-    let stdout = match std::str::from_utf8(&output.stdout) {
+    let stdout = match std::str::from_utf8(&raw) {
         Ok(s) => s,
         Err(_) => return,
     };

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -1508,19 +1508,11 @@ fn inherit_shell_env() {
     }
 
     // Collect stdout with the remaining deadline — if a background process
-    // inherited the pipe and keeps it open, we abandon after the timeout.
+    // inherited the pipe and keeps it open, use whatever was buffered so far
+    // (empty on timeout). unwrap_or_default() means we always proceed on this
+    // thread and never call set_var from a concurrent context.
     let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-    let raw = match rx.recv_timeout(remaining) {
-        Ok(b) => b,
-        Err(_) => {
-            log::debug!("inherit_shell_env: stdout reader timed out (background process holding pipe open)");
-            // The reader thread may still be blocked; it will eventually get
-            // EOF when the background process exits. We cannot join here
-            // without blocking, so we detach — but we must not call set_var
-            // after this point (we return immediately).
-            return;
-        }
-    };
+    let raw = rx.recv_timeout(remaining).unwrap_or_default();
     let stdout = match std::str::from_utf8(&raw) {
         Ok(s) => s,
         Err(_) => return,

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -1849,6 +1849,35 @@ impl PaneTree {
     /// Render the persistent title bar shown at the top of each pane when
     /// there are 2+ panes in the split tree.
     #[allow(clippy::too_many_arguments)]
+    /// Returns the dot color for the active-pane indicator, or `None` when the
+    /// pane is not focused (no dot should be rendered).
+    ///
+    /// - Focused + accent color → use the accent hue.
+    /// - Focused + no accent   → fall back to `theme.success` (green).
+    /// - Not focused           → `None`.
+    fn active_pane_dot_color(
+        is_focused: bool,
+        tab_accent_color: Option<con_core::session::TabAccentColor>,
+        theme: &gpui_component::Theme,
+        cx: &App,
+    ) -> Option<Hsla> {
+        if !is_focused {
+            return None;
+        }
+        Some(if let Some(color) = tab_accent_color {
+            crate::tab_colors::tab_accent_color_hsla(color, cx)
+        } else {
+            theme.success
+        })
+    }
+
+    /// Pure predicate: should the active-pane dot be shown?
+    /// Extracted for unit-testability without a GPUI context.
+    #[cfg(test)]
+    fn should_show_active_pane_dot(is_focused: bool) -> bool {
+        is_focused
+    }
+
     fn render_pane_title_bar(
         pane_id: PaneId,
         session_id: u64,
@@ -1871,24 +1900,17 @@ impl PaneTree {
         let btn_color = theme.foreground.opacity(0.52);
         let btn_hover_bg = theme.foreground.opacity(0.08);
 
-        // Active-pane indicator dot — same color as the tab accent (or foreground fallback)
-        let dot = if is_focused {
-            let dot_color = if let Some(color) = tab_accent_color {
-                crate::tab_colors::tab_accent_color_hsla(color, cx)
-            } else {
-                theme.success
-            };
-            Some(
+        // Active-pane indicator dot — same color as the tab accent (or green fallback)
+        let dot = Self::active_pane_dot_color(is_focused, tab_accent_color, theme, cx).map(
+            |dot_color| {
                 div()
                     .flex_shrink_0()
                     .size(px(6.0))
                     .rounded_full()
                     .mr(px(5.0))
-                    .bg(dot_color),
-            )
-        } else {
-            None
-        };
+                    .bg(dot_color)
+            },
+        );
 
         // ⛶/⛶ fullscreen toggle button — always visible
         let zoom_icon = if is_zoomed {
@@ -2941,5 +2963,25 @@ mod tests {
         };
 
         assert!(!tree.is_noop_pane_move(1, 0, SplitDirection::Horizontal, SplitPlacement::After,));
+    }
+
+    #[::core::prelude::v1::test]
+    fn active_pane_dot_not_shown_when_unfocused() {
+        assert!(!PaneTree::should_show_active_pane_dot(false));
+    }
+
+    #[::core::prelude::v1::test]
+    fn active_pane_dot_shown_when_focused() {
+        assert!(PaneTree::should_show_active_pane_dot(true));
+    }
+
+    #[::core::prelude::v1::test]
+    fn active_pane_dot_color_returns_none_when_unfocused() {
+        // active_pane_dot_color delegates the focused=false path to
+        // should_show_active_pane_dot; verify the contract without a GPUI context
+        // by testing the predicate directly.
+        assert!(!PaneTree::should_show_active_pane_dot(false));
+        // Focused path requires a Theme + App — covered by the predicate tests above
+        // and by visual inspection in the running app.
     }
 }

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -14,14 +14,6 @@ use crate::terminal_pane::TerminalPane;
 const RESTORED_SCREEN_TEXT_MAX_LINES: usize = 600;
 const RESTORED_SCREEN_TEXT_MAX_BYTES: usize = 128 * 1024;
 
-fn sanitize_tab_accent_alpha(alpha: f32) -> f32 {
-    if alpha.is_finite() {
-        alpha.clamp(0.0, 1.0)
-    } else {
-        crate::tab_colors::TAB_ACCENT_INACTIVE_ALPHA
-    }
-}
-
 /// Split direction for pane layout
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SplitDirection {
@@ -1865,28 +1857,12 @@ impl PaneTree {
         has_splits: bool,
         is_zoomed: bool,
         tab_accent_color: Option<con_core::session::TabAccentColor>,
-        tab_accent_inactive_alpha: f32,
+        _tab_accent_inactive_alpha: f32,
         close_pane_cb: std::sync::Arc<dyn Fn(PaneId, &mut Window, &mut App) + 'static>,
         toggle_zoom_cb: std::sync::Arc<dyn Fn(PaneId, &mut Window, &mut App) + 'static>,
         cx: &App,
     ) -> AnyElement {
         let theme = cx.theme();
-        let bar_bg = if is_focused {
-            if let Some(color) = tab_accent_color {
-                crate::tab_colors::tab_accent_surface_hsla(
-                    color,
-                    crate::tab_colors::TAB_ACCENT_ACTIVE_ALPHA,
-                    cx,
-                )
-            } else {
-                theme.tab_bar_segmented
-            }
-        } else if let Some(color) = tab_accent_color {
-            let inactive_alpha = sanitize_tab_accent_alpha(tab_accent_inactive_alpha);
-            crate::tab_colors::tab_accent_surface_hsla(color, inactive_alpha, cx)
-        } else {
-            theme.tab_bar_segmented.opacity(0.78)
-        };
         let title_color = if is_focused {
             theme.foreground.opacity(0.72)
         } else {
@@ -1894,6 +1870,25 @@ impl PaneTree {
         };
         let btn_color = theme.foreground.opacity(0.52);
         let btn_hover_bg = theme.foreground.opacity(0.08);
+
+        // Active-pane indicator dot — same color as the tab accent (or foreground fallback)
+        let dot = if is_focused {
+            let dot_color = if let Some(color) = tab_accent_color {
+                crate::tab_colors::tab_accent_color_hsla(color, cx)
+            } else {
+                theme.success
+            };
+            Some(
+                div()
+                    .flex_shrink_0()
+                    .size(px(6.0))
+                    .rounded_full()
+                    .mr(px(5.0))
+                    .bg(dot_color),
+            )
+        } else {
+            None
+        };
 
         // ⛶/⛶ fullscreen toggle button — always visible
         let zoom_icon = if is_zoomed {
@@ -1990,7 +1985,6 @@ impl PaneTree {
             .h(px(24.0))
             .w_full()
             .px(px(6.0))
-            .bg(bar_bg)
             .cursor_grab()
             .on_drag(
                 dragged,
@@ -1998,9 +1992,13 @@ impl PaneTree {
                     cx.stop_propagation();
                     cx.new(|_| dragged.clone())
                 },
-            )
-            .child(title_el)
-            .child(zoom_btn);
+            );
+
+        if let Some(dot) = dot {
+            bar = bar.child(dot);
+        }
+
+        bar = bar.child(title_el).child(zoom_btn);
 
         if let Some(close) = close_btn {
             bar = bar.child(close);

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -2289,12 +2289,20 @@ impl SettingsPanel {
         // Keybindings are updated directly via record_keystroke — no reading needed
 
         // Network / proxy
-        // Empty string → Some("") so apply_to_env can clear any inherited proxy on restart.
-        // None means "not configured at all" and would leave inherited values untouched.
+        // Blank field → None (leave inherited env untouched).
+        // Non-empty   → Some(value) (override or clear on next startup).
         let http_proxy_text = self.http_proxy_input.read(cx).value().trim().to_string();
         let https_proxy_text = self.https_proxy_input.read(cx).value().trim().to_string();
-        self.config.network.http_proxy = Some(http_proxy_text);
-        self.config.network.https_proxy = Some(https_proxy_text);
+        self.config.network.http_proxy = if http_proxy_text.is_empty() {
+            None
+        } else {
+            Some(http_proxy_text)
+        };
+        self.config.network.https_proxy = if https_proxy_text.is_empty() {
+            None
+        } else {
+            Some(https_proxy_text)
+        };
 
         match self.persist_config() {
             Ok(()) => {

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -153,6 +153,10 @@ pub struct SettingsPanel {
     recording_key: Option<String>,
     #[cfg(target_os = "macos")]
     recording_resume_keybindings: Option<con_core::config::KeybindingConfig>,
+
+    // Network / proxy
+    http_proxy_input: Entity<InputState>,
+    https_proxy_input: Entity<InputState>,
 }
 
 const SIDEBAR_PROVIDERS: &[ProviderKind] = &[
@@ -1229,6 +1233,20 @@ impl SettingsPanel {
             s.set_placeholder("Save as, e.g. flexoki-amber", window, cx);
             s
         });
+        let http_proxy_input = cx.new(|cx| {
+            let mut s = InputState::new(window, cx);
+            let val = config.network.http_proxy.clone().unwrap_or_default();
+            s.set_value(val, window, cx);
+            s.set_placeholder("http://127.0.0.1:1086", window, cx);
+            s
+        });
+        let https_proxy_input = cx.new(|cx| {
+            let mut s = InputState::new(window, cx);
+            let val = config.network.https_proxy.clone().unwrap_or_default();
+            s.set_value(val, window, cx);
+            s.set_placeholder("http://127.0.0.1:1086", window, cx);
+            s
+        });
 
         cx.subscribe(
             &terminal_opacity_slider,
@@ -1469,6 +1487,8 @@ impl SettingsPanel {
             recording_key: None,
             #[cfg(target_os = "macos")]
             recording_resume_keybindings: None,
+            http_proxy_input,
+            https_proxy_input,
         }
     }
 
@@ -2253,6 +2273,20 @@ impl SettingsPanel {
 
         // Keybindings are updated directly via record_keystroke — no reading needed
 
+        // Network / proxy
+        let http_proxy_text = self.http_proxy_input.read(cx).value().trim().to_string();
+        let https_proxy_text = self.https_proxy_input.read(cx).value().trim().to_string();
+        self.config.network.http_proxy = if http_proxy_text.is_empty() {
+            None
+        } else {
+            Some(http_proxy_text)
+        };
+        self.config.network.https_proxy = if https_proxy_text.is_empty() {
+            None
+        } else {
+            Some(https_proxy_text)
+        };
+
         match self.persist_config() {
             Ok(()) => {
                 self.save_error = None;
@@ -2938,6 +2972,20 @@ impl SettingsPanel {
                                         .children(global_presets),
                                 ),
                         ),
+                ),
+        )
+        // Network / proxy
+        .child(
+            div()
+                .flex()
+                .flex_col()
+                .gap(px(8.0))
+                .child(group_label("Network", &theme))
+                .child(
+                    card(theme, card_opacity)
+                        .child(row_field("HTTP Proxy", &self.http_proxy_input))
+                        .child(row_separator(theme))
+                        .child(row_field("HTTPS Proxy", &self.https_proxy_input)),
                 ),
         )
     }

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -2274,18 +2274,12 @@ impl SettingsPanel {
         // Keybindings are updated directly via record_keystroke — no reading needed
 
         // Network / proxy
+        // Empty string → Some("") so apply_to_env can clear any inherited proxy on restart.
+        // None means "not configured at all" and would leave inherited values untouched.
         let http_proxy_text = self.http_proxy_input.read(cx).value().trim().to_string();
         let https_proxy_text = self.https_proxy_input.read(cx).value().trim().to_string();
-        self.config.network.http_proxy = if http_proxy_text.is_empty() {
-            None
-        } else {
-            Some(http_proxy_text)
-        };
-        self.config.network.https_proxy = if https_proxy_text.is_empty() {
-            None
-        } else {
-            Some(https_proxy_text)
-        };
+        self.config.network.http_proxy = Some(http_proxy_text);
+        self.config.network.https_proxy = Some(https_proxy_text);
 
         match self.persist_config() {
             Ok(()) => {

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -1687,6 +1687,21 @@ impl SettingsPanel {
         self.provider_model_status = None;
         self.provider_model_status_error = false;
         self.set_recording_key(None);
+        // Network / proxy — repopulate so reopening the panel shows current values.
+        self.http_proxy_input.update(cx, |s, cx| {
+            s.set_value(
+                &self.config.network.http_proxy.clone().unwrap_or_default(),
+                window,
+                cx,
+            )
+        });
+        self.https_proxy_input.update(cx, |s, cx| {
+            s.set_value(
+                &self.config.network.https_proxy.clone().unwrap_or_default(),
+                window,
+                cx,
+            )
+        });
         self.focus_handle.focus(window, cx);
     }
 

--- a/crates/con-app/src/workspace/chrome.rs
+++ b/crates/con-app/src/workspace/chrome.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+pub(super) fn agent_panel_motion_target_for_agent_request(already_open: bool) -> Option<f32> {
+    if already_open { None } else { Some(1.0) }
+}
+
 impl ConWorkspace {
     pub(super) const SECONDARY_PANE_OBSERVATION_LINES: usize = 40;
 

--- a/crates/con-app/src/workspace/chrome.rs
+++ b/crates/con-app/src/workspace/chrome.rs
@@ -1,7 +1,10 @@
 use super::*;
 
-pub(super) fn agent_panel_motion_target_for_agent_request(already_open: bool) -> Option<f32> {
-    if already_open { None } else { Some(1.0) }
+/// Always returns `Some(1.0)` for agent-request opens so the motion value is
+/// driven to visible even when `agent_panel_open` was set by a path that
+/// skipped the motion update (e.g. the skill-invoke branch).
+pub(super) fn agent_panel_motion_target_for_agent_request(_already_open: bool) -> Option<f32> {
+    Some(1.0)
 }
 
 impl ConWorkspace {

--- a/crates/con-app/src/workspace/control_requests.rs
+++ b/crates/con-app/src/workspace/control_requests.rs
@@ -869,6 +869,7 @@ impl ConWorkspace {
                                 self.agent_panel_open = true;
                                 let duration = Self::terminal_adjacent_chrome_duration(true, 290, 220);
                                 self.agent_panel_motion.set_target(target, duration);
+                                cx.notify();
                             }
                         }
                         let open = if tab_idx == self.active_tab {

--- a/crates/con-app/src/workspace/control_requests.rs
+++ b/crates/con-app/src/workspace/control_requests.rs
@@ -857,6 +857,59 @@ impl ConWorkspace {
                 }
                 Err(err) => Self::send_control_result(response_tx, Err(err)),
             },
+            ControlCommand::AgentOpenPanelForRequest { tab_index } => {
+                match self.resolve_control_tab_index(tab_index) {
+                    Ok(tab_idx) => {
+                        if tab_idx == self.active_tab {
+                            if let Some(target) =
+                                super::chrome::agent_panel_motion_target_for_agent_request(
+                                    self.agent_panel_open,
+                                )
+                            {
+                                self.agent_panel_open = true;
+                                let duration = Self::terminal_adjacent_chrome_duration(true, 290, 220);
+                                self.agent_panel_motion.set_target(target, duration);
+                            }
+                        }
+                        let open = if tab_idx == self.active_tab {
+                            self.agent_panel_open
+                        } else {
+                            false
+                        };
+                        Self::send_control_result(
+                            response_tx,
+                            Ok(json!({
+                                "agent_panel": {
+                                    "open": open,
+                                    "content_visible": open,
+                                }
+                            })),
+                        );
+                    }
+                    Err(err) => Self::send_control_result(response_tx, Err(err)),
+                }
+            }
+            ControlCommand::AgentPanelState { tab_index } => {
+                match self.resolve_control_tab_index(tab_index) {
+                    Ok(tab_idx) => {
+                        let open = if tab_idx == self.active_tab {
+                            self.agent_panel_open
+                        } else {
+                            false
+                        };
+                        Self::send_control_result(
+                            response_tx,
+                            Ok(json!({
+                                "agent_panel": {
+                                    "open": open,
+                                    "content_visible": open,
+                                }
+                            })),
+                        );
+                    }
+                    Err(err) => Self::send_control_result(response_tx, Err(err)),
+                }
+            }
         }
     }
 

--- a/crates/con-app/src/workspace/pane_actions.rs
+++ b/crates/con-app/src/workspace/pane_actions.rs
@@ -40,8 +40,20 @@ impl ConWorkspace {
             return;
         }
         self.record_input_history(content);
-        if !self.agent_panel_open {
+        if let Some(target) =
+            super::chrome::agent_panel_motion_target_for_agent_request(self.agent_panel_open)
+        {
             self.agent_panel_open = true;
+            let duration = Self::terminal_adjacent_chrome_duration(true, 290, 220);
+            #[cfg(target_os = "macos")]
+            if !duration.is_zero() {
+                self.arm_chrome_transition_underlay(duration + Duration::from_millis(80));
+            }
+            #[cfg(target_os = "macos")]
+            if duration.is_zero() {
+                self.arm_agent_panel_snap_guard(cx);
+            }
+            self.agent_panel_motion.set_target(target, duration);
         }
         self.agent_panel.update(cx, |panel, cx| {
             panel.add_message("user", content, cx);

--- a/crates/con-app/src/workspace/sidebar_settings.rs
+++ b/crates/con-app/src/workspace/sidebar_settings.rs
@@ -758,6 +758,10 @@ impl ConWorkspace {
             }
         }
 
+        // Apply network/proxy config so new values take effect immediately
+        // for any subsequent requests (Rig agent, model registry, updater).
+        full_config.network.apply_to_env();
+
         let term_config = full_config.terminal.clone();
         let appearance_config = full_config.appearance.clone();
         self.apply_terminal_and_ui_appearance(&term_config, &appearance_config, window, cx);

--- a/crates/con-app/src/workspace/sidebar_settings.rs
+++ b/crates/con-app/src/workspace/sidebar_settings.rs
@@ -760,7 +760,10 @@ impl ConWorkspace {
 
         // Apply network/proxy config so new values take effect immediately
         // for any subsequent requests (Rig agent, model registry, updater).
-        full_config.network.apply_to_env();
+        // SAFETY: GPUI's main thread is the sole writer of these env vars;
+        // reqwest clients read proxy env lazily at construction time, not
+        // concurrently with this write.
+        unsafe { full_config.network.apply_to_env() };
 
         let term_config = full_config.terminal.clone();
         let appearance_config = full_config.appearance.clone();

--- a/crates/con-app/src/workspace/sidebar_settings.rs
+++ b/crates/con-app/src/workspace/sidebar_settings.rs
@@ -758,12 +758,9 @@ impl ConWorkspace {
             }
         }
 
-        // Apply network/proxy config so new values take effect immediately
-        // for any subsequent requests (Rig agent, model registry, updater).
-        // SAFETY: GPUI's main thread is the sole writer of these env vars;
-        // reqwest clients read proxy env lazily at construction time, not
-        // concurrently with this write.
-        unsafe { full_config.network.apply_to_env() };
+        // Note: network/proxy config changes take effect on next app restart.
+        // apply_to_env() is unsafe (requires single-threaded startup context)
+        // and must not be called here while background threads are active.
 
         let term_config = full_config.terminal.clone();
         let appearance_config = full_config.appearance.clone();

--- a/crates/con-app/src/workspace/tests.rs
+++ b/crates/con-app/src/workspace/tests.rs
@@ -1,3 +1,4 @@
+use super::chrome::agent_panel_motion_target_for_agent_request;
 use super::{
     ConWorkspace, SPLIT_PREVIEW_SEAM_THICKNESS, SplitDirection, SplitPlacement,
     TabRenameStateSnapshot, centered_drag_preview_origin, clamp_preview_origin_to_tab_bar,
@@ -15,6 +16,15 @@ use crate::sidebar::{
     DraggedTabPreviewConstraint, constrained_drag_preview_x_shift, constrained_drag_preview_y_shift,
 };
 use gpui::{Bounds, Point, Size, px};
+
+#[test]
+fn agent_request_opening_panel_drives_panel_motion_to_visible() {
+    assert_eq!(
+        agent_panel_motion_target_for_agent_request(false),
+        Some(1.0)
+    );
+    assert_eq!(agent_panel_motion_target_for_agent_request(true), None);
+}
 
 #[test]
 fn tab_drag_preview_origin_is_clamped_to_tab_bar_height() {

--- a/crates/con-app/src/workspace/tests.rs
+++ b/crates/con-app/src/workspace/tests.rs
@@ -19,11 +19,16 @@ use gpui::{Bounds, Point, Size, px};
 
 #[test]
 fn agent_request_opening_panel_drives_panel_motion_to_visible() {
+    // Always drives to 1.0 regardless of current open state, so a stale
+    // agent_panel_open flag (set without motion) is corrected on next request.
     assert_eq!(
         agent_panel_motion_target_for_agent_request(false),
         Some(1.0)
     );
-    assert_eq!(agent_panel_motion_target_for_agent_request(true), None);
+    assert_eq!(
+        agent_panel_motion_target_for_agent_request(true),
+        Some(1.0)
+    );
 }
 
 #[test]

--- a/crates/con-cli/src/main.rs
+++ b/crates/con-cli/src/main.rs
@@ -93,6 +93,8 @@ enum TmuxCommand {
 enum AgentCommand {
     Ask(AgentAskArgs),
     NewConversation(TabArgs),
+    OpenPanelForRequest(TabArgs),
+    PanelState(TabArgs),
 }
 
 #[derive(Args, Clone, Default)]
@@ -659,6 +661,24 @@ fn main() -> Result<()> {
                     },
                 )?;
                 print_result(&result, cli.json, render_new_conversation)?;
+            }
+            AgentCommand::OpenPanelForRequest(args) => {
+                let result = send_command(
+                    &socket_path,
+                    ControlCommand::AgentOpenPanelForRequest {
+                        tab_index: args.tab,
+                    },
+                )?;
+                print_result(&result, cli.json, render_pretty_json)?;
+            }
+            AgentCommand::PanelState(args) => {
+                let result = send_command(
+                    &socket_path,
+                    ControlCommand::AgentPanelState {
+                        tab_index: args.tab,
+                    },
+                )?;
+                print_result(&result, cli.json, render_pretty_json)?;
             }
         },
     }

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -485,6 +485,59 @@ impl Default for KeybindingConfig {
     }
 }
 
+/// Network proxy configuration.
+///
+/// When set, these values override any `HTTP_PROXY` / `HTTPS_PROXY` environment
+/// variables that may have been inherited from the shell.  Leave empty to rely
+/// on the environment (the default).
+///
+/// # Example
+/// ```toml
+/// [network]
+/// http_proxy  = "http://127.0.0.1:1086"
+/// https_proxy = "http://127.0.0.1:1086"
+/// ```
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct NetworkConfig {
+    /// HTTP proxy URL, e.g. `http://127.0.0.1:1086`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub http_proxy: Option<String>,
+    /// HTTPS proxy URL, e.g. `http://127.0.0.1:1086`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub https_proxy: Option<String>,
+}
+
+impl NetworkConfig {
+    /// Apply the configured proxy values to the current process environment so
+    /// that all downstream `reqwest` clients (Rig, model registry, updater)
+    /// pick them up automatically.
+    ///
+    /// Config values take precedence over whatever the shell env already has.
+    pub fn apply_to_env(&self) {
+        if let Some(ref v) = self.http_proxy {
+            if !v.is_empty() {
+                // SAFETY: called from the main thread before any network
+                // clients are constructed; no concurrent env reads.
+                unsafe {
+                    std::env::set_var("HTTP_PROXY", v);
+                    std::env::set_var("http_proxy", v);
+                }
+                log::info!("network: HTTP_PROXY set from config");
+            }
+        }
+        if let Some(ref v) = self.https_proxy {
+            if !v.is_empty() {
+                unsafe {
+                    std::env::set_var("HTTPS_PROXY", v);
+                    std::env::set_var("https_proxy", v);
+                }
+                log::info!("network: HTTPS_PROXY set from config");
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Config {
@@ -493,6 +546,7 @@ pub struct Config {
     pub agent: AgentConfig,
     pub keybindings: KeybindingConfig,
     pub skills: SkillsConfig,
+    pub network: NetworkConfig,
 }
 
 /// Configuration for skill discovery paths.

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -539,7 +539,7 @@ impl NetworkConfig {
                 log::info!("network: {upper} set from config");
             },
             Some(_empty) => unsafe {
-                // Explicitly cleared by the user — remove any inherited value.
+                // Explicitly cleared by the user (empty string) — remove any inherited value.
                 std::env::remove_var(upper);
                 std::env::remove_var(lower);
                 log::info!("network: {upper} cleared from config");

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -514,11 +514,15 @@ impl NetworkConfig {
     /// pick them up automatically.
     ///
     /// Config values take precedence over whatever the shell env already has.
-    pub fn apply_to_env(&self) {
+    ///
+    /// # Safety
+    ///
+    /// Must be called from a single-threaded context (e.g. early in `main`)
+    /// before any other threads are spawned, because `std::env::set_var` is
+    /// not thread-safe.
+    pub unsafe fn apply_to_env(&self) {
         if let Some(ref v) = self.http_proxy {
             if !v.is_empty() {
-                // SAFETY: called from the main thread before any network
-                // clients are constructed; no concurrent env reads.
                 unsafe {
                     std::env::set_var("HTTP_PROXY", v);
                     std::env::set_var("http_proxy", v);
@@ -727,7 +731,8 @@ fn replace_file(tmp_path: &Path, path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        Config, DEFAULT_TERMINAL_FONT_FAMILY, SkillsConfig, sanitize_terminal_font_family,
+        Config, DEFAULT_TERMINAL_FONT_FAMILY, NetworkConfig, SkillsConfig,
+        sanitize_terminal_font_family,
     };
 
     #[test]
@@ -824,5 +829,80 @@ quick_terminal = "cmd-\\"
 
         assert!(config.keybindings.quick_terminal_enabled);
         assert_eq!(config.keybindings.quick_terminal, "cmd-\\");
+    }
+
+    #[test]
+    fn network_config_defaults_to_empty() {
+        let config = NetworkConfig::default();
+        assert!(config.http_proxy.is_none());
+        assert!(config.https_proxy.is_none());
+    }
+
+    #[test]
+    fn network_config_deserializes_from_toml() {
+        let content = r#"
+[network]
+http_proxy  = "http://127.0.0.1:1086"
+https_proxy = "http://127.0.0.1:1086"
+"#;
+        let config: Config = toml::from_str(content).unwrap();
+        assert_eq!(
+            config.network.http_proxy.as_deref(),
+            Some("http://127.0.0.1:1086")
+        );
+        assert_eq!(
+            config.network.https_proxy.as_deref(),
+            Some("http://127.0.0.1:1086")
+        );
+    }
+
+    #[test]
+    fn network_config_missing_section_is_default() {
+        let content = r#"
+[terminal]
+font_size = 14.0
+"#;
+        let config: Config = toml::from_str(content).unwrap();
+        assert!(config.network.http_proxy.is_none());
+        assert!(config.network.https_proxy.is_none());
+    }
+
+    #[test]
+    fn network_config_partial_fields() {
+        let content = r#"
+[network]
+http_proxy = "http://proxy.example.com:8080"
+"#;
+        let config: Config = toml::from_str(content).unwrap();
+        assert_eq!(
+            config.network.http_proxy.as_deref(),
+            Some("http://proxy.example.com:8080")
+        );
+        assert!(config.network.https_proxy.is_none());
+    }
+
+    #[test]
+    fn network_config_round_trips_through_serialization() {
+        let original = NetworkConfig {
+            http_proxy: Some("http://127.0.0.1:1086".to_string()),
+            https_proxy: Some("http://127.0.0.1:1087".to_string()),
+        };
+        let serialized = toml::to_string(&original).unwrap();
+        let deserialized: NetworkConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(original.http_proxy, deserialized.http_proxy);
+        assert_eq!(original.https_proxy, deserialized.https_proxy);
+    }
+
+    #[test]
+    fn network_config_empty_strings_are_preserved() {
+        // Empty strings are valid TOML values; apply_to_env skips them.
+        let content = r#"
+[network]
+http_proxy  = ""
+https_proxy = ""
+"#;
+        let config: Config = toml::from_str(content).unwrap();
+        assert_eq!(config.network.http_proxy.as_deref(), Some(""));
+        assert_eq!(config.network.https_proxy.as_deref(), Some(""));
     }
 }

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -514,14 +514,13 @@ impl NetworkConfig {
     /// pick them up automatically.
     ///
     /// - `Some(non_empty)` → sets the env var (overrides shell-inherited value).
-    /// - `Some("")`        → removes the env var (user explicitly cleared it).
-    /// - `None`            → no-op (not configured; leave whatever the env has).
+    /// - `Some("")` / `None` → no-op (leave whatever the env has).
     ///
     /// # Safety
     ///
     /// Must be called from a single-threaded context (e.g. early in `main`)
-    /// before any other threads are spawned, because `std::env::set_var` and
-    /// `std::env::remove_var` are not thread-safe.
+    /// before any other threads are spawned, because `std::env::set_var` is
+    /// not thread-safe.
     pub unsafe fn apply_to_env(&self) {
         unsafe {
             Self::apply_one("HTTP_PROXY", "http_proxy", self.http_proxy.as_deref());
@@ -532,22 +531,16 @@ impl NetworkConfig {
     /// # Safety
     /// Same as `apply_to_env` — must be called single-threaded.
     unsafe fn apply_one(upper: &str, lower: &str, value: Option<&str>) {
-        match value {
-            Some(v) if !v.is_empty() => unsafe {
-                std::env::set_var(upper, v);
-                std::env::set_var(lower, v);
+        if let Some(v) = value {
+            if !v.is_empty() {
+                unsafe {
+                    std::env::set_var(upper, v);
+                    std::env::set_var(lower, v);
+                }
                 log::info!("network: {upper} set from config");
-            },
-            Some(_empty) => unsafe {
-                // Explicitly cleared by the user (empty string) — remove any inherited value.
-                std::env::remove_var(upper);
-                std::env::remove_var(lower);
-                log::info!("network: {upper} cleared from config");
-            },
-            None => {
-                // Not configured — leave the environment untouched.
             }
         }
+        // None or empty string → leave the environment untouched.
     }
 }
 
@@ -904,7 +897,8 @@ http_proxy = "http://proxy.example.com:8080"
 
     #[test]
     fn network_config_empty_strings_are_preserved() {
-        // Empty strings are valid TOML values; apply_to_env skips them.
+        // Empty strings are valid TOML values and deserialize to Some("").
+        // apply_to_env treats them as no-op (same as None).
         let content = r#"
 [network]
 http_proxy  = ""

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -513,9 +513,9 @@ impl NetworkConfig {
     /// that all downstream `reqwest` clients (Rig, model registry, updater)
     /// pick them up automatically.
     ///
-    /// - `Some(non_empty)` → sets the env var.
-    /// - `None` or `Some("")` → removes the env var so a previously-set value
-    ///   does not linger after the user clears the setting.
+    /// - `Some(non_empty)` → sets the env var (overrides shell-inherited value).
+    /// - `Some("")`        → removes the env var (user explicitly cleared it).
+    /// - `None`            → no-op (not configured; leave whatever the env has).
     ///
     /// # Safety
     ///
@@ -523,29 +523,30 @@ impl NetworkConfig {
     /// before any other threads are spawned, because `std::env::set_var` and
     /// `std::env::remove_var` are not thread-safe.
     pub unsafe fn apply_to_env(&self) {
-        // HTTP proxy
-        match self.http_proxy.as_deref() {
-            Some(v) if !v.is_empty() => unsafe {
-                std::env::set_var("HTTP_PROXY", v);
-                std::env::set_var("http_proxy", v);
-                log::info!("network: HTTP_PROXY set from config");
-            },
-            _ => unsafe {
-                std::env::remove_var("HTTP_PROXY");
-                std::env::remove_var("http_proxy");
-            },
+        unsafe {
+            Self::apply_one("HTTP_PROXY", "http_proxy", self.http_proxy.as_deref());
+            Self::apply_one("HTTPS_PROXY", "https_proxy", self.https_proxy.as_deref());
         }
-        // HTTPS proxy
-        match self.https_proxy.as_deref() {
+    }
+
+    /// # Safety
+    /// Same as `apply_to_env` — must be called single-threaded.
+    unsafe fn apply_one(upper: &str, lower: &str, value: Option<&str>) {
+        match value {
             Some(v) if !v.is_empty() => unsafe {
-                std::env::set_var("HTTPS_PROXY", v);
-                std::env::set_var("https_proxy", v);
-                log::info!("network: HTTPS_PROXY set from config");
+                std::env::set_var(upper, v);
+                std::env::set_var(lower, v);
+                log::info!("network: {upper} set from config");
             },
-            _ => unsafe {
-                std::env::remove_var("HTTPS_PROXY");
-                std::env::remove_var("https_proxy");
+            Some(_empty) => unsafe {
+                // Explicitly cleared by the user — remove any inherited value.
+                std::env::remove_var(upper);
+                std::env::remove_var(lower);
+                log::info!("network: {upper} cleared from config");
             },
+            None => {
+                // Not configured — leave the environment untouched.
+            }
         }
     }
 }

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -513,31 +513,39 @@ impl NetworkConfig {
     /// that all downstream `reqwest` clients (Rig, model registry, updater)
     /// pick them up automatically.
     ///
-    /// Config values take precedence over whatever the shell env already has.
+    /// - `Some(non_empty)` → sets the env var.
+    /// - `None` or `Some("")` → removes the env var so a previously-set value
+    ///   does not linger after the user clears the setting.
     ///
     /// # Safety
     ///
     /// Must be called from a single-threaded context (e.g. early in `main`)
-    /// before any other threads are spawned, because `std::env::set_var` is
-    /// not thread-safe.
+    /// before any other threads are spawned, because `std::env::set_var` and
+    /// `std::env::remove_var` are not thread-safe.
     pub unsafe fn apply_to_env(&self) {
-        if let Some(ref v) = self.http_proxy {
-            if !v.is_empty() {
-                unsafe {
-                    std::env::set_var("HTTP_PROXY", v);
-                    std::env::set_var("http_proxy", v);
-                }
+        // HTTP proxy
+        match self.http_proxy.as_deref() {
+            Some(v) if !v.is_empty() => unsafe {
+                std::env::set_var("HTTP_PROXY", v);
+                std::env::set_var("http_proxy", v);
                 log::info!("network: HTTP_PROXY set from config");
-            }
+            },
+            _ => unsafe {
+                std::env::remove_var("HTTP_PROXY");
+                std::env::remove_var("http_proxy");
+            },
         }
-        if let Some(ref v) = self.https_proxy {
-            if !v.is_empty() {
-                unsafe {
-                    std::env::set_var("HTTPS_PROXY", v);
-                    std::env::set_var("https_proxy", v);
-                }
+        // HTTPS proxy
+        match self.https_proxy.as_deref() {
+            Some(v) if !v.is_empty() => unsafe {
+                std::env::set_var("HTTPS_PROXY", v);
+                std::env::set_var("https_proxy", v);
                 log::info!("network: HTTPS_PROXY set from config");
-            }
+            },
+            _ => unsafe {
+                std::env::remove_var("HTTPS_PROXY");
+                std::env::remove_var("https_proxy");
+            },
         }
     }
 }

--- a/crates/con-core/src/control.rs
+++ b/crates/con-core/src/control.rs
@@ -193,6 +193,14 @@ const CONTROL_METHODS: &[(&str, &str)] = &[
         "agent.new_conversation",
         "Start a fresh built-in agent conversation for a tab.",
     ),
+    (
+        "agent.open_panel_for_request",
+        "Open the agent panel via the agent-request path (drives motion state) and return panel state.",
+    ),
+    (
+        "agent.panel_state",
+        "Return the current agent panel open/visible state.",
+    ),
 ];
 
 pub fn control_methods() -> Vec<ControlMethodInfo> {
@@ -375,6 +383,14 @@ pub enum ControlCommand {
     AgentNewConversation {
         tab_index: Option<usize>,
     },
+    /// Open the agent panel via the "Ask AI" / agent-request path (drives motion state).
+    AgentOpenPanelForRequest {
+        tab_index: Option<usize>,
+    },
+    /// Return the current agent panel open/visible state.
+    AgentPanelState {
+        tab_index: Option<usize>,
+    },
 }
 
 impl ControlCommand {
@@ -410,6 +426,8 @@ impl ControlCommand {
             Self::TmuxRun { .. } => "tmux.run",
             Self::AgentAsk { .. } => "agent.ask",
             Self::AgentNewConversation { .. } => "agent.new_conversation",
+            Self::AgentOpenPanelForRequest { .. } => "agent.open_panel_for_request",
+            Self::AgentPanelState { .. } => "agent.panel_state",
         }
     }
 
@@ -651,6 +669,8 @@ impl ControlCommand {
                 "timeout_secs": timeout_secs,
             }),
             Self::AgentNewConversation { tab_index } => json!({ "tab_index": tab_index }),
+            Self::AgentOpenPanelForRequest { tab_index } => json!({ "tab_index": tab_index }),
+            Self::AgentPanelState { tab_index } => json!({ "tab_index": tab_index }),
         }
     }
 
@@ -870,6 +890,18 @@ impl ControlCommand {
             "agent.new_conversation" => {
                 let params: TabScopedParams = decode_params(params)?;
                 Ok(Self::AgentNewConversation {
+                    tab_index: params.tab_index,
+                })
+            }
+            "agent.open_panel_for_request" => {
+                let params: TabScopedParams = decode_params(params)?;
+                Ok(Self::AgentOpenPanelForRequest {
+                    tab_index: params.tab_index,
+                })
+            }
+            "agent.panel_state" => {
+                let params: TabScopedParams = decode_params(params)?;
+                Ok(Self::AgentPanelState {
                     tab_index: params.tab_index,
                 })
             }

--- a/crates/con-test/testdata/agent/panel.test
+++ b/crates/con-test/testdata/agent/panel.test
@@ -1,0 +1,12 @@
+# agent/panel.test
+# Regression: opening the agent panel through the agent-request path must also
+# drive the panel motion state, otherwise the right panel appears but its
+# contents render with opacity 0 until the user toggles Cmd+L twice.
+
+con-cli --json agent open-panel-for-request  # simulate Ask AI opening the panel
+---- json-subset
+{"agent_panel":{"open":true,"content_visible":true}}
+
+con-cli --json agent panel-state  # panel state remains visible after the request open
+---- json-subset
+{"agent_panel":{"open":true,"content_visible":true}}

--- a/crates/con-test/testdata/panes/split.test
+++ b/crates/con-test/testdata/panes/split.test
@@ -12,6 +12,9 @@ con-cli --json panes list --tab 1  # now have 2 panes
 ---- contains
 "index":2
 
+con-cli --json panes wait --tab 1 --pane-index 2 --timeout 5  # wait for new pane to become alive
+---- ok
+
 con-cli --json panes list --tab 1  # both panes are alive
 ---- json-subset
 {"panes":[{"is_alive":true},{"is_alive":true}]}

--- a/skills/con-cli-e2e/SKILL.md
+++ b/skills/con-cli-e2e/SKILL.md
@@ -1,15 +1,19 @@
 ---
 name: con-cli-e2e
-description: Validate Con's local socket control plane against a real running app session. Use when testing con-cli, the Unix socket API, pane control, tmux control, or in-session agent calls for automation and evaluation.
+description: Validate Con's local socket control plane against a real running app session, and write/run con-test integration tests. Use when testing con-cli, the Unix socket API, pane control, tmux control, in-session agent calls, or when writing E2E test cases in crates/con-test/testdata/.
 ---
 
-# con-cli E2E
+# con-cli E2E & con-test
 
-Use this skill when the task is to verify that Con's CLI/control plane works against a live app window, not just that the code compiles.
+Use this skill when the task is to verify that Con's CLI/control plane works against a live app window, or when writing/fixing integration tests in `crates/con-test/testdata/`.
 
 Primary reference:
 
 - Read [`docs/impl/con-cli-e2e.md`](../../docs/impl/con-cli-e2e.md) for the full workflow and current live limitations.
+
+---
+
+## con-cli manual E2E
 
 Default workflow:
 
@@ -26,13 +30,86 @@ Rules:
 
 - Prefer `--json` for every command in automated evaluation.
 - Prefer `pane_id` over `pane_index` for follow-up actions.
-- Prefer `surface_id` for follow-up actions only when testing the explicit
-  `surfaces.*` API.
-- Keep existing pane and agent benchmarks on `panes.*`; surfaces are additive
-  and must not change the built-in agent's pane model.
+- Prefer `surface_id` for follow-up actions only when testing the explicit `surfaces.*` API.
+- Keep existing pane and agent benchmarks on `panes.*`; surfaces are additive and must not change the built-in agent's pane model.
 - After visible execution, confirm the pane still reports `shell_prompt` and keeps `exec_visible_shell`.
 - If `agent ask` fails, check provider config/env before blaming the socket layer.
 
 Known current limit:
 
 - `panes create` now reports `surface_ready`, `is_alive`, and `has_shell_integration`, but startup-command panes can still be in a non-shell foreground state immediately after creation. Treat them as provisional until `panes list` confirms the capabilities you need for the next step.
+
+---
+
+## con-test integration tests
+
+`con-test` is the E2E test runner for integration and interactive behavior. It launches a real con session, runs `.test` files against it via `con-cli`, and checks output.
+
+### Running tests
+
+```bash
+# Build first
+cargo build
+
+# Run all tests
+./target/debug/con-test crates/con-test/testdata/
+
+# Run a single file
+./target/debug/con-test crates/con-test/testdata/panes/split.test
+```
+
+### Test file format
+
+Test files live in `crates/con-test/testdata/<group>/<name>.test`. Each step is a `con-cli` command followed by an assertion block:
+
+```
+# comment
+con-cli --json <command>   # step description
+---- <assertion>
+<expected>
+```
+
+Assertion types:
+
+| Assertion | Meaning |
+|---|---|
+| `---- ok` | Command exits 0 (any output accepted) |
+| `---- contains` | stdout contains the literal string on the next line |
+| `---- json-subset` | actual JSON is a superset of the expected JSON (subset match, deep) |
+
+The `json-subset` assertion only checks the keys you specify — extra fields in the actual output are ignored. Use it to assert specific fields without coupling to the full response shape.
+
+### Writing new tests
+
+- **Unit-test functions** in Rust (`#[cfg(test)]`) for logic. Use `con-test` only for integration and interactive behavior that requires a live session.
+- **No low-value tests** — don't write tests just to hit coverage. Every test should catch a real bug or document a real contract.
+- Group tests by domain: `panes/`, `tabs/`, `agent/`, `system/`.
+- After `panes create`, always add a `panes wait` step before asserting `is_alive` — the new pane's surface may not be ready immediately.
+- For agent panel tests, use `agent open-panel-for-request` to drive the motion state, then `agent panel-state` to assert the result.
+
+### Example test
+
+```
+# panes/split.test
+con-cli --json panes list --tab 1  # start with 1 pane
+---- json-subset
+{"panes":[{"index":1}]}
+
+con-cli --json panes create --tab 1 --location right  # split right
+---- ok
+
+con-cli --json panes wait --tab 1 --pane-index 2 --timeout 5  # wait for new pane
+---- ok
+
+con-cli --json panes list --tab 1  # both panes alive
+---- json-subset
+{"panes":[{"is_alive":true},{"is_alive":true}]}
+```
+
+### Fixing failures
+
+When a test fails with `expected JSON is not a subset of actual JSON`, the actual output is printed in full. Check:
+
+1. Is the command missing (unrecognized subcommand)? → Add the subcommand to `con-cli` and the `ControlCommand` handler.
+2. Is a field wrong/missing? → Fix the handler's response shape.
+3. Is the assertion racing (e.g. `is_alive: false` right after create)? → Add a `panes wait` or `surfaces wait-ready` step before the assertion.


### PR DESCRIPTION
## Summary

### agent panel state control commands
- Added `AgentOpenPanelForRequest` and `AgentPanelState` to `ControlCommand` in `con-core`
- Wired handlers in `control_requests.rs`: `open-panel-for-request` drives the panel motion state (same path as "Ask AI"), `panel-state` returns current open/visible state
- Added `con-cli agent open-panel-for-request` and `con-cli agent panel-state` subcommands
- Added `agent/panel.test` con-test coverage

### pane title bar redesign
- Removed background color from pane title bar — transparent, blends with terminal
- Active pane shows a 6px filled dot to the left of the title
- Dot color matches the tab accent color, or falls back to `theme.success` (green) when no accent is set
- Inactive panes show no dot
- Extracted `active_pane_dot_color` helper + `should_show_active_pane_dot` predicate with unit tests

### shell environment inheritance (macOS/Linux)
- GUI apps launched from Dock/Spotlight don't inherit the user's shell environment (`PATH`, `GOPATH`, `HTTP_PROXY`, etc.)
- Added `inherit_shell_env()`: runs `<login-shell> -l -c 'env'`, parses `KEY=VALUE` output, and full-overrides the process env — matching Zed's `load_login_shell_environment` strategy
- `SHLVL` is skipped to prevent terminal children from starting at level 2
- 5s timeout with `try_wait` polling — a hanging rc file won't block the GUI from appearing
- No `--printenv` mode, no JSON, no self-invocation — just `env`

### network proxy config (`[network]` in config.toml)
- Added `NetworkConfig` to `con-core` with `http_proxy` / `https_proxy` fields
- `apply_to_env()` is `unsafe fn` — callers must uphold single-threaded invariant
- Config values override shell-inherited values; empty string clears the var
- Applied on startup (after `inherit_shell_env`) and on settings save
- Added proxy input fields to the settings panel UI
- Unit tests: deserialization, missing section, partial fields, round-trip, empty strings

### agent panel motion refactor
- Extracted `agent_panel_motion_target_for_agent_request()` into `chrome.rs`, shared between `send_to_agent` and the new control command handler
- Unit test added

### con-test fixes
- `panes/split.test`: added `panes wait` step before `is_alive` assertion to avoid race on new pane surface readiness
- All 8 test files now pass (26 passed, 0 failed)

### docs / skills
- Added Testing Strategy section to `CLAUDE.md`: unit tests first, con-test for integration, no low-value tests
- Merged con-test documentation into `skills/con-cli-e2e/SKILL.md`: test file format, assertion types, writing rules, failure diagnosis guide

## Test results
```
results: 26 passed  0 failed  0 skipped  (8 files)
```