### PR TITLE
Fix surface tab chrome leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## `v0.1.0-beta.69` - unreleased
+
+### Fixed
+
+**Panes**
+
+- Fixed pane-local surface tab strips so they use the same themed chrome
+  backing as split-pane title bars instead of leaking transparent window
+  content, and tightened their spacing, typography, and active/hover states.
+
 ## `v0.1.0-beta.68` - 2026-05-09
 
 ### Added

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -1901,16 +1901,15 @@ impl PaneTree {
         let btn_hover_bg = theme.foreground.opacity(0.08);
 
         // Active-pane indicator dot — same color as the tab accent (or green fallback)
-        let dot = Self::active_pane_dot_color(is_focused, tab_accent_color, theme, cx).map(
-            |dot_color| {
+        let dot =
+            Self::active_pane_dot_color(is_focused, tab_accent_color, theme, cx).map(|dot_color| {
                 div()
                     .flex_shrink_0()
                     .size(px(6.0))
                     .rounded_full()
                     .mr(px(5.0))
                     .bg(dot_color)
-            },
-        );
+            });
 
         // ⛶/⛶ fullscreen toggle button — always visible
         let zoom_icon = if is_zoomed {
@@ -2123,14 +2122,15 @@ impl PaneTree {
                 surfaces.len(),
                 if surfaces.len() == 1 { "" } else { "s" }
             );
+            let strip_bg = theme.title_bar.opacity(1.0);
             let rail_bg = if is_focused {
-                theme.tab_bar_segmented
+                theme.tab_bar_segmented.opacity(0.72)
             } else {
-                theme.tab_bar_segmented.opacity(0.78)
+                theme.tab_bar_segmented.opacity(0.58)
             };
             let rail_text = theme
                 .foreground
-                .opacity(if is_focused { 0.68 } else { 0.56 });
+                .opacity(if is_focused { 0.66 } else { 0.50 });
 
             let mut surface_rail = div()
                 .id(("surface-tab-strip", pane_id))
@@ -2138,12 +2138,11 @@ impl PaneTree {
                 .items_center()
                 .gap(px(4.0))
                 .h(px(24.0))
+                .w_full()
                 .max_w(relative(1.0))
-                .ml(px(8.0))
-                .mr(px(8.0))
                 .px(px(4.0))
-                .rounded(px(8.0))
-                .font_family(theme.font_family.clone())
+                .rounded(px(7.0))
+                .font_family(theme.mono_font_family.clone())
                 .bg(rail_bg)
                 .overflow_x_scroll();
 
@@ -2157,13 +2156,13 @@ impl PaneTree {
                     .pr(px(4.0))
                     .text_size(px(11.0))
                     .line_height(px(13.0))
-                    .font_weight(FontWeight::MEDIUM)
+                    .font_weight(FontWeight::NORMAL)
                     .text_color(rail_text)
                     .child(
                         svg()
                             .path("phosphor/stack.svg")
                             .size(px(9.0))
-                            .text_color(rail_text.opacity(0.86)),
+                            .text_color(rail_text.opacity(0.82)),
                     )
                     .child(SharedString::from(rail_label)),
             );
@@ -2182,22 +2181,22 @@ impl PaneTree {
                     .clone()
                     .unwrap_or_else(|| format!("Surface {}", index + 1));
                 let color = if is_active {
-                    theme.foreground.opacity(0.92)
+                    theme.foreground.opacity(0.90)
                 } else {
-                    theme.foreground.opacity(0.60)
+                    theme.foreground.opacity(0.54)
                 };
                 let bg = if is_active {
-                    theme.tab_active
+                    theme.tab_active.opacity(0.96)
                 } else {
                     theme.transparent
                 };
                 let icon_color = if is_active {
-                    theme.foreground.opacity(0.70)
+                    theme.foreground.opacity(0.66)
                 } else {
-                    theme.foreground.opacity(0.42)
+                    theme.foreground.opacity(0.38)
                 };
                 let hover_bg = if is_active {
-                    theme.tab_active
+                    theme.tab_active.opacity(1.0)
                 } else {
                     theme.foreground.opacity(0.08)
                 };
@@ -2219,7 +2218,7 @@ impl PaneTree {
                     .flex()
                     .items_center()
                     .gap(px(4.0))
-                    .h(px(18.0))
+                    .h(px(20.0))
                     .max_w(px(190.0))
                     .flex_shrink_0()
                     .pl(px(6.0))
@@ -2263,7 +2262,7 @@ impl PaneTree {
                                     .truncate()
                                     .text_size(px(12.0))
                                     .line_height(px(14.0))
-                                    .font_family(theme.font_family.clone())
+                                    .font_family(theme.mono_font_family.clone())
                                     .font_weight(if is_active {
                                         FontWeight::MEDIUM
                                     } else {
@@ -2281,9 +2280,9 @@ impl PaneTree {
                             .flex()
                             .items_center()
                             .justify_center()
-                            .size(px(14.0))
+                            .size(px(15.0))
                             .flex_shrink_0()
-                            .rounded(px(4.0))
+                            .rounded(px(5.0))
                             .text_color(if is_active {
                                 theme.foreground.opacity(0.56)
                             } else {
@@ -2336,9 +2335,11 @@ impl PaneTree {
             let strip = div()
                 .flex()
                 .items_center()
-                .h(px(24.0))
+                .h(px(28.0))
                 .w_full()
-                .bg(theme.transparent)
+                .px(px(6.0))
+                .py(px(2.0))
+                .bg(strip_bg)
                 .child(surface_rail);
 
             col = col.child(strip);

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -1878,6 +1878,29 @@ impl PaneTree {
         is_focused
     }
 
+    fn inactive_title_bar_opacity(tab_accent_inactive_alpha: f32) -> f32 {
+        // Map tab_accent_inactive_alpha (0.0..=MAX ~0.30) to a title-bar-friendly
+        // opacity range (0.55..=0.85) so the bar always has a solid themed
+        // background regardless of the accent slider position.
+        let max_accent = con_core::config::AppearanceConfig::MAX_TAB_ACCENT_INACTIVE_ALPHA;
+        let t = (tab_accent_inactive_alpha / max_accent.max(f32::EPSILON)).clamp(0.0, 1.0);
+        (0.55 + t * 0.30).clamp(0.55, 0.85) // 0.55 at min → 0.85 at max
+    }
+
+    fn pane_chrome_bg(
+        theme: &gpui_component::Theme,
+        is_focused: bool,
+        tab_accent_inactive_alpha: f32,
+    ) -> Hsla {
+        if is_focused {
+            theme.title_bar.opacity(1.0)
+        } else {
+            theme
+                .title_bar
+                .opacity(Self::inactive_title_bar_opacity(tab_accent_inactive_alpha))
+        }
+    }
+
     fn render_pane_title_bar(
         pane_id: PaneId,
         session_id: u64,
@@ -1998,17 +2021,7 @@ impl PaneTree {
         };
         // The whole title bar is draggable. The visible pane drag preview is
         // rendered by Workspace, centred at the live cursor position.
-        // Map tab_accent_inactive_alpha (0.0..=MAX ~0.30) to a title-bar-friendly
-        // opacity range (0.55..=0.85) so the bar always has a solid themed
-        // background regardless of the accent slider position.
-        let max_accent = con_core::config::AppearanceConfig::MAX_TAB_ACCENT_INACTIVE_ALPHA;
-        let t = (tab_accent_inactive_alpha / max_accent.max(f32::EPSILON)).clamp(0.0, 1.0);
-        let inactive_bar_opacity = (0.55 + t * 0.30).clamp(0.55, 0.85); // 0.55 at min → 0.85 at max
-        let bar_bg = if is_focused {
-            theme.title_bar.opacity(1.0)
-        } else {
-            theme.title_bar.opacity(inactive_bar_opacity)
-        };
+        let bar_bg = Self::pane_chrome_bg(theme, is_focused, tab_accent_inactive_alpha);
         let mut bar = div()
             .id(ElementId::Name(format!("pane-title-bar-{pane_id}").into()))
             .flex()
@@ -2122,14 +2135,7 @@ impl PaneTree {
                 surfaces.len(),
                 if surfaces.len() == 1 { "" } else { "s" }
             );
-            let max_accent = con_core::config::AppearanceConfig::MAX_TAB_ACCENT_INACTIVE_ALPHA;
-            let t = (tab_accent_inactive_alpha / max_accent.max(f32::EPSILON)).clamp(0.0, 1.0);
-            let inactive_bar_opacity = (0.55 + t * 0.30).clamp(0.55, 0.85);
-            let strip_bg = if is_focused {
-                theme.title_bar.opacity(1.0)
-            } else {
-                theme.title_bar.opacity(inactive_bar_opacity)
-            };
+            let strip_bg = Self::pane_chrome_bg(theme, is_focused, tab_accent_inactive_alpha);
             let rail_bg = if is_focused {
                 theme.tab_bar_segmented.opacity(0.72)
             } else {

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -2122,7 +2122,14 @@ impl PaneTree {
                 surfaces.len(),
                 if surfaces.len() == 1 { "" } else { "s" }
             );
-            let strip_bg = theme.title_bar.opacity(1.0);
+            let max_accent = con_core::config::AppearanceConfig::MAX_TAB_ACCENT_INACTIVE_ALPHA;
+            let t = (tab_accent_inactive_alpha / max_accent.max(f32::EPSILON)).clamp(0.0, 1.0);
+            let inactive_bar_opacity = (0.55 + t * 0.30).clamp(0.55, 0.85);
+            let strip_bg = if is_focused {
+                theme.title_bar.opacity(1.0)
+            } else {
+                theme.title_bar.opacity(inactive_bar_opacity)
+            };
             let rail_bg = if is_focused {
                 theme.tab_bar_segmented.opacity(0.72)
             } else {


### PR DESCRIPTION
## Summary

Fix pane-local surface tab strips so their visible chrome no longer leaks transparent window or terminal content.

## Root cause

The surface strip container was explicitly rendered with `theme.transparent`, while only the inset rounded rail had a background. That left the rail margins and rounded corners as real transparent holes, unlike split-pane title bars which now own a themed title-bar backing.

## Changes

- Give the full surface strip a `theme.title_bar` backing, matching split-pane chrome.
- Tighten the surface rail spacing and active/inactive opacity states.
- Use the terminal chrome mono font for surface tab labels.
- Add a beta.69 changelog entry.

## Validation

- `cargo check -p con --no-default-features --features con/bin-con-app`
- `cargo test -p con-core --lib`
- `rustfmt --edition 2024 --check --config skip_children=true crates/con-app/src/pane_tree.rs`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts pane surface-tab styling and shared background opacity calculations; primary risk is minor visual regressions across themes/opacity settings.
> 
> **Overview**
> Fixes pane-local surface tab strips so their outer container uses the same `title_bar` themed backing as split-pane title bars, eliminating transparent “holes” that leaked window/terminal content.
> 
> Refactors the inactive title-bar opacity mapping into reusable helpers and retunes surface-strip spacing, fonts (switching labels to the mono chrome font), and active/hover/opacity states for a tighter, more consistent look. Adds a `v0.1.0-beta.69` changelog entry documenting the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dffde223791c6bbcc97b4c4b68dcd803362b0fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->