### PR TITLE
fix: clear stale AI label on CWD change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## `v0.1.0-beta.71` - unreleased
+
+### Fixed
+
+**Tabs**
+
+- Fixed vertical tab titles so changing directories clears stale AI-generated
+  labels immediately and ignores late summary responses for the previous
+  directory. _(PR
+  [#192](https://github.com/nowledge-co/con-terminal/pull/192) by
+  [@iknowu10](https://github.com/iknowu10))_
+
 ## `v0.1.0-beta.70` - 2026-05-12
 
 ### Changed

--- a/crates/con-app/src/workspace/chrome_actions.rs
+++ b/crates/con-app/src/workspace/chrome_actions.rs
@@ -354,6 +354,7 @@ impl ConWorkspace {
             ai_icon: None,
             color: tab_state.color,
             summary_id,
+            summary_epoch: 0,
             needs_attention: false,
             session: AgentSession::new(),
             agent_routing: if tab_state.agent_routing.is_empty() {

--- a/crates/con-app/src/workspace/lifecycle.rs
+++ b/crates/con-app/src/workspace/lifecycle.rs
@@ -190,6 +190,7 @@ impl ConWorkspace {
                     ai_icon: None,
                     color: tab_state.color,
                     summary_id: i as u64,
+                    summary_epoch: 0,
                     needs_attention: false,
                     session: agent_session,
                     agent_routing: if tab_state.agent_routing.is_empty() {
@@ -214,6 +215,7 @@ impl ConWorkspace {
                 ai_icon: None,
                 color: None,
                 summary_id: 0,
+                summary_epoch: 0,
                 needs_attention: false,
                 session: AgentSession::new(),
                 agent_routing: Self::default_agent_routing(&config.agent),
@@ -521,9 +523,11 @@ impl ConWorkspace {
                         workspace.apply_shell_suggestion(result, cx);
                     }
 
-                    while let Ok((generation, summary)) = workspace.tab_summary_rx.try_recv() {
+                    while let Ok((generation, summary_epoch, summary)) =
+                        workspace.tab_summary_rx.try_recv()
+                    {
                         got_event = true;
-                        workspace.apply_tab_summary(generation, summary, cx);
+                        workspace.apply_tab_summary(generation, summary_epoch, summary, cx);
                     }
 
                     if workspace.pump_ghostty_views(cx) {
@@ -640,8 +644,9 @@ impl ConWorkspace {
                     recent_output: vec![],
                 };
                 let tx = tx.clone();
+                let summary_epoch = tab.summary_epoch;
                 tab_summary_engine.request(req, move |summary| {
-                    let _ = tx.send((0, summary));
+                    let _ = tx.send((0, summary_epoch, summary));
                 });
             }
         }

--- a/crates/con-app/src/workspace/mod.rs
+++ b/crates/con-app/src/workspace/mod.rs
@@ -230,8 +230,8 @@ pub struct ConWorkspace {
     /// vertical-tabs row. Shares the harness's tokio runtime and the
     /// user's `agent.suggestion_model` settings.
     tab_summary_engine: TabSummaryEngine,
-    tab_summary_rx: crossbeam_channel::Receiver<(u64, TabSummary)>,
-    tab_summary_tx: crossbeam_channel::Sender<(u64, TabSummary)>,
+    tab_summary_rx: crossbeam_channel::Receiver<(u64, u64, TabSummary)>,
+    tab_summary_tx: crossbeam_channel::Sender<(u64, u64, TabSummary)>,
     /// Bumped whenever summary-model settings change so late async
     /// responses from the old configuration are ignored.
     tab_summary_generation: u64,

--- a/crates/con-app/src/workspace/pane_actions.rs
+++ b/crates/con-app/src/workspace/pane_actions.rs
@@ -750,6 +750,7 @@ impl ConWorkspace {
                 ai_icon: None,
                 color: None,
                 summary_id,
+                summary_epoch: 0,
                 needs_attention: false,
                 session: AgentSession::new(),
                 agent_routing: Self::default_agent_routing(self.harness.config()),

--- a/crates/con-app/src/workspace/suggestions.rs
+++ b/crates/con-app/src/workspace/suggestions.rs
@@ -539,6 +539,7 @@ impl ConWorkspace {
     pub(super) fn apply_tab_summary(
         &mut self,
         generation: u64,
+        summary_epoch: u64,
         summary: TabSummary,
         cx: &mut Context<Self>,
     ) {
@@ -556,6 +557,16 @@ impl ConWorkspace {
             // Tab was closed while the request was in flight.
             return;
         };
+        if !tab_summary_epoch_matches(summary_epoch, tab.summary_epoch) {
+            log::debug!(
+                target: "con::tab_summary",
+                "tab_summary drop stale tab_id={} request_epoch={} current_epoch={}",
+                summary.tab_id,
+                summary_epoch,
+                tab.summary_epoch,
+            );
+            return;
+        }
         let label = summary.label.trim().to_string();
         let icon = summary.icon;
         let label_changed = tab.ai_label.as_deref() != Some(label.as_str());
@@ -603,6 +614,7 @@ impl ConWorkspace {
         let tx = self.tab_summary_tx.clone();
         let generation = self.tab_summary_generation;
         for (i, tab) in self.tabs.iter().enumerate() {
+            let summary_epoch = tab.summary_epoch;
             let terminal = tab.pane_tree.focused_terminal();
             // The terminal's recent scrollback is the only signal we
             // get for commands the user typed *directly* into the
@@ -629,8 +641,23 @@ impl ConWorkspace {
             };
             let tx = tx.clone();
             self.tab_summary_engine.request(req, move |summary| {
-                let _ = tx.send((generation, summary));
+                let _ = tx.send((generation, summary_epoch, summary));
             });
         }
+    }
+}
+
+fn tab_summary_epoch_matches(request_epoch: u64, current_epoch: u64) -> bool {
+    request_epoch == current_epoch
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tab_summary_epoch_matches;
+
+    #[test]
+    fn tab_summary_epoch_rejects_late_response_after_context_change() {
+        assert!(tab_summary_epoch_matches(7, 7));
+        assert!(!tab_summary_epoch_matches(7, 8));
     }
 }

--- a/crates/con-app/src/workspace/tab_actions.rs
+++ b/crates/con-app/src/workspace/tab_actions.rs
@@ -422,7 +422,10 @@ impl ConWorkspace {
         let invalidated_summary_id = self
             .tabs
             .iter_mut()
-            .find(|tab| tab.pane_tree.pane_id_for_entity(entity_id).is_some())
+            // Tab summaries and smart_tab_presentation are derived from each
+            // tab's focused terminal. A background split or inactive surface can
+            // report OSC-7 too, but that should not clear the visible tab label.
+            .find(|tab| tab.pane_tree.focused_terminal().entity_id() == entity_id)
             .map(|tab| {
                 tab.ai_label = None;
                 tab.ai_icon = None;

--- a/crates/con-app/src/workspace/tab_actions.rs
+++ b/crates/con-app/src/workspace/tab_actions.rs
@@ -419,13 +419,18 @@ impl ConWorkspace {
         // directory immediately while request_tab_summaries re-derives a
         // fresh label.
         let entity_id = entity.entity_id();
-        if let Some(tab) = self
+        let invalidated_summary_id = self
             .tabs
             .iter_mut()
             .find(|tab| tab.pane_tree.pane_id_for_entity(entity_id).is_some())
-        {
-            tab.ai_label = None;
-            tab.ai_icon = None;
+            .map(|tab| {
+                tab.ai_label = None;
+                tab.ai_icon = None;
+                tab.summary_epoch = tab.summary_epoch.wrapping_add(1);
+                tab.summary_id
+            });
+        if let Some(summary_id) = invalidated_summary_id {
+            self.tab_summary_engine.invalidate_tab(summary_id);
         }
         // Shell integration reports cwd independently from title/output.
         // Persist immediately so restart continuity survives a later crash or
@@ -555,6 +560,7 @@ impl ConWorkspace {
             ai_icon: None,
             color: self.tabs[index].color,
             summary_id,
+            summary_epoch: 0,
             needs_attention: false,
             session: AgentSession::new(),
             agent_routing: self.tabs[index].agent_routing.clone(),

--- a/crates/con-app/src/workspace/tab_actions.rs
+++ b/crates/con-app/src/workspace/tab_actions.rs
@@ -408,12 +408,25 @@ impl ConWorkspace {
 
     pub(crate) fn on_terminal_cwd_changed(
         &mut self,
-        _entity: &Entity<GhosttyView>,
+        entity: &Entity<GhosttyView>,
         event: &GhosttyCwdChanged,
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         let _reported_cwd = event.0.as_deref();
+        // Stale AI label would take priority over the new CWD basename in
+        // smart_tab_presentation. Clear it so the tab reflects the new
+        // directory immediately while request_tab_summaries re-derives a
+        // fresh label.
+        let entity_id = entity.entity_id();
+        if let Some(tab) = self
+            .tabs
+            .iter_mut()
+            .find(|tab| tab.pane_tree.pane_id_for_entity(entity_id).is_some())
+        {
+            tab.ai_label = None;
+            tab.ai_icon = None;
+        }
         // Shell integration reports cwd independently from title/output.
         // Persist immediately so restart continuity survives a later crash or
         // force-quit instead of depending on an unrelated tab/layout save.

--- a/crates/con-app/src/workspace/types.rs
+++ b/crates/con-app/src/workspace/types.rs
@@ -210,6 +210,9 @@ pub(super) struct Tab {
     /// reorders, closes, and re-opens don't collide. Allocated from
     /// `next_tab_summary_id` at tab construction time.
     pub(super) summary_id: u64,
+    /// Bumped when the tab's terminal context changes in a way that
+    /// invalidates in-flight AI summaries for the previous context.
+    pub(super) summary_epoch: u64,
     pub(super) needs_attention: bool,
     pub(super) session: AgentSession,
     pub(super) agent_routing: AgentRoutingState,

--- a/crates/con-app/src/workspace/window_actions.rs
+++ b/crates/con-app/src/workspace/window_actions.rs
@@ -317,6 +317,7 @@ impl ConWorkspace {
             ai_icon: None,
             color: None,
             summary_id,
+            summary_epoch: 0,
             needs_attention: false,
             session: AgentSession::new(),
             agent_routing: Self::default_agent_routing(self.harness.config()),

--- a/crates/con-core/src/tab_summary.rs
+++ b/crates/con-core/src/tab_summary.rs
@@ -167,6 +167,11 @@ struct PerTabState {
     last_was_success: bool,
     /// `true` while a request is in flight; prevents duplicate work.
     in_flight: bool,
+    /// Set when a tab context changes while a request is already in
+    /// flight. We keep `in_flight` true to cap model work at one
+    /// request per tab, then make the next poll eligible to dispatch
+    /// immediately once the stale worker exits.
+    refresh_after_in_flight: bool,
 }
 
 /// Background engine. Cheap to construct; safe to call `request` from
@@ -225,17 +230,23 @@ impl TabSummaryEngine {
     }
 
     /// Invalidate cached and in-flight work for one tab without
-    /// affecting other tabs. The next request for this tab can
-    /// dispatch immediately, and any older worker completion will see
-    /// the generation mismatch and drop itself.
+    /// affecting other tabs. If no request is running, the next
+    /// request for this tab can dispatch immediately. If one is
+    /// already running, keep the in-flight guard so rapid OSC-7
+    /// churn cannot fan out into multiple concurrent LLM calls; the
+    /// stale worker will drop itself on generation mismatch and make
+    /// the next poll eligible for a fresh request.
     pub fn invalidate_tab(&self, tab_id: u64) {
         let mut guard = self.state.lock();
         let entry = guard.entry(tab_id).or_default();
         entry.generation = entry.generation.wrapping_add(1);
         entry.last_success_key = None;
-        entry.last_dispatch = None;
         entry.last_was_success = false;
-        entry.in_flight = false;
+        if entry.in_flight {
+            entry.refresh_after_in_flight = true;
+        } else {
+            entry.last_dispatch = None;
+        }
     }
 
     /// Ask the engine to produce a [`TabSummary`] for `req`. Returns
@@ -350,6 +361,7 @@ impl TabSummaryEngine {
                 return;
             }
             entry.in_flight = true;
+            entry.refresh_after_in_flight = false;
             entry.last_dispatch = Some(Instant::now());
             let request_tab_generation = entry.generation;
             drop(guard);
@@ -362,16 +374,23 @@ impl TabSummaryEngine {
                 let result = request_summary(&config, &req).await;
 
                 let mut should_callback = false;
-                if let Some(entry) = state.lock().get_mut(&tab_id)
-                    && entry.generation == request_tab_generation
-                {
+                if let Some(entry) = state.lock().get_mut(&tab_id) {
                     entry.in_flight = false;
-                    let cache_is_current =
-                        cache_generation.load(Ordering::Relaxed) == request_generation;
-                    entry.last_was_success = cache_is_current && result.is_some();
-                    if cache_is_current && result.is_some() {
-                        entry.last_success_key = Some(key);
-                        should_callback = true;
+                    if entry.generation == request_tab_generation {
+                        let cache_is_current =
+                            cache_generation.load(Ordering::Relaxed) == request_generation;
+                        entry.last_was_success = cache_is_current && result.is_some();
+                        if cache_is_current && result.is_some() {
+                            entry.last_success_key = Some(key);
+                            should_callback = true;
+                        }
+                    } else {
+                        entry.last_was_success = false;
+                        entry.last_success_key = None;
+                        if entry.refresh_after_in_flight {
+                            entry.refresh_after_in_flight = false;
+                            entry.last_dispatch = None;
+                        }
                     }
                 }
 
@@ -854,7 +873,7 @@ mod tests {
     }
 
     #[test]
-    fn invalidate_tab_clears_only_that_tab_and_unblocks_new_context() {
+    fn invalidate_tab_preserves_in_flight_guard_for_that_tab_only() {
         let engine = TabSummaryEngine::new(
             AgentConfig::default(),
             Arc::new(Runtime::new().expect("test runtime")),
@@ -867,6 +886,7 @@ mod tests {
                 last_success_key: Some(42),
                 last_was_success: true,
                 last_dispatch: Some(Instant::now()),
+                ..Default::default()
             },
         );
         engine.state.lock().insert(
@@ -877,6 +897,45 @@ mod tests {
                 last_success_key: Some(99),
                 last_was_success: true,
                 last_dispatch: Some(Instant::now()),
+                ..Default::default()
+            },
+        );
+
+        engine.invalidate_tab(7);
+
+        let state = engine.state.lock();
+        let invalidated = state.get(&7).expect("invalidated tab");
+        assert_eq!(invalidated.generation, 3);
+        assert!(invalidated.in_flight);
+        assert!(invalidated.refresh_after_in_flight);
+        assert_eq!(invalidated.last_success_key, None);
+        assert!(invalidated.last_dispatch.is_some());
+        assert!(!invalidated.last_was_success);
+
+        let untouched = state.get(&8).expect("other tab");
+        assert_eq!(untouched.generation, 4);
+        assert!(untouched.in_flight);
+        assert_eq!(untouched.last_success_key, Some(99));
+        assert!(untouched.last_was_success);
+        assert!(untouched.last_dispatch.is_some());
+        assert!(!untouched.refresh_after_in_flight);
+    }
+
+    #[test]
+    fn invalidate_tab_without_in_flight_unblocks_new_context_immediately() {
+        let engine = TabSummaryEngine::new(
+            AgentConfig::default(),
+            Arc::new(Runtime::new().expect("test runtime")),
+        );
+        engine.state.lock().insert(
+            7,
+            PerTabState {
+                generation: 2,
+                in_flight: false,
+                last_success_key: Some(42),
+                last_was_success: true,
+                last_dispatch: Some(Instant::now()),
+                ..Default::default()
             },
         );
 
@@ -886,16 +945,10 @@ mod tests {
         let invalidated = state.get(&7).expect("invalidated tab");
         assert_eq!(invalidated.generation, 3);
         assert!(!invalidated.in_flight);
+        assert!(!invalidated.refresh_after_in_flight);
         assert_eq!(invalidated.last_success_key, None);
         assert_eq!(invalidated.last_dispatch, None);
         assert!(!invalidated.last_was_success);
-
-        let untouched = state.get(&8).expect("other tab");
-        assert_eq!(untouched.generation, 4);
-        assert!(untouched.in_flight);
-        assert_eq!(untouched.last_success_key, Some(99));
-        assert!(untouched.last_was_success);
-        assert!(untouched.last_dispatch.is_some());
     }
 
     /// Tab reorder math (mirrors `on_sidebar_reorder` in workspace.rs).

--- a/crates/con-core/src/tab_summary.rs
+++ b/crates/con-core/src/tab_summary.rs
@@ -147,6 +147,10 @@ pub struct TabSummaryRequest {
 
 #[derive(Default)]
 struct PerTabState {
+    /// Per-tab invalidation counter. Incremented when the workspace
+    /// knows the visible context changed enough that an in-flight
+    /// request must not write back.
+    generation: u64,
     /// Hash key of the last request that *succeeded*. We dedupe on
     /// this — if the context hasn't moved since the last accepted
     /// label, no need to re-ask. Failures DO NOT update this so a
@@ -218,6 +222,20 @@ impl TabSummaryEngine {
     /// Forget a single tab's cache (e.g. after the tab is closed).
     pub fn forget(&self, tab_id: u64) {
         self.state.lock().remove(&tab_id);
+    }
+
+    /// Invalidate cached and in-flight work for one tab without
+    /// affecting other tabs. The next request for this tab can
+    /// dispatch immediately, and any older worker completion will see
+    /// the generation mismatch and drop itself.
+    pub fn invalidate_tab(&self, tab_id: u64) {
+        let mut guard = self.state.lock();
+        let entry = guard.entry(tab_id).or_default();
+        entry.generation = entry.generation.wrapping_add(1);
+        entry.last_success_key = None;
+        entry.last_dispatch = None;
+        entry.last_was_success = false;
+        entry.in_flight = false;
     }
 
     /// Ask the engine to produce a [`TabSummary`] for `req`. Returns
@@ -333,33 +351,40 @@ impl TabSummaryEngine {
             }
             entry.in_flight = true;
             entry.last_dispatch = Some(Instant::now());
-        }
+            let request_tab_generation = entry.generation;
+            drop(guard);
 
-        let config = self.config.clone();
-        let state = self.state.clone();
-        let cache_generation = self.cache_generation.clone();
-        let request_generation = cache_generation.load(Ordering::Relaxed);
-        self.runtime.spawn(async move {
-            let result = request_summary(&config, &req).await;
+            let config = self.config.clone();
+            let state = self.state.clone();
+            let cache_generation = self.cache_generation.clone();
+            let request_generation = cache_generation.load(Ordering::Relaxed);
+            self.runtime.spawn(async move {
+                let result = request_summary(&config, &req).await;
 
-            if let Some(entry) = state.lock().get_mut(&tab_id) {
-                entry.in_flight = false;
-                let cache_is_current =
-                    cache_generation.load(Ordering::Relaxed) == request_generation;
-                entry.last_was_success = cache_is_current && result.is_some();
-                if cache_is_current && result.is_some() {
-                    entry.last_success_key = Some(key);
+                let mut should_callback = false;
+                if let Some(entry) = state.lock().get_mut(&tab_id)
+                    && entry.generation == request_tab_generation
+                {
+                    entry.in_flight = false;
+                    let cache_is_current =
+                        cache_generation.load(Ordering::Relaxed) == request_generation;
+                    entry.last_was_success = cache_is_current && result.is_some();
+                    if cache_is_current && result.is_some() {
+                        entry.last_success_key = Some(key);
+                        should_callback = true;
+                    }
                 }
-            }
 
-            if let Some((label, icon)) = result {
-                callback(TabSummary {
-                    tab_id,
-                    label,
-                    icon,
-                });
-            }
-        });
+                if should_callback && let Some((label, icon)) = result {
+                    callback(TabSummary {
+                        tab_id,
+                        label,
+                        icon,
+                    });
+                }
+            });
+            return;
+        }
     }
 }
 
@@ -814,6 +839,7 @@ mod tests {
                 last_success_key: Some(42),
                 last_was_success: true,
                 last_dispatch: Some(Instant::now()),
+                ..Default::default()
             },
         );
 
@@ -825,6 +851,51 @@ mod tests {
         assert_eq!(state.last_success_key, None);
         assert!(!state.last_was_success);
         assert!(state.last_dispatch.is_some());
+    }
+
+    #[test]
+    fn invalidate_tab_clears_only_that_tab_and_unblocks_new_context() {
+        let engine = TabSummaryEngine::new(
+            AgentConfig::default(),
+            Arc::new(Runtime::new().expect("test runtime")),
+        );
+        engine.state.lock().insert(
+            7,
+            PerTabState {
+                generation: 2,
+                in_flight: true,
+                last_success_key: Some(42),
+                last_was_success: true,
+                last_dispatch: Some(Instant::now()),
+            },
+        );
+        engine.state.lock().insert(
+            8,
+            PerTabState {
+                generation: 4,
+                in_flight: true,
+                last_success_key: Some(99),
+                last_was_success: true,
+                last_dispatch: Some(Instant::now()),
+            },
+        );
+
+        engine.invalidate_tab(7);
+
+        let state = engine.state.lock();
+        let invalidated = state.get(&7).expect("invalidated tab");
+        assert_eq!(invalidated.generation, 3);
+        assert!(!invalidated.in_flight);
+        assert_eq!(invalidated.last_success_key, None);
+        assert_eq!(invalidated.last_dispatch, None);
+        assert!(!invalidated.last_was_success);
+
+        let untouched = state.get(&8).expect("other tab");
+        assert_eq!(untouched.generation, 4);
+        assert!(untouched.in_flight);
+        assert_eq!(untouched.last_success_key, Some(99));
+        assert!(untouched.last_was_success);
+        assert!(untouched.last_dispatch.is_some());
     }
 
     /// Tab reorder math (mirrors `on_sidebar_reorder` in workspace.rs).

--- a/postmortem/2026-05-12-stale-tab-ai-label-after-cwd-change.md
+++ b/postmortem/2026-05-12-stale-tab-ai-label-after-cwd-change.md
@@ -1,0 +1,33 @@
+# Stale AI Tab Label After Directory Change
+
+## What Happened
+
+Vertical tab titles could keep showing an AI-generated label from the previous
+working directory after the user ran `cd`. This was easiest to reproduce when
+the suggestion model was disabled, because no new AI summary arrived to replace
+the stale one. With the suggestion model enabled, the tab could also briefly
+show the old label until a fresh summary completed.
+
+## Root Cause
+
+`smart_tab_presentation` intentionally gives AI labels higher priority than the
+current directory basename. `on_terminal_cwd_changed` synced the sidebar before
+clearing the tab's AI label, so the old label still won. Clearing the label
+fixed the immediate display, but it was not enough: a summary request already
+in flight for the previous directory could complete later and reapply the old
+label.
+
+## Fix Applied
+
+On CWD changes, Con now clears the affected tab's AI label, invalidates that
+tab's summary-engine state, and bumps a tab-local summary epoch. Summary
+callbacks carry the epoch they were requested under, and `apply_tab_summary`
+drops callbacks whose epoch no longer matches the tab. This preserves immediate
+CWD fallback, allows a fresh request to dispatch without the normal summary
+budget delay, and prevents late stale AI responses from overwriting it.
+
+## What We Learned
+
+For async UI decoration, clearing visible state is only half the fix. Any
+in-flight producer that can write the same state must carry enough identity to
+prove it still belongs to the current user-visible context.


### PR DESCRIPTION
## Summary

When the shell reports a new working directory via OSC 7, the tab's \`ai_label\` was not cleared before calling \`sync_sidebar\`. \`smart_tab_presentation\` gives AI labels higher priority (tier 2) than CWD basename (tier 5), so the tab kept showing the old label (e.g. \`niuma-ranch\`) even after \`cd ignition\`.

This bug exists in two forms depending on whether the suggestion model is enabled:

- **With suggestion model enabled**: the stale label persists until the AI summary request completes — the tab shows the wrong name during that window
- **Without suggestion model**: \`request_tab_summaries\` is a no-op, so the stale label is never evicted and the tab name never updates at all

Both forms share the same root cause: \`ai_label\` is not cleared when the CWD changes.

## Fix

In \`on_terminal_cwd_changed\`, clear \`ai_label\` and \`ai_icon\` for the affected tab before calling \`sync_sidebar\`. The CWD basename shows instantly; \`request_tab_summaries\` re-derives a fresh AI label if the suggestion model is enabled.

## Test plan

- [ ] Open a tab, wait for AI label to appear (e.g. "My Project")
- [ ] \`cd\` to a different directory — tab name should update immediately to the new directory basename
- [ ] Verify with \`suggestion_model.enabled = false\` — tab should still update correctly on \`cd\`
- [ ] Verify with suggestion model enabled — tab shows CWD basename first, then AI label once it returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vertical tab titles and icons now clear immediately when changing directories and ignore late AI summary responses, preventing stale labels.
* **Documentation**
  * Added a postmortem and unreleased changelog entry describing the tab-label fix and summary invalidation behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/con-terminal/pull/192)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->