### PR TITLE
Harden shell integration fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ## `v0.1.0-beta.70` - unreleased
 
+### Changed
+
+**Docs**
+
+- Added shell-integration troubleshooting to the install guide, with manual
+  zsh, bash, and fish fallback snippets for users whose startup files prevent
+  Ghostty's auto-injection from loading. _(PR
+  [#187](https://github.com/nowledge-co/con-terminal/pull/187) by
+  [@iknowu10](https://github.com/iknowu10))_
+
+### Fixed
+
+**macOS**
+
+- Set `GHOSTTY_RESOURCES_DIR` from the installed app bundle when the build-time
+  Ghostty resources path is unavailable, so manual shell-integration source
+  fallbacks work in release builds as well as `cargo run` builds. _(PR
+  [#188](https://github.com/nowledge-co/con-terminal/pull/188) by
+  [@wey-gu](https://github.com/wey-gu), following PR
+  [#187](https://github.com/nowledge-co/con-terminal/pull/187) by
+  [@iknowu10](https://github.com/iknowu10))_
+
+
 ## `v0.1.0-beta.69` - 2026-05-11
 
 ### Added

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -14,7 +14,7 @@ use std::collections::VecDeque;
 use std::ffi::{CStr, CString};
 use std::io::Write;
 use std::os::raw::c_void;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, Ordering};
 use std::sync::{Arc, Once};
@@ -358,18 +358,39 @@ fn ensure_resources_dir_env() {
         return;
     }
 
-    let Some(resources_dir) = option_env!("CON_GHOSTTY_RESOURCES_DIR") else {
+    let resources_dir = installed_app_ghostty_resources_dir().or_else(|| {
+        let resources_dir = option_env!("CON_GHOSTTY_RESOURCES_DIR")?;
+        Path::new(resources_dir)
+            .is_dir()
+            .then(|| PathBuf::from(resources_dir))
+    });
+
+    let Some(resources_dir) = resources_dir else {
         return;
     };
-    if !Path::new(resources_dir).exists() {
-        return;
-    }
 
     // SAFETY: this runs during Ghostty initialization before the app spins up
     // worker threads, so mutating process env here is acceptable.
     unsafe {
         std::env::set_var("GHOSTTY_RESOURCES_DIR", resources_dir);
     }
+}
+
+fn installed_app_ghostty_resources_dir() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    installed_app_ghostty_resources_dir_for_exe(&exe)
+}
+
+fn installed_app_ghostty_resources_dir_for_exe(exe: &Path) -> Option<PathBuf> {
+    for ancestor in exe.ancestors() {
+        if ancestor.extension().is_some_and(|ext| ext == "app") {
+            let resources_dir = ancestor.join("Contents/Resources/ghostty");
+            if resources_dir.is_dir() {
+                return Some(resources_dir);
+            }
+        }
+    }
+    None
 }
 
 // ── GhosttyApp — singleton managing all surfaces ────────────
@@ -1576,7 +1597,7 @@ unsafe extern "C" fn close_surface_callback(userdata: *mut c_void, _process_aliv
 
 #[cfg(test)]
 mod tests {
-    use super::{GhosttyConfigPatch, TerminalColors};
+    use super::{GhosttyConfigPatch, TerminalColors, installed_app_ghostty_resources_dir_for_exe};
 
     fn sample_colors(seed: u8) -> TerminalColors {
         TerminalColors {
@@ -1659,5 +1680,34 @@ mod tests {
         let config = GhosttyConfigPatch::default().to_config_string();
 
         assert!(config.contains("shell-integration-features = no-cursor,ssh-env,ssh-terminfo"));
+    }
+
+    #[test]
+    fn finds_ghostty_resources_inside_installed_app_bundle() {
+        struct Cleanup(std::path::PathBuf);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "con-ghostty-resources-test-{}-{unique}",
+            std::process::id()
+        ));
+        let _cleanup = Cleanup(root.clone());
+        let app_root = root.join("con Beta.app");
+        let macos_dir = app_root.join("Contents/MacOS");
+        let resources_dir = app_root.join("Contents/Resources/ghostty");
+        std::fs::create_dir_all(&macos_dir).unwrap();
+        std::fs::create_dir_all(&resources_dir).unwrap();
+
+        let found = installed_app_ghostty_resources_dir_for_exe(&macos_dir.join("con"));
+
+        assert_eq!(found.as_deref(), Some(resources_dir.as_path()));
     }
 }

--- a/docs/install.md
+++ b/docs/install.md
@@ -88,24 +88,24 @@ current limits and fixes.
 ## Shell integration
 
 con embeds Ghostty's shell-integration scripts and tries to auto-inject them
-into the shells it spawns. Most users won't notice — Ghostty handles this
+into the shells it spawns. Most users will never notice: Ghostty handles this
 through `ZDOTDIR` for zsh, `XDG_DATA_DIRS` for fish, and `--rcfile` for bash.
 
 Auto-injection can be skipped, though, when something else owns the shell
 startup path: tmux, `exec zsh`, login-shell mode, a framework that resets
-`ZDOTDIR`, etc. The symptoms are subtle but inconvenient — every restored tab
-opens at `$HOME` instead of where you left it, the sidebar can't read the
-foreground process / cwd, and AI tab labels have nothing to summarize.
+`ZDOTDIR`, and similar setups. When that happens, con still works as a
+terminal, but it loses shell metadata: new panes may open at `$HOME`, the
+sidebar may miss the foreground process or cwd, and AI tab labels have less
+context.
 
-To verify it's loaded, run this in a fresh con tab:
+You can check whether integration loaded in a fresh con tab:
 
-```sh
-echo $precmd_functions   # zsh
-```
+- zsh: `echo $precmd_functions | grep _ghostty_precmd`
+- bash: `declare -F | grep __ghostty_precmd`
+- fish: `functions -a | grep __ghostty_mark_prompt_start`
 
-You should see `_ghostty_precmd` in the list. If you don't, source the
-integration script explicitly. Add the line for your shell to its rc file
-and open a new tab:
+If the command prints nothing, source the integration script explicitly. Add
+the line for your shell to its startup file, save it, and open a new tab:
 
 **zsh** (`~/.zshrc`):
 
@@ -122,10 +122,14 @@ if [[ -n "$GHOSTTY_RESOURCES_DIR" ]]; then
 fi
 ```
 
+If you run bash as a login shell, put the same snippet in `~/.bash_profile` or
+`~/.profile`, or make that file source `~/.bashrc`. Login bash does not always
+read `~/.bashrc` on its own.
+
 **fish** (`~/.config/fish/config.fish`):
 
 ```fish
-if set -q GHOSTTY_RESOURCES_DIR
+if set -q GHOSTTY_RESOURCES_DIR; and string length -q -- "$GHOSTTY_RESOURCES_DIR"
     source "$GHOSTTY_RESOURCES_DIR/shell-integration/fish/vendor_conf.d/ghostty-shell-integration.fish"
 end
 ```


### PR DESCRIPTION
## Summary

This carries PR #187's shell-integration install docs forward and adds the missing runtime guarantee those docs depend on:

- document zsh, bash, and fish checks for Ghostty shell integration
- document manual source fallbacks for shells where auto-injection is skipped
- seed `GHOSTTY_RESOURCES_DIR` from the installed macOS app bundle when the build-time resources path is gone
- credit @iknowu10's docs work in the beta.70 changelog

## Why

PR #187 correctly documents the workaround, but the existing app code only seeded `GHOSTTY_RESOURCES_DIR` from the build-time Ghostty resources path. That is fine for local debug builds, but installed app bundles need to resolve `Contents/Resources/ghostty` at runtime.

## Validation

- `python3 scripts/docs/validate-manifest.py`
- `CON_SKIP_GHOSTTY_VT=1 cargo test -p con-ghostty finds_ghostty_resources_inside_installed_app_bundle`
- `CON_SKIP_GHOSTTY_VT=1 cargo check -p con`

Supersedes/follows up PR #187.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Ghostty initialization by changing how `GHOSTTY_RESOURCES_DIR` is derived, which could impact macOS startup and resource loading if path detection is wrong (mitigated by added unit test and fallback behavior).
> 
> **Overview**
> **Hardens Ghostty shell-integration fallback behavior.** The app now seeds `GHOSTTY_RESOURCES_DIR` at runtime by discovering `Contents/Resources/ghostty` inside an installed macOS `.app` bundle when the build-time `CON_GHOSTTY_RESOURCES_DIR` is missing, ensuring manual `source` fallbacks work in release installs.
> 
> Updates the install docs with concrete zsh/bash/fish integration checks and explicit rc-file fallback snippets (including login-bash guidance and a stricter fish guard), and records both the docs change and the macOS fix in the `v0.1.0-beta.70` changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98cccd6da61cd7fef2176c487bcf807192641323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS shell integration to better locate Ghostty resources, including app bundle detection with fallback support for release builds.

* **Documentation**
  * Enhanced installation guide with shell-integration verification steps per shell type and manual integration snippets for cases where auto-injection is unavailable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/con-terminal/pull/188)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->