### PR TITLE
chore: add mise-pinned dev toolchain

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -43,10 +43,26 @@ For the full breakdown, see `docs/impl/agent-harness.md`.
 - **Zig**: use **Zig 0.15.2 exactly** for full terminal builds.
   Do not read this as `0.15.2+`: Zig `0.16.0` changes build APIs
   that the pinned Ghostty revision does not support yet, and
-  `con-ghostty` will fail while compiling libghostty. If your package
-  manager only offers a newer Zig, install the official 0.15.2 archive
-  from `https://ziglang.org/download/0.15.2/` and either put that
-  directory first on `PATH` or set `CON_ZIG_BIN=/path/to/zig`.
+  `con-ghostty` will fail while compiling libghostty.
+
+### Quick setup with mise (recommended)
+
+If you use [mise](https://mise.jdx.dev/), the repo root `mise.toml`
+pins the exact Zig version. Run:
+
+```bash
+mise install   # installs zig 0.15.2
+```
+
+Then use `just` for all build / run / test tasks (see below).
+
+### Manual setup
+
+If you do not use mise, install the prerequisites yourself:
+
+- **Zig**: download the official 0.15.2 archive from
+  `https://ziglang.org/download/0.15.2/` and put the directory on
+  `PATH`, or set `CON_ZIG_BIN=/path/to/zig`.
 - **macOS**: `cmake` plus Zig 0.15.2. The macOS release workflow installs Zig 0.15.2 explicitly before building embedded libghostty.
 - **Windows**: Zig 0.15.2, Visual Studio 2022 Build Tools with the Windows 10/11 SDK. Run full builds from a _Developer Command Prompt for VS 2022_ so `rc.exe` is on `PATH`. If Windows Defender is on, either add an exclusion for the repo dir or disable real-time scanning — Zig's sub-build exes get briefly locked by MpEngine and spawn with `FileNotFound`.
 - **Linux**: Zig 0.15.2, plus the GPUI runtime apt deps the CI job already installs:

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,15 @@
+# con development environment
+# https://mise.jdx.dev/
+#
+# Usage:
+#   mise install    # Install pinned tool versions
+#   just build      # Build the project
+#   just run        # Run from source
+#
+# Note: mise manages tool versions only. Task running is delegated to
+# the justfile to keep a single source of truth for build commands.
+
+[tools]
+cmake = "latest"
+rust = "stable"
+zig = "0.15.2"


### PR DESCRIPTION
fixes #174 

## Summary
- add `mise.toml` with pinned Zig toolchain and usage notes
- pin `rust = "stable"` and `cmake = "latest"` in mise tools
- align contributor setup docs in `HACKING.md` for `mise install` + `just` workflow

## Validation
- `mise install`
- `mise current`
- `mise x -- cargo check -p con-core -p con-cli -p con-agent -p con-terminal`
- `mise x -- cargo test -p con-core -p con-cli -p con-agent -p con-terminal`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup instructions with improved Zig version guidance and prerequisites.
  * Added a recommended quick setup method for contributors.

* **Chores**
  * Introduced development toolchain configuration for automated dependency management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/con-terminal/pull/183)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->