### PR TITLE
Polish vertical sidebar tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ con is still pre-release, so entries may group related beta work while the produ
 - Restored vertical tabs inside the left sidebar and brought back full sidebar
   hide/unhide behavior. `appearance.tabs_orientation` again controls horizontal
   vs. vertical tabs, and Files/Search now opens as a lightweight drawer instead
-  of a permanent second sidebar beside vertical tabs. _(PR
+  of a permanent second sidebar beside vertical tabs. A compact in-sidebar
+  launcher keeps Files/Search discoverable when the drawer is closed. _(PR
   [#194](https://github.com/nowledge-co/con-terminal/pull/194) by
+  [@wey-gu](https://github.com/wey-gu), PR
+  [#200](https://github.com/nowledge-co/con-terminal/pull/200) by
   [@wey-gu](https://github.com/wey-gu))_
 
 **Tabs**

--- a/crates/con-app/src/activity_bar.rs
+++ b/crates/con-app/src/activity_bar.rs
@@ -87,24 +87,18 @@ impl Render for ActivityBar {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
         let active_slot = self.active_slot;
-        let compact_launcher = !self.left_panel_open;
 
         div()
             .id("activity-bar")
+            .h(px(ACTIVITY_BAR_HEADER_HEIGHT))
+            .w_full()
             .flex()
+            .flex_row()
             .items_center()
             .justify_center()
             .gap(px(4.0))
+            .px(px(8.0))
             .flex_shrink_0()
-            .when(compact_launcher, |bar| {
-                bar.w(px(36.0)).h(px(70.0)).flex_col()
-            })
-            .when(!compact_launcher, |bar| {
-                bar.h(px(ACTIVITY_BAR_HEADER_HEIGHT))
-                    .w_full()
-                    .flex_row()
-                    .px(px(8.0))
-            })
             .child(activity_slot_button(
                 "activity-files",
                 "phosphor/folders.svg",

--- a/crates/con-app/src/activity_bar.rs
+++ b/crates/con-app/src/activity_bar.rs
@@ -87,18 +87,24 @@ impl Render for ActivityBar {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
         let active_slot = self.active_slot;
+        let compact_launcher = !self.left_panel_open;
 
         div()
             .id("activity-bar")
-            .h(px(ACTIVITY_BAR_HEADER_HEIGHT))
-            .w_full()
             .flex()
-            .flex_row()
             .items_center()
             .justify_center()
             .gap(px(4.0))
-            .px(px(8.0))
             .flex_shrink_0()
+            .when(compact_launcher, |bar| {
+                bar.w(px(36.0)).h(px(70.0)).flex_col()
+            })
+            .when(!compact_launcher, |bar| {
+                bar.h(px(ACTIVITY_BAR_HEADER_HEIGHT))
+                    .w_full()
+                    .flex_row()
+                    .px(px(8.0))
+            })
             .child(activity_slot_button(
                 "activity-files",
                 "phosphor/folders.svg",

--- a/crates/con-app/src/sidebar.rs
+++ b/crates/con-app/src/sidebar.rs
@@ -14,6 +14,7 @@
 //! - Surface separation comes from `surface_tone()` (foreground
 //!   blended into background at small intensities), not borders.
 
+use crate::activity_bar::ActivitySlot;
 use crate::motion::MotionValue;
 use gpui::{
     AnyElement, App, Bounds, Context, Div, Entity, EventEmitter, FontWeight, Hsla,
@@ -291,6 +292,10 @@ pub struct SidebarSetColor {
     pub color: Option<con_core::session::TabAccentColor>,
 }
 
+pub struct SidebarOpenToolSlot {
+    pub slot: ActivitySlot,
+}
+
 impl EventEmitter<SidebarSelect> for SessionSidebar {}
 impl EventEmitter<NewSession> for SessionSidebar {}
 impl EventEmitter<SidebarCloseTab> for SessionSidebar {}
@@ -300,6 +305,7 @@ impl EventEmitter<SidebarReorder> for SessionSidebar {}
 impl EventEmitter<SidebarPaneToTab> for SessionSidebar {}
 impl EventEmitter<SidebarCloseOthers> for SessionSidebar {}
 impl EventEmitter<SidebarSetColor> for SessionSidebar {}
+impl EventEmitter<SidebarOpenToolSlot> for SessionSidebar {}
 
 impl SessionSidebar {
     pub fn new(_cx: &mut Context<Self>) -> Self {
@@ -795,6 +801,35 @@ impl SessionSidebar {
                     .w(px(20.0))
                     .my(px(2.0))
                     .bg(theme.muted_foreground.opacity(0.18)),
+            )
+            .child(rail_icon_button(
+                "tab-sidebar-rail-files",
+                "phosphor/folders.svg",
+                theme.muted_foreground,
+                theme,
+                cx.listener(|_, _, _, cx| {
+                    cx.emit(SidebarOpenToolSlot {
+                        slot: ActivitySlot::Files,
+                    })
+                }),
+            ))
+            .child(rail_icon_button(
+                "tab-sidebar-rail-search",
+                "phosphor/file-magnifying-glass.svg",
+                theme.muted_foreground,
+                theme,
+                cx.listener(|_, _, _, cx| {
+                    cx.emit(SidebarOpenToolSlot {
+                        slot: ActivitySlot::Search,
+                    })
+                }),
+            ))
+            .child(
+                div()
+                    .h(px(1.0))
+                    .w(px(20.0))
+                    .my(px(2.0))
+                    .bg(theme.muted_foreground.opacity(0.18)),
             );
 
         for (i, session) in self.sessions.iter().enumerate() {
@@ -1055,6 +1090,8 @@ impl SessionSidebar {
         let body_bg;
         let header_color;
         let header_font;
+        let files_btn;
+        let search_btn;
         let new_btn;
         let toggle_btn;
         {
@@ -1062,6 +1099,26 @@ impl SessionSidebar {
             body_bg = sidebar_surface(theme, self.ui_opacity, 0.045);
             header_color = theme.muted_foreground.opacity(0.55);
             header_font = theme.font_family.clone();
+            files_btn = panel_icon_button(
+                "tab-sidebar-panel-files",
+                "phosphor/folders.svg",
+                theme,
+                cx.listener(|_this, _, _, cx| {
+                    cx.emit(SidebarOpenToolSlot {
+                        slot: ActivitySlot::Files,
+                    })
+                }),
+            );
+            search_btn = panel_icon_button(
+                "tab-sidebar-panel-search",
+                "phosphor/file-magnifying-glass.svg",
+                theme,
+                cx.listener(|_this, _, _, cx| {
+                    cx.emit(SidebarOpenToolSlot {
+                        slot: ActivitySlot::Search,
+                    })
+                }),
+            );
             new_btn = panel_icon_button(
                 "tab-sidebar-panel-new",
                 "phosphor/plus.svg",
@@ -1101,7 +1158,15 @@ impl SessionSidebar {
                             .font_family(header_font)
                             .child(format!("{} TABS", self.sessions.len())),
                     )
-                    .child(div().flex().gap(px(2.0)).child(new_btn).child(toggle_btn)),
+                    .child(
+                        div()
+                            .flex()
+                            .gap(px(2.0))
+                            .child(files_btn)
+                            .child(search_btn)
+                            .child(new_btn)
+                            .child(toggle_btn),
+                    ),
             );
 
         let total = self.sessions.len();

--- a/crates/con-app/src/workspace/caption.rs
+++ b/crates/con-app/src/workspace/caption.rs
@@ -13,14 +13,14 @@ mod tests {
 
     #[::core::prelude::v1::test]
     fn sidebar_max_width_reserves_main_content_and_caps_panel() {
-        let window_width = RAIL_WIDTH + TERMINAL_MIN_CONTENT_WIDTH + PANEL_MAX_WIDTH + 120.0;
+        let window_width = TERMINAL_MIN_CONTENT_WIDTH + PANEL_MAX_WIDTH + 120.0;
 
         assert_eq!(max_sidebar_panel_width(window_width, 0.0), PANEL_MAX_WIDTH);
 
-        let constrained_width = RAIL_WIDTH + TERMINAL_MIN_CONTENT_WIDTH + 260.0;
+        let constrained_width = TERMINAL_MIN_CONTENT_WIDTH + 260.0;
         assert_eq!(max_sidebar_panel_width(constrained_width, 0.0), 260.0);
 
-        let tiny_width = RAIL_WIDTH + TERMINAL_MIN_CONTENT_WIDTH - 20.0;
+        let tiny_width = TERMINAL_MIN_CONTENT_WIDTH - 20.0;
         assert_eq!(max_sidebar_panel_width(tiny_width, 0.0), PANEL_MIN_WIDTH);
     }
 }
@@ -63,7 +63,7 @@ pub(super) fn max_agent_panel_width(window_width: f32) -> f32 {
 }
 
 pub(super) fn max_sidebar_panel_width(window_width: f32, agent_panel_outer_width: f32) -> f32 {
-    (window_width - agent_panel_outer_width - RAIL_WIDTH - TERMINAL_MIN_CONTENT_WIDTH)
+    (window_width - agent_panel_outer_width - TERMINAL_MIN_CONTENT_WIDTH)
         .clamp(PANEL_MIN_WIDTH, PANEL_MAX_WIDTH)
 }
 

--- a/crates/con-app/src/workspace/lifecycle.rs
+++ b/crates/con-app/src/workspace/lifecycle.rs
@@ -366,6 +366,8 @@ impl ConWorkspace {
             .detach();
         cx.subscribe_in(&sidebar, window, Self::on_sidebar_set_color)
             .detach();
+        cx.subscribe_in(&sidebar, window, Self::on_sidebar_open_tool_slot)
+            .detach();
         cx.observe(&sidebar, |_this, _sidebar, cx| {
             cx.notify();
         })

--- a/crates/con-app/src/workspace/mod.rs
+++ b/crates/con-app/src/workspace/mod.rs
@@ -56,9 +56,9 @@ use crate::pane_tree::{
 };
 use crate::settings_panel::{self, AppearancePreview, SaveSettings, SettingsPanel, ThemePreview};
 use crate::sidebar::{
-    DraggedTab, DraggedTabOrigin, NewSession, PANEL_MAX_WIDTH, PANEL_MIN_WIDTH, RAIL_WIDTH,
-    SessionEntry, SessionSidebar, SidebarCloseOthers, SidebarCloseTab, SidebarDuplicate,
-    SidebarPaneToTab, SidebarRename, SidebarReorder, SidebarSelect, SidebarSetColor,
+    DraggedTab, DraggedTabOrigin, NewSession, PANEL_MAX_WIDTH, PANEL_MIN_WIDTH, SessionEntry,
+    SessionSidebar, SidebarCloseOthers, SidebarCloseTab, SidebarDuplicate, SidebarPaneToTab,
+    SidebarRename, SidebarReorder, SidebarSelect, SidebarSetColor,
 };
 use crate::sidebar_search_view::SidebarSearchView;
 use crate::terminal_pane::{TerminalPane, subscribe_terminal_pane};

--- a/crates/con-app/src/workspace/mod.rs
+++ b/crates/con-app/src/workspace/mod.rs
@@ -57,8 +57,8 @@ use crate::pane_tree::{
 use crate::settings_panel::{self, AppearancePreview, SaveSettings, SettingsPanel, ThemePreview};
 use crate::sidebar::{
     DraggedTab, DraggedTabOrigin, NewSession, PANEL_MAX_WIDTH, PANEL_MIN_WIDTH, SessionEntry,
-    SessionSidebar, SidebarCloseOthers, SidebarCloseTab, SidebarDuplicate, SidebarPaneToTab,
-    SidebarRename, SidebarReorder, SidebarSelect, SidebarSetColor,
+    SessionSidebar, SidebarCloseOthers, SidebarCloseTab, SidebarDuplicate, SidebarOpenToolSlot,
+    SidebarPaneToTab, SidebarRename, SidebarReorder, SidebarSelect, SidebarSetColor,
 };
 use crate::sidebar_search_view::SidebarSearchView;
 use crate::terminal_pane::{TerminalPane, subscribe_terminal_pane};

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -4,6 +4,45 @@ mod top_bar;
 use super::*;
 
 impl ConWorkspace {
+    fn render_vertical_sidebar_tools_launcher(
+        &self,
+        tab_sidebar_width: f32,
+        theme: &Theme,
+    ) -> AnyElement {
+        let launcher_width = 36.0;
+        let launcher_height = 70.0;
+        let collapsed_rail = tab_sidebar_width <= 68.0;
+        let launcher_left = if collapsed_rail {
+            ((tab_sidebar_width - launcher_width) / 2.0).max(4.0)
+        } else {
+            (tab_sidebar_width - launcher_width - 12.0).max(6.0)
+        };
+        let launcher_top = if collapsed_rail { 82.0 } else { 46.0 };
+        let surface = if theme.is_dark() {
+            theme.background.blend(theme.foreground.opacity(0.08))
+        } else {
+            theme.background.blend(theme.foreground.opacity(0.055))
+        };
+
+        div()
+            .id("vertical-sidebar-tools-launcher")
+            .absolute()
+            .left(px(launcher_left))
+            .top(px(launcher_top))
+            .w(px(launcher_width))
+            .h(px(launcher_height))
+            .flex()
+            .flex_col()
+            .items_center()
+            .justify_center()
+            .gap(px(4.0))
+            .rounded(px(7.0))
+            .occlude()
+            .bg(surface)
+            .child(self.activity_bar.clone())
+            .into_any_element()
+    }
+
     fn has_active_resize_drag(&self) -> bool {
         self.sidebar_drag.is_some()
             || self.agent_panel_drag.is_some()
@@ -71,7 +110,10 @@ impl ConWorkspace {
                 0.0
             };
             let max_width = if self.vertical_tabs_enabled() {
-                PANEL_MAX_WIDTH
+                max_sidebar_panel_width(
+                    (win_w - self.sidebar.read(cx).rendered_width()).max(0.0),
+                    agent_w,
+                )
             } else {
                 max_sidebar_panel_width(win_w, agent_w)
             };
@@ -748,6 +790,7 @@ impl Render for ConWorkspace {
 
         if show_left_panel {
             let mut left_sidebar = div()
+                .relative()
                 .w(px(left_panel_width))
                 .h_full()
                 .flex()
@@ -763,6 +806,11 @@ impl Render for ConWorkspace {
                         .flex_shrink_0()
                         .child(self.sidebar.clone()),
                 );
+                if !show_sidebar_tools {
+                    left_sidebar = left_sidebar.child(
+                        self.render_vertical_sidebar_tools_launcher(tab_sidebar_width, theme),
+                    );
+                }
             }
             if !vertical_tabs_enabled && show_sidebar_tools {
                 let sidebar_content: AnyElement = match self.activity_slot {
@@ -793,21 +841,6 @@ impl Render for ConWorkspace {
             .child(terminal_area);
 
         main_area = main_area.child(main_column);
-
-        if vertical_tabs_enabled && show_left_panel && !show_sidebar_tools {
-            main_area = main_area.child(
-                div()
-                    .absolute()
-                    .top(px(6.0))
-                    .left(px(tab_sidebar_width + 6.0))
-                    .w(px(72.0))
-                    .h(px(36.0))
-                    .overflow_hidden()
-                    .occlude()
-                    .bg(elevated_panel_surface_color)
-                    .child(self.activity_bar.clone()),
-            );
-        }
 
         if vertical_tabs_enabled && show_sidebar_tools {
             let sidebar_content: AnyElement = match self.activity_slot {

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -4,45 +4,6 @@ mod top_bar;
 use super::*;
 
 impl ConWorkspace {
-    fn render_vertical_sidebar_tools_launcher(
-        &self,
-        tab_sidebar_width: f32,
-        theme: &Theme,
-    ) -> AnyElement {
-        let launcher_width = 36.0;
-        let launcher_height = 70.0;
-        let collapsed_rail = tab_sidebar_width <= 68.0;
-        let launcher_left = if collapsed_rail {
-            ((tab_sidebar_width - launcher_width) / 2.0).max(4.0)
-        } else {
-            (tab_sidebar_width - launcher_width - 12.0).max(6.0)
-        };
-        let launcher_top = if collapsed_rail { 82.0 } else { 46.0 };
-        let surface = if theme.is_dark() {
-            theme.background.blend(theme.foreground.opacity(0.08))
-        } else {
-            theme.background.blend(theme.foreground.opacity(0.055))
-        };
-
-        div()
-            .id("vertical-sidebar-tools-launcher")
-            .absolute()
-            .left(px(launcher_left))
-            .top(px(launcher_top))
-            .w(px(launcher_width))
-            .h(px(launcher_height))
-            .flex()
-            .flex_col()
-            .items_center()
-            .justify_center()
-            .gap(px(4.0))
-            .rounded(px(7.0))
-            .occlude()
-            .bg(surface)
-            .child(self.activity_bar.clone())
-            .into_any_element()
-    }
-
     fn has_active_resize_drag(&self) -> bool {
         self.sidebar_drag.is_some()
             || self.agent_panel_drag.is_some()
@@ -790,7 +751,6 @@ impl Render for ConWorkspace {
 
         if show_left_panel {
             let mut left_sidebar = div()
-                .relative()
                 .w(px(left_panel_width))
                 .h_full()
                 .flex()
@@ -806,11 +766,6 @@ impl Render for ConWorkspace {
                         .flex_shrink_0()
                         .child(self.sidebar.clone()),
                 );
-                if !show_sidebar_tools {
-                    left_sidebar = left_sidebar.child(
-                        self.render_vertical_sidebar_tools_launcher(tab_sidebar_width, theme),
-                    );
-                }
             }
             if !vertical_tabs_enabled && show_sidebar_tools {
                 let sidebar_content: AnyElement = match self.activity_slot {

--- a/crates/con-app/src/workspace/sidebar_settings.rs
+++ b/crates/con-app/src/workspace/sidebar_settings.rs
@@ -824,11 +824,6 @@ impl ConWorkspace {
         let term_config = settings.read(cx).terminal_config().clone();
         let appearance_config = settings.read(cx).appearance_config().clone();
         self.apply_terminal_and_ui_appearance(&term_config, &appearance_config, window, cx);
-        self.config.appearance.tabs_orientation = appearance_config.tabs_orientation;
-        if !self.vertical_tabs_enabled() {
-            self.sidebar_tools_open = self.left_panel_open;
-        }
-        self.sync_tab_strip_motion();
         cx.notify();
     }
 

--- a/crates/con-app/src/workspace/sidebar_settings.rs
+++ b/crates/con-app/src/workspace/sidebar_settings.rs
@@ -506,6 +506,25 @@ impl ConWorkspace {
         self.set_tab_color(index, event.color, cx);
     }
 
+    pub(super) fn on_sidebar_open_tool_slot(
+        &mut self,
+        _sidebar: &Entity<SessionSidebar>,
+        event: &SidebarOpenToolSlot,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.activity_slot = event.slot;
+        self.left_panel_open = true;
+        self.sidebar_tools_open = true;
+        self.activity_bar.update(cx, |bar, cx| {
+            bar.active_slot = event.slot;
+            bar.left_panel_open = true;
+            cx.notify();
+        });
+        self.save_session(cx);
+        cx.notify();
+    }
+
     pub(super) fn sync_sidebar(&self, cx: &mut Context<Self>) {
         let sessions: Vec<SessionEntry> = self
             .tabs

--- a/docs/impl/code-editor-design.md
+++ b/docs/impl/code-editor-design.md
@@ -15,7 +15,8 @@ The left side of the window has two tab-orientation modes:
 
 - horizontal tabs: file/search is the left sidebar panel,
 - vertical tabs: `SessionSidebar` is the permanent left navigation surface, and
-  file/search opens as an overlay drawer from that sidebar edge.
+  a compact in-sidebar launcher opens file/search as an overlay drawer from
+  that sidebar edge.
 
 Hiding the left sidebar removes all left chrome. Unhiding restores the selected
 tab orientation, the previous vertical-tab folded/unfolded mode, and the active

--- a/docs/impl/left-sidebar.md
+++ b/docs/impl/left-sidebar.md
@@ -20,7 +20,8 @@ When the left sidebar is visible:
 
 - vertical tabs can stay folded as a 44 px rail or unfold into the pinned tab
   panel when `appearance.tabs_orientation = "vertical"`,
-- the file/search icon strip opens a lightweight drawer from the sidebar edge,
+- the file/search icon strip stays on the vertical-tabs sidebar surface and
+  opens a lightweight drawer from the sidebar edge,
 - the drawer overlays the workspace instead of permanently consuming layout
   width beside vertical tabs.
 

--- a/docs/impl/vertical-tabs.md
+++ b/docs/impl/vertical-tabs.md
@@ -31,8 +31,8 @@ the compact state.
 
 Unfolded mode renders the pinned vertical tab panel with tab titles, subtitles,
 rename, close, drag/drop, and create-tab controls. File/search remains available
-as an auxiliary drawer; unfolding tabs does not replace editor navigation and
-opening the drawer does not widen the permanent sidebar.
+from a compact launcher on the tab sidebar; unfolding tabs does not replace
+editor navigation and opening the drawer does not widen the permanent sidebar.
 
 ## Compatibility
 


### PR DESCRIPTION
## Summary

- address the late PR #194 review threads around sidebar max-width clamping and redundant appearance-preview sync
- keep the Files/Search launcher visible on the vertical-tabs sidebar surface instead of rendering it over the terminal surface
- keep the drawer lightweight in vertical-tabs mode while making Files/Search discoverable in the closed state
- update sidebar/editor design docs for the in-sidebar launcher model

## Validation

- cargo check -p con
- cargo test -p con
- cargo test -p con sidebar_max_width_reserves_main_content_and_caps_panel
- git diff --check