### PR TITLE
feat: add cmd-m minimize window shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ## `v0.1.0-beta.68` - unreleased
 
+### Added
+
+**macOS**
+
+- Added the standard <kbd>⌘</kbd><kbd>M</kbd> shortcut and Window menu action
+  for minimizing Con windows, including terminal-focused windows. _(PR
+  [#175](https://github.com/nowledge-co/con-terminal/pull/175) by
+  [@chenghuzi](https://github.com/chenghuzi))_
+
 ## `v0.1.0-beta.67` - 2026-05-08
 
 ### Fixed

--- a/crates/con-app/src/command_palette.rs
+++ b/crates/con-app/src/command_palette.rs
@@ -68,6 +68,13 @@ const PALETTE_ACTIONS: &[PaletteAction] = &[
     },
     #[cfg(target_os = "macos")]
     PaletteAction {
+        id: "minimize-window",
+        label: "Minimize Window",
+        shortcut: "secondary-m",
+        category: "App",
+    },
+    #[cfg(target_os = "macos")]
+    PaletteAction {
         id: "quick-terminal",
         label: "Quick Terminal",
         shortcut: "",

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -1398,8 +1398,8 @@ impl GhosttyView {
                 "q" | "w" | "t" | "," | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" => {
                     return false;
                 }
-                // Window cycling (cmd-`, cmd-shift-`)
-                "`" | "~" | ">" | "<" => return false,
+                // Window management (cmd-m, cmd-`, cmd-shift-`)
+                "m" | "`" | "~" | ">" | "<" => return false,
                 // Splits (cmd-d, cmd-shift-d)
                 "d" => return false,
                 // Agent & input

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -142,7 +142,8 @@ actions!(
         Cut,
         Copy,
         Paste,
-        SelectAll
+        SelectAll,
+        Minimize
     ]
 );
 
@@ -1277,6 +1278,8 @@ pub(crate) fn bind_app_keybindings(cx: &mut App, kb: &KeybindingConfig) {
         KeyBinding::new("cmd-shift-`", PreviousWindow, None),
         KeyBinding::new("cmd-~", PreviousWindow, None),
         KeyBinding::new("cmd-<", PreviousWindow, None),
+        KeyBinding::new("cmd-m", Minimize, None),
+        KeyBinding::new("cmd-m", Minimize, Some("Input")),
         KeyBinding::new("cmd-h", HideApp, Some("Input")),
         KeyBinding::new("cmd-alt-h", HideOtherApps, Some("Input")),
         KeyBinding::new("cmd-alt-shift-h", ShowAllApps, Some("Input")),
@@ -1838,6 +1841,8 @@ fn main() {
             Menu {
                 name: "Window".into(),
                 items: vec![
+                    MenuItem::action("Minimize", Minimize),
+                    MenuItem::separator(),
                     MenuItem::action("Next Window", NextWindow),
                     MenuItem::action("Previous Window", PreviousWindow),
                 ],

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -915,6 +915,19 @@ pub(crate) fn toggle_global_summon(cx: &mut App) {
     }
 }
 
+fn minimize_frontmost_window(cx: &mut App) {
+    let frontmost_window = cx.active_window().or_else(|| {
+        cx.window_stack()
+            .and_then(|windows| windows.first().cloned())
+    });
+
+    if let Some(window_handle) = frontmost_window {
+        let _ = cx.update_window(window_handle, |_, window, _| {
+            window.minimize_window();
+        });
+    }
+}
+
 #[cfg(target_os = "macos")]
 fn bundle_info_value(key: &'static [u8]) -> Option<String> {
     use objc::{class, msg_send, sel, sel_impl};
@@ -1721,6 +1734,9 @@ fn main() {
         #[cfg(target_os = "macos")]
         cx.on_action(|_: &PreviousWindow, _cx: &mut App| {
             macos_windowing::cycle_app_window(true);
+        });
+        cx.on_action(|_: &Minimize, cx: &mut App| {
+            minimize_frontmost_window(cx);
         });
         cx.on_action(|_: &NewTab, cx: &mut App| {
             if cx.active_window().is_none() {

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -4756,6 +4756,8 @@ impl SettingsPanel {
         #[cfg(target_os = "macos")]
         let fixed_tab_card = fixed_tab_card
             .child(row_separator(theme))
+            .child(key_row("Minimize Window", "cmd-m", theme))
+            .child(row_separator(theme))
             .child(key_row("Next Window", "cmd-`", theme))
             .child(row_separator(theme))
             .child(key_row("Previous Window", "cmd-shift-`", theme));

--- a/crates/con-app/src/workspace/mod.rs
+++ b/crates/con-app/src/workspace/mod.rs
@@ -71,8 +71,8 @@ use crate::ghostty_view::{
 };
 use crate::{
     AddWorkspaceLayoutTabs, ClearRestoredTerminalHistory, ClearTerminal, ClosePane, CloseSurface,
-    CloseTab, CollapseSidebar, CycleInputMode, ExportWorkspaceLayout, FocusInput, NewSurface,
-    NewSurfaceSplitDown, NewSurfaceSplitRight, NewTab, NextSurface, NextTab,
+    CloseTab, CollapseSidebar, CycleInputMode, ExportWorkspaceLayout, FocusInput, Minimize,
+    NewSurface, NewSurfaceSplitDown, NewSurfaceSplitRight, NewTab, NextSurface, NextTab,
     OpenWorkspaceLayoutWindow, PreviousSurface, PreviousTab, Quit, RenameSurface, SelectTab1,
     SelectTab2, SelectTab3, SelectTab4, SelectTab5, SelectTab6, SelectTab7, SelectTab8, SelectTab9,
     SplitDown, SplitLeft, SplitRight, SplitUp, ToggleAgentPanel, TogglePaneScopePicker,

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -1003,6 +1003,7 @@ impl Render for ConWorkspace {
                 }),
             )
             .on_action(cx.listener(Self::quit))
+            .on_action(cx.listener(Self::minimize))
             .on_action(cx.listener(Self::toggle_agent_panel))
             .on_action(cx.listener(Self::toggle_input_bar))
             .on_action(cx.listener(Self::toggle_vertical_tabs))

--- a/crates/con-app/src/workspace/sidebar_settings.rs
+++ b/crates/con-app/src/workspace/sidebar_settings.rs
@@ -550,6 +550,10 @@ impl ConWorkspace {
                 cx.dispatch_action(&crate::NewWindow);
             }
             #[cfg(target_os = "macos")]
+            "minimize-window" => {
+                cx.dispatch_action(&crate::Minimize);
+            }
+            #[cfg(target_os = "macos")]
             "quick-terminal" => {
                 cx.dispatch_action(&crate::ToggleQuickTerminal);
             }

--- a/crates/con-app/src/workspace/window_actions.rs
+++ b/crates/con-app/src/workspace/window_actions.rs
@@ -1,6 +1,10 @@
 use super::*;
 
 impl ConWorkspace {
+    pub(super) fn minimize(&mut self, _: &Minimize, window: &mut Window, _cx: &mut Context<Self>) {
+        window.minimize_window();
+    }
+
     pub(super) fn quit(&mut self, _: &Quit, _window: &mut Window, cx: &mut Context<Self>) {
         self.cancel_all_sessions();
         self.flush_session_save(cx);


### PR DESCRIPTION
## Summary

Add minimize window support via the standard Cmd+M shortcut on macOS.

## Changes

- Add `Minimize` action and bind `cmd-m` in both global and Input contexts
- Register workspace-level handler (`window.minimize_window()`) to avoid `active_window()` returning None during menu click
- Add "Minimize" item to the Window menu

## Test plan

- [x] Cmd+M minimizes the active window from terminal focus
- [x] Cmd+M minimizes the active window from input bar focus  
- [x] Window > Minimize menu item works via mouse click

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added window minimize action with Cmd+M on macOS, available from the Window menu and via keyboard.
  * Minimize works for the active/frontmost window, including terminal-focused windows.
* **Documentation**
  * Changelog updated noting the new macOS minimize shortcut.
* **Settings**
  * "Minimize Window" added to the Fixed Shortcuts list in Settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/con-terminal/pull/175)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->