### PR TITLE
Polish Linux rounded window chrome

### DIFF
--- a/crates/con-app/build.rs
+++ b/crates/con-app/build.rs
@@ -33,8 +33,7 @@ fn main() {
         );
     }
 
-    #[cfg(target_os = "macos")]
-    {
+    if target_os == "macos" {
         cc::Build::new()
             .file("src/objc/sparkle_trampoline.m")
             .file("src/objc/global_hotkey_trampoline.m")

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -27,7 +27,7 @@ mod quick_terminal;
 // The terminal-view module is selected per platform:
 //   macOS   -> ghostty_view.rs (libghostty + child NSView)
 //   Windows -> windows_view.rs (libghostty-vt + ConPTY + D3D11 child HWND)
-//   Linux   -> linux_view.rs (Linux-specific placeholder until backend lands)
+//   Linux   -> linux_view.rs (Unix PTY + libghostty-vt + GPUI paint path)
 //   other   -> stub_view.rs
 //
 // All three expose the same public type names (`GhosttyView`,
@@ -280,24 +280,16 @@ pub fn set_windows_backdrop_blur(window: &mut Window, blur: bool) {
 /// can toggle "background blur" in settings without restarting the
 /// window.
 ///
-/// `blur=true` requests `WindowBackgroundAppearance::Blurred`. The
-/// gpui_linux Wayland backend honors that via the
-/// `org_kde_kwin_blur` protocol (real Gaussian blur of what's
-/// behind the window — works on KDE Plasma Wayland). On X11 and on
-/// Wayland compositors that don't expose the blur protocol
-/// (mutter / GNOME, sway by default), the renderer keeps the
-/// window transparent but does NOT draw a blur — there's no
-/// equivalent of DWM's Acrylic API there. We still flip to
-/// `Transparent` in that case so per-pane opacity has a desktop
-/// to composite over.
+/// Linux keeps the native surface transparent even when the user
+/// has background blur enabled. GPUI's current KWin blur integration
+/// commits blur for the whole Wayland surface instead of a rounded
+/// region, which makes the transparent corners read as a rectangular
+/// blur block. Until the platform layer can expose a rounded blur
+/// region, alpha shape correctness wins over blur.
 #[cfg(target_os = "linux")]
-pub fn set_linux_window_blur(window: &mut Window, blur: bool) {
+pub fn set_linux_window_blur(window: &mut Window, _blur: bool) {
     use gpui::WindowBackgroundAppearance;
-    window.set_background_appearance(if blur {
-        WindowBackgroundAppearance::Blurred
-    } else {
-        WindowBackgroundAppearance::Transparent
-    });
+    window.set_background_appearance(WindowBackgroundAppearance::Transparent);
 }
 
 #[cfg(target_os = "macos")]
@@ -444,7 +436,7 @@ fn default_window_background(
     config: &con_core::Config,
     transparent: bool,
 ) -> WindowBackgroundAppearance {
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     let _ = config;
 
     if !transparent {
@@ -463,7 +455,16 @@ fn default_window_background(
         }
     }
 
-    WindowBackgroundAppearance::Transparent
+    #[cfg(target_os = "linux")]
+    {
+        let _ = config;
+        WindowBackgroundAppearance::Transparent
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        WindowBackgroundAppearance::Transparent
+    }
 }
 
 fn default_workspace_window_bounds(cx: &mut App) -> WindowBounds {
@@ -595,6 +596,13 @@ pub(crate) fn open_con_window(
                     // Ghostty NSView below GPUI stays visible, even on
                     // Monterey where the top-level window falls back to
                     // opaque.
+                    cx.theme().transparent
+                } else if cfg!(target_os = "linux") {
+                    // Linux relies on a transparent top-level Root so
+                    // the workspace's rounded `overflow_hidden` clip
+                    // exposes the compositor at the outer corners.
+                    // Painting the Root with the theme background here
+                    // makes the clipped workspace look square again.
                     cx.theme().transparent
                 } else {
                     cx.theme().background

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -3498,16 +3498,31 @@ impl SettingsPanel {
                         .child(row_separator(theme))
                         .child(toggle_row(
                             "Terminal Blur",
-                            "Blur the desktop behind transparent terminal surfaces.",
-                            Switch::new("terminal-blur-toggle")
-                                .checked(self.terminal_blur)
-                                .small()
-                                .on_click(cx.listener(|this, checked: &bool, _, cx| {
-                                    this.terminal_blur = *checked;
-                                    this.config.appearance.terminal_blur = *checked;
-                                    cx.emit(AppearancePreview);
-                                    cx.notify();
-                                })),
+                            if cfg!(target_os = "linux") {
+                                "Disabled on Linux until rounded compositor blur regions are available."
+                            } else {
+                                "Blur the desktop behind transparent terminal surfaces."
+                            },
+                            {
+                                let terminal_blur_supported = !cfg!(target_os = "linux");
+                                let mut toggle = Switch::new("terminal-blur-toggle")
+                                    .checked(self.terminal_blur && terminal_blur_supported)
+                                    .small()
+                                    .disabled(!terminal_blur_supported);
+
+                                if terminal_blur_supported {
+                                    toggle = toggle.on_click(cx.listener(
+                                        |this, checked: &bool, _, cx| {
+                                            this.terminal_blur = *checked;
+                                            this.config.appearance.terminal_blur = *checked;
+                                            cx.emit(AppearancePreview);
+                                            cx.notify();
+                                        },
+                                    ));
+                                }
+
+                                toggle
+                            },
                             theme,
                         ))
                         .child(row_separator(theme))

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -3,6 +3,9 @@ mod top_bar;
 
 use super::*;
 
+#[cfg(target_os = "linux")]
+const LINUX_WINDOW_CORNER_RADIUS: Pixels = px(14.0);
+
 impl ConWorkspace {
     fn has_active_resize_drag(&self) -> bool {
         self.sidebar_drag.is_some()
@@ -953,19 +956,6 @@ impl Render for ConWorkspace {
             .font_family(theme.mono_font_family.clone())
             .track_focus(&self.workspace_focus);
 
-        // Linux: con paints its own client-side decorations, so we
-        // also have to clip the window to a rounded rectangle the
-        // same way macOS gets from NSWindow + transparent backdrop
-        // and Windows 11 gets from DWM. Wrap with `overflow_hidden`
-        // so child surfaces (top bar, terminal pane, modals) all
-        // respect the corner radius. 14px matches Mica's perceived
-        // radius on Win11 and reads as "windowed" rather than
-        // "phone-app sheet".
-        #[cfg(target_os = "linux")]
-        {
-            root = root.rounded(px(14.0)).overflow_hidden();
-        }
-
         root = root
             .key_context("ConWorkspace")
             // Pane drag-to-resize: capture mouse move/up on root so it works
@@ -1562,6 +1552,36 @@ impl Render for ConWorkspace {
         let palette_visible = self.command_palette.read(cx).is_visible();
         if palette_visible {
             root = root.child(self.command_palette.clone());
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let mut workspace_frame = root;
+
+            if let Decorations::Client { tiling } = window.window_decorations()
+                && !window.is_maximized()
+                && !window.is_fullscreen()
+            {
+                if !(tiling.top || tiling.left) {
+                    workspace_frame = workspace_frame.rounded_tl(LINUX_WINDOW_CORNER_RADIUS);
+                }
+                if !(tiling.top || tiling.right) {
+                    workspace_frame = workspace_frame.rounded_tr(LINUX_WINDOW_CORNER_RADIUS);
+                }
+                if !(tiling.bottom || tiling.left) {
+                    workspace_frame = workspace_frame.rounded_bl(LINUX_WINDOW_CORNER_RADIUS);
+                }
+                if !(tiling.bottom || tiling.right) {
+                    workspace_frame = workspace_frame.rounded_br(LINUX_WINDOW_CORNER_RADIUS);
+                }
+                workspace_frame = workspace_frame.overflow_hidden();
+            }
+
+            root = div()
+                .relative()
+                .size_full()
+                .bg(transparent_black())
+                .child(workspace_frame);
         }
 
         root.into_any_element()

--- a/docs/impl/linux-port.md
+++ b/docs/impl/linux-port.md
@@ -7,7 +7,7 @@ macOS now opens on Linux with client-side decorations (no native WM
 titlebar stacked on top of the GPUI shell), a transparent ARGB
 window with rounded corners, the same caption cluster Windows
 ships, IoskeleyMono-shaped styled cells, the user's theme palette,
-and KWin Wayland backdrop blur where the compositor exposes it.
+and per-pane / per-surface opacity composited by the desktop.
 This document is the Linux single-source-of-truth equivalent of
 `docs/impl/windows-port.md`: it captures the upstream constraints,
 the recommended architecture, and the staged path from today's
@@ -74,14 +74,19 @@ What that gives you:
   relying on libghostty-vt's terminal-only stream handler, so Linux
   pane/session state can follow shell-reported directory changes
 - transparent ARGB window with rounded corners (14 px on Linux, no
-  corners from `NSWindow` or DWM here so we clip the GPUI root
-  ourselves) and per-pane / per-surface opacity that composites
+  corners from `NSWindow` or DWM here so we use a transparent GPUI
+  toplevel and clip the workspace frame itself). The top-level
+  GPUI `Root` must stay transparent; otherwise the clipped workspace
+  still sits over an opaque rectangular app fill and the outer
+  corners read as square. Per-pane / per-surface opacity composites
   through to the desktop
-- backdrop blur on KDE Plasma Wayland via `org_kde_kwin_blur` —
-  real Gaussian blur of what's behind the window. On X11 / mutter /
-  sway the blur toggle still ships but the visible result is
-  transparency only (no portable backdrop-blur protocol exists
-  outside KWin)
+- Linux backdrop blur is intentionally not enabled yet. KWin exposes
+  `org_kde_kwin_blur`, but GPUI's current Wayland hook commits blur
+  for the whole surface instead of a rounded region, which makes the
+  window look rectangular even when the app paint is clipped. Shape
+  correctness wins until the platform layer can set a rounded blur
+  region. On X11 / mutter / sway there is no portable backdrop-blur
+  protocol anyway
 - a snappy paint pipeline: redundant per-tick snapshot refreshes
   and `Vec<Cell>` deep-equality compares were removed, PTY output now
   wakes the Linux terminal view directly instead of waiting for the
@@ -287,7 +292,7 @@ can ship.
 | 2b | GPUI feasibility spike | confirm whether con needs foreign-surface embedding, texture interop, or neither | bounded GPUI worklist exists, or path is ruled out | ✅ landed |
 | 2c | Architecture decision | pick Linux backend lane | one recommended implementation path, no split-brain plan | ✅ landed |
 | 3 | Linux backend scaffold | `con-ghostty/src/linux/` plus `con-app/src/linux_view.rs` (or equivalent) with real lifecycle types | Linux no longer routes through the generic stub path conceptually | ✅ landed |
-| 4 | First real terminal surface | PTY spawn, resize, exit, `libghostty-vt` state, GPUI-owned pane paint, real product chrome (no native WM titlebar), embedded mono font, transparent + rounded window with compositor-gated blur | VT-backed Linux pane compiles and displays live shell state with SGR colors / bold / italic / underline / strikethrough / inverse, cursor block, theme palette synced from settings, IoskeleyMono shaping, client-side titlebar with min/max/close caption cluster, transparent ARGB window with rounded corners and per-pane / per-surface opacity, real KWin Wayland blur where available, fast paint pipeline (16 ms keystroke-echo round-trip), no placeholder flash on alt-screen TUIs | ✅ landed (preview) |
+| 4 | First real terminal surface | PTY spawn, resize, exit, `libghostty-vt` state, GPUI-owned pane paint, real product chrome (no native WM titlebar), embedded mono font, transparent + rounded window | VT-backed Linux pane compiles and displays live shell state with SGR colors / bold / italic / underline / strikethrough / inverse, cursor block, theme palette synced from settings, IoskeleyMono shaping, client-side titlebar with min/max/close caption cluster, transparent ARGB window with rounded corners and per-pane / per-surface opacity, fast paint pipeline (16 ms keystroke-echo round-trip), no placeholder flash on alt-screen TUIs | ✅ landed (preview) |
 | 5 | Input + selection + glyph-atlas grid renderer | keyboard, mouse, clipboard, bracketed paste, DECCKM, CJK IME text/preedit input, selection, plus the long-term GPUI-owned glyph-atlas grid renderer matching the D3D11/DirectWrite path Windows uses | vim/tmux/fzf/less usable on Linux at full speed | 🚧 in progress (DECCKM, bracketed paste, CJK IME text/preedit input, terminal-local Tab / Shift+Tab capture, and basic left-drag text selection are wired; mouse reporting, scrollback gestures, desktop IME validation matrix, and the glyph-atlas renderer remain) |
 | 6 | Packaging | one-line installer, tarball release, desktop entry, icon integration, appcast / notify-only updater, plus native artifact strategy (`.deb`, AppImage, Flatpak, etc.) | tarball installer exists; runtime Linux app id, desktop-file basename, and `StartupWMClass` are aligned as `co.nowledge.con`; native package format decision remains | 🚧 partially landed |
 
@@ -317,10 +322,9 @@ With phase 4 landed (preview), the remaining Linux tasks are:
    a terminal-local key context so shell completion and reverse focus
    traversal are not intercepted by GPUI's app-level focus navigation.
 3. Validate on hardware-accelerated native Linux desktops (Wayland
-   on KDE Plasma to confirm `org_kde_kwin_blur`; Wayland on
-   GNOME / sway and X11 on each major WM to confirm the
-   transparency / CSD / caption-cluster fallback paths). The
-   cloud-VM XFCE + llvmpipe + Xvfb-style display has covered the
+   on KDE Plasma, GNOME / sway, and X11 on each major WM to confirm
+   the transparency / rounded-CSD / caption-cluster fallback paths).
+   The cloud-VM XFCE + llvmpipe + Xvfb-style display has covered the
    software path end to end (full launch flow, styled output,
    transparent rounded chrome, htop in the alternate screen,
    keystroke-echo benchmark), but the hardware path still wants a


### PR DESCRIPTION
## Summary

- render Linux chrome as a transparent toplevel plus a rounded workspace frame that clips all visible app chrome and overlays
- keep Linux native windows on transparent alpha instead of whole-surface KWin blur so rounded corners do not read as a rectangular blur block
- disable the Linux Terminal Blur settings switch until GPUI exposes rounded compositor blur regions
- keep the build script target-aware so Linux cross-checks do not compile macOS Objective-C trampolines
- document the Linux transparency / rounded-frame / blur-region constraints in the Linux port notes

## Root Cause

Linux needs three separate pieces for rounded client-side windows: a transparent native surface, a transparent GPUI toplevel, and a content frame that owns and clips every painted child. The previous patch only addressed transparency at the root/background level, so the app could still present as a rectangular surface in practice.

The default blur path also worked against the shape goal: GPUI currently commits KWin blur for the whole Wayland surface, not a rounded region. With blur enabled by default, transparent corners can still look rectangular even when app paint is clipped.

While verifying the Linux-selected build from macOS, the app build script also exposed a platform-boundary issue: `#[cfg(target_os = "macos")]` in `build.rs` follows the build-script host, not the Cargo target. Cross-checking Linux therefore tried to compile macOS Objective-C trampolines for Linux.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo check -p con`
- `cargo check -p con --no-default-features --features bin-con-app`
- `env RUST_FONTCONFIG_DLOPEN=1 CC_x86_64_unknown_linux_gnu=/private/tmp/con-zig-linux-cc CXX_x86_64_unknown_linux_gnu=/private/tmp/con-zig-linux-cxx cargo check -p con --target x86_64-unknown-linux-gnu`
- `cargo test -p con-core` (72 tests)

## Notes

I could not take a real Linux desktop screenshot from the available remote Linux host because it is a TTY session with no `DISPLAY` or `WAYLAND_DISPLAY`. This is intentionally a draft PR for follow-up testing on a Linux desktop.
