### PR TITLE
Fix macOS bundle Ghostty terminfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ con is still pre-release, so entries may group related beta work while the produ
   [#194](https://github.com/nowledge-co/con-terminal/pull/194) by
   [@wey-gu](https://github.com/wey-gu))_
 
+**macOS**
+
+- Bundled Ghostty's compiled `xterm-ghostty` terminfo database inside the macOS
+  app, so release builds can use the same terminal capabilities as local
+  `cargo run` builds. The macOS verifier now fails the release if the terminfo
+  entry is missing. _(PR
+  [#195](https://github.com/nowledge-co/con-terminal/pull/195) by
+  [@sundy-li](https://github.com/sundy-li))_
+
 **Tabs**
 
 - Fixed vertical tab titles so changing directories clears stale AI-generated

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -386,13 +386,37 @@ fn installed_app_ghostty_resources_dir_for_exe(exe: &Path) -> Option<PathBuf> {
         if ancestor.extension().is_some_and(|ext| ext == "app") {
             let resources_root = ancestor.join("Contents/Resources");
             let ghostty_dir = resources_root.join("ghostty");
-            let terminfo_sentinel = resources_root.join("terminfo/78/xterm-ghostty");
-            if ghostty_dir.is_dir() && terminfo_sentinel.is_file() {
+            let terminfo_dir = resources_root.join("terminfo");
+            if ghostty_dir.is_dir() && has_xterm_ghostty_terminfo(&terminfo_dir) {
                 return Some(ghostty_dir);
             }
         }
     }
     None
+}
+
+fn has_xterm_ghostty_terminfo(terminfo_dir: &Path) -> bool {
+    contains_file_named(terminfo_dir, std::ffi::OsStr::new("xterm-ghostty"))
+}
+
+fn contains_file_named(dir: &Path, file_name: &std::ffi::OsStr) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_file() && entry.file_name() == file_name {
+            return true;
+        }
+        if file_type.is_dir() && contains_file_named(&entry.path(), file_name) {
+            return true;
+        }
+    }
+
+    false
 }
 
 // ── GhosttyApp — singleton managing all surfaces ────────────
@@ -1686,22 +1710,7 @@ mod tests {
 
     #[test]
     fn finds_ghostty_resources_inside_installed_app_bundle() {
-        struct Cleanup(std::path::PathBuf);
-        impl Drop for Cleanup {
-            fn drop(&mut self) {
-                let _ = std::fs::remove_dir_all(&self.0);
-            }
-        }
-
-        let unique = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let root = std::env::temp_dir().join(format!(
-            "con-ghostty-resources-test-{}-{unique}",
-            std::process::id()
-        ));
-        let _cleanup = Cleanup(root.clone());
+        let (_cleanup, root) = temp_test_dir("con-ghostty-resources-test");
         let app_root = root.join("con Beta.app");
         let macos_dir = app_root.join("Contents/MacOS");
         let resources_dir = app_root.join("Contents/Resources/ghostty");
@@ -1717,23 +1726,25 @@ mod tests {
     }
 
     #[test]
-    fn ignores_installed_app_resources_when_bundled_terminfo_is_missing() {
-        struct Cleanup(std::path::PathBuf);
-        impl Drop for Cleanup {
-            fn drop(&mut self) {
-                let _ = std::fs::remove_dir_all(&self.0);
-            }
-        }
+    fn finds_ghostty_resources_when_terminfo_uses_letter_bucket() {
+        let (_cleanup, root) = temp_test_dir("con-ghostty-letter-terminfo-test");
+        let app_root = root.join("con Beta.app");
+        let macos_dir = app_root.join("Contents/MacOS");
+        let resources_dir = app_root.join("Contents/Resources/ghostty");
+        let terminfo_file = app_root.join("Contents/Resources/terminfo/x/xterm-ghostty");
+        std::fs::create_dir_all(&macos_dir).unwrap();
+        std::fs::create_dir_all(&resources_dir).unwrap();
+        std::fs::create_dir_all(terminfo_file.parent().unwrap()).unwrap();
+        std::fs::write(&terminfo_file, b"terminfo").unwrap();
 
-        let unique = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let root = std::env::temp_dir().join(format!(
-            "con-ghostty-missing-terminfo-test-{}-{unique}",
-            std::process::id()
-        ));
-        let _cleanup = Cleanup(root.clone());
+        let found = installed_app_ghostty_resources_dir_for_exe(&macos_dir.join("con"));
+
+        assert_eq!(found.as_deref(), Some(resources_dir.as_path()));
+    }
+
+    #[test]
+    fn ignores_installed_app_resources_when_bundled_terminfo_is_missing() {
+        let (_cleanup, root) = temp_test_dir("con-ghostty-missing-terminfo-test");
         let app_root = root.join("con.app");
         let macos_dir = app_root.join("Contents/MacOS");
         let resources_dir = app_root.join("Contents/Resources/ghostty");
@@ -1743,5 +1754,22 @@ mod tests {
         let found = installed_app_ghostty_resources_dir_for_exe(&macos_dir.join("con"));
 
         assert_eq!(found, None);
+    }
+
+    struct Cleanup(std::path::PathBuf);
+
+    impl Drop for Cleanup {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn temp_test_dir(prefix: &str) -> (Cleanup, std::path::PathBuf) {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("{prefix}-{}-{unique}", std::process::id()));
+        (Cleanup(root.clone()), root)
     }
 }

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -396,6 +396,17 @@ fn installed_app_ghostty_resources_dir_for_exe(exe: &Path) -> Option<PathBuf> {
 }
 
 fn has_xterm_ghostty_terminfo(terminfo_dir: &Path) -> bool {
+    // Compiled terminfo databases normally bucket `xterm-ghostty` by either
+    // its first byte in hex (`78`) or first character (`x`). Check those
+    // directly so startup does not walk the whole bundled database.
+    for bucket in ["78", "x"] {
+        if terminfo_dir.join(bucket).join("xterm-ghostty").is_file() {
+            return true;
+        }
+    }
+
+    // Keep a compatibility fallback for alternate tic layouts, but only after
+    // the known O(1) bundle layouts fail.
     contains_file_named(terminfo_dir, std::ffi::OsStr::new("xterm-ghostty"))
 }
 

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -384,9 +384,11 @@ fn installed_app_ghostty_resources_dir() -> Option<PathBuf> {
 fn installed_app_ghostty_resources_dir_for_exe(exe: &Path) -> Option<PathBuf> {
     for ancestor in exe.ancestors() {
         if ancestor.extension().is_some_and(|ext| ext == "app") {
-            let resources_dir = ancestor.join("Contents/Resources/ghostty");
-            if resources_dir.is_dir() {
-                return Some(resources_dir);
+            let resources_root = ancestor.join("Contents/Resources");
+            let ghostty_dir = resources_root.join("ghostty");
+            let terminfo_sentinel = resources_root.join("terminfo/78/xterm-ghostty");
+            if ghostty_dir.is_dir() && terminfo_sentinel.is_file() {
+                return Some(ghostty_dir);
             }
         }
     }
@@ -1703,11 +1705,43 @@ mod tests {
         let app_root = root.join("con Beta.app");
         let macos_dir = app_root.join("Contents/MacOS");
         let resources_dir = app_root.join("Contents/Resources/ghostty");
+        let terminfo_file = app_root.join("Contents/Resources/terminfo/78/xterm-ghostty");
+        std::fs::create_dir_all(&macos_dir).unwrap();
+        std::fs::create_dir_all(&resources_dir).unwrap();
+        std::fs::create_dir_all(terminfo_file.parent().unwrap()).unwrap();
+        std::fs::write(&terminfo_file, b"terminfo").unwrap();
+
+        let found = installed_app_ghostty_resources_dir_for_exe(&macos_dir.join("con"));
+
+        assert_eq!(found.as_deref(), Some(resources_dir.as_path()));
+    }
+
+    #[test]
+    fn ignores_installed_app_resources_when_bundled_terminfo_is_missing() {
+        struct Cleanup(std::path::PathBuf);
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "con-ghostty-missing-terminfo-test-{}-{unique}",
+            std::process::id()
+        ));
+        let _cleanup = Cleanup(root.clone());
+        let app_root = root.join("con.app");
+        let macos_dir = app_root.join("Contents/MacOS");
+        let resources_dir = app_root.join("Contents/Resources/ghostty");
         std::fs::create_dir_all(&macos_dir).unwrap();
         std::fs::create_dir_all(&resources_dir).unwrap();
 
         let found = installed_app_ghostty_resources_dir_for_exe(&macos_dir.join("con"));
 
-        assert_eq!(found.as_deref(), Some(resources_dir.as_path()));
+        assert_eq!(found, None);
     }
 }

--- a/postmortem/2026-05-12-macos-bundle-terminfo.md
+++ b/postmortem/2026-05-12-macos-bundle-terminfo.md
@@ -1,0 +1,37 @@
+# macOS Bundle Missing Ghostty Terminfo
+
+## What happened
+
+`just macos-install` produced a `/Applications/con.app` bundle whose embedded
+terminal launched with `TERM=xterm-ghostty`, but the app bundle did not include
+Ghostty's compiled terminfo database. Shells and terminal-aware programs could
+not resolve the terminal capabilities, which showed up as missing colors,
+broken prompt rendering, and cursor/input display glitches.
+
+## Root cause
+
+`scripts/macos/build-app.sh` copied `zig-out/share/ghostty` into
+`Contents/Resources/ghostty`, but did not copy sibling
+`zig-out/share/terminfo` into `Contents/Resources/terminfo`. Ghostty's macOS
+runtime expects the resources directory to be `Contents/Resources/ghostty` and
+sets `TERMINFO` to the sibling `Contents/Resources/terminfo`.
+
+Con also set `GHOSTTY_RESOURCES_DIR` whenever `Contents/Resources/ghostty`
+existed, even if the sibling terminfo directory was absent. That made the bad
+bundle look valid to Ghostty instead of allowing a safer fallback path.
+
+## Fix applied
+
+- Copy Ghostty's `share/terminfo` into the macOS app bundle.
+- Make macOS verification fail when `terminfo/78/xterm-ghostty` is missing.
+- Make runtime app-bundle resource discovery require the terminfo sentinel
+  before setting `GHOSTTY_RESOURCES_DIR`.
+- Added a regression test for a bundle with `Resources/ghostty` but no
+  `Resources/terminfo`.
+
+## What we learned
+
+Ghostty's embedded resource directory and terminfo database are coupled by
+layout, not by a single copied directory. Future packaging changes should treat
+`Contents/Resources/ghostty` and `Contents/Resources/terminfo` as one runtime
+contract and verify both before release or local install.

--- a/postmortem/2026-05-12-macos-bundle-terminfo.md
+++ b/postmortem/2026-05-12-macos-bundle-terminfo.md
@@ -23,11 +23,12 @@ bundle look valid to Ghostty instead of allowing a safer fallback path.
 ## Fix applied
 
 - Copy Ghostty's `share/terminfo` into the macOS app bundle.
-- Make macOS verification fail when `terminfo/78/xterm-ghostty` is missing.
+- Make macOS verification fail when no compiled `xterm-ghostty` entry exists
+  anywhere under `Contents/Resources/terminfo`.
 - Make runtime app-bundle resource discovery require the terminfo sentinel
   before setting `GHOSTTY_RESOURCES_DIR`.
 - Added a regression test for a bundle with `Resources/ghostty` but no
-  `Resources/terminfo`.
+  `Resources/terminfo`, plus coverage for alternate compiled terminfo buckets.
 
 ## What we learned
 

--- a/scripts/macos/build-app.sh
+++ b/scripts/macos/build-app.sh
@@ -50,13 +50,11 @@ log "Embedded Ghostty resources from $ghostty_resources_dir"
 ghostty_share_dir="$(dirname "$ghostty_resources_dir")"
 ghostty_terminfo_dir="$ghostty_share_dir/terminfo"
 if [[ ! -d "$ghostty_terminfo_dir" ]]; then
-  log "Ghostty terminfo not found in cargo build output"
-  exit 1
+  fail "Ghostty terminfo directory not found in cargo build output: $ghostty_terminfo_dir"
 fi
 ghostty_terminfo_entry="$(find "$ghostty_terminfo_dir" -type f -name xterm-ghostty -print -quit)"
 if [[ -z "$ghostty_terminfo_entry" || ! -r "$ghostty_terminfo_entry" ]]; then
-  log "Ghostty xterm-ghostty terminfo entry not found in cargo build output: $ghostty_terminfo_dir"
-  exit 1
+  fail "Ghostty xterm-ghostty terminfo entry not found under cargo build output: $ghostty_terminfo_dir"
 fi
 rsync -a "$ghostty_terminfo_dir/" "$resources_dir/terminfo/"
 log "Embedded Ghostty terminfo from $ghostty_terminfo_dir"

--- a/scripts/macos/build-app.sh
+++ b/scripts/macos/build-app.sh
@@ -47,6 +47,15 @@ fi
 rsync -a "$ghostty_resources_dir/" "$resources_dir/ghostty/"
 log "Embedded Ghostty resources from $ghostty_resources_dir"
 
+ghostty_share_dir="$(dirname "$ghostty_resources_dir")"
+ghostty_terminfo_dir="$ghostty_share_dir/terminfo"
+if [[ -z "$ghostty_terminfo_dir" || ! -d "$ghostty_terminfo_dir" ]]; then
+  log "Ghostty terminfo not found in cargo build output"
+  exit 1
+fi
+rsync -a "$ghostty_terminfo_dir/" "$resources_dir/terminfo/"
+log "Embedded Ghostty terminfo from $ghostty_terminfo_dir"
+
 iconset_parent="$(mktemp -d "$CON_DIST_ROOT/iconset.XXXXXX")"
 iconset_dir="$iconset_parent/con.iconset"
 mkdir -p "$iconset_dir"

--- a/scripts/macos/build-app.sh
+++ b/scripts/macos/build-app.sh
@@ -49,8 +49,13 @@ log "Embedded Ghostty resources from $ghostty_resources_dir"
 
 ghostty_share_dir="$(dirname "$ghostty_resources_dir")"
 ghostty_terminfo_dir="$ghostty_share_dir/terminfo"
-if [[ -z "$ghostty_terminfo_dir" || ! -d "$ghostty_terminfo_dir" ]]; then
+if [[ ! -d "$ghostty_terminfo_dir" ]]; then
   log "Ghostty terminfo not found in cargo build output"
+  exit 1
+fi
+ghostty_terminfo_entry="$(find "$ghostty_terminfo_dir" -type f -name xterm-ghostty -print -quit)"
+if [[ -z "$ghostty_terminfo_entry" || ! -r "$ghostty_terminfo_entry" ]]; then
+  log "Ghostty xterm-ghostty terminfo entry not found in cargo build output: $ghostty_terminfo_dir"
   exit 1
 fi
 rsync -a "$ghostty_terminfo_dir/" "$resources_dir/terminfo/"

--- a/scripts/macos/verify.sh
+++ b/scripts/macos/verify.sh
@@ -17,9 +17,13 @@ if [[ ! -x "$cli_binary" ]]; then
   fail "con-cli missing from app bundle: $cli_binary"
 fi
 
-terminfo_file="$CON_APP_BUNDLE_PATH/Contents/Resources/terminfo/78/xterm-ghostty"
-if [[ ! -f "$terminfo_file" ]]; then
-  fail "Ghostty terminfo missing from app bundle: $terminfo_file"
+terminfo_dir="$CON_APP_BUNDLE_PATH/Contents/Resources/terminfo"
+if [[ ! -d "$terminfo_dir" ]]; then
+  fail "Ghostty terminfo directory missing from app bundle: $terminfo_dir"
+fi
+terminfo_entry="$(find "$terminfo_dir" -type f -name xterm-ghostty -print -quit)"
+if [[ -z "$terminfo_entry" || ! -r "$terminfo_entry" ]]; then
+  fail "Ghostty xterm-ghostty terminfo entry missing from app bundle: $terminfo_dir"
 fi
 
 log "Verifying code signature for $CON_APP_BUNDLE_PATH"

--- a/scripts/macos/verify.sh
+++ b/scripts/macos/verify.sh
@@ -17,6 +17,11 @@ if [[ ! -x "$cli_binary" ]]; then
   fail "con-cli missing from app bundle: $cli_binary"
 fi
 
+terminfo_file="$CON_APP_BUNDLE_PATH/Contents/Resources/terminfo/78/xterm-ghostty"
+if [[ ! -f "$terminfo_file" ]]; then
+  fail "Ghostty terminfo missing from app bundle: $terminfo_file"
+fi
+
 log "Verifying code signature for $CON_APP_BUNDLE_PATH"
 codesign --verify --deep --strict --verbose=2 "$CON_APP_BUNDLE_PATH"
 


### PR DESCRIPTION
## Summary
- Copy Ghostty's compiled terminfo database into macOS app bundles alongside `Resources/ghostty`.
- Require the `xterm-ghostty` terminfo sentinel before treating an installed `.app` as a valid Ghostty resource source.
- Add bundle verification, regression coverage, and a postmortem for the packaging regression.

## Test Plan
- `just macos-install`
- `cargo test -p con-ghostty --target aarch64-apple-darwin`
- `bash -n scripts/macos/build-app.sh scripts/macos/verify.sh`
- `git diff --check`
- `TERMINFO=/Applications/con.app/Contents/Resources/terminfo infocmp xterm-ghostty`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS app packaging to include the terminfo database so terminal capabilities (xterm-ghostty) are detected reliably and validation fails when missing.
* **Documentation**
  * Added a macOS packaging postmortem documenting the issue, root cause, and mitigation.
* **Tests**
  * Added regression tests to ensure bundles lacking terminfo are detected and treated as invalid.
* **Chores**
  * Improved packaging and verification scripts to embed and verify terminfo during build.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/con-terminal/pull/195)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->