### PR TITLE
docs(install): shell-integration source fallback

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -85,6 +85,54 @@ Linux is in preview. Follow the
 [Linux tracker](https://github.com/nowledge-co/con-terminal/issues/18) for
 current limits and fixes.
 
+## Shell integration
+
+con embeds Ghostty's shell-integration scripts and tries to auto-inject them
+into the shells it spawns. Most users won't notice — Ghostty handles this
+through `ZDOTDIR` for zsh, `XDG_DATA_DIRS` for fish, and `--rcfile` for bash.
+
+Auto-injection can be skipped, though, when something else owns the shell
+startup path: tmux, `exec zsh`, login-shell mode, a framework that resets
+`ZDOTDIR`, etc. The symptoms are subtle but inconvenient — every restored tab
+opens at `$HOME` instead of where you left it, the sidebar can't read the
+foreground process / cwd, and AI tab labels have nothing to summarize.
+
+To verify it's loaded, run this in a fresh con tab:
+
+```sh
+echo $precmd_functions   # zsh
+```
+
+You should see `_ghostty_precmd` in the list. If you don't, source the
+integration script explicitly. Add the line for your shell to its rc file
+and open a new tab:
+
+**zsh** (`~/.zshrc`):
+
+```zsh
+[[ -n $GHOSTTY_RESOURCES_DIR ]] && \
+  source "$GHOSTTY_RESOURCES_DIR/shell-integration/zsh/ghostty-integration"
+```
+
+**bash** (`~/.bashrc`):
+
+```bash
+if [[ -n "$GHOSTTY_RESOURCES_DIR" ]]; then
+  builtin source "$GHOSTTY_RESOURCES_DIR/shell-integration/bash/ghostty.bash"
+fi
+```
+
+**fish** (`~/.config/fish/config.fish`):
+
+```fish
+if set -q GHOSTTY_RESOURCES_DIR
+    source "$GHOSTTY_RESOURCES_DIR/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish"
+end
+```
+
+`$GHOSTTY_RESOURCES_DIR` resolves correctly under both the installed app
+bundle and a `cargo run` debug build, so the same line works in either.
+
 ## Build from source
 
 If you want to build or change con itself, use the


### PR DESCRIPTION
## Summary

Document the manual \`source \"\$GHOSTTY_RESOURCES_DIR/...\"\` line that
unblocks users whose shell isn't picking up Ghostty's auto-injection.

## Why

Ghostty's auto-injection (ZDOTDIR / XDG_DATA_DIRS / \`--rcfile\`) works for
the common case but silently no-ops when something else owns the shell
startup path: tmux, \`exec zsh\`, certain login-shell flows, a framework
that resets ZDOTDIR. con itself receives OSC 7 / OSC 133 correctly when
the shell emits them — verified by manually \`printf '\\033]7;...'\` from
inside an affected tab — so the wire is fine, only the auto-injection
fails.

When this happens it doesn't look like a shell-integration problem to the
end user. It looks like a con bug — every restored tab opens at \`\$HOME\`,
the sidebar can't read the foreground process or cwd, and AI tab labels
have nothing to summarize. There's currently no docs entry to point them
at.

This PR adds a \"Shell integration\" section to \`docs/install.md\` covering:

- A one-liner \`echo \$precmd_functions\` probe to detect whether
  auto-injection succeeded
- The explicit source line for zsh / bash / fish, taken verbatim from the
  ghostty integration script headers
- A note that \`\$GHOSTTY_RESOURCES_DIR\` resolves correctly under both
  the installed \`.app\` bundle and \`cargo run\` debug builds, so the same
  rc-file line works in either

## Future work (separate)

Longer-term, con could match iTerm2 / Terminal.app by reading the shell
child's cwd via \`proc_pidinfo\` on macOS, which removes the dependency on
shell integration entirely for cwd tracking. That needs either a new
\`ghostty_surface_pid()\` upstream FFI or a process-enumeration fallback,
so out of scope for this docs PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Shell integration section documenting how shell-integration scripts are automatically injected into spawned shells, conditions when auto-injection can be skipped (e.g., tmux, login-shell mode), verification methods, and configuration snippets for zsh, bash, and fish.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/con-terminal/pull/187)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->