### PR TITLE
fix: scale terminal-adjacent UI fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ con is still pre-release, so entries may group related beta work while the produ
   [#189](https://github.com/nowledge-co/con-terminal/pull/189) by
   [@wey-gu](https://github.com/wey-gu))_
 
+**UI**
+
+- Fixed UI font-size scaling in terminal-adjacent chrome: the bottom input bar,
+  agent panel messages, and run-trace cards now follow the Appearance → UI Size
+  setting instead of staying at small fixed system sizes. _(Issue
+  [#190](https://github.com/nowledge-co/con-terminal/issues/190), reported by
+  [@leek_ed](https://x.com/leek_ed))_
+
 **macOS**
 
 - Set `GHOSTTY_RESOURCES_DIR` from the installed app bundle when the build-time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,9 @@ con is still pre-release, so entries may group related beta work while the produ
 - Fixed UI font-size scaling in terminal-adjacent chrome: the bottom input bar,
   agent panel messages, and run-trace cards now follow the Appearance → UI Size
   setting instead of staying at small fixed system sizes. _(Issue
-  [#190](https://github.com/nowledge-co/con-terminal/issues/190), reported by
+  [#190](https://github.com/nowledge-co/con-terminal/issues/190), PR
+  [#191](https://github.com/nowledge-co/con-terminal/pull/191) by
+  [@wey-gu](https://github.com/wey-gu), reported by
   [@leek_ed](https://x.com/leek_ed))_
 
 **macOS**

--- a/crates/con-app/src/agent_panel.rs
+++ b/crates/con-app/src/agent_panel.rs
@@ -35,9 +35,7 @@ use crate::chat_markdown::{
 use crate::input_bar::SkillEntry;
 use crate::motion::{MotionValue, vertical_reveal_offset};
 use crate::settings_panel::provider_label;
-use crate::ui_scale::{
-    mono_density_scale, mono_px, mono_space_px, ui_density_scale, ui_px, ui_space_px,
-};
+use crate::ui_scale::{mono_px, mono_space_px, ui_px, ui_space_px};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AgentStatus {
@@ -2754,18 +2752,17 @@ fn render_inline_state(
     color: Hsla,
     theme: &gpui_component::Theme,
 ) -> AnyElement {
-    let scale = ui_density_scale(theme);
     div()
         .flex()
         .items_center()
-        .gap(px(5.0 * scale))
-        .px(px(7.0 * scale))
-        .py(px(3.0 * scale))
+        .gap(ui_space_px(theme, 5.0))
+        .px(ui_space_px(theme, 7.0))
+        .py(ui_space_px(theme, 3.0))
         .rounded_full()
         .bg(color.opacity(0.10))
         .child(
             div()
-                .size(px(5.0 * scale))
+                .size(ui_space_px(theme, 5.0))
                 .rounded_full()
                 .bg(color.opacity(0.85)),
         )
@@ -2786,10 +2783,12 @@ fn render_meta_chip(
     theme: &gpui_component::Theme,
     mono: bool,
 ) -> AnyElement {
-    let scale = if mono {
-        mono_density_scale(theme)
-    } else {
-        ui_density_scale(theme)
+    let chip_px = |value| {
+        if mono {
+            mono_space_px(theme, value)
+        } else {
+            ui_space_px(theme, value)
+        }
     };
     let mut label_el = div()
         .text_size(if mono {
@@ -2808,9 +2807,9 @@ fn render_meta_chip(
     div()
         .flex()
         .items_center()
-        .px(px(8.0 * scale))
-        .py(px(3.0 * scale))
-        .rounded(px(7.0 * scale))
+        .px(chip_px(8.0))
+        .py(chip_px(3.0))
+        .rounded(chip_px(7.0))
         .bg(surface)
         .child(label_el)
         .into_any_element()
@@ -2863,8 +2862,7 @@ fn render_model_chips(
     theme: &gpui_component::Theme,
 ) -> AnyElement {
     let (provider, label) = split_model_identity(model);
-    let scale = ui_density_scale(theme);
-    let mut row = div().flex().items_center().gap(px(6.0 * scale));
+    let mut row = div().flex().items_center().gap(ui_space_px(theme, 6.0));
 
     if let Some(provider) = provider {
         row = row
@@ -2877,7 +2875,7 @@ fn render_model_chips(
             )
             .child(
                 div()
-                    .size(px(3.0 * scale))
+                    .size(ui_space_px(theme, 3.0))
                     .rounded_full()
                     .bg(theme.muted_foreground.opacity(0.18)),
             );
@@ -3189,7 +3187,7 @@ fn render_assistant_message(
                 ));
             }
             if let Some(suffix) = unparsed_markdown_suffix(msg) {
-                content_el = content_el.child(div().mt(ui_px(theme, 6.0)).child(
+                content_el = content_el.child(div().mt(ui_space_px(theme, 6.0)).child(
                     render_plain_multiline_text(
                         suffix,
                         theme.mono_font_family.clone(),
@@ -3203,7 +3201,7 @@ fn render_assistant_message(
                 let remaining = markdown.block_count().saturating_sub(visible_blocks);
                 let more_view = view.clone();
                 content_el = content_el.child(
-                    div().mt(ui_px(theme, 8.0)).child(
+                    div().mt(ui_space_px(theme, 8.0)).child(
                         div()
                             .id(SharedString::from(format!("assistant-more-{msg_idx}")))
                             .flex()
@@ -3266,8 +3264,6 @@ fn render_assistant_message(
     }
 
     if !msg.steps.is_empty() {
-        let ui_scale = ui_density_scale(theme);
-        let mono_scale = mono_density_scale(theme);
         let step_count = msg.steps.len();
         let collapsed = msg.steps_collapsed;
         let chevron = if collapsed {
@@ -3295,16 +3291,16 @@ fn render_assistant_message(
 
         let run_panel = panel.clone();
         let mut run_card = div()
-            .ml(px(19.0 * ui_scale))
-            .mr(px(4.0 * ui_scale))
-            .mt(px(6.0 * ui_scale))
-            .px(px(10.0 * ui_scale))
-            .py(px(10.0 * ui_scale))
-            .rounded(px(12.0 * ui_scale))
+            .ml(ui_space_px(theme, 19.0))
+            .mr(ui_space_px(theme, 4.0))
+            .mt(ui_space_px(theme, 6.0))
+            .px(ui_space_px(theme, 10.0))
+            .py(ui_space_px(theme, 10.0))
+            .rounded(ui_space_px(theme, 12.0))
             .bg(trace_group_surface(theme))
             .flex()
             .flex_col()
-            .gap(px(10.0 * ui_scale));
+            .gap(ui_space_px(theme, 10.0));
 
         run_card = run_card.child(
             div()
@@ -3312,11 +3308,11 @@ fn render_assistant_message(
                 .flex()
                 .items_center()
                 .min_w_0()
-                .gap(px(8.0 * ui_scale))
-                .px(px(4.0 * ui_scale))
-                .py(px(3.0 * ui_scale))
+                .gap(ui_space_px(theme, 8.0))
+                .px(ui_space_px(theme, 4.0))
+                .py(ui_space_px(theme, 3.0))
                 .cursor_pointer()
-                .rounded(px(10.0 * ui_scale))
+                .rounded(ui_space_px(theme, 10.0))
                 .hover(|s| s.bg(theme.muted.opacity(0.035)))
                 .on_mouse_down(MouseButton::Left, move |_, _, cx| {
                     let _ = run_panel.update(cx, |this, cx| {
@@ -3340,7 +3336,7 @@ fn render_assistant_message(
                         .flex_col()
                         .flex_1()
                         .min_w_0()
-                        .gap(px(2.0 * ui_scale))
+                        .gap(ui_space_px(theme, 2.0))
                         .child(render_section_kicker(run_title, theme))
                         .child(
                             div()
@@ -3361,7 +3357,7 @@ fn render_assistant_message(
                     let mut summary = div()
                         .flex()
                         .items_center()
-                        .gap(px(8.0 * ui_scale))
+                        .gap(ui_space_px(theme, 8.0))
                         .flex_shrink_0()
                         .child(
                             div()
@@ -3389,7 +3385,7 @@ fn render_assistant_message(
         );
 
         if !collapsed {
-            let mut steps_el = div().flex().flex_col().gap(px(8.0 * ui_scale));
+            let mut steps_el = div().flex().flex_col().gap(ui_space_px(theme, 8.0));
 
             for (step_idx, step) in msg.steps.iter().enumerate() {
                 let icon_color = match step.status {
@@ -3410,7 +3406,7 @@ fn render_assistant_message(
                 let mut top_line = div()
                     .flex()
                     .items_center()
-                    .gap(px(6.0 * ui_scale))
+                    .gap(ui_space_px(theme, 6.0))
                     .child(
                         svg()
                             .path(step.icon)
@@ -3447,7 +3443,7 @@ fn render_assistant_message(
                         div()
                             .flex()
                             .items_center()
-                            .gap(px(4.0 * mono_scale))
+                            .gap(mono_space_px(theme, 4.0))
                             .child(
                                 div()
                                     .text_size(mono_px(theme, 10.0))
@@ -3472,15 +3468,15 @@ fn render_assistant_message(
                 let mut step_header = div()
                     .flex()
                     .flex_col()
-                    .gap(px(3.0 * ui_scale))
-                    .px(px(12.0 * ui_scale))
-                    .py(px(10.0 * ui_scale))
+                    .gap(ui_space_px(theme, 3.0))
+                    .px(ui_space_px(theme, 12.0))
+                    .py(ui_space_px(theme, 10.0))
                     .child(top_line);
 
                 if let Some(detail_text) = step_detail {
                     step_header = step_header.child(
                         div()
-                            .ml(px(18.0 * mono_scale))
+                            .ml(mono_space_px(theme, 18.0))
                             .text_size(mono_px(theme, 10.5))
                             .line_height(mono_px(theme, 15.0))
                             .text_color(theme.muted_foreground.opacity(0.56))
@@ -3494,14 +3490,14 @@ fn render_assistant_message(
                 let mut step_shell = div()
                     .flex()
                     .flex_col()
-                    .rounded(px(12.0 * ui_scale))
+                    .rounded(ui_space_px(theme, 12.0))
                     .overflow_hidden()
                     .bg(trace_step_surface(theme))
                     .gap(px(0.0));
 
                 let step_header_shell = step_header
                     .bg(trace_step_header_surface(theme))
-                    .min_h(px(44.0 * ui_scale));
+                    .min_h(ui_space_px(theme, 44.0));
 
                 if has_detail {
                     let step_panel = panel.clone();
@@ -3539,8 +3535,8 @@ fn render_assistant_message(
                         result_preview(detail, TOOL_RESULT_PREVIEW_LINES)
                     };
                     let detail_block = div()
-                        .px(px(12.0 * ui_scale))
-                        .pt(px(10.0 * ui_scale))
+                        .px(ui_space_px(theme, 12.0))
+                        .pt(ui_space_px(theme, 10.0))
                         .bg(trace_detail_surface(theme))
                         .child(render_result_block(
                             &visible_detail,
@@ -3561,9 +3557,9 @@ fn render_assistant_message(
                         let button_label = result_toggle_label(detail, expanded);
                         let detail_toggle_panel = panel.clone();
                         let detail_toggle = div()
-                            .px(px(12.0 * ui_scale))
-                            .pt(px(4.0 * ui_scale))
-                            .pb(px(10.0 * ui_scale))
+                            .px(ui_space_px(theme, 12.0))
+                            .pt(ui_space_px(theme, 4.0))
+                            .pb(ui_space_px(theme, 10.0))
                             .bg(trace_detail_surface(theme))
                             .child(
                                 div()
@@ -3572,7 +3568,8 @@ fn render_assistant_message(
                                     )))
                                     .cursor_pointer()
                                     .hover(|s| {
-                                        s.bg(theme.muted.opacity(0.03)).rounded(px(6.0 * ui_scale))
+                                        s.bg(theme.muted.opacity(0.03))
+                                            .rounded(ui_space_px(theme, 6.0))
                                     })
                                     .on_mouse_down(MouseButton::Left, move |_, _, cx| {
                                         let _ = detail_toggle_panel.update(cx, |this, cx| {
@@ -3589,8 +3586,8 @@ fn render_assistant_message(
                                     })
                                     .child(
                                         div()
-                                            .px(px(2.0 * mono_scale))
-                                            .py(px(2.0 * mono_scale))
+                                            .px(mono_space_px(theme, 2.0))
+                                            .py(mono_space_px(theme, 2.0))
                                             .child(render_result_toggle_chrome(
                                                 expanded,
                                                 button_label,
@@ -3611,8 +3608,8 @@ fn render_assistant_message(
                     } else {
                         step_shell = step_shell.child(
                             div()
-                                .px(px(10.0 * ui_scale))
-                                .pb(px(10.0 * ui_scale))
+                                .px(ui_space_px(theme, 10.0))
+                                .pb(ui_space_px(theme, 10.0))
                                 .bg(trace_detail_surface(theme)),
                         );
                     }
@@ -3953,33 +3950,31 @@ impl Render for AgentPanel {
             .collect();
 
         if !visible_tool_calls.is_empty() {
-            let ui_scale = ui_density_scale(theme);
-            let mono_scale = mono_density_scale(theme);
             let mut tc_container = div()
                 .flex()
                 .flex_col()
-                .ml(px(19.0 * ui_scale))
-                .mr(px(4.0 * ui_scale))
-                .gap(px(10.0 * ui_scale))
-                .px(px(10.0 * ui_scale))
-                .py(px(10.0 * ui_scale))
-                .rounded(px(12.0 * ui_scale))
+                .ml(ui_space_px(theme, 19.0))
+                .mr(ui_space_px(theme, 4.0))
+                .gap(ui_space_px(theme, 10.0))
+                .px(ui_space_px(theme, 10.0))
+                .py(ui_space_px(theme, 10.0))
+                .rounded(ui_space_px(theme, 12.0))
                 .bg(trace_group_surface(theme))
                 .child(
                     div()
                         .flex()
                         .items_center()
                         .min_w_0()
-                        .gap(px(8.0 * ui_scale))
-                        .px(px(4.0 * ui_scale))
-                        .py(px(3.0 * ui_scale))
+                        .gap(ui_space_px(theme, 8.0))
+                        .px(ui_space_px(theme, 4.0))
+                        .py(ui_space_px(theme, 3.0))
                         .child(
                             div()
                                 .flex()
                                 .flex_col()
                                 .flex_1()
                                 .min_w_0()
-                                .gap(px(2.0 * ui_scale))
+                                .gap(ui_space_px(theme, 2.0))
                                 .child(render_section_kicker("Working now", theme))
                                 .child(
                                     div()
@@ -4043,7 +4038,7 @@ impl Render for AgentPanel {
                 let top_line = div()
                     .flex()
                     .items_center()
-                    .gap(px(6.0 * ui_scale))
+                    .gap(ui_space_px(theme, 6.0))
                     .child(icon_el)
                     .child(
                         div()
@@ -4070,16 +4065,16 @@ impl Render for AgentPanel {
                 let mut tc_row = div()
                     .flex()
                     .flex_col()
-                    .gap(px(3.0 * ui_scale))
-                    .px(px(12.0 * ui_scale))
-                    .py(px(10.0 * ui_scale))
+                    .gap(ui_space_px(theme, 3.0))
+                    .px(ui_space_px(theme, 12.0))
+                    .py(ui_space_px(theme, 10.0))
                     .child(top_line);
 
                 // Args on second line
                 if !args_display.is_empty() {
                     tc_row = tc_row.child(
                         div()
-                            .ml(px(18.0 * mono_scale))
+                            .ml(mono_space_px(theme, 18.0))
                             .text_size(mono_px(theme, 10.75))
                             .text_color(theme.muted_foreground.opacity(0.50))
                             .font_family(theme.mono_font_family.clone())
@@ -4092,14 +4087,14 @@ impl Render for AgentPanel {
                 let mut tc_el = div()
                     .flex()
                     .flex_col()
-                    .rounded(px(12.0 * ui_scale))
+                    .rounded(ui_space_px(theme, 12.0))
                     .overflow_hidden()
                     .bg(trace_step_surface(theme))
                     .gap(px(0.0))
                     .child(
                         tc_row
                             .bg(trace_step_header_surface(theme))
-                            .min_h(px(44.0 * ui_scale)),
+                            .min_h(ui_space_px(theme, 44.0)),
                     );
 
                 // Result preview
@@ -4534,20 +4529,19 @@ impl Render for AgentPanel {
 
         let live_activity_strip = if let Some(approval) = self.state.pending_approvals.first() {
             let args_display = format_tool_args(&approval.tool_name, &approval.args);
-            let ui_scale = ui_density_scale(theme);
             Some(
                 div()
                     .flex()
                     .flex_col()
-                    .gap(px(7.0 * ui_scale))
-                    .mx(px(14.0 * ui_scale))
-                    .mb(px(8.0 * ui_scale))
+                    .gap(ui_space_px(theme, 7.0))
+                    .mx(ui_space_px(theme, 14.0))
+                    .mb(ui_space_px(theme, 8.0))
                     .child(render_section_kicker("Needs approval", theme))
                     .child(
                         div()
                             .flex()
                             .items_center()
-                            .gap(px(8.0 * ui_scale))
+                            .gap(ui_space_px(theme, 8.0))
                             .child(render_inline_state(
                                 "Approval waiting".into(),
                                 theme.warning,
@@ -4571,20 +4565,19 @@ impl Render for AgentPanel {
         } else if let Some(tc) = self.running_tool_call() {
             let args_display = format_tool_args(&tc.tool_name, &tc.args);
             let human_name = humanize_tool_name(&tc.tool_name);
-            let ui_scale = ui_density_scale(theme);
             Some(
                 div()
                     .flex()
                     .flex_col()
-                    .gap(px(7.0 * ui_scale))
-                    .mx(px(14.0 * ui_scale))
-                    .mb(px(8.0 * ui_scale))
+                    .gap(ui_space_px(theme, 7.0))
+                    .mx(ui_space_px(theme, 14.0))
+                    .mb(ui_space_px(theme, 8.0))
                     .child(render_section_kicker("Current run", theme))
                     .child(
                         div()
                             .flex()
                             .items_center()
-                            .gap(px(8.0 * ui_scale))
+                            .gap(ui_space_px(theme, 8.0))
                             .child(Spinner::new().small().color(theme.warning))
                             .child(
                                 div()
@@ -4609,20 +4602,19 @@ impl Render for AgentPanel {
                     .into_any_element(),
             )
         } else if let Some((_icon, label)) = self.status_text() {
-            let ui_scale = ui_density_scale(theme);
             Some(
                 div()
                     .flex()
                     .flex_col()
-                    .gap(px(7.0 * ui_scale))
-                    .mx(px(14.0 * ui_scale))
-                    .mb(px(8.0 * ui_scale))
+                    .gap(ui_space_px(theme, 7.0))
+                    .mx(ui_space_px(theme, 14.0))
+                    .mb(ui_space_px(theme, 8.0))
                     .child(render_section_kicker("Live status", theme))
                     .child(
                         div()
                             .flex()
                             .items_center()
-                            .gap(px(8.0 * ui_scale))
+                            .gap(ui_space_px(theme, 8.0))
                             .child(
                                 Spinner::new()
                                     .small()
@@ -4888,7 +4880,6 @@ impl Render for AgentPanel {
 
             let has_text = self.inline_input_has_text;
             let has_skills = self.inline_input_has_skills;
-            let mono_scale = mono_density_scale(theme);
             let inline_control_size = mono_space_px(theme, 24.0);
             let inline_input_text_size = mono_px(theme, 13.0);
 
@@ -4899,7 +4890,7 @@ impl Render for AgentPanel {
                 .items_center()
                 .justify_center()
                 .size(inline_control_size)
-                .rounded(px(12.0 * mono_scale))
+                .rounded(mono_space_px(theme, 12.0))
                 .cursor_pointer()
                 .flex_shrink_0()
                 .bg(if has_text && !has_skills {
@@ -4940,9 +4931,9 @@ impl Render for AgentPanel {
             panel = panel.child(
                 div()
                     .absolute()
-                    .left(px(8.0 * mono_scale))
-                    .right(px(9.0 * mono_scale))
-                    .bottom(px(8.0 * mono_scale))
+                    .left(mono_space_px(theme, 8.0))
+                    .right(mono_space_px(theme, 9.0))
+                    .bottom(mono_space_px(theme, 8.0))
                     .on_key_down(cx.listener(move |this, event: &KeyDownEvent, window, cx| {
                         let key = event.keystroke.key.as_str();
                         let has_completions = !this.filtered_inline_skills(cx).is_empty();
@@ -4985,12 +4976,12 @@ impl Render for AgentPanel {
                             .flex()
                             .items_center()
                             .w_full()
-                            .min_h(px(46.0 * mono_scale))
-                            .gap(px(8.0 * mono_scale))
-                            .pl(px(7.0 * mono_scale))
-                            .pr(px(8.0 * mono_scale))
-                            .py(px(8.0 * mono_scale))
-                            .rounded(px(14.0 * mono_scale))
+                            .min_h(mono_space_px(theme, 46.0))
+                            .gap(mono_space_px(theme, 8.0))
+                            .pl(mono_space_px(theme, 7.0))
+                            .pr(mono_space_px(theme, 8.0))
+                            .py(mono_space_px(theme, 8.0))
+                            .rounded(mono_space_px(theme, 14.0))
                             .bg(theme.background)
                             .on_mouse_down(
                                 MouseButton::Left,
@@ -5005,7 +4996,7 @@ impl Render for AgentPanel {
                                 div()
                                     .flex_1()
                                     .w_full()
-                                    .min_w(px(120.0 * mono_scale))
+                                    .min_w(mono_space_px(theme, 120.0))
                                     .font_family(theme.mono_font_family.clone())
                                     .text_size(inline_input_text_size)
                                     .child(

--- a/crates/con-app/src/agent_panel.rs
+++ b/crates/con-app/src/agent_panel.rs
@@ -4056,7 +4056,8 @@ impl Render for AgentPanel {
                     .child(
                         div()
                             .flex_shrink_0()
-                            .text_size(ui_px(theme, 10.0))
+                            .text_size(mono_px(theme, 10.0))
+                            .font_family(theme.mono_font_family.clone())
                             .text_color(theme.muted_foreground.opacity(0.36))
                             .child(format_step_duration(dur)),
                     );

--- a/crates/con-app/src/agent_panel.rs
+++ b/crates/con-app/src/agent_panel.rs
@@ -35,7 +35,9 @@ use crate::chat_markdown::{
 use crate::input_bar::SkillEntry;
 use crate::motion::{MotionValue, vertical_reveal_offset};
 use crate::settings_panel::provider_label;
-use crate::ui_scale::{mono_font_scale, mono_px, ui_font_scale, ui_px};
+use crate::ui_scale::{
+    mono_density_scale, mono_px, mono_space_px, ui_density_scale, ui_px, ui_space_px,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AgentStatus {
@@ -2752,7 +2754,7 @@ fn render_inline_state(
     color: Hsla,
     theme: &gpui_component::Theme,
 ) -> AnyElement {
-    let scale = ui_font_scale(theme);
+    let scale = ui_density_scale(theme);
     div()
         .flex()
         .items_center()
@@ -2785,9 +2787,9 @@ fn render_meta_chip(
     mono: bool,
 ) -> AnyElement {
     let scale = if mono {
-        mono_font_scale(theme)
+        mono_density_scale(theme)
     } else {
-        ui_font_scale(theme)
+        ui_density_scale(theme)
     };
     let mut label_el = div()
         .text_size(if mono {
@@ -2861,7 +2863,7 @@ fn render_model_chips(
     theme: &gpui_component::Theme,
 ) -> AnyElement {
     let (provider, label) = split_model_identity(model);
-    let scale = ui_font_scale(theme);
+    let scale = ui_density_scale(theme);
     let mut row = div().flex().items_center().gap(px(6.0 * scale));
 
     if let Some(provider) = provider {
@@ -2918,8 +2920,8 @@ fn render_result_toggle_chrome(
     div()
         .flex()
         .items_center()
-        .gap(px(5.0 * mono_font_scale(theme)))
-        .py(px(2.0 * mono_font_scale(theme)))
+        .gap(mono_space_px(theme, 5.0))
+        .py(mono_space_px(theme, 2.0))
         .child(
             svg()
                 .path(if expanded {
@@ -2927,7 +2929,7 @@ fn render_result_toggle_chrome(
                 } else {
                     "phosphor/caret-down.svg"
                 })
-                .size(mono_px(theme, 9.5))
+                .size(mono_space_px(theme, 9.5))
                 .text_color(theme.muted_foreground.opacity(0.30)),
         )
         .child(
@@ -2988,7 +2990,7 @@ fn render_user_message_text(
     let mut block = div()
         .flex()
         .flex_col()
-        .gap(px(4.0 * ui_font_scale(theme)))
+        .gap(ui_space_px(theme, 4.0))
         .text_size(ui_px(theme, 13.5))
         .line_height(ui_px(theme, 21.0))
         .text_color(theme.foreground);
@@ -3206,10 +3208,10 @@ fn render_assistant_message(
                             .id(SharedString::from(format!("assistant-more-{msg_idx}")))
                             .flex()
                             .items_center()
-                            .gap(px(6.0 * mono_font_scale(theme)))
-                            .px(px(8.0 * mono_font_scale(theme)))
-                            .py(px(4.0 * mono_font_scale(theme)))
-                            .rounded(px(7.0 * mono_font_scale(theme)))
+                            .gap(mono_space_px(theme, 6.0))
+                            .px(mono_space_px(theme, 8.0))
+                            .py(mono_space_px(theme, 4.0))
+                            .rounded(mono_space_px(theme, 7.0))
                             .cursor_pointer()
                             .bg(theme.muted.opacity(0.05))
                             .hover(|s| s.bg(theme.muted.opacity(0.09)))
@@ -3230,7 +3232,7 @@ fn render_assistant_message(
                             .child(
                                 svg()
                                     .path("phosphor/caret-down.svg")
-                                    .size(mono_px(theme, 10.0))
+                                    .size(mono_space_px(theme, 10.0))
                                     .text_color(theme.muted_foreground.opacity(0.55)),
                             )
                             .child(
@@ -3264,8 +3266,8 @@ fn render_assistant_message(
     }
 
     if !msg.steps.is_empty() {
-        let ui_scale = ui_font_scale(theme);
-        let mono_scale = mono_font_scale(theme);
+        let ui_scale = ui_density_scale(theme);
+        let mono_scale = mono_density_scale(theme);
         let step_count = msg.steps.len();
         let collapsed = msg.steps_collapsed;
         let chevron = if collapsed {
@@ -3329,7 +3331,7 @@ fn render_assistant_message(
                 .child(
                     svg()
                         .path(chevron)
-                        .size(ui_px(theme, 11.0))
+                        .size(ui_space_px(theme, 11.0))
                         .text_color(theme.muted_foreground.opacity(0.34)),
                 )
                 .child(
@@ -3412,7 +3414,7 @@ fn render_assistant_message(
                     .child(
                         svg()
                             .path(step.icon)
-                            .size(ui_px(theme, 12.0))
+                            .size(ui_space_px(theme, 12.0))
                             .flex_shrink_0()
                             .text_color(icon_color),
                     )
@@ -3460,7 +3462,7 @@ fn render_assistant_message(
                                     } else {
                                         "phosphor/caret-down.svg"
                                     })
-                                    .size(mono_px(theme, 10.0))
+                                    .size(mono_space_px(theme, 10.0))
                                     .flex_shrink_0()
                                     .text_color(theme.muted_foreground.opacity(0.30)),
                             ),
@@ -3692,8 +3694,8 @@ impl AgentPanel {
         if is_system {
             msg_el = msg_el.child(
                 div()
-                    .px(px(6.0 * ui_font_scale(theme)))
-                    .py(px(8.0 * ui_font_scale(theme)))
+                    .px(ui_space_px(theme, 6.0))
+                    .py(ui_space_px(theme, 8.0))
                     .text_size(ui_px(theme, 12.5))
                     .text_color(theme.muted_foreground.opacity(0.40))
                     .line_height(ui_px(theme, 19.0))
@@ -3951,8 +3953,8 @@ impl Render for AgentPanel {
             .collect();
 
         if !visible_tool_calls.is_empty() {
-            let ui_scale = ui_font_scale(theme);
-            let mono_scale = mono_font_scale(theme);
+            let ui_scale = ui_density_scale(theme);
+            let mono_scale = mono_density_scale(theme);
             let mut tc_container = div()
                 .flex()
                 .flex_col()
@@ -4024,7 +4026,7 @@ impl Render for AgentPanel {
                 let icon_el: AnyElement = if is_done {
                     svg()
                         .path(icon)
-                        .size(ui_px(theme, 12.0))
+                        .size(ui_space_px(theme, 12.0))
                         .flex_shrink_0()
                         .text_color(icon_color)
                         .into_any_element()
@@ -4531,7 +4533,7 @@ impl Render for AgentPanel {
 
         let live_activity_strip = if let Some(approval) = self.state.pending_approvals.first() {
             let args_display = format_tool_args(&approval.tool_name, &approval.args);
-            let ui_scale = ui_font_scale(theme);
+            let ui_scale = ui_density_scale(theme);
             Some(
                 div()
                     .flex()
@@ -4568,7 +4570,7 @@ impl Render for AgentPanel {
         } else if let Some(tc) = self.running_tool_call() {
             let args_display = format_tool_args(&tc.tool_name, &tc.args);
             let human_name = humanize_tool_name(&tc.tool_name);
-            let ui_scale = ui_font_scale(theme);
+            let ui_scale = ui_density_scale(theme);
             Some(
                 div()
                     .flex()
@@ -4606,7 +4608,7 @@ impl Render for AgentPanel {
                     .into_any_element(),
             )
         } else if let Some((_icon, label)) = self.status_text() {
-            let ui_scale = ui_font_scale(theme);
+            let ui_scale = ui_density_scale(theme);
             Some(
                 div()
                     .flex()
@@ -4885,8 +4887,8 @@ impl Render for AgentPanel {
 
             let has_text = self.inline_input_has_text;
             let has_skills = self.inline_input_has_skills;
-            let mono_scale = mono_font_scale(theme);
-            let inline_control_size = mono_px(theme, 24.0);
+            let mono_scale = mono_density_scale(theme);
+            let inline_control_size = mono_space_px(theme, 24.0);
             let inline_input_text_size = mono_px(theme, 13.0);
 
             // Send button — circular, matches main input bar
@@ -4926,7 +4928,7 @@ impl Render for AgentPanel {
                 .child(
                     svg()
                         .path("phosphor/arrow-up.svg")
-                        .size(mono_px(theme, 12.0))
+                        .size(mono_space_px(theme, 12.0))
                         .text_color(if has_text && !has_skills {
                             theme.primary_foreground
                         } else {

--- a/crates/con-app/src/agent_panel.rs
+++ b/crates/con-app/src/agent_panel.rs
@@ -35,6 +35,7 @@ use crate::chat_markdown::{
 use crate::input_bar::SkillEntry;
 use crate::motion::{MotionValue, vertical_reveal_offset};
 use crate::settings_panel::provider_label;
+use crate::ui_scale::{mono_font_scale, mono_px, ui_font_scale, ui_px};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AgentStatus {
@@ -2751,18 +2752,24 @@ fn render_inline_state(
     color: Hsla,
     theme: &gpui_component::Theme,
 ) -> AnyElement {
+    let scale = ui_font_scale(theme);
     div()
         .flex()
         .items_center()
-        .gap(px(5.0))
-        .px(px(7.0))
-        .py(px(3.0))
+        .gap(px(5.0 * scale))
+        .px(px(7.0 * scale))
+        .py(px(3.0 * scale))
         .rounded_full()
         .bg(color.opacity(0.10))
-        .child(div().size(px(5.0)).rounded_full().bg(color.opacity(0.85)))
         .child(
             div()
-                .text_size(px(10.0))
+                .size(px(5.0 * scale))
+                .rounded_full()
+                .bg(color.opacity(0.85)),
+        )
+        .child(
+            div()
+                .text_size(ui_px(theme, 10.0))
                 .font_weight(FontWeight::MEDIUM)
                 .text_color(theme.foreground.opacity(0.62))
                 .child(label),
@@ -2777,8 +2784,17 @@ fn render_meta_chip(
     theme: &gpui_component::Theme,
     mono: bool,
 ) -> AnyElement {
+    let scale = if mono {
+        mono_font_scale(theme)
+    } else {
+        ui_font_scale(theme)
+    };
     let mut label_el = div()
-        .text_size(px(10.25))
+        .text_size(if mono {
+            mono_px(theme, 10.25)
+        } else {
+            ui_px(theme, 10.25)
+        })
         .font_weight(FontWeight::MEDIUM)
         .text_color(text)
         .child(label.into());
@@ -2790,9 +2806,9 @@ fn render_meta_chip(
     div()
         .flex()
         .items_center()
-        .px(px(8.0))
-        .py(px(3.0))
-        .rounded(px(7.0))
+        .px(px(8.0 * scale))
+        .py(px(3.0 * scale))
+        .rounded(px(7.0 * scale))
         .bg(surface)
         .child(label_el)
         .into_any_element()
@@ -2845,20 +2861,21 @@ fn render_model_chips(
     theme: &gpui_component::Theme,
 ) -> AnyElement {
     let (provider, label) = split_model_identity(model);
-    let mut row = div().flex().items_center().gap(px(6.0));
+    let scale = ui_font_scale(theme);
+    let mut row = div().flex().items_center().gap(px(6.0 * scale));
 
     if let Some(provider) = provider {
         row = row
             .child(
                 div()
-                    .text_size(px(10.5))
+                    .text_size(ui_px(theme, 10.5))
                     .font_weight(FontWeight::MEDIUM)
                     .text_color(theme.muted_foreground.opacity(0.48))
                     .child(provider),
             )
             .child(
                 div()
-                    .size(px(3.0))
+                    .size(px(3.0 * scale))
                     .rounded_full()
                     .bg(theme.muted_foreground.opacity(0.18)),
             );
@@ -2875,7 +2892,7 @@ fn render_model_chips(
     if let Some(dur) = duration_ms {
         row = row.child(
             div()
-                .text_size(px(10.0))
+                .text_size(mono_px(theme, 10.0))
                 .font_family(theme.mono_font_family.clone())
                 .text_color(theme.muted_foreground.opacity(0.38))
                 .child(format_duration_ms(dur)),
@@ -2901,8 +2918,8 @@ fn render_result_toggle_chrome(
     div()
         .flex()
         .items_center()
-        .gap(px(5.0))
-        .py(px(2.0))
+        .gap(px(5.0 * mono_font_scale(theme)))
+        .py(px(2.0 * mono_font_scale(theme)))
         .child(
             svg()
                 .path(if expanded {
@@ -2910,12 +2927,12 @@ fn render_result_toggle_chrome(
                 } else {
                     "phosphor/caret-down.svg"
                 })
-                .size(px(9.5))
+                .size(mono_px(theme, 9.5))
                 .text_color(theme.muted_foreground.opacity(0.30)),
         )
         .child(
             div()
-                .text_size(px(10.0))
+                .text_size(mono_px(theme, 10.0))
                 .font_family(theme.mono_font_family.clone())
                 .text_color(theme.muted_foreground.opacity(0.40))
                 .child(label),
@@ -2925,7 +2942,7 @@ fn render_result_toggle_chrome(
 
 fn render_section_kicker(label: &str, theme: &gpui_component::Theme) -> AnyElement {
     div()
-        .text_size(px(8.5))
+        .text_size(ui_px(theme, 8.5))
         .font_weight(FontWeight::SEMIBOLD)
         .text_color(theme.muted_foreground.opacity(0.32))
         .child(label.to_ascii_uppercase())
@@ -2961,8 +2978,8 @@ fn render_user_message_text(
 ) -> AnyElement {
     if !content.contains('\n') {
         return div()
-            .text_size(px(13.5))
-            .line_height(px(21.0))
+            .text_size(ui_px(theme, 13.5))
+            .line_height(ui_px(theme, 21.0))
             .text_color(theme.foreground)
             .child(content.to_string())
             .into_any_element();
@@ -2971,9 +2988,9 @@ fn render_user_message_text(
     let mut block = div()
         .flex()
         .flex_col()
-        .gap(px(4.0))
-        .text_size(px(13.5))
-        .line_height(px(21.0))
+        .gap(px(4.0 * ui_font_scale(theme)))
+        .text_size(ui_px(theme, 13.5))
+        .line_height(ui_px(theme, 21.0))
         .text_color(theme.foreground);
 
     for (line_idx, line) in content.lines().enumerate() {
@@ -3170,28 +3187,29 @@ fn render_assistant_message(
                 ));
             }
             if let Some(suffix) = unparsed_markdown_suffix(msg) {
-                content_el =
-                    content_el.child(div().mt(px(6.0)).child(render_plain_multiline_text(
+                content_el = content_el.child(div().mt(ui_px(theme, 6.0)).child(
+                    render_plain_multiline_text(
                         suffix,
                         theme.mono_font_family.clone(),
-                        px(14.0),
-                        px(23.0),
+                        mono_px(theme, 14.0),
+                        mono_px(theme, 23.0),
                         theme.foreground.opacity(0.78),
-                    )));
+                    ),
+                ));
             }
             if visible_blocks < markdown.block_count() {
                 let remaining = markdown.block_count().saturating_sub(visible_blocks);
                 let more_view = view.clone();
                 content_el = content_el.child(
-                    div().mt(px(8.0)).child(
+                    div().mt(ui_px(theme, 8.0)).child(
                         div()
                             .id(SharedString::from(format!("assistant-more-{msg_idx}")))
                             .flex()
                             .items_center()
-                            .gap(px(6.0))
-                            .px(px(8.0))
-                            .py(px(4.0))
-                            .rounded(px(7.0))
+                            .gap(px(6.0 * mono_font_scale(theme)))
+                            .px(px(8.0 * mono_font_scale(theme)))
+                            .py(px(4.0 * mono_font_scale(theme)))
+                            .rounded(px(7.0 * mono_font_scale(theme)))
                             .cursor_pointer()
                             .bg(theme.muted.opacity(0.05))
                             .hover(|s| s.bg(theme.muted.opacity(0.09)))
@@ -3212,12 +3230,12 @@ fn render_assistant_message(
                             .child(
                                 svg()
                                     .path("phosphor/caret-down.svg")
-                                    .size(px(10.0))
+                                    .size(mono_px(theme, 10.0))
                                     .text_color(theme.muted_foreground.opacity(0.55)),
                             )
                             .child(
                                 div()
-                                    .text_size(px(10.5))
+                                    .text_size(mono_px(theme, 10.5))
                                     .font_family(theme.mono_font_family.clone())
                                     .text_color(theme.muted_foreground.opacity(0.58))
                                     .child(format!("Show more · {remaining} blocks left")),
@@ -3229,8 +3247,8 @@ fn render_assistant_message(
             content_el = content_el.child(render_plain_multiline_text(
                 &msg.content,
                 theme.mono_font_family.clone(),
-                px(14.0),
-                px(23.0),
+                mono_px(theme, 14.0),
+                mono_px(theme, 23.0),
                 theme.foreground.opacity(0.88),
             ));
         }
@@ -3246,6 +3264,8 @@ fn render_assistant_message(
     }
 
     if !msg.steps.is_empty() {
+        let ui_scale = ui_font_scale(theme);
+        let mono_scale = mono_font_scale(theme);
         let step_count = msg.steps.len();
         let collapsed = msg.steps_collapsed;
         let chevron = if collapsed {
@@ -3273,16 +3293,16 @@ fn render_assistant_message(
 
         let run_panel = panel.clone();
         let mut run_card = div()
-            .ml(px(19.0))
-            .mr(px(4.0))
-            .mt(px(6.0))
-            .px(px(10.0))
-            .py(px(10.0))
-            .rounded(px(12.0))
+            .ml(px(19.0 * ui_scale))
+            .mr(px(4.0 * ui_scale))
+            .mt(px(6.0 * ui_scale))
+            .px(px(10.0 * ui_scale))
+            .py(px(10.0 * ui_scale))
+            .rounded(px(12.0 * ui_scale))
             .bg(trace_group_surface(theme))
             .flex()
             .flex_col()
-            .gap(px(10.0));
+            .gap(px(10.0 * ui_scale));
 
         run_card = run_card.child(
             div()
@@ -3290,11 +3310,11 @@ fn render_assistant_message(
                 .flex()
                 .items_center()
                 .min_w_0()
-                .gap(px(8.0))
-                .px(px(4.0))
-                .py(px(3.0))
+                .gap(px(8.0 * ui_scale))
+                .px(px(4.0 * ui_scale))
+                .py(px(3.0 * ui_scale))
                 .cursor_pointer()
-                .rounded(px(10.0))
+                .rounded(px(10.0 * ui_scale))
                 .hover(|s| s.bg(theme.muted.opacity(0.035)))
                 .on_mouse_down(MouseButton::Left, move |_, _, cx| {
                     let _ = run_panel.update(cx, |this, cx| {
@@ -3309,7 +3329,7 @@ fn render_assistant_message(
                 .child(
                     svg()
                         .path(chevron)
-                        .size(px(11.0))
+                        .size(ui_px(theme, 11.0))
                         .text_color(theme.muted_foreground.opacity(0.34)),
                 )
                 .child(
@@ -3318,18 +3338,18 @@ fn render_assistant_message(
                         .flex_col()
                         .flex_1()
                         .min_w_0()
-                        .gap(px(2.0))
+                        .gap(px(2.0 * ui_scale))
                         .child(render_section_kicker(run_title, theme))
                         .child(
                             div()
-                                .text_size(px(12.75))
+                                .text_size(ui_px(theme, 12.75))
                                 .font_weight(FontWeight::MEDIUM)
                                 .text_color(theme.foreground.opacity(0.74))
                                 .child("Actions, probes, and output"),
                         )
                         .child(
                             div()
-                                .text_size(px(10.75))
+                                .text_size(ui_px(theme, 10.75))
                                 .text_color(theme.muted_foreground.opacity(0.46))
                                 .min_w_0()
                                 .child("A compact trace of what the agent actually did"),
@@ -3339,11 +3359,11 @@ fn render_assistant_message(
                     let mut summary = div()
                         .flex()
                         .items_center()
-                        .gap(px(8.0))
+                        .gap(px(8.0 * ui_scale))
                         .flex_shrink_0()
                         .child(
                             div()
-                                .text_size(px(10.5))
+                                .text_size(mono_px(theme, 10.5))
                                 .font_family(theme.mono_font_family.clone())
                                 .text_color(theme.muted_foreground.opacity(0.40))
                                 .child(run_status_summary(step_count, running_count, denied_count)),
@@ -3367,7 +3387,7 @@ fn render_assistant_message(
         );
 
         if !collapsed {
-            let mut steps_el = div().flex().flex_col().gap(px(8.0));
+            let mut steps_el = div().flex().flex_col().gap(px(8.0 * ui_scale));
 
             for (step_idx, step) in msg.steps.iter().enumerate() {
                 let icon_color = match step.status {
@@ -3388,17 +3408,17 @@ fn render_assistant_message(
                 let mut top_line = div()
                     .flex()
                     .items_center()
-                    .gap(px(6.0))
+                    .gap(px(6.0 * ui_scale))
                     .child(
                         svg()
                             .path(step.icon)
-                            .size(px(12.0))
+                            .size(ui_px(theme, 12.0))
                             .flex_shrink_0()
                             .text_color(icon_color),
                     )
                     .child(
                         div()
-                            .text_size(px(12.5))
+                            .text_size(ui_px(theme, 12.5))
                             .text_color(theme.foreground.opacity(0.66))
                             .font_weight(FontWeight::MEDIUM)
                             .child(step_name.to_string()),
@@ -3413,7 +3433,7 @@ fn render_assistant_message(
                     top_line = top_line.child(
                         div()
                             .flex_shrink_0()
-                            .text_size(px(10.0))
+                            .text_size(mono_px(theme, 10.0))
                             .font_family(theme.mono_font_family.clone())
                             .text_color(theme.muted_foreground.opacity(0.36))
                             .child(format_step_duration(dur)),
@@ -3425,10 +3445,10 @@ fn render_assistant_message(
                         div()
                             .flex()
                             .items_center()
-                            .gap(px(4.0))
+                            .gap(px(4.0 * mono_scale))
                             .child(
                                 div()
-                                    .text_size(px(10.0))
+                                    .text_size(mono_px(theme, 10.0))
                                     .font_family(theme.mono_font_family.clone())
                                     .text_color(theme.muted_foreground.opacity(0.34))
                                     .child(if detail_collapsed { "Details" } else { "Hide" }),
@@ -3440,7 +3460,7 @@ fn render_assistant_message(
                                     } else {
                                         "phosphor/caret-down.svg"
                                     })
-                                    .size(px(10.0))
+                                    .size(mono_px(theme, 10.0))
                                     .flex_shrink_0()
                                     .text_color(theme.muted_foreground.opacity(0.30)),
                             ),
@@ -3450,17 +3470,17 @@ fn render_assistant_message(
                 let mut step_header = div()
                     .flex()
                     .flex_col()
-                    .gap(px(3.0))
-                    .px(px(12.0))
-                    .py(px(10.0))
+                    .gap(px(3.0 * ui_scale))
+                    .px(px(12.0 * ui_scale))
+                    .py(px(10.0 * ui_scale))
                     .child(top_line);
 
                 if let Some(detail_text) = step_detail {
                     step_header = step_header.child(
                         div()
-                            .ml(px(18.0))
-                            .text_size(px(10.5))
-                            .line_height(px(15.0))
+                            .ml(px(18.0 * mono_scale))
+                            .text_size(mono_px(theme, 10.5))
+                            .line_height(mono_px(theme, 15.0))
                             .text_color(theme.muted_foreground.opacity(0.56))
                             .font_family(theme.mono_font_family.clone())
                             .overflow_x_hidden()
@@ -3472,14 +3492,14 @@ fn render_assistant_message(
                 let mut step_shell = div()
                     .flex()
                     .flex_col()
-                    .rounded(px(12.0))
+                    .rounded(px(12.0 * ui_scale))
                     .overflow_hidden()
                     .bg(trace_step_surface(theme))
                     .gap(px(0.0));
 
                 let step_header_shell = step_header
                     .bg(trace_step_header_surface(theme))
-                    .min_h(px(44.0));
+                    .min_h(px(44.0 * ui_scale));
 
                 if has_detail {
                     let step_panel = panel.clone();
@@ -3517,8 +3537,8 @@ fn render_assistant_message(
                         result_preview(detail, TOOL_RESULT_PREVIEW_LINES)
                     };
                     let detail_block = div()
-                        .px(px(12.0))
-                        .pt(px(10.0))
+                        .px(px(12.0 * ui_scale))
+                        .pt(px(10.0 * ui_scale))
                         .bg(trace_detail_surface(theme))
                         .child(render_result_block(
                             &visible_detail,
@@ -3539,9 +3559,9 @@ fn render_assistant_message(
                         let button_label = result_toggle_label(detail, expanded);
                         let detail_toggle_panel = panel.clone();
                         let detail_toggle = div()
-                            .px(px(12.0))
-                            .pt(px(4.0))
-                            .pb(px(10.0))
+                            .px(px(12.0 * ui_scale))
+                            .pt(px(4.0 * ui_scale))
+                            .pb(px(10.0 * ui_scale))
                             .bg(trace_detail_surface(theme))
                             .child(
                                 div()
@@ -3549,7 +3569,9 @@ fn render_assistant_message(
                                         "step-detail-expand-{msg_idx}-{step_idx}"
                                     )))
                                     .cursor_pointer()
-                                    .hover(|s| s.bg(theme.muted.opacity(0.03)).rounded(px(6.0)))
+                                    .hover(|s| {
+                                        s.bg(theme.muted.opacity(0.03)).rounded(px(6.0 * ui_scale))
+                                    })
                                     .on_mouse_down(MouseButton::Left, move |_, _, cx| {
                                         let _ = detail_toggle_panel.update(cx, |this, cx| {
                                             if let Some(message) =
@@ -3563,9 +3585,16 @@ fn render_assistant_message(
                                             cx.notify();
                                         });
                                     })
-                                    .child(div().px(px(2.0)).py(px(2.0)).child(
-                                        render_result_toggle_chrome(expanded, button_label, theme),
-                                    )),
+                                    .child(
+                                        div()
+                                            .px(px(2.0 * mono_scale))
+                                            .py(px(2.0 * mono_scale))
+                                            .child(render_result_toggle_chrome(
+                                                expanded,
+                                                button_label,
+                                                theme,
+                                            )),
+                                    ),
                             );
                         step_shell = step_shell.child(
                             detail_toggle.with_animation(
@@ -3580,8 +3609,8 @@ fn render_assistant_message(
                     } else {
                         step_shell = step_shell.child(
                             div()
-                                .px(px(10.0))
-                                .pb(px(10.0))
+                                .px(px(10.0 * ui_scale))
+                                .pb(px(10.0 * ui_scale))
                                 .bg(trace_detail_surface(theme)),
                         );
                     }
@@ -3663,11 +3692,11 @@ impl AgentPanel {
         if is_system {
             msg_el = msg_el.child(
                 div()
-                    .px(px(6.0))
-                    .py(px(8.0))
-                    .text_size(px(12.5))
+                    .px(px(6.0 * ui_font_scale(theme)))
+                    .py(px(8.0 * ui_font_scale(theme)))
+                    .text_size(ui_px(theme, 12.5))
                     .text_color(theme.muted_foreground.opacity(0.40))
-                    .line_height(px(19.0))
+                    .line_height(ui_px(theme, 19.0))
                     .child(msg.content.clone()),
             );
         } else if is_user {
@@ -3922,42 +3951,44 @@ impl Render for AgentPanel {
             .collect();
 
         if !visible_tool_calls.is_empty() {
+            let ui_scale = ui_font_scale(theme);
+            let mono_scale = mono_font_scale(theme);
             let mut tc_container = div()
                 .flex()
                 .flex_col()
-                .ml(px(19.0))
-                .mr(px(4.0))
-                .gap(px(10.0))
-                .px(px(10.0))
-                .py(px(10.0))
-                .rounded(px(12.0))
+                .ml(px(19.0 * ui_scale))
+                .mr(px(4.0 * ui_scale))
+                .gap(px(10.0 * ui_scale))
+                .px(px(10.0 * ui_scale))
+                .py(px(10.0 * ui_scale))
+                .rounded(px(12.0 * ui_scale))
                 .bg(trace_group_surface(theme))
                 .child(
                     div()
                         .flex()
                         .items_center()
                         .min_w_0()
-                        .gap(px(8.0))
-                        .px(px(4.0))
-                        .py(px(3.0))
+                        .gap(px(8.0 * ui_scale))
+                        .px(px(4.0 * ui_scale))
+                        .py(px(3.0 * ui_scale))
                         .child(
                             div()
                                 .flex()
                                 .flex_col()
                                 .flex_1()
                                 .min_w_0()
-                                .gap(px(2.0))
+                                .gap(px(2.0 * ui_scale))
                                 .child(render_section_kicker("Working now", theme))
                                 .child(
                                     div()
-                                        .text_size(px(12.75))
+                                        .text_size(ui_px(theme, 12.75))
                                         .font_weight(FontWeight::MEDIUM)
                                         .text_color(theme.foreground.opacity(0.74))
                                         .child("Live tools for this reply"),
                                 )
                                 .child(
                                     div()
-                                        .text_size(px(10.75))
+                                        .text_size(ui_px(theme, 10.75))
                                         .text_color(theme.muted_foreground.opacity(0.46))
                                         .min_w_0()
                                         .child("Commands and reads still in progress"),
@@ -3993,7 +4024,7 @@ impl Render for AgentPanel {
                 let icon_el: AnyElement = if is_done {
                     svg()
                         .path(icon)
-                        .size(px(12.0))
+                        .size(ui_px(theme, 12.0))
                         .flex_shrink_0()
                         .text_color(icon_color)
                         .into_any_element()
@@ -4010,11 +4041,11 @@ impl Render for AgentPanel {
                 let top_line = div()
                     .flex()
                     .items_center()
-                    .gap(px(6.0))
+                    .gap(px(6.0 * ui_scale))
                     .child(icon_el)
                     .child(
                         div()
-                            .text_size(px(12.5))
+                            .text_size(ui_px(theme, 12.5))
                             .text_color(theme.foreground.opacity(0.66))
                             .font_weight(FontWeight::MEDIUM)
                             .child(human_name),
@@ -4023,7 +4054,7 @@ impl Render for AgentPanel {
                     .child(
                         div()
                             .flex_shrink_0()
-                            .text_size(px(10.0))
+                            .text_size(ui_px(theme, 10.0))
                             .text_color(theme.muted_foreground.opacity(0.36))
                             .child(format_step_duration(dur)),
                     );
@@ -4036,17 +4067,17 @@ impl Render for AgentPanel {
                 let mut tc_row = div()
                     .flex()
                     .flex_col()
-                    .gap(px(3.0))
-                    .px(px(12.0))
-                    .py(px(10.0))
+                    .gap(px(3.0 * ui_scale))
+                    .px(px(12.0 * ui_scale))
+                    .py(px(10.0 * ui_scale))
                     .child(top_line);
 
                 // Args on second line
                 if !args_display.is_empty() {
                     tc_row = tc_row.child(
                         div()
-                            .ml(px(18.0))
-                            .text_size(px(10.75))
+                            .ml(px(18.0 * mono_scale))
+                            .text_size(mono_px(theme, 10.75))
                             .text_color(theme.muted_foreground.opacity(0.50))
                             .font_family(theme.mono_font_family.clone())
                             .overflow_x_hidden()
@@ -4058,11 +4089,15 @@ impl Render for AgentPanel {
                 let mut tc_el = div()
                     .flex()
                     .flex_col()
-                    .rounded(px(12.0))
+                    .rounded(px(12.0 * ui_scale))
                     .overflow_hidden()
                     .bg(trace_step_surface(theme))
                     .gap(px(0.0))
-                    .child(tc_row.bg(trace_step_header_surface(theme)).min_h(px(44.0)));
+                    .child(
+                        tc_row
+                            .bg(trace_step_header_surface(theme))
+                            .min_h(px(44.0 * ui_scale)),
+                    );
 
                 // Result preview
                 if let Some(result) = &tc.result {
@@ -4496,19 +4531,20 @@ impl Render for AgentPanel {
 
         let live_activity_strip = if let Some(approval) = self.state.pending_approvals.first() {
             let args_display = format_tool_args(&approval.tool_name, &approval.args);
+            let ui_scale = ui_font_scale(theme);
             Some(
                 div()
                     .flex()
                     .flex_col()
-                    .gap(px(7.0))
-                    .mx(px(14.0))
-                    .mb(px(8.0))
+                    .gap(px(7.0 * ui_scale))
+                    .mx(px(14.0 * ui_scale))
+                    .mb(px(8.0 * ui_scale))
                     .child(render_section_kicker("Needs approval", theme))
                     .child(
                         div()
                             .flex()
                             .items_center()
-                            .gap(px(8.0))
+                            .gap(px(8.0 * ui_scale))
                             .child(render_inline_state(
                                 "Approval waiting".into(),
                                 theme.warning,
@@ -4516,8 +4552,8 @@ impl Render for AgentPanel {
                             ))
                             .child(
                                 div()
-                                    .text_size(px(10.5))
-                                    .line_height(px(15.0))
+                                    .text_size(mono_px(theme, 10.5))
+                                    .line_height(mono_px(theme, 15.0))
                                     .font_family(theme.mono_font_family.clone())
                                     .text_color(theme.muted_foreground.opacity(0.60))
                                     .min_w_0()
@@ -4532,31 +4568,32 @@ impl Render for AgentPanel {
         } else if let Some(tc) = self.running_tool_call() {
             let args_display = format_tool_args(&tc.tool_name, &tc.args);
             let human_name = humanize_tool_name(&tc.tool_name);
+            let ui_scale = ui_font_scale(theme);
             Some(
                 div()
                     .flex()
                     .flex_col()
-                    .gap(px(7.0))
-                    .mx(px(14.0))
-                    .mb(px(8.0))
+                    .gap(px(7.0 * ui_scale))
+                    .mx(px(14.0 * ui_scale))
+                    .mb(px(8.0 * ui_scale))
                     .child(render_section_kicker("Current run", theme))
                     .child(
                         div()
                             .flex()
                             .items_center()
-                            .gap(px(8.0))
+                            .gap(px(8.0 * ui_scale))
                             .child(Spinner::new().small().color(theme.warning))
                             .child(
                                 div()
-                                    .text_size(px(12.0))
+                                    .text_size(ui_px(theme, 12.0))
                                     .font_weight(FontWeight::MEDIUM)
                                     .text_color(theme.foreground.opacity(0.74))
                                     .child(human_name),
                             )
                             .child(
                                 div()
-                                    .text_size(px(10.5))
-                                    .line_height(px(15.0))
+                                    .text_size(mono_px(theme, 10.5))
+                                    .line_height(mono_px(theme, 15.0))
                                     .font_family(theme.mono_font_family.clone())
                                     .text_color(theme.muted_foreground.opacity(0.60))
                                     .min_w_0()
@@ -4569,19 +4606,20 @@ impl Render for AgentPanel {
                     .into_any_element(),
             )
         } else if let Some((_icon, label)) = self.status_text() {
+            let ui_scale = ui_font_scale(theme);
             Some(
                 div()
                     .flex()
                     .flex_col()
-                    .gap(px(7.0))
-                    .mx(px(14.0))
-                    .mb(px(8.0))
+                    .gap(px(7.0 * ui_scale))
+                    .mx(px(14.0 * ui_scale))
+                    .mb(px(8.0 * ui_scale))
                     .child(render_section_kicker("Live status", theme))
                     .child(
                         div()
                             .flex()
                             .items_center()
-                            .gap(px(8.0))
+                            .gap(px(8.0 * ui_scale))
                             .child(
                                 Spinner::new()
                                     .small()
@@ -4589,7 +4627,7 @@ impl Render for AgentPanel {
                             )
                             .child(
                                 div()
-                                    .text_size(px(12.0))
+                                    .text_size(ui_px(theme, 12.0))
                                     .text_color(theme.foreground.opacity(0.66))
                                     .child(label),
                             ),
@@ -4613,6 +4651,7 @@ impl Render for AgentPanel {
             .items_stretch()
             .bg(theme.title_bar.opacity(self.ui_opacity))
             .font_family(theme.font_family.clone())
+            .text_size(theme.font_size)
             .child(header)
             .child(Divider::horizontal().color(theme.muted.opacity(0.08)));
 
@@ -4846,6 +4885,9 @@ impl Render for AgentPanel {
 
             let has_text = self.inline_input_has_text;
             let has_skills = self.inline_input_has_skills;
+            let mono_scale = mono_font_scale(theme);
+            let inline_control_size = mono_px(theme, 24.0);
+            let inline_input_text_size = mono_px(theme, 13.0);
 
             // Send button — circular, matches main input bar
             let send_button = div()
@@ -4853,8 +4895,8 @@ impl Render for AgentPanel {
                 .flex()
                 .items_center()
                 .justify_center()
-                .size(px(24.0))
-                .rounded(px(12.0))
+                .size(inline_control_size)
+                .rounded(px(12.0 * mono_scale))
                 .cursor_pointer()
                 .flex_shrink_0()
                 .bg(if has_text && !has_skills {
@@ -4884,7 +4926,7 @@ impl Render for AgentPanel {
                 .child(
                     svg()
                         .path("phosphor/arrow-up.svg")
-                        .size(px(12.0))
+                        .size(mono_px(theme, 12.0))
                         .text_color(if has_text && !has_skills {
                             theme.primary_foreground
                         } else {
@@ -4895,9 +4937,9 @@ impl Render for AgentPanel {
             panel = panel.child(
                 div()
                     .absolute()
-                    .left(px(8.0))
-                    .right(px(9.0))
-                    .bottom(px(8.0))
+                    .left(px(8.0 * mono_scale))
+                    .right(px(9.0 * mono_scale))
+                    .bottom(px(8.0 * mono_scale))
                     .on_key_down(cx.listener(move |this, event: &KeyDownEvent, window, cx| {
                         let key = event.keystroke.key.as_str();
                         let has_completions = !this.filtered_inline_skills(cx).is_empty();
@@ -4940,12 +4982,12 @@ impl Render for AgentPanel {
                             .flex()
                             .items_center()
                             .w_full()
-                            .min_h(px(46.0))
-                            .gap(px(8.0))
-                            .pl(px(7.0))
-                            .pr(px(8.0))
-                            .py(px(8.0))
-                            .rounded(px(14.0))
+                            .min_h(px(46.0 * mono_scale))
+                            .gap(px(8.0 * mono_scale))
+                            .pl(px(7.0 * mono_scale))
+                            .pr(px(8.0 * mono_scale))
+                            .py(px(8.0 * mono_scale))
+                            .rounded(px(14.0 * mono_scale))
                             .bg(theme.background)
                             .on_mouse_down(
                                 MouseButton::Left,
@@ -4960,15 +5002,16 @@ impl Render for AgentPanel {
                                 div()
                                     .flex_1()
                                     .w_full()
-                                    .min_w(px(120.0))
+                                    .min_w(px(120.0 * mono_scale))
                                     .font_family(theme.mono_font_family.clone())
-                                    .text_size(px(13.0))
+                                    .text_size(inline_input_text_size)
                                     .child(
                                         div().w_full().child(
                                             Input::new(&inline_input)
                                                 .appearance(false)
                                                 .cleanable(false)
-                                                .font_family(theme.mono_font_family.clone()),
+                                                .font_family(theme.mono_font_family.clone())
+                                                .text_size(inline_input_text_size),
                                         ),
                                     ),
                             )

--- a/crates/con-app/src/agent_panel.rs
+++ b/crates/con-app/src/agent_panel.rs
@@ -3000,7 +3000,7 @@ fn render_user_message_text(
             block.child(
                 div()
                     .id(format!("user-msg-{msg_idx}-blank-{line_idx}"))
-                    .h(px(10.0)),
+                    .h(ui_space_px(theme, 10.0)),
             )
         } else {
             block.child(

--- a/crates/con-app/src/chat_markdown.rs
+++ b/crates/con-app/src/chat_markdown.rs
@@ -18,6 +18,8 @@ use gpui_component::{Colorize, Theme};
 use markdown::{ParseOptions, mdast};
 use ropey::Rope;
 
+use crate::ui_scale::{mono_px, ui_px};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChatMarkdownTone {
     Message,
@@ -293,10 +295,10 @@ impl<'a> ChatMarkdownStyle<'a> {
                 theme,
                 tone,
                 content_width: px(720.0),
-                base_font_size: px(15.0),
-                base_line_height: px(24.0),
+                base_font_size: ui_px(theme, 15.0),
+                base_line_height: ui_px(theme, 24.0),
                 code_font_size: theme.mono_font_size,
-                code_line_height: px(21.0),
+                code_line_height: mono_px(theme, 21.0),
                 text_color: theme.foreground.opacity(0.88),
                 muted_text_color: theme.muted_foreground.opacity(0.74),
                 inline_code_background: theme
@@ -321,17 +323,17 @@ impl<'a> ChatMarkdownStyle<'a> {
                 link_color: theme.primary,
                 table_border: theme.muted_foreground.opacity(0.10),
                 table_cell_background: theme.background.opacity(0.96),
-                block_gap: px(13.0),
-                inner_gap: px(9.0),
+                block_gap: ui_px(theme, 13.0),
+                inner_gap: ui_px(theme, 9.0),
             },
             ChatMarkdownTone::Thinking => Self {
                 theme,
                 tone,
                 content_width: px(640.0),
-                base_font_size: px(12.75),
-                base_line_height: px(20.0),
+                base_font_size: ui_px(theme, 12.75),
+                base_line_height: ui_px(theme, 20.0),
                 code_font_size: theme.mono_font_size,
-                code_line_height: px(19.0),
+                code_line_height: mono_px(theme, 19.0),
                 text_color: theme.muted_foreground.opacity(0.66),
                 muted_text_color: theme.muted_foreground.opacity(0.58),
                 inline_code_background: theme
@@ -356,8 +358,8 @@ impl<'a> ChatMarkdownStyle<'a> {
                 link_color: theme.primary.opacity(0.82),
                 table_border: theme.muted_foreground.opacity(0.08),
                 table_cell_background: theme.background.opacity(0.82),
-                block_gap: px(10.0),
-                inner_gap: px(8.0),
+                block_gap: ui_px(theme, 10.0),
+                inner_gap: ui_px(theme, 8.0),
             },
         }
     }
@@ -377,12 +379,36 @@ impl<'a> ChatMarkdownStyle<'a> {
 
     fn heading_text_style(&self, level: u8) -> TextStyle {
         let (font_size, line_height, weight) = match (self.tone, level) {
-            (ChatMarkdownTone::Message, 1) => (px(19.0), px(27.0), FontWeight::BOLD),
-            (ChatMarkdownTone::Message, 2) => (px(17.0), px(25.0), FontWeight::SEMIBOLD),
-            (ChatMarkdownTone::Message, 3) => (px(15.5), px(23.0), FontWeight::SEMIBOLD),
-            (ChatMarkdownTone::Thinking, 1) => (px(14.5), px(21.0), FontWeight::SEMIBOLD),
-            (ChatMarkdownTone::Thinking, 2) => (px(13.5), px(20.0), FontWeight::SEMIBOLD),
-            (ChatMarkdownTone::Thinking, _) => (px(12.75), px(19.0), FontWeight::MEDIUM),
+            (ChatMarkdownTone::Message, 1) => (
+                ui_px(self.theme, 19.0),
+                ui_px(self.theme, 27.0),
+                FontWeight::BOLD,
+            ),
+            (ChatMarkdownTone::Message, 2) => (
+                ui_px(self.theme, 17.0),
+                ui_px(self.theme, 25.0),
+                FontWeight::SEMIBOLD,
+            ),
+            (ChatMarkdownTone::Message, 3) => (
+                ui_px(self.theme, 15.5),
+                ui_px(self.theme, 23.0),
+                FontWeight::SEMIBOLD,
+            ),
+            (ChatMarkdownTone::Thinking, 1) => (
+                ui_px(self.theme, 14.5),
+                ui_px(self.theme, 21.0),
+                FontWeight::SEMIBOLD,
+            ),
+            (ChatMarkdownTone::Thinking, 2) => (
+                ui_px(self.theme, 13.5),
+                ui_px(self.theme, 20.0),
+                FontWeight::SEMIBOLD,
+            ),
+            (ChatMarkdownTone::Thinking, _) => (
+                ui_px(self.theme, 12.75),
+                ui_px(self.theme, 19.0),
+                FontWeight::MEDIUM,
+            ),
             (_, _) => (
                 self.base_font_size,
                 self.base_line_height,

--- a/crates/con-app/src/input_bar.rs
+++ b/crates/con-app/src/input_bar.rs
@@ -5,6 +5,8 @@ use gpui_component::{
     tooltip::Tooltip,
 };
 
+use crate::ui_scale::{mono_font_scale, mono_px};
+
 actions!(
     input_bar,
     [
@@ -1174,6 +1176,10 @@ impl Render for InputBar {
         let has_text = !input_state.read(cx).value().trim().is_empty();
         let input_value = input_state.read(cx).value().to_string();
         let input_cursor = input_state.read(cx).cursor();
+        let mono_scale = mono_font_scale(theme);
+        let control_size = mono_px(theme, 24.0);
+        let mode_icon_size = mono_px(theme, 14.0);
+        let compact_icon_size = mono_px(theme, 11.0);
 
         let mode_tint = self.mode.tint(cx);
 
@@ -1183,8 +1189,8 @@ impl Render for InputBar {
             .flex()
             .items_center()
             .justify_center()
-            .size(px(24.0))
-            .rounded(px(6.0))
+            .size(control_size)
+            .rounded(px(6.0 * mono_scale))
             .cursor_pointer()
             .bg(mode_tint.opacity(0.08))
             .hover(|s| s.bg(mode_tint.opacity(0.14)))
@@ -1201,7 +1207,7 @@ impl Render for InputBar {
             .child(
                 svg()
                     .path(self.mode.icon())
-                    .size(px(14.0))
+                    .size(mode_icon_size)
                     .text_color(mode_tint),
             );
 
@@ -1222,9 +1228,9 @@ impl Render for InputBar {
                     .child(
                         div()
                             .id("pane-scope")
-                            .h(px(24.0))
-                            .px(px(8.0))
-                            .rounded(px(7.0))
+                            .h(control_size)
+                            .px(px(8.0 * mono_scale))
+                            .rounded(px(7.0 * mono_scale))
                             .cursor_pointer()
                             .flex()
                             .items_center()
@@ -1257,11 +1263,16 @@ impl Render for InputBar {
                                         .update(cx, |state, cx| state.focus(window, cx));
                                 }),
                             )
-                            .child(svg().path(scope_icon).size(px(11.0)).text_color(scope_tint))
+                            .child(
+                                svg()
+                                    .path(scope_icon)
+                                    .size(compact_icon_size)
+                                    .text_color(scope_tint),
+                            )
                             .child(
                                 div()
-                                    .text_size(px(10.5))
-                                    .line_height(px(12.0))
+                                    .text_size(mono_px(theme, 10.5))
+                                    .line_height(mono_px(theme, 12.0))
                                     .font_family(theme.mono_font_family.clone())
                                     .font_weight(FontWeight::MEDIUM)
                                     .text_color(
@@ -1288,8 +1299,8 @@ impl Render for InputBar {
             .flex()
             .items_center()
             .justify_center()
-            .size(px(24.0))
-            .rounded(px(12.0))
+            .size(control_size)
+            .rounded(px(12.0 * mono_scale))
             .cursor_pointer()
             .flex_shrink_0()
             .bg(if has_text {
@@ -1313,7 +1324,7 @@ impl Render for InputBar {
             .child(
                 svg()
                     .path("phosphor/arrow-up.svg")
-                    .size(px(12.0))
+                    .size(mono_px(theme, 12.0))
                     .text_color(if has_text {
                         theme.primary_foreground
                     } else {
@@ -1324,8 +1335,8 @@ impl Render for InputBar {
         // Keep all terminal-adjacent inputs in the mono family for consistency.
         let input_font = theme.mono_font_family.clone();
         let input_text_size = match self.mode {
-            InputMode::Agent => px(14.0),
-            _ => px(13.0),
+            InputMode::Agent => mono_px(theme, 14.0),
+            _ => mono_px(theme, 13.0),
         };
         let input_line_height = match self.mode {
             InputMode::Agent => rems(1.15),
@@ -1367,7 +1378,7 @@ impl Render for InputBar {
 
         let input_field = div()
             .flex_1()
-            .min_h(px(24.0))
+            .min_h(control_size)
             .relative()
             .key_context("ConCommandInput")
             .on_action(cx.listener(|this, _: &AcceptSuggestion, window, cx| {
@@ -1508,7 +1519,7 @@ impl Render for InputBar {
                     .right_0()
                     .top_0()
                     .bottom_0()
-                    .px(px(12.0))
+                    .px(px(12.0 * mono_scale))
                     .flex()
                     .items_center()
                     .line_height(input_line_height)
@@ -1531,7 +1542,7 @@ impl Render for InputBar {
                     .right_0()
                     .top_0()
                     .bottom_0()
-                    .px(px(12.0))
+                    .px(px(12.0 * mono_scale))
                     .flex()
                     .items_center()
                     .line_height(input_line_height)
@@ -1559,8 +1570,8 @@ impl Render for InputBar {
                         })
                         .text_size(input_text_size)
                         .line_height(input_line_height)
-                        .pl(px(12.0))
-                        .h(px(24.0))
+                        .pl(px(12.0 * mono_scale))
+                        .h(control_size)
                         .into_any_element()
                 } else {
                     Input::new(&input_state)
@@ -1574,7 +1585,7 @@ impl Render for InputBar {
                         })
                         .text_size(input_text_size)
                         .line_height(input_line_height)
-                        .h(px(24.0))
+                        .h(control_size)
                         .into_any_element()
                 },
             ));
@@ -1589,13 +1600,13 @@ impl Render for InputBar {
             // ── Flat container ──
             .child(
                 div()
-                    .px(px(12.0))
-                    .py(px(7.0))
-                    .min_h(px(42.0))
+                    .px(px(12.0 * mono_scale))
+                    .py(px(7.0 * mono_scale))
+                    .min_h(px(42.0 * mono_scale))
                     .flex()
                     .items_center()
-                    .h(px(30.0))
-                    .gap(px(8.0))
+                    .h(px(30.0 * mono_scale))
+                    .gap(px(8.0 * mono_scale))
                     .child(mode_prefix)
                     .children(pane_row)
                     .child(div().flex_1().min_w_0().child(input_field))

--- a/crates/con-app/src/input_bar.rs
+++ b/crates/con-app/src/input_bar.rs
@@ -5,7 +5,7 @@ use gpui_component::{
     tooltip::Tooltip,
 };
 
-use crate::ui_scale::{mono_font_scale, mono_px};
+use crate::ui_scale::{mono_density_scale, mono_px, mono_space_px};
 
 actions!(
     input_bar,
@@ -1176,10 +1176,10 @@ impl Render for InputBar {
         let has_text = !input_state.read(cx).value().trim().is_empty();
         let input_value = input_state.read(cx).value().to_string();
         let input_cursor = input_state.read(cx).cursor();
-        let mono_scale = mono_font_scale(theme);
-        let control_size = mono_px(theme, 24.0);
-        let mode_icon_size = mono_px(theme, 14.0);
-        let compact_icon_size = mono_px(theme, 11.0);
+        let mono_scale = mono_density_scale(theme);
+        let control_size = mono_space_px(theme, 24.0);
+        let mode_icon_size = mono_space_px(theme, 14.0);
+        let compact_icon_size = mono_space_px(theme, 11.0);
 
         let mode_tint = self.mode.tint(cx);
 
@@ -1324,7 +1324,7 @@ impl Render for InputBar {
             .child(
                 svg()
                     .path("phosphor/arrow-up.svg")
-                    .size(mono_px(theme, 12.0))
+                    .size(mono_space_px(theme, 12.0))
                     .text_color(if has_text {
                         theme.primary_foreground
                     } else {

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -71,6 +71,7 @@ mod terminal_paste;
 mod terminal_restore;
 mod terminal_shortcuts;
 mod theme;
+mod ui_scale;
 mod updater;
 mod workspace;
 

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -23,6 +23,7 @@ use gpui_component::{ActiveTheme, Disableable, Icon, IndexPath, Sizable as _, in
 
 use crate::model_registry::ModelRegistry;
 use crate::motion::{MotionValue, vertical_reveal_offset};
+use crate::ui_scale::ui_density_scale;
 use std::collections::HashMap;
 use std::sync::Arc;
 use url::Url;
@@ -5383,7 +5384,12 @@ impl Render for SettingsPanel {
         let save_button_tint = theme
             .foreground
             .opacity(if theme.is_dark() { 0.84 } else { 0.78 });
-        let save_button_style = ButtonCustomVariant::new(cx).color(save_button_tint);
+        let save_button_style = ButtonCustomVariant::new(cx)
+            .color(save_button_tint.opacity(0.10))
+            .foreground(save_button_tint)
+            .hover(save_button_tint.opacity(0.16))
+            .active(save_button_tint.opacity(0.20));
+        let header_density = ui_density_scale(theme);
         let surface_rounding = if self.standalone { px(0.0) } else { px(12.0) };
         let header_left_padding = if self.standalone && cfg!(target_os = "macos") {
             px(78.0)
@@ -5571,10 +5577,28 @@ impl Render for SettingsPanel {
                                                 Button::new("settings-apply")
                                                     .small()
                                                     .compact()
-                                                    .rounded(px(8.0))
                                                     .custom(save_button_style)
-                                                    .icon(Icon::default().path("phosphor/check.svg"))
-                                                    .label("Save Changes")
+                                                    .h(px(30.0 * header_density))
+                                                    .px(px(11.0 * header_density))
+                                                    .rounded(px(9.0 * header_density))
+                                                    .gap(px(6.0 * header_density))
+                                                    .child(
+                                                        svg()
+                                                            .path("phosphor/check.svg")
+                                                            .size(px(13.0 * header_density))
+                                                            .text_color(save_button_tint),
+                                                    )
+                                                    .child(
+                                                        div()
+                                                            .text_size(px(13.0 * header_density))
+                                                            .line_height(px(
+                                                                16.0 * header_density,
+                                                            ))
+                                                            .font_weight(FontWeight::MEDIUM)
+                                                            .text_color(save_button_tint)
+                                                            .whitespace_nowrap()
+                                                            .child("Save Changes"),
+                                                    )
                                                     .on_click(cx.listener(|this, _, window, cx| {
                                                         this.save(window, cx);
                                                     })),

--- a/crates/con-app/src/ui_scale.rs
+++ b/crates/con-app/src/ui_scale.rs
@@ -1,0 +1,49 @@
+use gpui::{Pixels, px};
+use gpui_component::Theme;
+
+const DEFAULT_UI_FONT_SIZE: f32 = 16.0;
+const DEFAULT_MONO_FONT_SIZE: f32 = 13.0;
+const MIN_FONT_SCALE: f32 = 0.85;
+const MAX_FONT_SCALE: f32 = 1.70;
+
+pub(crate) fn ui_font_scale(theme: &Theme) -> f32 {
+    font_scale(theme.font_size.as_f32(), DEFAULT_UI_FONT_SIZE)
+}
+
+pub(crate) fn mono_font_scale(theme: &Theme) -> f32 {
+    font_scale(theme.mono_font_size.as_f32(), DEFAULT_MONO_FONT_SIZE)
+}
+
+pub(crate) fn ui_px(theme: &Theme, base_px: f32) -> Pixels {
+    px(base_px * ui_font_scale(theme))
+}
+
+pub(crate) fn mono_px(theme: &Theme, base_px: f32) -> Pixels {
+    px(base_px * mono_font_scale(theme))
+}
+
+fn font_scale(current_px: f32, default_px: f32) -> f32 {
+    if !current_px.is_finite() || !default_px.is_finite() || default_px <= 0.0 {
+        return 1.0;
+    }
+
+    (current_px / default_px).clamp(MIN_FONT_SCALE, MAX_FONT_SCALE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::font_scale;
+
+    #[test]
+    fn font_scale_preserves_default_and_clamps_extremes() {
+        assert_eq!(font_scale(16.0, 16.0), 1.0);
+        assert_eq!(font_scale(1.0, 16.0), 0.85);
+        assert_eq!(font_scale(200.0, 16.0), 1.70);
+    }
+
+    #[test]
+    fn font_scale_ignores_invalid_values() {
+        assert_eq!(font_scale(f32::NAN, 16.0), 1.0);
+        assert_eq!(font_scale(16.0, 0.0), 1.0);
+    }
+}

--- a/crates/con-app/src/ui_scale.rs
+++ b/crates/con-app/src/ui_scale.rs
@@ -5,6 +5,9 @@ const DEFAULT_UI_FONT_SIZE: f32 = 16.0;
 const DEFAULT_MONO_FONT_SIZE: f32 = 13.0;
 const MIN_FONT_SCALE: f32 = 0.85;
 const MAX_FONT_SCALE: f32 = 1.70;
+const MIN_DENSITY_SCALE: f32 = 0.92;
+const MAX_DENSITY_SCALE: f32 = 1.25;
+const DENSITY_SCALE_WEIGHT: f32 = 0.45;
 
 pub(crate) fn ui_font_scale(theme: &Theme) -> f32 {
     font_scale(theme.font_size.as_f32(), DEFAULT_UI_FONT_SIZE)
@@ -12,6 +15,14 @@ pub(crate) fn ui_font_scale(theme: &Theme) -> f32 {
 
 pub(crate) fn mono_font_scale(theme: &Theme) -> f32 {
     font_scale(theme.mono_font_size.as_f32(), DEFAULT_MONO_FONT_SIZE)
+}
+
+pub(crate) fn ui_density_scale(theme: &Theme) -> f32 {
+    density_scale(ui_font_scale(theme))
+}
+
+pub(crate) fn mono_density_scale(theme: &Theme) -> f32 {
+    density_scale(mono_font_scale(theme))
 }
 
 pub(crate) fn ui_px(theme: &Theme, base_px: f32) -> Pixels {
@@ -22,6 +33,14 @@ pub(crate) fn mono_px(theme: &Theme, base_px: f32) -> Pixels {
     px(base_px * mono_font_scale(theme))
 }
 
+pub(crate) fn ui_space_px(theme: &Theme, base_px: f32) -> Pixels {
+    px(base_px * ui_density_scale(theme))
+}
+
+pub(crate) fn mono_space_px(theme: &Theme, base_px: f32) -> Pixels {
+    px(base_px * mono_density_scale(theme))
+}
+
 fn font_scale(current_px: f32, default_px: f32) -> f32 {
     if !current_px.is_finite() || !default_px.is_finite() || default_px <= 0.0 {
         return 1.0;
@@ -30,9 +49,17 @@ fn font_scale(current_px: f32, default_px: f32) -> f32 {
     (current_px / default_px).clamp(MIN_FONT_SCALE, MAX_FONT_SCALE)
 }
 
+fn density_scale(font_scale: f32) -> f32 {
+    if !font_scale.is_finite() {
+        return 1.0;
+    }
+
+    (1.0 + (font_scale - 1.0) * DENSITY_SCALE_WEIGHT).clamp(MIN_DENSITY_SCALE, MAX_DENSITY_SCALE)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::font_scale;
+    use super::{density_scale, font_scale};
 
     #[test]
     fn font_scale_preserves_default_and_clamps_extremes() {
@@ -45,5 +72,12 @@ mod tests {
     fn font_scale_ignores_invalid_values() {
         assert_eq!(font_scale(f32::NAN, 16.0), 1.0);
         assert_eq!(font_scale(16.0, 0.0), 1.0);
+    }
+
+    #[test]
+    fn density_scale_grows_slower_than_text() {
+        assert_eq!(density_scale(1.0), 1.0);
+        assert!(density_scale(1.5) < 1.5);
+        assert_eq!(density_scale(1.7), 1.25);
     }
 }

--- a/crates/con-app/src/ui_scale.rs
+++ b/crates/con-app/src/ui_scale.rs
@@ -1,20 +1,29 @@
+use con_core::config::{MAX_UI_FONT_SIZE, MIN_UI_FONT_SIZE};
 use gpui::{Pixels, px};
 use gpui_component::Theme;
 
 const DEFAULT_UI_FONT_SIZE: f32 = 16.0;
 const DEFAULT_MONO_FONT_SIZE: f32 = 13.0;
-const MIN_FONT_SCALE: f32 = 0.85;
-const MAX_FONT_SCALE: f32 = 1.70;
 const MIN_DENSITY_SCALE: f32 = 0.92;
 const MAX_DENSITY_SCALE: f32 = 1.25;
 const DENSITY_SCALE_WEIGHT: f32 = 0.45;
 
 pub(crate) fn ui_font_scale(theme: &Theme) -> f32 {
-    font_scale(theme.font_size.as_f32(), DEFAULT_UI_FONT_SIZE)
+    font_scale(
+        theme.font_size.as_f32(),
+        DEFAULT_UI_FONT_SIZE,
+        MIN_UI_FONT_SIZE / DEFAULT_UI_FONT_SIZE,
+        MAX_UI_FONT_SIZE / DEFAULT_UI_FONT_SIZE,
+    )
 }
 
 pub(crate) fn mono_font_scale(theme: &Theme) -> f32 {
-    font_scale(theme.mono_font_size.as_f32(), DEFAULT_MONO_FONT_SIZE)
+    font_scale(
+        theme.mono_font_size.as_f32(),
+        DEFAULT_MONO_FONT_SIZE,
+        (MIN_UI_FONT_SIZE - 1.0) / DEFAULT_MONO_FONT_SIZE,
+        (MAX_UI_FONT_SIZE - 3.0) / DEFAULT_MONO_FONT_SIZE,
+    )
 }
 
 pub(crate) fn ui_density_scale(theme: &Theme) -> f32 {
@@ -41,12 +50,18 @@ pub(crate) fn mono_space_px(theme: &Theme, base_px: f32) -> Pixels {
     px(base_px * mono_density_scale(theme))
 }
 
-fn font_scale(current_px: f32, default_px: f32) -> f32 {
-    if !current_px.is_finite() || !default_px.is_finite() || default_px <= 0.0 {
+fn font_scale(current_px: f32, default_px: f32, min_scale: f32, max_scale: f32) -> f32 {
+    if !current_px.is_finite()
+        || !default_px.is_finite()
+        || !min_scale.is_finite()
+        || !max_scale.is_finite()
+        || default_px <= 0.0
+        || min_scale > max_scale
+    {
         return 1.0;
     }
 
-    (current_px / default_px).clamp(MIN_FONT_SCALE, MAX_FONT_SCALE)
+    (current_px / default_px).clamp(min_scale, max_scale)
 }
 
 fn density_scale(font_scale: f32) -> f32 {
@@ -63,15 +78,16 @@ mod tests {
 
     #[test]
     fn font_scale_preserves_default_and_clamps_extremes() {
-        assert_eq!(font_scale(16.0, 16.0), 1.0);
-        assert_eq!(font_scale(1.0, 16.0), 0.85);
-        assert_eq!(font_scale(200.0, 16.0), 1.70);
+        assert_eq!(font_scale(16.0, 16.0, 0.75, 1.5), 1.0);
+        assert_eq!(font_scale(1.0, 16.0, 0.75, 1.5), 0.75);
+        assert_eq!(font_scale(200.0, 16.0, 0.75, 1.5), 1.5);
     }
 
     #[test]
     fn font_scale_ignores_invalid_values() {
-        assert_eq!(font_scale(f32::NAN, 16.0), 1.0);
-        assert_eq!(font_scale(16.0, 0.0), 1.0);
+        assert_eq!(font_scale(f32::NAN, 16.0, 0.75, 1.5), 1.0);
+        assert_eq!(font_scale(16.0, 0.0, 0.75, 1.5), 1.0);
+        assert_eq!(font_scale(16.0, 16.0, 1.5, 0.75), 1.0);
     }
 
     #[test]

--- a/postmortem/2026-05-11-ui-font-size-scope.md
+++ b/postmortem/2026-05-11-ui-font-size-scope.md
@@ -21,6 +21,11 @@ active GPUI theme. The helper preserves the shipped default sizes exactly, then
 scales only the relevant terminal-adjacent typography, spacing, and control
 heights when the user changes UI Size.
 
+After testing at UI Size 24, the scaling was refined into two tracks: text uses
+the full font scale, while dense chrome uses a slower density scale. This keeps
+large text readable without turning titlebar buttons, pills, icons, and trace
+cards into oversized blocks.
+
 The fix covers:
 
 - Bottom input bar text, mode button, pane selector, inline suggestion overlay,
@@ -36,3 +41,7 @@ Theme-level font settings are not enough if component code pins dense UI with
 literal pixel sizes. New terminal-adjacent UI should either inherit the theme
 font size or use a theme-derived scale helper, with the default scale resolving
 to `1.0` to avoid accidental visual drift.
+
+Readable text and spatial density should not share the exact same scale curve.
+Accessibility sizing needs larger glyphs; polished app chrome needs controlled
+growth so the layout remains stable at large UI sizes.

--- a/postmortem/2026-05-11-ui-font-size-scope.md
+++ b/postmortem/2026-05-11-ui-font-size-scope.md
@@ -26,6 +26,11 @@ the full font scale, while dense chrome uses a slower density scale. This keeps
 large text readable without turning titlebar buttons, pills, icons, and trace
 cards into oversized blocks.
 
+Review feedback also caught that text scaling must honor the full configured
+range, including the minimum UI size. Font scale clamps are now derived from
+the same UI Size bounds the settings panel exposes, while density scale remains
+separately capped for layout stability.
+
 The fix covers:
 
 - Bottom input bar text, mode button, pane selector, inline suggestion overlay,

--- a/postmortem/2026-05-11-ui-font-size-scope.md
+++ b/postmortem/2026-05-11-ui-font-size-scope.md
@@ -1,0 +1,38 @@
+# UI Font Size Scope
+
+## What happened
+
+A user raised issue #190 after setting Appearance -> UI Size to a large value:
+the terminal text scaled, but terminal-adjacent UI such as the bottom input bar
+and the agent panel run trace still looked small.
+
+## Root cause
+
+The Appearance setting correctly updated `Theme::font_size` and
+`Theme::mono_font_size`, but several high-density UI components bypassed those
+theme metrics with literal `px(...)` text sizes. The affected pieces were mostly
+terminal chrome and agent trace/status cards, so the app looked inconsistent at
+larger UI sizes even though the setting itself was saved and applied.
+
+## Fix applied
+
+Added a small `ui_scale` helper that derives UI and mono scale factors from the
+active GPUI theme. The helper preserves the shipped default sizes exactly, then
+scales only the relevant terminal-adjacent typography, spacing, and control
+heights when the user changes UI Size.
+
+The fix covers:
+
+- Bottom input bar text, mode button, pane selector, inline suggestion overlay,
+  and send button.
+- Agent panel prose markdown base sizing, headings, code block line height, and
+  message fallback text.
+- Agent run status, run trace cards, tool rows, compact chips, and inline agent
+  input when the bottom input bar is hidden.
+
+## What we learned
+
+Theme-level font settings are not enough if component code pins dense UI with
+literal pixel sizes. New terminal-adjacent UI should either inherit the theme
+font size or use a theme-derived scale helper, with the default scale resolving
+to `1.0` to avoid accidental visual drift.


### PR DESCRIPTION
## Summary

- Fixes #190 by making terminal-adjacent UI respect Appearance -> UI Size.

- Scales bottom input text, agent panel message typography, run-trace text, and inline agent input from theme-derived UI/mono font metrics.

- Preserves design density at large UI sizes with a separate capped density scale for pills, icons, compact controls, spacing, and the Settings titlebar save control.

- Preserves the shipped default visual scale: text and density helpers resolve to 1.0 at the current 16px UI / 13px mono defaults.

## Validation

- git diff --check

- CON_SKIP_GHOSTTY_VT=1 cargo check -p con --bin con

- CON_SKIP_GHOSTTY_VT=1 cargo check -p con --no-default-features --features bin-con-app --bin con-app

- CON_SKIP_GHOSTTY_VT=1 cargo test -p con --bin con ui_scale

## Notes

- Reporter credit in CHANGELOG uses the source X handle @leek_ed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it refactors sizing across several frequently-used UI surfaces (input bar, agent panel, markdown rendering, settings header), which could introduce layout regressions at different DPI/font-size settings.
> 
> **Overview**
> Fixes terminal-adjacent UI elements that were pinned to fixed `px(...)` sizes so they now follow the Appearance → UI Size setting.
> 
> Introduces a new `ui_scale` module that derives text and *density* scaling from `Theme` (with clamped ranges and tests), then migrates the bottom input bar, agent panel chips/run-trace/tool rows, and chat markdown typography to use `ui_px`/`mono_px` and `ui_space_px`/`mono_space_px` instead of hardcoded pixel values.
> 
> Also tweaks the Settings header “Save Changes” control styling/sizing to respect the density scale, and documents the incident + fix in a new postmortem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77757fd79c44ac2236c07f942c03dfd47e58152c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->