### PR TITLE
Fix keyboard shortcut lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ## `v0.1.0-beta.69` - unreleased
 
+### Added
+
+**macOS**
+
+- Added the standard <kbd>⌘</kbd><kbd>M</kbd> shortcut and Window menu action
+  for minimizing Con windows, including terminal-focused windows. _(PR
+  [#175](https://github.com/nowledge-co/con-terminal/pull/175) by
+  [@chenghuzi](https://github.com/chenghuzi))_
+
+**Developer Experience**
+
+- Added a mise-pinned contributor toolchain for Rust, Zig, and CMake, and
+  updated the hacking guide so new contributors can bootstrap the exact
+  supported build tools with `mise install` before running the usual checks.
+  _(Issue [#174](https://github.com/nowledge-co/con-terminal/issues/174), PR
+  [#183](https://github.com/nowledge-co/con-terminal/pull/183) by
+  [@tao12345666333](https://github.com/tao12345666333))_
+
 ### Changed
 
 **Windows**
@@ -178,15 +196,6 @@ con is still pre-release, so entries may group related beta work while the produ
   match terminal-launched sessions more closely. _(PR
   [#173](https://github.com/nowledge-co/con-terminal/pull/173) by
   [@sundy-li](https://github.com/sundy-li))_
-
-### Added
-
-**macOS**
-
-- Added the standard <kbd>⌘</kbd><kbd>M</kbd> shortcut and Window menu action
-  for minimizing Con windows, including terminal-focused windows. _(PR
-  [#175](https://github.com/nowledge-co/con-terminal/pull/175) by
-  [@chenghuzi](https://github.com/chenghuzi))_
 
 ## `v0.1.0-beta.67` - 2026-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ### Fixed
 
+**Keyboard Shortcuts**
+
+- Fixed shortcut lifecycle issues in Settings: changed shortcuts now apply
+  immediately without restarting Con, duplicate assignments are blocked with a
+  clear conflict warning, and the command palette shortcut now refocuses the
+  palette instead of getting stuck when pressed repeatedly while modifiers are
+  held. _(Issue
+  [#182](https://github.com/nowledge-co/con-terminal/issues/182), PR
+  [#186](https://github.com/nowledge-co/con-terminal/pull/186) by
+  [@wey-gu](https://github.com/wey-gu))_
+
 **Panes**
 
 - Fixed pane-local surface tab strips so they use the same themed chrome

--- a/crates/con-app/src/command_palette.rs
+++ b/crates/con-app/src/command_palette.rs
@@ -308,22 +308,32 @@ impl CommandPalette {
     }
 
     pub fn toggle(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        self.visible = !self.visible;
-        if self.visible {
+        if !self.visible {
+            self.show(window, cx);
+        } else {
+            self.visible = false;
             self.overlay_motion
-                .set_target(1.0, std::time::Duration::from_millis(180));
+                .set_target(0.0, std::time::Duration::from_millis(150));
+            cx.notify();
+        }
+    }
+
+    pub fn show(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let was_visible = self.visible;
+        self.visible = true;
+        self.overlay_motion
+            .set_target(1.0, std::time::Duration::from_millis(180));
+        if !was_visible {
             self.query_text.clear();
             self.selected_index = 0;
             self.reveal_selected = true;
             self.query.update(cx, |s, cx| {
                 s.set_value("", window, cx);
-                // Focus the input directly so the user can type immediately
-                s.focus(window, cx);
             });
-        } else {
-            self.overlay_motion
-                .set_target(0.0, std::time::Duration::from_millis(150));
         }
+        self.query.update(cx, |s, cx| {
+            s.focus(window, cx);
+        });
         cx.notify();
     }
 

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -1299,11 +1299,18 @@ pub(crate) fn fixed_app_keybinding_shortcuts() -> Vec<(&'static str, &'static st
 }
 
 fn is_fixed_configurable_app_keybinding(key: &str, action_name: &SharedString) -> bool {
+    let Some(key) = con_core::config::canonical_keybinding(key) else {
+        return false;
+    };
+    let fixed_next_tab = con_core::config::canonical_keybinding("secondary-shift-]")
+        .expect("fixed shortcut is valid");
+    let fixed_previous_tab = con_core::config::canonical_keybinding("secondary-shift-[")
+        .expect("fixed shortcut is valid");
     let next_tab: SharedString = gpui::Action::name(&NextTab).into();
     let previous_tab: SharedString = gpui::Action::name(&PreviousTab).into();
 
-    (key == "secondary-shift-]" && action_name == &next_tab)
-        || (key == "secondary-shift-[" && action_name == &previous_tab)
+    (key == fixed_next_tab && action_name == &next_tab)
+        || (key == fixed_previous_tab && action_name == &previous_tab)
 }
 
 pub(crate) fn bind_app_keybindings(cx: &mut App, kb: &KeybindingConfig) {

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -1183,13 +1183,82 @@ fn show_about_window(cx: &mut App) {
     }
 }
 
+macro_rules! configurable_app_keybindings {
+    ($bindings:expr, $kb:expr, $push:ident) => {{
+        $push!($bindings, &($kb).quit, Quit);
+        $push!($bindings, &($kb).new_window, NewWindow);
+        $push!($bindings, &($kb).new_tab, NewTab);
+        $push!($bindings, &($kb).next_tab, NextTab);
+        $push!($bindings, &($kb).previous_tab, PreviousTab);
+        $push!($bindings, &($kb).toggle_agent, ToggleAgentPanel);
+        $push!($bindings, &($kb).close_tab, CloseTab);
+        $push!($bindings, &($kb).close_pane, ClosePane);
+        $push!($bindings, &($kb).toggle_pane_zoom, TogglePaneZoom);
+        $push!($bindings, &($kb).settings, settings_panel::ToggleSettings);
+        $push!(
+            $bindings,
+            &($kb).command_palette,
+            command_palette::ToggleCommandPalette
+        );
+        $push!($bindings, &($kb).split_right, SplitRight);
+        $push!($bindings, &($kb).split_down, SplitDown);
+        $push!($bindings, &($kb).new_surface, NewSurface);
+        $push!(
+            $bindings,
+            &($kb).new_surface_split_right,
+            NewSurfaceSplitRight
+        );
+        $push!(
+            $bindings,
+            &($kb).new_surface_split_down,
+            NewSurfaceSplitDown
+        );
+        $push!($bindings, &($kb).next_surface, NextSurface);
+        $push!($bindings, &($kb).previous_surface, PreviousSurface);
+        $push!($bindings, &($kb).rename_surface, RenameSurface);
+        $push!($bindings, &($kb).close_surface, CloseSurface);
+        $push!($bindings, &($kb).focus_input, FocusInput);
+        $push!($bindings, &($kb).cycle_input_mode, CycleInputMode);
+        $push!($bindings, &($kb).toggle_input_bar, ToggleInputBar);
+        $push!($bindings, &($kb).toggle_pane_scope, TogglePaneScopePicker);
+        $push!($bindings, &($kb).toggle_vertical_tabs, ToggleVerticalTabs);
+        $push!($bindings, &($kb).collapse_sidebar, CollapseSidebar);
+    }};
+}
+
+macro_rules! push_app_keybinding {
+    ($bindings:expr, $key:expr, $action:path) => {{
+        let key = $key;
+        if !key.trim().is_empty() {
+            $bindings.push(KeyBinding::new(key, $action, None));
+            $bindings.push(KeyBinding::new(key, $action, Some("Input")));
+        }
+    }};
+}
+
+macro_rules! push_app_keybinding_unbind {
+    ($bindings:expr, $key:expr, $action:path) => {{
+        let key = $key;
+        if !key.trim().is_empty() {
+            let action_name: SharedString = gpui::Action::name(&$action).into();
+            $bindings.push(KeyBinding::new(
+                key,
+                gpui::Unbind(action_name.clone()),
+                None,
+            ));
+            $bindings.push(KeyBinding::new(
+                key,
+                gpui::Unbind(action_name),
+                Some("Input"),
+            ));
+        }
+    }};
+}
+
 pub(crate) fn bind_app_keybindings(cx: &mut App, kb: &KeybindingConfig) {
-    cx.bind_keys([
-        KeyBinding::new(&kb.quit, Quit, None),
-        KeyBinding::new(&kb.new_window, NewWindow, None),
-        KeyBinding::new(&kb.new_tab, NewTab, None),
-        KeyBinding::new(&kb.next_tab, NextTab, None),
-        KeyBinding::new(&kb.previous_tab, PreviousTab, None),
+    let mut bindings = Vec::new();
+    configurable_app_keybindings!(bindings, kb, push_app_keybinding);
+    bindings.extend([
         KeyBinding::new("secondary-shift-]", NextTab, None),
         KeyBinding::new("secondary-shift-[", PreviousTab, None),
         KeyBinding::new("secondary-1", SelectTab1, None),
@@ -1201,36 +1270,6 @@ pub(crate) fn bind_app_keybindings(cx: &mut App, kb: &KeybindingConfig) {
         KeyBinding::new("secondary-7", SelectTab7, None),
         KeyBinding::new("secondary-8", SelectTab8, None),
         KeyBinding::new("secondary-9", SelectTab9, None),
-        KeyBinding::new(&kb.toggle_agent, ToggleAgentPanel, None),
-        KeyBinding::new(&kb.close_tab, CloseTab, None),
-        KeyBinding::new(&kb.close_pane, ClosePane, None),
-        KeyBinding::new(&kb.toggle_pane_zoom, TogglePaneZoom, None),
-        KeyBinding::new(&kb.settings, settings_panel::ToggleSettings, None),
-        KeyBinding::new(
-            &kb.command_palette,
-            command_palette::ToggleCommandPalette,
-            None,
-        ),
-        KeyBinding::new(&kb.split_right, SplitRight, None),
-        KeyBinding::new(&kb.split_down, SplitDown, None),
-        KeyBinding::new(&kb.new_surface, NewSurface, None),
-        KeyBinding::new(&kb.new_surface_split_right, NewSurfaceSplitRight, None),
-        KeyBinding::new(&kb.new_surface_split_down, NewSurfaceSplitDown, None),
-        KeyBinding::new(&kb.next_surface, NextSurface, None),
-        KeyBinding::new(&kb.previous_surface, PreviousSurface, None),
-        KeyBinding::new(&kb.rename_surface, RenameSurface, None),
-        KeyBinding::new(&kb.close_surface, CloseSurface, None),
-        KeyBinding::new(&kb.focus_input, FocusInput, None),
-        KeyBinding::new(&kb.cycle_input_mode, CycleInputMode, None),
-        KeyBinding::new(&kb.toggle_input_bar, ToggleInputBar, None),
-        KeyBinding::new(&kb.toggle_pane_scope, TogglePaneScopePicker, None),
-        KeyBinding::new(&kb.toggle_vertical_tabs, ToggleVerticalTabs, None),
-        KeyBinding::new(&kb.collapse_sidebar, CollapseSidebar, None),
-        KeyBinding::new(&kb.quit, Quit, Some("Input")),
-        KeyBinding::new(&kb.new_window, NewWindow, Some("Input")),
-        KeyBinding::new(&kb.new_tab, NewTab, Some("Input")),
-        KeyBinding::new(&kb.next_tab, NextTab, Some("Input")),
-        KeyBinding::new(&kb.previous_tab, PreviousTab, Some("Input")),
         KeyBinding::new("secondary-shift-]", NextTab, Some("Input")),
         KeyBinding::new("secondary-shift-[", PreviousTab, Some("Input")),
         KeyBinding::new("secondary-1", SelectTab1, Some("Input")),
@@ -1242,40 +1281,8 @@ pub(crate) fn bind_app_keybindings(cx: &mut App, kb: &KeybindingConfig) {
         KeyBinding::new("secondary-7", SelectTab7, Some("Input")),
         KeyBinding::new("secondary-8", SelectTab8, Some("Input")),
         KeyBinding::new("secondary-9", SelectTab9, Some("Input")),
-        KeyBinding::new(&kb.toggle_agent, ToggleAgentPanel, Some("Input")),
-        KeyBinding::new(&kb.close_tab, CloseTab, Some("Input")),
-        KeyBinding::new(&kb.close_pane, ClosePane, Some("Input")),
-        KeyBinding::new(&kb.toggle_pane_zoom, TogglePaneZoom, Some("Input")),
-        KeyBinding::new(&kb.settings, settings_panel::ToggleSettings, Some("Input")),
-        KeyBinding::new(
-            &kb.command_palette,
-            command_palette::ToggleCommandPalette,
-            Some("Input"),
-        ),
-        KeyBinding::new(&kb.split_right, SplitRight, Some("Input")),
-        KeyBinding::new(&kb.split_down, SplitDown, Some("Input")),
-        KeyBinding::new(&kb.new_surface, NewSurface, Some("Input")),
-        KeyBinding::new(
-            &kb.new_surface_split_right,
-            NewSurfaceSplitRight,
-            Some("Input"),
-        ),
-        KeyBinding::new(
-            &kb.new_surface_split_down,
-            NewSurfaceSplitDown,
-            Some("Input"),
-        ),
-        KeyBinding::new(&kb.next_surface, NextSurface, Some("Input")),
-        KeyBinding::new(&kb.previous_surface, PreviousSurface, Some("Input")),
-        KeyBinding::new(&kb.rename_surface, RenameSurface, Some("Input")),
-        KeyBinding::new(&kb.close_surface, CloseSurface, Some("Input")),
-        KeyBinding::new(&kb.focus_input, FocusInput, Some("Input")),
-        KeyBinding::new(&kb.cycle_input_mode, CycleInputMode, Some("Input")),
-        KeyBinding::new(&kb.toggle_input_bar, ToggleInputBar, Some("Input")),
-        KeyBinding::new(&kb.toggle_pane_scope, TogglePaneScopePicker, Some("Input")),
-        KeyBinding::new(&kb.toggle_vertical_tabs, ToggleVerticalTabs, Some("Input")),
-        KeyBinding::new(&kb.collapse_sidebar, CollapseSidebar, Some("Input")),
     ]);
+    cx.bind_keys(bindings);
 
     // Hide app / Hide others / Show all are macOS system-menu conventions
     // with no equivalent on Windows or Linux — cmd-h, cmd-alt-h, and
@@ -1302,6 +1309,19 @@ pub(crate) fn bind_app_keybindings(cx: &mut App, kb: &KeybindingConfig) {
         KeyBinding::new("cmd-~", PreviousWindow, Some("Input")),
         KeyBinding::new("cmd-<", PreviousWindow, Some("Input")),
     ]);
+}
+
+fn bind_configurable_app_keybindings(cx: &mut App, kb: &KeybindingConfig) {
+    let mut bindings = Vec::new();
+    configurable_app_keybindings!(bindings, kb, push_app_keybinding);
+    cx.bind_keys(bindings);
+}
+
+pub(crate) fn rebind_app_keybindings(cx: &mut App, old: &KeybindingConfig, new: &KeybindingConfig) {
+    let mut unbinds = Vec::new();
+    configurable_app_keybindings!(unbinds, old, push_app_keybinding_unbind);
+    cx.bind_keys(unbinds);
+    bind_configurable_app_keybindings(cx, new);
 }
 
 /// Install a panic hook that writes every panic (including from

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -1185,44 +1185,37 @@ fn show_about_window(cx: &mut App) {
 
 macro_rules! configurable_app_keybindings {
     ($bindings:expr, $kb:expr, $push:ident) => {{
-        $push!($bindings, &($kb).quit, Quit);
-        $push!($bindings, &($kb).new_window, NewWindow);
-        $push!($bindings, &($kb).new_tab, NewTab);
-        $push!($bindings, &($kb).next_tab, NextTab);
-        $push!($bindings, &($kb).previous_tab, PreviousTab);
-        $push!($bindings, &($kb).toggle_agent, ToggleAgentPanel);
-        $push!($bindings, &($kb).close_tab, CloseTab);
-        $push!($bindings, &($kb).close_pane, ClosePane);
-        $push!($bindings, &($kb).toggle_pane_zoom, TogglePaneZoom);
-        $push!($bindings, &($kb).settings, settings_panel::ToggleSettings);
+        let kb = $kb;
+        $push!($bindings, &kb.quit, Quit);
+        $push!($bindings, &kb.new_window, NewWindow);
+        $push!($bindings, &kb.new_tab, NewTab);
+        $push!($bindings, &kb.next_tab, NextTab);
+        $push!($bindings, &kb.previous_tab, PreviousTab);
+        $push!($bindings, &kb.toggle_agent, ToggleAgentPanel);
+        $push!($bindings, &kb.close_tab, CloseTab);
+        $push!($bindings, &kb.close_pane, ClosePane);
+        $push!($bindings, &kb.toggle_pane_zoom, TogglePaneZoom);
+        $push!($bindings, &kb.settings, settings_panel::ToggleSettings);
         $push!(
             $bindings,
-            &($kb).command_palette,
+            &kb.command_palette,
             command_palette::ToggleCommandPalette
         );
-        $push!($bindings, &($kb).split_right, SplitRight);
-        $push!($bindings, &($kb).split_down, SplitDown);
-        $push!($bindings, &($kb).new_surface, NewSurface);
-        $push!(
-            $bindings,
-            &($kb).new_surface_split_right,
-            NewSurfaceSplitRight
-        );
-        $push!(
-            $bindings,
-            &($kb).new_surface_split_down,
-            NewSurfaceSplitDown
-        );
-        $push!($bindings, &($kb).next_surface, NextSurface);
-        $push!($bindings, &($kb).previous_surface, PreviousSurface);
-        $push!($bindings, &($kb).rename_surface, RenameSurface);
-        $push!($bindings, &($kb).close_surface, CloseSurface);
-        $push!($bindings, &($kb).focus_input, FocusInput);
-        $push!($bindings, &($kb).cycle_input_mode, CycleInputMode);
-        $push!($bindings, &($kb).toggle_input_bar, ToggleInputBar);
-        $push!($bindings, &($kb).toggle_pane_scope, TogglePaneScopePicker);
-        $push!($bindings, &($kb).toggle_vertical_tabs, ToggleVerticalTabs);
-        $push!($bindings, &($kb).collapse_sidebar, CollapseSidebar);
+        $push!($bindings, &kb.split_right, SplitRight);
+        $push!($bindings, &kb.split_down, SplitDown);
+        $push!($bindings, &kb.new_surface, NewSurface);
+        $push!($bindings, &kb.new_surface_split_right, NewSurfaceSplitRight);
+        $push!($bindings, &kb.new_surface_split_down, NewSurfaceSplitDown);
+        $push!($bindings, &kb.next_surface, NextSurface);
+        $push!($bindings, &kb.previous_surface, PreviousSurface);
+        $push!($bindings, &kb.rename_surface, RenameSurface);
+        $push!($bindings, &kb.close_surface, CloseSurface);
+        $push!($bindings, &kb.focus_input, FocusInput);
+        $push!($bindings, &kb.cycle_input_mode, CycleInputMode);
+        $push!($bindings, &kb.toggle_input_bar, ToggleInputBar);
+        $push!($bindings, &kb.toggle_pane_scope, TogglePaneScopePicker);
+        $push!($bindings, &kb.toggle_vertical_tabs, ToggleVerticalTabs);
+        $push!($bindings, &kb.collapse_sidebar, CollapseSidebar);
     }};
 }
 

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -1232,8 +1232,8 @@ macro_rules! push_app_keybinding {
 macro_rules! push_app_keybinding_unbind {
     ($bindings:expr, $key:expr, $action:path) => {{
         let key = $key;
-        if !key.trim().is_empty() {
-            let action_name: SharedString = gpui::Action::name(&$action).into();
+        let action_name: SharedString = gpui::Action::name(&$action).into();
+        if !key.trim().is_empty() && !is_fixed_configurable_app_keybinding(key, &action_name) {
             $bindings.push(KeyBinding::new(
                 key,
                 gpui::Unbind(action_name.clone()),
@@ -1248,60 +1248,69 @@ macro_rules! push_app_keybinding_unbind {
     }};
 }
 
+macro_rules! fixed_app_keybindings {
+    ($items:expr, $push:ident) => {{
+        $push!($items, "Next Tab", "secondary-shift-]", NextTab);
+        $push!($items, "Previous Tab", "secondary-shift-[", PreviousTab);
+        $push!($items, "Select Tab 1", "secondary-1", SelectTab1);
+        $push!($items, "Select Tab 2", "secondary-2", SelectTab2);
+        $push!($items, "Select Tab 3", "secondary-3", SelectTab3);
+        $push!($items, "Select Tab 4", "secondary-4", SelectTab4);
+        $push!($items, "Select Tab 5", "secondary-5", SelectTab5);
+        $push!($items, "Select Tab 6", "secondary-6", SelectTab6);
+        $push!($items, "Select Tab 7", "secondary-7", SelectTab7);
+        $push!($items, "Select Tab 8", "secondary-8", SelectTab8);
+        $push!($items, "Select Tab 9", "secondary-9", SelectTab9);
+
+        #[cfg(target_os = "macos")]
+        {
+            $push!($items, "Hide Con", "cmd-h", HideApp);
+            $push!($items, "Hide Other Apps", "cmd-alt-h", HideOtherApps);
+            $push!($items, "Show All Apps", "cmd-alt-shift-h", ShowAllApps);
+            $push!($items, "Next Window", "cmd-`", NextWindow);
+            $push!($items, "Next Window", "cmd->", NextWindow);
+            $push!($items, "Previous Window", "cmd-shift-`", PreviousWindow);
+            $push!($items, "Previous Window", "cmd-~", PreviousWindow);
+            $push!($items, "Previous Window", "cmd-<", PreviousWindow);
+            $push!($items, "Minimize Window", "cmd-m", Minimize);
+        }
+    }};
+}
+
+macro_rules! push_fixed_app_keybinding {
+    ($bindings:expr, $label:expr, $key:expr, $action:path) => {{
+        let _ = $label;
+        $bindings.push(KeyBinding::new($key, $action, None));
+        $bindings.push(KeyBinding::new($key, $action, Some("Input")));
+    }};
+}
+
+macro_rules! push_fixed_app_keybinding_shortcut {
+    ($shortcuts:expr, $label:expr, $key:expr, $action:path) => {{
+        let _ = &$action;
+        $shortcuts.push(($label, $key));
+    }};
+}
+
+pub(crate) fn fixed_app_keybinding_shortcuts() -> Vec<(&'static str, &'static str)> {
+    let mut shortcuts = Vec::new();
+    fixed_app_keybindings!(shortcuts, push_fixed_app_keybinding_shortcut);
+    shortcuts
+}
+
+fn is_fixed_configurable_app_keybinding(key: &str, action_name: &SharedString) -> bool {
+    let next_tab: SharedString = gpui::Action::name(&NextTab).into();
+    let previous_tab: SharedString = gpui::Action::name(&PreviousTab).into();
+
+    (key == "secondary-shift-]" && action_name == &next_tab)
+        || (key == "secondary-shift-[" && action_name == &previous_tab)
+}
+
 pub(crate) fn bind_app_keybindings(cx: &mut App, kb: &KeybindingConfig) {
     let mut bindings = Vec::new();
     configurable_app_keybindings!(bindings, kb, push_app_keybinding);
-    bindings.extend([
-        KeyBinding::new("secondary-shift-]", NextTab, None),
-        KeyBinding::new("secondary-shift-[", PreviousTab, None),
-        KeyBinding::new("secondary-1", SelectTab1, None),
-        KeyBinding::new("secondary-2", SelectTab2, None),
-        KeyBinding::new("secondary-3", SelectTab3, None),
-        KeyBinding::new("secondary-4", SelectTab4, None),
-        KeyBinding::new("secondary-5", SelectTab5, None),
-        KeyBinding::new("secondary-6", SelectTab6, None),
-        KeyBinding::new("secondary-7", SelectTab7, None),
-        KeyBinding::new("secondary-8", SelectTab8, None),
-        KeyBinding::new("secondary-9", SelectTab9, None),
-        KeyBinding::new("secondary-shift-]", NextTab, Some("Input")),
-        KeyBinding::new("secondary-shift-[", PreviousTab, Some("Input")),
-        KeyBinding::new("secondary-1", SelectTab1, Some("Input")),
-        KeyBinding::new("secondary-2", SelectTab2, Some("Input")),
-        KeyBinding::new("secondary-3", SelectTab3, Some("Input")),
-        KeyBinding::new("secondary-4", SelectTab4, Some("Input")),
-        KeyBinding::new("secondary-5", SelectTab5, Some("Input")),
-        KeyBinding::new("secondary-6", SelectTab6, Some("Input")),
-        KeyBinding::new("secondary-7", SelectTab7, Some("Input")),
-        KeyBinding::new("secondary-8", SelectTab8, Some("Input")),
-        KeyBinding::new("secondary-9", SelectTab9, Some("Input")),
-    ]);
+    fixed_app_keybindings!(bindings, push_fixed_app_keybinding);
     cx.bind_keys(bindings);
-
-    // Hide app / Hide others / Show all are macOS system-menu conventions
-    // with no equivalent on Windows or Linux — cmd-h, cmd-alt-h, and
-    // cmd-alt-shift-h are the canonical modifiers, so we keep them
-    // verbatim inside a cfg gate rather than routing through `secondary`.
-    #[cfg(target_os = "macos")]
-    cx.bind_keys([
-        KeyBinding::new("cmd-h", HideApp, None),
-        KeyBinding::new("cmd-alt-h", HideOtherApps, None),
-        KeyBinding::new("cmd-alt-shift-h", ShowAllApps, None),
-        KeyBinding::new("cmd-`", NextWindow, None),
-        KeyBinding::new("cmd->", NextWindow, None),
-        KeyBinding::new("cmd-shift-`", PreviousWindow, None),
-        KeyBinding::new("cmd-~", PreviousWindow, None),
-        KeyBinding::new("cmd-<", PreviousWindow, None),
-        KeyBinding::new("cmd-m", Minimize, None),
-        KeyBinding::new("cmd-m", Minimize, Some("Input")),
-        KeyBinding::new("cmd-h", HideApp, Some("Input")),
-        KeyBinding::new("cmd-alt-h", HideOtherApps, Some("Input")),
-        KeyBinding::new("cmd-alt-shift-h", ShowAllApps, Some("Input")),
-        KeyBinding::new("cmd-`", NextWindow, Some("Input")),
-        KeyBinding::new("cmd->", NextWindow, Some("Input")),
-        KeyBinding::new("cmd-shift-`", PreviousWindow, Some("Input")),
-        KeyBinding::new("cmd-~", PreviousWindow, Some("Input")),
-        KeyBinding::new("cmd-<", PreviousWindow, Some("Input")),
-    ]);
 }
 
 fn bind_configurable_app_keybindings(cx: &mut App, kb: &KeybindingConfig) {

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -2287,6 +2287,11 @@ impl SettingsPanel {
         self.config.appearance.background_image_repeat = self.background_image_repeat;
 
         // Keybindings are updated directly via record_keystroke — no reading needed
+        if let Some(message) = keybinding_conflict_message(&self.config.keybindings) {
+            self.save_error = Some(message);
+            cx.notify();
+            return;
+        }
 
         // Network / proxy
         // Blank field → None (leave inherited env untouched).
@@ -2413,6 +2418,7 @@ impl SettingsPanel {
             _ => {}
         }
         self.set_recording_key(None);
+        self.save_error = keybinding_conflict_message(&self.config.keybindings);
         cx.notify();
     }
 
@@ -5477,6 +5483,11 @@ impl Render for SettingsPanel {
             )
             // Error banner
             .children(self.save_error.as_ref().map(|err| {
+                let message = if err.starts_with("Shortcut conflict:") {
+                    err.to_string()
+                } else {
+                    format!("Save failed: {err}")
+                };
                 div()
                     .px_4()
                     .py_2()
@@ -5486,7 +5497,7 @@ impl Render for SettingsPanel {
                     .bg(theme.danger)
                     .text_color(theme.danger_foreground)
                     .text_xs()
-                    .child(format!("Save failed: {}", err))
+                    .child(message)
             }))
             // Body
             .child(
@@ -5877,6 +5888,56 @@ fn keystroke_to_binding(ks: &gpui::Keystroke) -> String {
     }
     parts.push(&ks.key);
     parts.join("-")
+}
+
+fn keybinding_conflict_message(kb: &con_core::config::KeybindingConfig) -> Option<String> {
+    let conflicts = kb.shortcut_conflicts(&reserved_keybinding_shortcuts());
+    let conflict = conflicts.first()?;
+    Some(format!(
+        "Shortcut conflict: {} is assigned to {}. Pick a different shortcut before saving.",
+        conflict.binding,
+        human_join(&conflict.actions)
+    ))
+}
+
+fn reserved_keybinding_shortcuts() -> Vec<(&'static str, &'static str)> {
+    let mut shortcuts = vec![
+        ("Select Tab 1", "secondary-1"),
+        ("Select Tab 2", "secondary-2"),
+        ("Select Tab 3", "secondary-3"),
+        ("Select Tab 4", "secondary-4"),
+        ("Select Tab 5", "secondary-5"),
+        ("Select Tab 6", "secondary-6"),
+        ("Select Tab 7", "secondary-7"),
+        ("Select Tab 8", "secondary-8"),
+        ("Select Tab 9", "secondary-9"),
+    ];
+
+    #[cfg(target_os = "macos")]
+    shortcuts.extend([
+        ("Hide Con", "cmd-h"),
+        ("Hide Other Apps", "cmd-alt-h"),
+        ("Show All Apps", "cmd-alt-shift-h"),
+        ("Next Window", "cmd-`"),
+        ("Previous Window", "cmd-shift-`"),
+        ("Minimize Window", "cmd-m"),
+    ]);
+
+    shortcuts
+}
+
+fn human_join(items: &[String]) -> String {
+    match items {
+        [] => String::new(),
+        [one] => one.clone(),
+        [first, second] => format!("{first} and {second}"),
+        _ => {
+            let mut text = items[..items.len() - 1].join(", ");
+            text.push_str(", and ");
+            text.push_str(&items[items.len() - 1]);
+            text
+        }
+    }
 }
 
 fn key_row(action: &str, shortcut: &str, theme: &gpui_component::Theme) -> Div {

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -5949,39 +5949,7 @@ fn sync_keybinding_conflict_error(
 }
 
 fn reserved_keybinding_shortcuts() -> Vec<(&'static str, &'static str)> {
-    let shortcuts = vec![
-        ("Next Tab", "secondary-shift-]"),
-        ("Previous Tab", "secondary-shift-["),
-        ("Select Tab 1", "secondary-1"),
-        ("Select Tab 2", "secondary-2"),
-        ("Select Tab 3", "secondary-3"),
-        ("Select Tab 4", "secondary-4"),
-        ("Select Tab 5", "secondary-5"),
-        ("Select Tab 6", "secondary-6"),
-        ("Select Tab 7", "secondary-7"),
-        ("Select Tab 8", "secondary-8"),
-        ("Select Tab 9", "secondary-9"),
-    ];
-
-    #[cfg(target_os = "macos")]
-    {
-        let mut shortcuts = shortcuts;
-        shortcuts.extend([
-            ("Hide Con", "cmd-h"),
-            ("Hide Other Apps", "cmd-alt-h"),
-            ("Show All Apps", "cmd-alt-shift-h"),
-            ("Next Window", "cmd-`"),
-            ("Next Window", "cmd->"),
-            ("Previous Window", "cmd-shift-`"),
-            ("Previous Window", "cmd-~"),
-            ("Previous Window", "cmd-<"),
-            ("Minimize Window", "cmd-m"),
-        ]);
-        shortcuts
-    }
-
-    #[cfg(not(target_os = "macos"))]
-    shortcuts
+    crate::fixed_app_keybinding_shortcuts()
 }
 
 fn human_join(items: &[String]) -> String {

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -5922,8 +5922,8 @@ fn is_keybinding_conflict_error(message: &str) -> bool {
 
 fn reserved_keybinding_shortcuts() -> Vec<(&'static str, &'static str)> {
     let shortcuts = vec![
-        ("Next Tab (Alternate)", "secondary-shift-]"),
-        ("Previous Tab (Alternate)", "secondary-shift-["),
+        ("Next Tab", "secondary-shift-]"),
+        ("Previous Tab", "secondary-shift-["),
         ("Select Tab 1", "secondary-1"),
         ("Select Tab 2", "secondary-2"),
         ("Select Tab 3", "secondary-3"),

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -5901,7 +5901,7 @@ fn keybinding_conflict_message(kb: &con_core::config::KeybindingConfig) -> Optio
 }
 
 fn reserved_keybinding_shortcuts() -> Vec<(&'static str, &'static str)> {
-    let mut shortcuts = vec![
+    let shortcuts = vec![
         ("Select Tab 1", "secondary-1"),
         ("Select Tab 2", "secondary-2"),
         ("Select Tab 3", "secondary-3"),
@@ -5914,15 +5914,20 @@ fn reserved_keybinding_shortcuts() -> Vec<(&'static str, &'static str)> {
     ];
 
     #[cfg(target_os = "macos")]
-    shortcuts.extend([
-        ("Hide Con", "cmd-h"),
-        ("Hide Other Apps", "cmd-alt-h"),
-        ("Show All Apps", "cmd-alt-shift-h"),
-        ("Next Window", "cmd-`"),
-        ("Previous Window", "cmd-shift-`"),
-        ("Minimize Window", "cmd-m"),
-    ]);
+    {
+        let mut shortcuts = shortcuts;
+        shortcuts.extend([
+            ("Hide Con", "cmd-h"),
+            ("Hide Other Apps", "cmd-alt-h"),
+            ("Show All Apps", "cmd-alt-shift-h"),
+            ("Next Window", "cmd-`"),
+            ("Previous Window", "cmd-shift-`"),
+            ("Minimize Window", "cmd-m"),
+        ]);
+        shortcuts
+    }
 
+    #[cfg(not(target_os = "macos"))]
     shortcuts
 }
 

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -142,6 +142,7 @@ pub struct SettingsPanel {
     background_image_repeat: bool,
     hide_pane_title_bar: bool,
     save_error: Option<String>,
+    save_error_kind: Option<SettingsSaveErrorKind>,
     last_saved_at: Option<std::time::SystemTime>,
 
     // Theme import
@@ -157,6 +158,12 @@ pub struct SettingsPanel {
     // Network / proxy
     http_proxy_input: Entity<InputState>,
     https_proxy_input: Entity<InputState>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SettingsSaveErrorKind {
+    KeybindingConflict,
+    Other,
 }
 
 const SIDEBAR_PROVIDERS: &[ProviderKind] = &[
@@ -1478,6 +1485,7 @@ impl SettingsPanel {
             background_image_repeat: config.appearance.background_image_repeat,
             hide_pane_title_bar: config.appearance.hide_pane_title_bar,
             save_error: None,
+            save_error_kind: None,
             last_saved_at: std::fs::metadata(Config::config_path())
                 .and_then(|m| m.modified())
                 .ok(),
@@ -2250,6 +2258,7 @@ impl SettingsPanel {
                 "UI Size must be a number between {:.1} and {:.1}.",
                 MIN_UI_FONT_SIZE, MAX_UI_FONT_SIZE
             ));
+            self.save_error_kind = Some(SettingsSaveErrorKind::Other);
             cx.notify();
             return;
         };
@@ -2289,6 +2298,7 @@ impl SettingsPanel {
         // Keybindings are updated directly via record_keystroke — no reading needed
         if let Some(message) = keybinding_conflict_message(&self.config.keybindings) {
             self.save_error = Some(message);
+            self.save_error_kind = Some(SettingsSaveErrorKind::KeybindingConflict);
             cx.notify();
             return;
         }
@@ -2312,6 +2322,7 @@ impl SettingsPanel {
         match self.persist_config() {
             Ok(()) => {
                 self.save_error = None;
+                self.save_error_kind = None;
                 self.last_saved_at = Some(std::time::SystemTime::now());
                 self.preview_snapshot = Some(self.config.clone());
                 if !self.standalone {
@@ -2324,6 +2335,7 @@ impl SettingsPanel {
             Err(e) => {
                 log::error!("Failed to save config: {}", e);
                 self.save_error = Some(e.to_string());
+                self.save_error_kind = Some(SettingsSaveErrorKind::Other);
             }
         }
         cx.notify();
@@ -2418,7 +2430,11 @@ impl SettingsPanel {
             _ => {}
         }
         self.set_recording_key(None);
-        sync_keybinding_conflict_error(&mut self.save_error, &self.config.keybindings);
+        sync_keybinding_conflict_error(
+            &mut self.save_error,
+            &mut self.save_error_kind,
+            &self.config.keybindings,
+        );
         cx.notify();
     }
 
@@ -3484,6 +3500,7 @@ impl SettingsPanel {
                                             "settings: persist tabs_orientation failed: {err}"
                                         );
                                         this.save_error = Some(err.to_string());
+                                        this.save_error_kind = Some(SettingsSaveErrorKind::Other);
                                         cx.notify();
                                         return;
                                     }
@@ -3492,6 +3509,7 @@ impl SettingsPanel {
                                             this.config.appearance.tabs_orientation;
                                     }
                                     this.save_error = None;
+                                    this.save_error_kind = None;
                                     cx.emit(TabsOrientationChanged);
                                     cx.notify();
                                 })),
@@ -3515,6 +3533,7 @@ impl SettingsPanel {
                                             "settings: persist hide_pane_title_bar failed: {err}"
                                         );
                                         this.save_error = Some(err.to_string());
+                                        this.save_error_kind = Some(SettingsSaveErrorKind::Other);
                                         cx.notify();
                                         return;
                                     }
@@ -3522,6 +3541,7 @@ impl SettingsPanel {
                                         snapshot.appearance.hide_pane_title_bar = *checked;
                                     }
                                     this.save_error = None;
+                                    this.save_error_kind = None;
                                     cx.emit(AppearancePreview);
                                     cx.notify();
                                 })),
@@ -4842,6 +4862,11 @@ impl SettingsPanel {
                                     this.config.keybindings.global_summon =
                                         "alt-space".to_string();
                                 }
+                                sync_keybinding_conflict_error(
+                                    &mut this.save_error,
+                                    &mut this.save_error_kind,
+                                    &this.config.keybindings,
+                                );
                                 cx.notify();
                             })),
                     ),
@@ -4985,6 +5010,11 @@ impl SettingsPanel {
                                     {
                                         this.config.keybindings.quick_terminal = "cmd-\\".to_string();
                                     }
+                                    sync_keybinding_conflict_error(
+                                        &mut this.save_error,
+                                        &mut this.save_error_kind,
+                                        &this.config.keybindings,
+                                    );
                                     cx.notify();
                                 })),
                         ),
@@ -5483,7 +5513,7 @@ impl Render for SettingsPanel {
             )
             // Error banner
             .children(self.save_error.as_ref().map(|err| {
-                let message = if is_keybinding_conflict_error(err) {
+                let message = if self.save_error_kind == Some(SettingsSaveErrorKind::KeybindingConflict) {
                     err.to_string()
                 } else {
                     format!("Save failed: {err}")
@@ -5902,22 +5932,20 @@ fn keybinding_conflict_message(kb: &con_core::config::KeybindingConfig) -> Optio
 
 fn sync_keybinding_conflict_error(
     save_error: &mut Option<String>,
+    save_error_kind: &mut Option<SettingsSaveErrorKind>,
     kb: &con_core::config::KeybindingConfig,
 ) {
     match keybinding_conflict_message(kb) {
-        Some(message) => *save_error = Some(message),
-        None if save_error
-            .as_deref()
-            .is_some_and(is_keybinding_conflict_error) =>
-        {
+        Some(message) => {
+            *save_error = Some(message);
+            *save_error_kind = Some(SettingsSaveErrorKind::KeybindingConflict);
+        }
+        None if *save_error_kind == Some(SettingsSaveErrorKind::KeybindingConflict) => {
             *save_error = None;
+            *save_error_kind = None;
         }
         None => {}
     }
-}
-
-fn is_keybinding_conflict_error(message: &str) -> bool {
-    message.starts_with("Shortcut conflict:")
 }
 
 fn reserved_keybinding_shortcuts() -> Vec<(&'static str, &'static str)> {

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -2418,7 +2418,7 @@ impl SettingsPanel {
             _ => {}
         }
         self.set_recording_key(None);
-        self.save_error = keybinding_conflict_message(&self.config.keybindings);
+        sync_keybinding_conflict_error(&mut self.save_error, &self.config.keybindings);
         cx.notify();
     }
 
@@ -5483,7 +5483,7 @@ impl Render for SettingsPanel {
             )
             // Error banner
             .children(self.save_error.as_ref().map(|err| {
-                let message = if err.starts_with("Shortcut conflict:") {
+                let message = if is_keybinding_conflict_error(err) {
                     err.to_string()
                 } else {
                     format!("Save failed: {err}")
@@ -5898,6 +5898,26 @@ fn keybinding_conflict_message(kb: &con_core::config::KeybindingConfig) -> Optio
         conflict.binding,
         human_join(&conflict.actions)
     ))
+}
+
+fn sync_keybinding_conflict_error(
+    save_error: &mut Option<String>,
+    kb: &con_core::config::KeybindingConfig,
+) {
+    match keybinding_conflict_message(kb) {
+        Some(message) => *save_error = Some(message),
+        None if save_error
+            .as_deref()
+            .is_some_and(is_keybinding_conflict_error) =>
+        {
+            *save_error = None;
+        }
+        None => {}
+    }
+}
+
+fn is_keybinding_conflict_error(message: &str) -> bool {
+    message.starts_with("Shortcut conflict:")
 }
 
 fn reserved_keybinding_shortcuts() -> Vec<(&'static str, &'static str)> {

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -5902,6 +5902,8 @@ fn keybinding_conflict_message(kb: &con_core::config::KeybindingConfig) -> Optio
 
 fn reserved_keybinding_shortcuts() -> Vec<(&'static str, &'static str)> {
     let shortcuts = vec![
+        ("Next Tab (Alternate)", "secondary-shift-]"),
+        ("Previous Tab (Alternate)", "secondary-shift-["),
         ("Select Tab 1", "secondary-1"),
         ("Select Tab 2", "secondary-2"),
         ("Select Tab 3", "secondary-3"),
@@ -5921,7 +5923,10 @@ fn reserved_keybinding_shortcuts() -> Vec<(&'static str, &'static str)> {
             ("Hide Other Apps", "cmd-alt-h"),
             ("Show All Apps", "cmd-alt-shift-h"),
             ("Next Window", "cmd-`"),
+            ("Next Window", "cmd->"),
             ("Previous Window", "cmd-shift-`"),
+            ("Previous Window", "cmd-~"),
+            ("Previous Window", "cmd-<"),
             ("Minimize Window", "cmd-m"),
         ]);
         shortcuts

--- a/crates/con-app/src/workspace/sidebar_settings.rs
+++ b/crates/con-app/src/workspace/sidebar_settings.rs
@@ -708,6 +708,7 @@ impl ConWorkspace {
     ) {
         let full_config = settings.read(cx).config().clone();
         let restore_terminal_text_was_enabled = self.config.appearance.restore_terminal_text;
+        let old_keybindings = self.config.keybindings.clone();
         self.config = full_config.clone();
         let new_agent_config = full_config.agent.clone();
         let auto_approve = new_agent_config.auto_approve_tools;
@@ -775,7 +776,7 @@ impl ConWorkspace {
 
         // Re-apply keybindings at runtime so changes take effect immediately
         let kb = full_config.keybindings.clone();
-        crate::bind_app_keybindings(cx, &kb);
+        crate::rebind_app_keybindings(cx, &old_keybindings, &kb);
         #[cfg(target_os = "macos")]
         crate::global_hotkey::update_from_keybindings(&kb);
 

--- a/crates/con-app/src/workspace/window_actions.rs
+++ b/crates/con-app/src/workspace/window_actions.rs
@@ -131,12 +131,8 @@ impl ConWorkspace {
             });
         }
         self.command_palette.update(cx, |palette, cx| {
-            palette.toggle(window, cx);
+            palette.show(window, cx);
         });
-        // Restore terminal focus if palette just closed
-        if !self.is_modal_open(cx) {
-            self.focus_terminal(window, cx);
-        }
         cx.notify();
     }
 

--- a/crates/con-app/src/workspace/window_actions.rs
+++ b/crates/con-app/src/workspace/window_actions.rs
@@ -130,6 +130,10 @@ impl ConWorkspace {
                 panel.toggle(window, cx);
             });
         }
+        // The action keeps its historic "toggle" name for keymap
+        // compatibility, but keyboard invocation is intentionally idempotent:
+        // repeated key-down events while modifiers are held should focus the
+        // palette, not close it and strand focus.
         self.command_palette.update(cx, |palette, cx| {
             palette.show(window, cx);
         });

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -571,7 +571,7 @@ impl Default for KeybindingConfig {
     }
 }
 
-fn canonical_keybinding(binding: &str) -> Option<String> {
+pub fn canonical_keybinding(binding: &str) -> Option<String> {
     let strokes = binding
         .split_whitespace()
         .filter_map(canonical_keystroke)

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -581,6 +581,8 @@ fn canonical_keybinding(binding: &str) -> Option<String> {
 
 fn canonical_keystroke(stroke: &str) -> Option<String> {
     let mut modifiers = Vec::<&'static str>::new();
+    // A trailing separator is the literal minus key, e.g. "ctrl--"
+    // means Control-Minus rather than a missing key token.
     let is_minus_key = stroke.ends_with('-');
     let mut key = is_minus_key.then(|| "-".to_string());
     let mut parts = stroke

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -519,8 +519,8 @@ impl KeybindingConfig {
                 continue;
             };
             let entry = seen
-                .entry(canonical)
-                .or_insert_with(|| (binding.to_string(), Vec::new()));
+                .entry(canonical.clone())
+                .or_insert_with(|| (canonical, Vec::new()));
             if !entry.1.iter().any(|existing| existing == label) {
                 entry.1.push(label.to_string());
             }

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -581,12 +581,17 @@ fn canonical_keybinding(binding: &str) -> Option<String> {
 
 fn canonical_keystroke(stroke: &str) -> Option<String> {
     let mut modifiers = Vec::<&'static str>::new();
-    let mut key = None;
-
-    for raw in stroke
+    let is_minus_key = stroke.ends_with('-');
+    let mut key = is_minus_key.then(|| "-".to_string());
+    let mut parts = stroke
         .split('-')
         .map(|part| part.trim().to_ascii_lowercase())
-    {
+        .collect::<Vec<_>>();
+    if is_minus_key {
+        parts.pop();
+    }
+
+    for raw in parts {
         if raw.is_empty() {
             continue;
         }
@@ -1001,6 +1006,21 @@ quick_terminal = "cmd-\\"
         } else {
             "ctrl-shift-p".to_string()
         };
+
+        let conflicts = config.keybindings.shortcut_conflicts(&[]);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(
+            conflicts[0].actions,
+            vec!["Command Palette".to_string(), "Toggle Agent".to_string()]
+        );
+    }
+
+    #[test]
+    fn keybinding_conflicts_include_minus_key_shortcuts() {
+        let mut config = Config::default();
+        config.keybindings.command_palette = "ctrl--".to_string();
+        config.keybindings.toggle_agent = "control--".to_string();
 
         let conflicts = config.keybindings.shortcut_conflicts(&[]);
 

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -448,6 +448,92 @@ pub struct KeybindingConfig {
     pub quick_terminal: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeybindingConflict {
+    pub binding: String,
+    pub actions: Vec<String>,
+}
+
+impl KeybindingConfig {
+    pub fn active_shortcuts(&self) -> Vec<(&'static str, &str)> {
+        let mut shortcuts = vec![
+            ("New Window", self.new_window.as_str()),
+            ("New Tab", self.new_tab.as_str()),
+            ("Next Tab", self.next_tab.as_str()),
+            ("Previous Tab", self.previous_tab.as_str()),
+            ("Close Tab", self.close_tab.as_str()),
+            ("Close Pane", self.close_pane.as_str()),
+            ("Toggle Pane Zoom", self.toggle_pane_zoom.as_str()),
+            ("Settings", self.settings.as_str()),
+            ("Command Palette", self.command_palette.as_str()),
+            ("Toggle Agent", self.toggle_agent.as_str()),
+            ("Toggle Input Bar", self.toggle_input_bar.as_str()),
+            ("Toggle Input / Terminal", self.focus_input.as_str()),
+            ("Cycle Input Mode", self.cycle_input_mode.as_str()),
+            ("Split Right", self.split_right.as_str()),
+            ("Split Down", self.split_down.as_str()),
+            ("Toggle Pane Scope", self.toggle_pane_scope.as_str()),
+            ("Toggle Vertical Tabs", self.toggle_vertical_tabs.as_str()),
+            ("Collapse/Expand Sidebar", self.collapse_sidebar.as_str()),
+            ("New Surface Tab", self.new_surface.as_str()),
+            (
+                "New Surface Pane Right",
+                self.new_surface_split_right.as_str(),
+            ),
+            (
+                "New Surface Pane Down",
+                self.new_surface_split_down.as_str(),
+            ),
+            ("Next Surface Tab", self.next_surface.as_str()),
+            ("Previous Surface Tab", self.previous_surface.as_str()),
+            ("Rename Surface", self.rename_surface.as_str()),
+            ("Close Surface", self.close_surface.as_str()),
+            ("Quit", self.quit.as_str()),
+        ];
+
+        if self.global_summon_enabled {
+            shortcuts.push(("Summon / Hide Con", self.global_summon.as_str()));
+        }
+        if self.quick_terminal_enabled {
+            shortcuts.push(("Quick Terminal", self.quick_terminal.as_str()));
+        }
+
+        shortcuts
+            .into_iter()
+            .filter(|(_, binding)| !binding.trim().is_empty())
+            .collect()
+    }
+
+    pub fn shortcut_conflicts(
+        &self,
+        reserved_shortcuts: &[(&'static str, &'static str)],
+    ) -> Vec<KeybindingConflict> {
+        let mut seen = std::collections::BTreeMap::<String, (String, Vec<String>)>::new();
+
+        for (label, binding) in self
+            .active_shortcuts()
+            .into_iter()
+            .chain(reserved_shortcuts.iter().copied())
+        {
+            let Some(canonical) = canonical_keybinding(binding) else {
+                continue;
+            };
+            let entry = seen
+                .entry(canonical)
+                .or_insert_with(|| (binding.to_string(), Vec::new()));
+            if !entry.1.iter().any(|existing| existing == label) {
+                entry.1.push(label.to_string());
+            }
+        }
+
+        seen.into_values()
+            .filter_map(|(binding, actions)| {
+                (actions.len() > 1).then_some(KeybindingConflict { binding, actions })
+            })
+            .collect()
+    }
+}
+
 impl Default for KeybindingConfig {
     fn default() -> Self {
         Self {
@@ -482,6 +568,55 @@ impl Default for KeybindingConfig {
             quick_terminal_enabled: default_quick_terminal_enabled(),
             quick_terminal: default_quick_terminal(),
         }
+    }
+}
+
+fn canonical_keybinding(binding: &str) -> Option<String> {
+    let strokes = binding
+        .split_whitespace()
+        .filter_map(canonical_keystroke)
+        .collect::<Vec<_>>();
+    (!strokes.is_empty()).then(|| strokes.join(" "))
+}
+
+fn canonical_keystroke(stroke: &str) -> Option<String> {
+    let mut modifiers = Vec::<&'static str>::new();
+    let mut key = None;
+
+    for raw in stroke
+        .split('-')
+        .map(|part| part.trim().to_ascii_lowercase())
+    {
+        if raw.is_empty() {
+            continue;
+        }
+        match raw.as_str() {
+            "cmd" | "command" | "meta" | "platform" | "secondary" => {
+                push_unique_modifier(&mut modifiers, "platform")
+            }
+            "ctrl" | "control" => push_unique_modifier(&mut modifiers, "ctrl"),
+            "alt" | "option" => push_unique_modifier(&mut modifiers, "alt"),
+            "shift" => push_unique_modifier(&mut modifiers, "shift"),
+            "fn" => push_unique_modifier(&mut modifiers, "fn"),
+            "return" => key = Some("enter".to_string()),
+            "esc" => key = Some("escape".to_string()),
+            other => key = Some(other.to_string()),
+        }
+    }
+
+    let key = key?;
+    let mut parts = ["platform", "ctrl", "alt", "shift", "fn"]
+        .into_iter()
+        .filter(|modifier| modifiers.contains(modifier))
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    parts.push(key);
+    Some(parts.join("-"))
+}
+
+fn push_unique_modifier(modifiers: &mut Vec<&'static str>, modifier: &'static str) {
+    if !modifiers.contains(&modifier) {
+        modifiers.push(modifier);
     }
 }
 
@@ -831,6 +966,46 @@ quick_terminal = "cmd-\\"
 
         assert!(config.keybindings.quick_terminal_enabled);
         assert_eq!(config.keybindings.quick_terminal, "cmd-\\");
+    }
+
+    #[test]
+    fn keybinding_conflicts_detect_duplicate_configured_shortcuts() {
+        let mut config = Config::default();
+        config.keybindings.command_palette = "cmd-shift-p".to_string();
+        config.keybindings.toggle_agent = "secondary-shift-p".to_string();
+
+        let conflicts = config.keybindings.shortcut_conflicts(&[]);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(
+            conflicts[0].actions,
+            vec!["Command Palette".to_string(), "Toggle Agent".to_string()]
+        );
+    }
+
+    #[test]
+    fn keybinding_conflicts_ignore_disabled_global_shortcuts() {
+        let mut config = Config::default();
+        config.keybindings.global_summon_enabled = false;
+        config.keybindings.global_summon = config.keybindings.command_palette.clone();
+
+        assert!(config.keybindings.shortcut_conflicts(&[]).is_empty());
+    }
+
+    #[test]
+    fn keybinding_conflicts_include_reserved_shortcuts() {
+        let mut config = Config::default();
+        config.keybindings.command_palette = "cmd-m".to_string();
+
+        let conflicts = config
+            .keybindings
+            .shortcut_conflicts(&[("Minimize Window", "secondary-m")]);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(
+            conflicts[0].actions,
+            vec!["Command Palette".to_string(), "Minimize Window".to_string()]
+        );
     }
 
     #[test]

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -591,8 +591,9 @@ fn canonical_keystroke(stroke: &str) -> Option<String> {
             continue;
         }
         match raw.as_str() {
-            "cmd" | "command" | "meta" | "platform" | "secondary" => {
-                push_unique_modifier(&mut modifiers, "platform")
+            "cmd" | "command" | "meta" => push_unique_modifier(&mut modifiers, "cmd"),
+            "platform" | "secondary" => {
+                push_unique_modifier(&mut modifiers, platform_modifier_name())
             }
             "ctrl" | "control" => push_unique_modifier(&mut modifiers, "ctrl"),
             "alt" | "option" => push_unique_modifier(&mut modifiers, "alt"),
@@ -605,13 +606,21 @@ fn canonical_keystroke(stroke: &str) -> Option<String> {
     }
 
     let key = key?;
-    let mut parts = ["platform", "ctrl", "alt", "shift", "fn"]
+    let mut parts = ["cmd", "ctrl", "alt", "shift", "fn"]
         .into_iter()
         .filter(|modifier| modifiers.contains(modifier))
         .map(str::to_string)
         .collect::<Vec<_>>();
     parts.push(key);
     Some(parts.join("-"))
+}
+
+fn platform_modifier_name() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "cmd"
+    } else {
+        "ctrl"
+    }
 }
 
 fn push_unique_modifier(modifiers: &mut Vec<&'static str>, modifier: &'static str) {
@@ -973,6 +982,25 @@ quick_terminal = "cmd-\\"
         let mut config = Config::default();
         config.keybindings.command_palette = "cmd-shift-p".to_string();
         config.keybindings.toggle_agent = "secondary-shift-p".to_string();
+
+        let conflicts = config.keybindings.shortcut_conflicts(&[]);
+
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(
+            conflicts[0].actions,
+            vec!["Command Palette".to_string(), "Toggle Agent".to_string()]
+        );
+    }
+
+    #[test]
+    fn keybinding_conflicts_match_secondary_to_platform_modifier() {
+        let mut config = Config::default();
+        config.keybindings.command_palette = "secondary-shift-p".to_string();
+        config.keybindings.toggle_agent = if cfg!(target_os = "macos") {
+            "cmd-shift-p".to_string()
+        } else {
+            "ctrl-shift-p".to_string()
+        };
 
         let conflicts = config.keybindings.shortcut_conflicts(&[]);
 

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -980,8 +980,8 @@ quick_terminal = "cmd-\\"
     #[test]
     fn keybinding_conflicts_detect_duplicate_configured_shortcuts() {
         let mut config = Config::default();
-        config.keybindings.command_palette = "cmd-shift-p".to_string();
-        config.keybindings.toggle_agent = "secondary-shift-p".to_string();
+        config.keybindings.command_palette = "ctrl-shift-p".to_string();
+        config.keybindings.toggle_agent = "control-shift-p".to_string();
 
         let conflicts = config.keybindings.shortcut_conflicts(&[]);
 
@@ -1023,7 +1023,11 @@ quick_terminal = "cmd-\\"
     #[test]
     fn keybinding_conflicts_include_reserved_shortcuts() {
         let mut config = Config::default();
-        config.keybindings.command_palette = "cmd-m".to_string();
+        config.keybindings.command_palette = if cfg!(target_os = "macos") {
+            "cmd-m".to_string()
+        } else {
+            "ctrl-m".to_string()
+        };
 
         let conflicts = config
             .keybindings

--- a/postmortem/2026-05-11-keybinding-runtime-lifecycle.md
+++ b/postmortem/2026-05-11-keybinding-runtime-lifecycle.md
@@ -1,0 +1,43 @@
+# Keybinding Runtime Lifecycle
+
+## What happened
+
+Keyboard shortcuts had three related failure modes:
+
+- Pressing the command palette shortcut repeatedly while still holding the
+  modifier keys could close the palette and leave the next press ignored until
+  the full chord was released.
+- Settings allowed two actions to use the same shortcut without warning.
+- Shortcut edits were saved to config, but existing app-level keybindings stayed
+  active until restart.
+
+## Root cause
+
+The command palette shortcut was modeled as a toggle even though summon-style
+modal shortcuts should be idempotent while the modifier chord is still active.
+The settings panel also treated recorded shortcuts as plain strings, so it never
+canonicalized or compared them before save.
+
+Runtime rebinding had a separate lifecycle bug: GPUI keybindings are appended
+unless an explicit `Unbind` is installed. Re-applying the new config without
+unbinding the old configurable shortcuts left stale chords in the app keymap.
+
+## Fix applied
+
+- The workspace action for the command palette now shows/refocuses the palette
+  instead of toggling it closed. Dismissal stays explicit through Escape,
+  backdrop click, or command execution.
+- Keybinding config now exposes canonical conflict detection, including enabled
+  global shortcuts and reserved app/system shortcuts.
+- Settings shows a shortcut-conflict error immediately after recording a
+  conflicting chord and blocks saving until the conflict is resolved.
+- Runtime settings apply now unbinds the previous configurable app shortcuts
+  before binding the new configurable shortcuts. Fixed/system shortcuts remain
+  startup-only, so repeated settings saves do not keep growing duplicate entries.
+
+## What we learned
+
+Shortcut settings need the same lifecycle discipline as any other mutable app
+resource: validate before save, remove old runtime state before installing new
+state, and keep summon-style modal shortcuts idempotent while the key chord is
+active.


### PR DESCRIPTION
## Summary

Fixes the shortcut lifecycle problems reported in #182:

- makes the command palette shortcut idempotently show/refocus the palette instead of toggling it into a modifier-held stuck state
- adds canonical duplicate-shortcut detection for configurable shortcuts, enabled global shortcuts, and reserved app/system shortcuts
- applies shortcut edits immediately by unbinding the previous configurable app chords before installing the new ones
- records the shortcut lifecycle root cause and guardrails in a postmortem

## Validation

- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p con-core keybinding_conflicts --lib`
- `CON_SKIP_GHOSTTY_VT=1 cargo check -p con`

Fixes #182

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes app-wide keybinding binding/unbinding behavior and adds new canonicalization/conflict detection, which could impact shortcut handling across platforms if edge cases are missed.
> 
> **Overview**
> Fixes keyboard shortcut lifecycle issues by making the Command Palette keybinding *idempotently show/refocus* the palette (instead of toggling it closed on repeated key-down events).
> 
> Adds canonical shortcut conflict detection in `con-core` (including `secondary`→platform modifier normalization and reserved/system shortcuts) and updates Settings to surface conflicts immediately, block saving on conflicts, and tailor the error banner messaging.
> 
> Makes shortcut edits take effect immediately at runtime by unbinding previous configurable app keybindings before rebinding the new ones, while keeping fixed/system bindings separate to avoid accumulating duplicates. Includes a new postmortem documenting the incident and guardrails, and updates the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b25158a1888d95faa7b9e2167292f9f691e0ab16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Keyboard shortcut settings now take effect immediately without requiring an application restart
  * Duplicate or conflicting shortcuts are now detected and prevented with a clear warning message
  * Command palette keyboard shortcut correctly refocuses the palette and no longer becomes unresponsive when pressed repeatedly while holding modifier keys

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/con-terminal/pull/186)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->