### PR TITLE
Inherit cwd for new windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ con is still pre-release, so entries may group related beta work while the produ
   _(PR [#184](https://github.com/nowledge-co/con-terminal/pull/184) by
   [@wey-gu](https://github.com/wey-gu))_
 
+**Windows, macOS, and Linux**
+
+- New windows opened from an existing Con window now inherit the focused
+  terminal's current directory instead of falling back to the shell default
+  home directory. _(PR
+  [#185](https://github.com/nowledge-co/con-terminal/pull/185) by
+  [@iknowu10](https://github.com/iknowu10))_
+
 **Windows**
 
 - Improved Windows CJK rendering by anchoring fallback CJK glyphs to the

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -1015,6 +1015,7 @@ impl Render for ConWorkspace {
             .on_action(cx.listener(Self::collapse_sidebar))
             .on_action(cx.listener(Self::toggle_settings))
             .on_action(cx.listener(Self::toggle_command_palette))
+            .on_action(cx.listener(Self::new_window))
             .on_action(cx.listener(Self::new_tab))
             .on_action(cx.listener(Self::next_tab))
             .on_action(cx.listener(Self::previous_tab))

--- a/crates/con-app/src/workspace/window_actions.rs
+++ b/crates/con-app/src/workspace/window_actions.rs
@@ -282,6 +282,23 @@ impl ConWorkspace {
             || self.command_palette.read(cx).is_visible()
     }
 
+    pub(super) fn new_window(
+        &mut self,
+        _: &crate::NewWindow,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let cwd = self
+            .has_active_tab()
+            .then(|| self.active_terminal().current_dir(cx))
+            .flatten();
+        let config = con_core::Config::load().unwrap_or_default();
+        let session = crate::fresh_window_session_with_history_for_cwd(
+            cwd.as_deref().map(std::path::PathBuf::from),
+        );
+        crate::open_con_window(config, session, false, cx);
+    }
+
     pub(super) fn new_tab(&mut self, _: &NewTab, window: &mut Window, cx: &mut Context<Self>) {
         let cwd = self
             .has_active_tab()


### PR DESCRIPTION
## Summary

Make `NewWindow` (Cmd+N) open in the active terminal's working directory,
mirroring the `NewTab` behavior added in #172. Without this, `Cmd+N`
always dropped the new window back to the shell default home directory
regardless of where the user had navigated.

The change adds a workspace-level `NewWindow` handler that captures
`active_terminal().current_dir(cx)` and threads it through
`fresh_window_session_with_history_for_cwd` to `open_con_window`. The
existing app-level handler in \`main.rs\` remains as the fallback for
when no workspace is focused.

## Validation

- \`cargo check -p con\` (macOS, debug)
- \`rustfmt --edition 2024 --check\` on the two touched files
- \`cargo test -p con-core --lib\` — 59 passed
- Manual: \`cd /tmp\` in an active tab, then Cmd+N → new window opens
  in /tmp instead of ~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New windows opened from an existing Con window now inherit the focused terminal’s current working directory (Windows, macOS, Linux) instead of defaulting to the home directory.
  * New windows automatically load your saved configuration and start with session history seeded from the inherited directory.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/con-terminal/pull/185)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->