### PR TITLE
Polish Linux integrated chrome and terminal rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,7 @@ dependencies = [
  "uuid",
  "windows 0.61.3",
  "winresource",
+ "x11rb",
 ]
 
 [[package]]

--- a/crates/con-app/Cargo.toml
+++ b/crates/con-app/Cargo.toml
@@ -85,7 +85,9 @@ image = { version = "0.25", default-features = false }
 smallvec = "1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
+raw-window-handle = "0.6"
 unicode-width.workspace = true
+x11rb = "0.13.2"
 
 [target.'cfg(unix)'.dependencies]
 socket2 = "0.6"

--- a/crates/con-app/build.rs
+++ b/crates/con-app/build.rs
@@ -33,8 +33,7 @@ fn main() {
         );
     }
 
-    #[cfg(target_os = "macos")]
-    {
+    if target_os == "macos" {
         cc::Build::new()
             .file("src/objc/sparkle_trampoline.m")
             .file("src/objc/global_hotkey_trampoline.m")

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -530,8 +530,8 @@ impl GhosttyView {
             rows,
             width_px,
             height_px,
-            cell_width_px,
-            cell_height_px,
+            cell_width_px: cell_width,
+            cell_height_px: cell_height,
         }
     }
 

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -1067,7 +1067,6 @@ impl Render for GhosttyView {
             configured_pane_opacity
         };
         let pane_background = theme.background.opacity(pane_opacity);
-        let row_clear_background = theme.transparent;
         let selection = self.selection;
         let selection_bg = theme.selection.opacity(0.42);
         self.sync_row_cache(
@@ -1116,7 +1115,6 @@ impl Render for GhosttyView {
                             &row,
                             px(font_size_px),
                             px(line_height_px),
-                            row_clear_background,
                         ));
                     }
                 } else if let Some(row) = self.row_cache.get(row_idx) {
@@ -1124,7 +1122,6 @@ impl Render for GhosttyView {
                         row,
                         px(font_size_px),
                         px(line_height_px),
-                        row_clear_background,
                     ));
                 }
             }
@@ -1565,7 +1562,6 @@ fn render_cached_terminal_row(
     row: &CachedTerminalRow,
     font_size: Pixels,
     line_height: Pixels,
-    clear_bg: Hsla,
 ) -> AnyElement {
     div()
         .w_full()
@@ -1578,7 +1574,6 @@ fn render_cached_terminal_row(
         // word-wrap breaks continuous runs at word boundaries and pushes
         // them down, making TUI layouts look garbled in narrow panes.
         .whitespace_nowrap()
-        .bg(clear_bg)
         .text_size(font_size)
         .line_height(line_height)
         .child(StyledText::new(row.text.clone()).with_runs(row.runs.clone()))

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -56,6 +56,14 @@ fn effective_font_size(configured: f32) -> f32 {
     base.max(MIN_FONT_SIZE_PX)
 }
 
+fn cell_width_px(font_size_px: f32) -> f32 {
+    (font_size_px * DEFAULT_CELL_WIDTH_RATIO).round().max(7.0)
+}
+
+fn cell_height_px(font_size_px: f32) -> f32 {
+    (font_size_px * DEFAULT_CELL_HEIGHT_RATIO).round().max(14.0)
+}
+
 actions!(ghostty, [ConsumeTab, ConsumeTabPrev]);
 
 #[allow(dead_code)]
@@ -508,12 +516,12 @@ impl GhosttyView {
         // make text overrun the estimated column count and lines
         // wrap unexpectedly on the alternate screen.
         let font_size_px = effective_font_size(self.initial_font_size) * scale_factor;
-        let cell_width_px = (font_size_px * DEFAULT_CELL_WIDTH_RATIO).round().max(7.0) as u32;
-        let cell_height_px = (font_size_px * DEFAULT_CELL_HEIGHT_RATIO).round().max(14.0) as u32;
-        let columns = (width_px / cell_width_px.max(1))
+        let cell_width = cell_width_px(font_size_px) as u32;
+        let cell_height = cell_height_px(font_size_px) as u32;
+        let columns = (width_px / cell_width.max(1))
             .max(1)
             .min(u32::from(u16::MAX)) as u16;
-        let rows = (height_px / cell_height_px.max(1))
+        let rows = (height_px / cell_height.max(1))
             .max(1)
             .min(u32::from(u16::MAX)) as u16;
 
@@ -543,8 +551,8 @@ impl GhosttyView {
         let bounds = self.pane_bounds?;
         let snapshot = self.snapshot.as_ref()?;
         let font_size_px = effective_font_size(self.initial_font_size);
-        let cell_width_px = (font_size_px * DEFAULT_CELL_WIDTH_RATIO).round().max(7.0);
-        let cell_height_px = (font_size_px * DEFAULT_CELL_HEIGHT_RATIO).round().max(14.0);
+        let cell_width_px = cell_width_px(font_size_px);
+        let cell_height_px = cell_height_px(font_size_px);
 
         let mut local_x = f32::from(pos.x) - f32::from(bounds.origin.x) - TERMINAL_PADDING_X_PX;
         let mut local_y = f32::from(pos.y) - f32::from(bounds.origin.y) - TERMINAL_PADDING_Y_PX;
@@ -836,8 +844,8 @@ impl GhosttyView {
         let bounds = self.pane_bounds?;
         let snapshot = self.snapshot.as_ref()?;
         let font_size_px = effective_font_size(self.initial_font_size);
-        let cell_width = (font_size_px * DEFAULT_CELL_WIDTH_RATIO).round().max(7.0);
-        let cell_height = (font_size_px * DEFAULT_CELL_HEIGHT_RATIO).round().max(14.0);
+        let cell_width = cell_width_px(font_size_px);
+        let cell_height = cell_height_px(font_size_px);
         let col = snapshot.cursor.col.min(snapshot.cols.saturating_sub(1)) as f32;
         let row = snapshot.cursor.row.min(snapshot.rows.saturating_sub(1)) as f32;
 
@@ -1020,8 +1028,8 @@ impl Render for GhosttyView {
         let entity = cx.entity().downgrade();
         let input_entity = entity.clone();
         let font_size_px = effective_font_size(self.initial_font_size);
-        let line_height_px = (font_size_px * 1.45).round();
-        let cell_width_px = (font_size_px * DEFAULT_CELL_WIDTH_RATIO).round().max(7.0);
+        let line_height_px = cell_height_px(font_size_px);
+        let cell_width_px = cell_width_px(font_size_px);
         let mono_font = Font {
             family: theme.mono_font_family.clone(),
             features: FontFeatures::default(),
@@ -1058,6 +1066,8 @@ impl Render for GhosttyView {
         } else {
             configured_pane_opacity
         };
+        let pane_background = theme.background.opacity(pane_opacity);
+        let row_clear_background = theme.transparent;
         let selection = self.selection;
         let selection_bg = theme.selection.opacity(0.42);
         self.sync_row_cache(
@@ -1106,7 +1116,7 @@ impl Render for GhosttyView {
                             &row,
                             px(font_size_px),
                             px(line_height_px),
-                            theme.background.opacity(pane_opacity),
+                            row_clear_background,
                         ));
                     }
                 } else if let Some(row) = self.row_cache.get(row_idx) {
@@ -1114,7 +1124,7 @@ impl Render for GhosttyView {
                         row,
                         px(font_size_px),
                         px(line_height_px),
-                        theme.background.opacity(pane_opacity),
+                        row_clear_background,
                     ));
                 }
             }
@@ -1139,7 +1149,7 @@ impl Render for GhosttyView {
             .min_w_0()
             .min_h_0()
             .overflow_hidden()
-            .bg(theme.background.opacity(pane_opacity))
+            .bg(pane_background)
             .px(px(TERMINAL_PADDING_X_PX))
             .py(px(TERMINAL_PADDING_Y_PX))
             .text_color(foreground)
@@ -1168,7 +1178,7 @@ impl Render for GhosttyView {
             .key_context("GhosttyTerminal")
             .track_focus(&self.focus_handle)
             .id(&self.focus_handle)
-            .bg(theme.background.opacity(pane_opacity))
+            .bg(theme.transparent)
             .on_action(cx.listener(|this, _: &ConsumeTab, window, cx| {
                 if !this.focus_handle.is_focused(window) {
                     return;
@@ -1859,7 +1869,8 @@ fn encode_special_key(key: &str, modifiers: &Modifiers, decckm: bool) -> Option<
 #[cfg(test)]
 mod tests {
     use super::{
-        TerminalSelection, build_terminal_row, extract_selection_text, rows_needing_refresh,
+        DEFAULT_FONT_SIZE, MIN_FONT_SIZE_PX, TerminalSelection, build_terminal_row, cell_height_px,
+        cell_width_px, effective_font_size, extract_selection_text, rows_needing_refresh,
         vt_color_to_hsla,
     };
     use con_ghostty::{ATTR_BOLD, ATTR_INVERSE, ATTR_UNDERLINE, ScreenSnapshot, VtCell, VtCursor};
@@ -1909,6 +1920,14 @@ mod tests {
     fn vt_color_zero_alpha_means_default() {
         assert_eq!(vt_color_to_hsla(0x000000_00), None);
         assert!(vt_color_to_hsla(0x112233_FF).is_some());
+    }
+
+    #[test]
+    fn cell_metrics_match_font_size_clamping() {
+        assert_eq!(effective_font_size(0.0), DEFAULT_FONT_SIZE);
+        assert_eq!(effective_font_size(8.0), MIN_FONT_SIZE_PX);
+        assert_eq!(cell_width_px(14.0), 9.0);
+        assert_eq!(cell_height_px(14.0), 20.0);
     }
 
     #[test]

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -27,7 +27,7 @@ mod quick_terminal;
 // The terminal-view module is selected per platform:
 //   macOS   -> ghostty_view.rs (libghostty + child NSView)
 //   Windows -> windows_view.rs (libghostty-vt + ConPTY + D3D11 child HWND)
-//   Linux   -> linux_view.rs (Linux-specific placeholder until backend lands)
+//   Linux   -> linux_view.rs (Unix PTY + libghostty-vt + GPUI paint path)
 //   other   -> stub_view.rs
 //
 // All three expose the same public type names (`GhosttyView`,
@@ -280,24 +280,16 @@ pub fn set_windows_backdrop_blur(window: &mut Window, blur: bool) {
 /// can toggle "background blur" in settings without restarting the
 /// window.
 ///
-/// `blur=true` requests `WindowBackgroundAppearance::Blurred`. The
-/// gpui_linux Wayland backend honors that via the
-/// `org_kde_kwin_blur` protocol (real Gaussian blur of what's
-/// behind the window — works on KDE Plasma Wayland). On X11 and on
-/// Wayland compositors that don't expose the blur protocol
-/// (mutter / GNOME, sway by default), the renderer keeps the
-/// window transparent but does NOT draw a blur — there's no
-/// equivalent of DWM's Acrylic API there. We still flip to
-/// `Transparent` in that case so per-pane opacity has a desktop
-/// to composite over.
+/// Linux keeps the native surface transparent even when the user
+/// has background blur enabled. GPUI's current KWin blur integration
+/// commits blur for the whole Wayland surface instead of a rounded
+/// region, which makes the transparent corners read as a rectangular
+/// blur block. Until the platform layer can expose a rounded blur
+/// region, alpha shape correctness wins over blur.
 #[cfg(target_os = "linux")]
-pub fn set_linux_window_blur(window: &mut Window, blur: bool) {
+pub fn set_linux_window_blur(window: &mut Window, _blur: bool) {
     use gpui::WindowBackgroundAppearance;
-    window.set_background_appearance(if blur {
-        WindowBackgroundAppearance::Blurred
-    } else {
-        WindowBackgroundAppearance::Transparent
-    });
+    window.set_background_appearance(WindowBackgroundAppearance::Transparent);
 }
 
 #[cfg(target_os = "macos")]
@@ -444,7 +436,7 @@ fn default_window_background(
     config: &con_core::Config,
     transparent: bool,
 ) -> WindowBackgroundAppearance {
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     let _ = config;
 
     if !transparent {
@@ -463,7 +455,16 @@ fn default_window_background(
         }
     }
 
-    WindowBackgroundAppearance::Transparent
+    #[cfg(target_os = "linux")]
+    {
+        let _ = config;
+        WindowBackgroundAppearance::Transparent
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        WindowBackgroundAppearance::Transparent
+    }
 }
 
 fn default_workspace_window_bounds(cx: &mut App) -> WindowBounds {
@@ -595,6 +596,13 @@ pub(crate) fn open_con_window(
                     // Ghostty NSView below GPUI stays visible, even on
                     // Monterey where the top-level window falls back to
                     // opaque.
+                    cx.theme().transparent
+                } else if cfg!(target_os = "linux") {
+                    // Linux relies on a transparent top-level Root so
+                    // the workspace's rounded `overflow_hidden` clip
+                    // exposes the compositor at the outer corners.
+                    // Painting the Root with the theme background here
+                    // makes the clipped workspace look square again.
                     cx.theme().transparent
                 } else {
                     cx.theme().background

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -203,7 +203,7 @@ fn set_dock_icon() {}
 
 #[cfg(target_os = "linux")]
 fn linux_uses_client_side_decorations() -> bool {
-    std::env::var_os("WAYLAND_DISPLAY").is_some_and(|display| !display.is_empty())
+    true
 }
 
 #[cfg(target_os = "macos")]
@@ -236,11 +236,9 @@ fn supports_transparent_main_window() -> bool {
 
 #[cfg(target_os = "linux")]
 fn supports_transparent_main_window() -> bool {
-    // Wayland has no universal server-side frame, so keep the client
-    // surface transparent and let Con's rounded workspace clip define
-    // the silhouette. On X11/Xfce, rounded outer corners are owned by
-    // the window manager's server-side frame; keeping Con opaque there
-    // avoids full-window alpha compositing and preserves native corners.
+    // Linux uses client-side decorations so Con's top bar stays
+    // consistent with macOS/Windows. Wayland gets the rounded shape from
+    // the transparent GPUI surface; X11 gets an explicit SHAPE mask.
     linux_uses_client_side_decorations()
 }
 
@@ -282,18 +280,159 @@ pub fn set_windows_backdrop_blur(window: &mut Window, blur: bool) {
 /// can toggle "background blur" in settings without restarting the
 /// window.
 ///
-/// Wayland keeps the native surface transparent so Con's rounded
-/// workspace clip can define the outer shape. X11 uses an opaque
-/// server-decorated window so the window manager owns rounded corners
-/// without paying for full-window alpha compositing.
+/// Linux keeps the top-level surface transparent so Con's rounded
+/// workspace clip can define the visible shape. On X11 we additionally
+/// apply a cheap server-side SHAPE mask so the top-level window hit box
+/// and outer silhouette match the clip without adding native chrome.
 #[cfg(target_os = "linux")]
 pub fn set_linux_window_blur(window: &mut Window, _blur: bool) {
     use gpui::WindowBackgroundAppearance;
-    window.set_background_appearance(if linux_uses_client_side_decorations() {
-        WindowBackgroundAppearance::Transparent
-    } else {
-        WindowBackgroundAppearance::Opaque
-    });
+    window.set_background_appearance(WindowBackgroundAppearance::Transparent);
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn sync_linux_x11_window_shape(
+    window: &mut Window,
+    width_px: u32,
+    height_px: u32,
+    radius_px: Option<u32>,
+) {
+    let Some(window_id) = linux_x11_window_id(window) else {
+        return;
+    };
+    let Some(rectangles) = linux_window_shape_rectangles(width_px, height_px, radius_px) else {
+        return;
+    };
+
+    if let Err(err) = apply_linux_x11_shape(window_id, &rectangles) {
+        log::debug!("failed to apply Linux X11 window shape: {err}");
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_x11_window_id(window: &Window) -> Option<u32> {
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+
+    let handle = HasWindowHandle::window_handle(window).ok()?;
+    match handle.as_raw() {
+        RawWindowHandle::Xlib(handle) => u32::try_from(handle.window).ok().filter(|id| *id != 0),
+        RawWindowHandle::Xcb(handle) => Some(handle.window.get()),
+        _ => None,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn linux_window_shape_rectangles(
+    width_px: u32,
+    height_px: u32,
+    radius_px: Option<u32>,
+) -> Option<Vec<x11rb::protocol::xproto::Rectangle>> {
+    use x11rb::protocol::xproto::Rectangle;
+
+    let width = u16::try_from(width_px).ok()?;
+    let height = u16::try_from(height_px).ok()?;
+    if width == 0 || height == 0 {
+        return None;
+    }
+
+    let Some(radius) = radius_px.filter(|radius| *radius > 0) else {
+        return Some(vec![Rectangle {
+            x: 0,
+            y: 0,
+            width,
+            height,
+        }]);
+    };
+
+    let radius = radius.min(u32::from(width / 2)).min(u32::from(height / 2));
+    if radius == 0 {
+        return Some(vec![Rectangle {
+            x: 0,
+            y: 0,
+            width,
+            height,
+        }]);
+    }
+
+    let radius_f = radius as f32;
+    let mut rows: Vec<(u16, u16, u16)> = Vec::with_capacity(usize::from(height));
+    for y in 0..height {
+        let y_u32 = u32::from(y);
+        let inset = if y_u32 < radius {
+            rounded_corner_inset(radius_f, radius_f - y_u32 as f32 - 0.5)
+        } else if y_u32 >= u32::from(height) - radius {
+            rounded_corner_inset(
+                radius_f,
+                y_u32 as f32 - (u32::from(height) - radius) as f32 + 0.5,
+            )
+        } else {
+            0
+        };
+        let inset = inset.min(width / 2);
+        let row_width = width.saturating_sub(inset.saturating_mul(2));
+        if row_width > 0 {
+            rows.push((y, inset, row_width));
+        }
+    }
+
+    let mut rectangles: Vec<Rectangle> = Vec::with_capacity(rows.len());
+    for (y, inset, row_width) in rows {
+        if let Some(last) = rectangles.last_mut() {
+            let same_x = last.x == inset as i16;
+            let same_width = last.width == row_width;
+            let contiguous = last.y as u16 + last.height == y;
+            if same_x && same_width && contiguous {
+                last.height = last.height.saturating_add(1);
+                continue;
+            }
+        }
+        rectangles.push(Rectangle {
+            x: inset as i16,
+            y: y as i16,
+            width: row_width,
+            height: 1,
+        });
+    }
+
+    Some(rectangles)
+}
+
+#[cfg(target_os = "linux")]
+fn rounded_corner_inset(radius: f32, distance_from_center: f32) -> u16 {
+    let inside = (radius * radius - distance_from_center * distance_from_center).max(0.0);
+    (radius - inside.sqrt()).ceil().max(0.0) as u16
+}
+
+#[cfg(target_os = "linux")]
+fn apply_linux_x11_shape(
+    window_id: u32,
+    rectangles: &[x11rb::protocol::xproto::Rectangle],
+) -> Result<(), Box<dyn std::error::Error>> {
+    use x11rb::connection::Connection;
+    use x11rb::protocol::shape::{ConnectionExt as _, SK, SO};
+    use x11rb::protocol::xproto::ClipOrdering;
+
+    let (conn, _) = x11rb::connect(None)?;
+    conn.shape_rectangles(
+        SO::SET,
+        SK::BOUNDING,
+        ClipOrdering::UNSORTED,
+        window_id,
+        0,
+        0,
+        rectangles,
+    )?;
+    conn.shape_rectangles(
+        SO::SET,
+        SK::CLIP,
+        ClipOrdering::UNSORTED,
+        window_id,
+        0,
+        0,
+        rectangles,
+    )?;
+    conn.flush()?;
+    Ok(())
 }
 
 #[cfg(target_os = "macos")]
@@ -538,11 +677,7 @@ fn default_titlebar_options(transparent: bool) -> Option<TitlebarOptions> {
 fn default_window_decorations() -> Option<WindowDecorations> {
     #[cfg(target_os = "linux")]
     {
-        if linux_uses_client_side_decorations() {
-            Some(WindowDecorations::Client)
-        } else {
-            Some(WindowDecorations::Server)
-        }
+        Some(WindowDecorations::Client)
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -1692,6 +1827,38 @@ mod tests {
 
     fn default_specs() -> Vec<BindingSpec> {
         binding_specs(&KeybindingConfig::default())
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_window_shape_uses_compact_rounded_rectangles() {
+        let rectangles = super::linux_window_shape_rectangles(120, 80, Some(14)).unwrap();
+
+        assert!(rectangles.len() > 1);
+        assert!(rectangles.first().unwrap().x > 0);
+        assert!(rectangles.first().unwrap().width < 120);
+        assert_eq!(rectangles.first().unwrap().x, rectangles.last().unwrap().x);
+        assert_eq!(
+            rectangles.first().unwrap().width,
+            rectangles.last().unwrap().width
+        );
+        assert!(
+            rectangles
+                .iter()
+                .any(|rect| rect.x == 0 && rect.width == 120)
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_window_shape_can_reset_to_full_rectangle() {
+        let rectangles = super::linux_window_shape_rectangles(120, 80, None).unwrap();
+
+        assert_eq!(rectangles.len(), 1);
+        assert_eq!(rectangles[0].x, 0);
+        assert_eq!(rectangles[0].y, 0);
+        assert_eq!(rectangles[0].width, 120);
+        assert_eq!(rectangles[0].height, 80);
     }
 
     fn specs_for_action<A: 'static>(specs: &[BindingSpec]) -> Vec<&BindingSpec> {

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -203,7 +203,7 @@ fn set_dock_icon() {}
 
 #[cfg(target_os = "linux")]
 fn linux_uses_client_side_decorations() -> bool {
-    std::env::var_os("WAYLAND_DISPLAY").is_some_and(|display| !display.is_empty())
+    true
 }
 
 #[cfg(target_os = "macos")]
@@ -236,10 +236,9 @@ fn supports_transparent_main_window() -> bool {
 
 #[cfg(target_os = "linux")]
 fn supports_transparent_main_window() -> bool {
-    // Wayland has no universal server-side frame, so Con's client-side
-    // chrome owns the rounded transparent shape. X11 desktop
-    // environments like Xfce already provide the native rounded frame,
-    // titlebar buttons, and shadow; use that instead of custom masking.
+    // Linux keeps Con's integrated client-side chrome so titlebar
+    // actions match macOS/Windows. Wayland uses the transparent GPUI
+    // surface directly; X11 additionally receives a SHAPE mask.
     linux_uses_client_side_decorations()
 }
 
@@ -281,17 +280,12 @@ pub fn set_windows_backdrop_blur(window: &mut Window, blur: bool) {
 /// can toggle "background blur" in settings without restarting the
 /// window.
 ///
-/// Linux uses a transparent top-level surface only for client-side
-/// decorated Wayland windows. X11 uses the compositor/window manager's
-/// native server-side frame, so keep the GPUI surface opaque there.
+/// Linux uses a transparent top-level surface so Con's integrated
+/// client-side chrome can define the visible rounded shape.
 #[cfg(target_os = "linux")]
 pub fn set_linux_window_blur(window: &mut Window, _blur: bool) {
     use gpui::WindowBackgroundAppearance;
-    window.set_background_appearance(if linux_uses_client_side_decorations() {
-        WindowBackgroundAppearance::Transparent
-    } else {
-        WindowBackgroundAppearance::Opaque
-    });
+    window.set_background_appearance(WindowBackgroundAppearance::Transparent);
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -203,7 +203,7 @@ fn set_dock_icon() {}
 
 #[cfg(target_os = "linux")]
 fn linux_uses_client_side_decorations() -> bool {
-    true
+    std::env::var_os("WAYLAND_DISPLAY").is_some_and(|display| !display.is_empty())
 }
 
 #[cfg(target_os = "macos")]
@@ -236,9 +236,10 @@ fn supports_transparent_main_window() -> bool {
 
 #[cfg(target_os = "linux")]
 fn supports_transparent_main_window() -> bool {
-    // Linux uses client-side decorations so Con's top bar stays
-    // consistent with macOS/Windows. Wayland gets the rounded shape from
-    // the transparent GPUI surface; X11 gets an explicit SHAPE mask.
+    // Wayland has no universal server-side frame, so Con's client-side
+    // chrome owns the rounded transparent shape. X11 desktop
+    // environments like Xfce already provide the native rounded frame,
+    // titlebar buttons, and shadow; use that instead of custom masking.
     linux_uses_client_side_decorations()
 }
 
@@ -280,14 +281,17 @@ pub fn set_windows_backdrop_blur(window: &mut Window, blur: bool) {
 /// can toggle "background blur" in settings without restarting the
 /// window.
 ///
-/// Linux keeps the top-level surface transparent so Con's rounded
-/// workspace clip can define the visible shape. On X11 we additionally
-/// apply a cheap server-side SHAPE mask so the top-level window hit box
-/// and outer silhouette match the clip without adding native chrome.
+/// Linux uses a transparent top-level surface only for client-side
+/// decorated Wayland windows. X11 uses the compositor/window manager's
+/// native server-side frame, so keep the GPUI surface opaque there.
 #[cfg(target_os = "linux")]
 pub fn set_linux_window_blur(window: &mut Window, _blur: bool) {
     use gpui::WindowBackgroundAppearance;
-    window.set_background_appearance(WindowBackgroundAppearance::Transparent);
+    window.set_background_appearance(if linux_uses_client_side_decorations() {
+        WindowBackgroundAppearance::Transparent
+    } else {
+        WindowBackgroundAppearance::Opaque
+    });
 }
 
 #[cfg(target_os = "linux")]
@@ -677,7 +681,11 @@ fn default_titlebar_options(transparent: bool) -> Option<TitlebarOptions> {
 fn default_window_decorations() -> Option<WindowDecorations> {
     #[cfg(target_os = "linux")]
     {
-        Some(WindowDecorations::Client)
+        if linux_uses_client_side_decorations() {
+            Some(WindowDecorations::Client)
+        } else {
+            Some(WindowDecorations::Server)
+        }
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -406,31 +406,46 @@ fn apply_linux_x11_shape(
     window_id: u32,
     rectangles: &[x11rb::protocol::xproto::Rectangle],
 ) -> Result<(), Box<dyn std::error::Error>> {
+    use std::cell::RefCell;
+
     use x11rb::connection::Connection;
     use x11rb::protocol::shape::{ConnectionExt as _, SK, SO};
     use x11rb::protocol::xproto::ClipOrdering;
+    use x11rb::rust_connection::RustConnection;
 
-    let (conn, _) = x11rb::connect(None)?;
-    conn.shape_rectangles(
-        SO::SET,
-        SK::BOUNDING,
-        ClipOrdering::UNSORTED,
-        window_id,
-        0,
-        0,
-        rectangles,
-    )?;
-    conn.shape_rectangles(
-        SO::SET,
-        SK::CLIP,
-        ClipOrdering::UNSORTED,
-        window_id,
-        0,
-        0,
-        rectangles,
-    )?;
-    conn.flush()?;
-    Ok(())
+    thread_local! {
+        static X11_SHAPE_CONNECTION: RefCell<Option<RustConnection>> = const { RefCell::new(None) };
+    }
+
+    X11_SHAPE_CONNECTION.with(|connection| {
+        let mut connection = connection.borrow_mut();
+        if connection.is_none() {
+            let (new_connection, _) = x11rb::connect(None)?;
+            *connection = Some(new_connection);
+        }
+
+        let conn = connection.as_ref().expect("shape connection initialized");
+        conn.shape_rectangles(
+            SO::SET,
+            SK::BOUNDING,
+            ClipOrdering::UNSORTED,
+            window_id,
+            0,
+            0,
+            rectangles,
+        )?;
+        conn.shape_rectangles(
+            SO::SET,
+            SK::CLIP,
+            ClipOrdering::UNSORTED,
+            window_id,
+            0,
+            0,
+            rectangles,
+        )?;
+        conn.flush()?;
+        Ok(())
+    })
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -289,16 +289,25 @@ pub fn set_linux_window_blur(window: &mut Window, _blur: bool) {
 }
 
 #[cfg(target_os = "linux")]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct LinuxWindowShapeRadii {
+    pub top_left: u32,
+    pub top_right: u32,
+    pub bottom_right: u32,
+    pub bottom_left: u32,
+}
+
+#[cfg(target_os = "linux")]
 pub(crate) fn sync_linux_x11_window_shape(
     window: &mut Window,
     width_px: u32,
     height_px: u32,
-    radius_px: Option<u32>,
+    radii: LinuxWindowShapeRadii,
 ) {
     let Some(window_id) = linux_x11_window_id(window) else {
         return;
     };
-    let Some(rectangles) = linux_window_shape_rectangles(width_px, height_px, radius_px) else {
+    let Some(rectangles) = linux_window_shape_rectangles(width_px, height_px, radii) else {
         return;
     };
 
@@ -323,7 +332,7 @@ fn linux_x11_window_id(window: &Window) -> Option<u32> {
 fn linux_window_shape_rectangles(
     width_px: u32,
     height_px: u32,
-    radius_px: Option<u32>,
+    radii: LinuxWindowShapeRadii,
 ) -> Option<Vec<x11rb::protocol::xproto::Rectangle>> {
     use x11rb::protocol::xproto::Rectangle;
 
@@ -333,43 +342,47 @@ fn linux_window_shape_rectangles(
         return None;
     }
 
-    let Some(radius) = radius_px.filter(|radius| *radius > 0) else {
-        return Some(vec![Rectangle {
+    let full_rect = || {
+        vec![Rectangle {
             x: 0,
             y: 0,
             width,
             height,
-        }]);
+        }]
     };
 
-    let radius = radius.min(u32::from(width / 2)).min(u32::from(height / 2));
-    if radius == 0 {
-        return Some(vec![Rectangle {
-            x: 0,
-            y: 0,
-            width,
-            height,
-        }]);
+    let max_dimension = i16::MAX as u16;
+    if width > max_dimension || height > max_dimension {
+        return Some(full_rect());
     }
 
-    let radius_f = radius as f32;
+    let max_radius = u32::from(width / 2).min(u32::from(height / 2));
+    let radii = LinuxWindowShapeRadii {
+        top_left: radii.top_left.min(max_radius),
+        top_right: radii.top_right.min(max_radius),
+        bottom_right: radii.bottom_right.min(max_radius),
+        bottom_left: radii.bottom_left.min(max_radius),
+    };
+    if radii == LinuxWindowShapeRadii::default() {
+        return Some(full_rect());
+    }
+
     let mut rows: Vec<(u16, u16, u16)> = Vec::with_capacity(usize::from(height));
     for y in 0..height {
         let y_u32 = u32::from(y);
-        let inset = if y_u32 < radius {
-            rounded_corner_inset(radius_f, radius_f - y_u32 as f32 - 0.5)
-        } else if y_u32 >= u32::from(height) - radius {
-            rounded_corner_inset(
-                radius_f,
-                y_u32 as f32 - (u32::from(height) - radius) as f32 + 0.5,
-            )
-        } else {
-            0
-        };
-        let inset = inset.min(width / 2);
-        let row_width = width.saturating_sub(inset.saturating_mul(2));
+        let left_inset =
+            corner_row_inset(y_u32, u32::from(height), radii.top_left, radii.bottom_left)
+                .min(width / 2);
+        let right_inset = corner_row_inset(
+            y_u32,
+            u32::from(height),
+            radii.top_right,
+            radii.bottom_right,
+        )
+        .min(width / 2);
+        let row_width = width.saturating_sub(left_inset.saturating_add(right_inset));
         if row_width > 0 {
-            rows.push((y, inset, row_width));
+            rows.push((y, left_inset, row_width));
         }
     }
 
@@ -393,6 +406,19 @@ fn linux_window_shape_rectangles(
     }
 
     Some(rectangles)
+}
+
+#[cfg(target_os = "linux")]
+fn corner_row_inset(y: u32, height: u32, top_radius: u32, bottom_radius: u32) -> u16 {
+    if top_radius > 0 && y < top_radius {
+        let radius = top_radius as f32;
+        rounded_corner_inset(radius, radius - y as f32 - 0.5)
+    } else if bottom_radius > 0 && y >= height.saturating_sub(bottom_radius) {
+        let radius = bottom_radius as f32;
+        rounded_corner_inset(radius, y as f32 - (height - bottom_radius) as f32 + 0.5)
+    } else {
+        0
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -1849,7 +1875,17 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn linux_window_shape_uses_compact_rounded_rectangles() {
-        let rectangles = super::linux_window_shape_rectangles(120, 80, Some(14)).unwrap();
+        let rectangles = super::linux_window_shape_rectangles(
+            120,
+            80,
+            super::LinuxWindowShapeRadii {
+                top_left: 14,
+                top_right: 14,
+                bottom_right: 14,
+                bottom_left: 14,
+            },
+        )
+        .unwrap();
 
         assert!(rectangles.len() > 1);
         assert!(rectangles.first().unwrap().x > 0);
@@ -1869,13 +1905,61 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn linux_window_shape_can_reset_to_full_rectangle() {
-        let rectangles = super::linux_window_shape_rectangles(120, 80, None).unwrap();
+        let rectangles =
+            super::linux_window_shape_rectangles(120, 80, super::LinuxWindowShapeRadii::default())
+                .unwrap();
 
         assert_eq!(rectangles.len(), 1);
         assert_eq!(rectangles[0].x, 0);
         assert_eq!(rectangles[0].y, 0);
         assert_eq!(rectangles[0].width, 120);
         assert_eq!(rectangles[0].height, 80);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_window_shape_supports_independent_corners() {
+        let rectangles = super::linux_window_shape_rectangles(
+            120,
+            80,
+            super::LinuxWindowShapeRadii {
+                top_left: 14,
+                top_right: 0,
+                bottom_right: 14,
+                bottom_left: 0,
+            },
+        )
+        .unwrap();
+
+        assert!(rectangles.first().unwrap().x > 0);
+        assert_eq!(
+            rectangles.first().unwrap().width,
+            120 - rectangles.first().unwrap().x as u16
+        );
+        assert!(rectangles.last().unwrap().x == 0);
+        assert!(rectangles.last().unwrap().width < 120);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_window_shape_large_dimensions_fall_back_to_full_rectangle() {
+        let rectangles = super::linux_window_shape_rectangles(
+            120,
+            i16::MAX as u32 + 1,
+            super::LinuxWindowShapeRadii {
+                top_left: 14,
+                top_right: 14,
+                bottom_right: 14,
+                bottom_left: 14,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(rectangles.len(), 1);
+        assert_eq!(rectangles[0].x, 0);
+        assert_eq!(rectangles[0].y, 0);
+        assert_eq!(rectangles[0].width, 120);
+        assert_eq!(rectangles[0].height, i16::MAX as u16 + 1);
     }
 
     fn specs_for_action<A: 'static>(specs: &[BindingSpec]) -> Vec<&BindingSpec> {

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -303,17 +303,20 @@ pub(crate) fn sync_linux_x11_window_shape(
     width_px: u32,
     height_px: u32,
     radii: LinuxWindowShapeRadii,
-) {
+) -> bool {
     let Some(window_id) = linux_x11_window_id(window) else {
-        return;
+        return false;
     };
     let Some(rectangles) = linux_window_shape_rectangles(width_px, height_px, radii) else {
-        return;
+        return false;
     };
 
     if let Err(err) = apply_linux_x11_shape(window_id, &rectangles) {
         log::debug!("failed to apply Linux X11 window shape: {err}");
+        return false;
     }
+
+    true
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -201,6 +201,11 @@ fn set_dock_icon() {
 #[cfg(not(target_os = "macos"))]
 fn set_dock_icon() {}
 
+#[cfg(target_os = "linux")]
+fn linux_uses_client_side_decorations() -> bool {
+    std::env::var_os("WAYLAND_DISPLAY").is_some_and(|display| !display.is_empty())
+}
+
 #[cfg(target_os = "macos")]
 fn supports_transparent_main_window() -> bool {
     use cocoa::base::nil;
@@ -231,15 +236,12 @@ fn supports_transparent_main_window() -> bool {
 
 #[cfg(target_os = "linux")]
 fn supports_transparent_main_window() -> bool {
-    // GPUI's X11 backend already creates the window against an ARGB
-    // (depth-32) visual when transparency is requested, and the
-    // Wayland backend drops the opaque-region hint so the compositor
-    // honors per-pixel alpha. Both xfwm4 / mutter / kwin composite
-    // through it, so an always-on transparent root is safe on every
-    // Linux session that has any compositor at all. Headless / minimal
-    // sessions still render correctly because the workspace itself
-    // paints `theme.background.opacity(...)` on its surfaces.
-    true
+    // Wayland has no universal server-side frame, so keep the client
+    // surface transparent and let Con's rounded workspace clip define
+    // the silhouette. On X11/Xfce, rounded outer corners are owned by
+    // the window manager's server-side frame; keeping Con opaque there
+    // avoids full-window alpha compositing and preserves native corners.
+    linux_uses_client_side_decorations()
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
@@ -280,16 +282,18 @@ pub fn set_windows_backdrop_blur(window: &mut Window, blur: bool) {
 /// can toggle "background blur" in settings without restarting the
 /// window.
 ///
-/// Linux keeps the native surface transparent even when the user
-/// has background blur enabled. GPUI's current KWin blur integration
-/// commits blur for the whole Wayland surface instead of a rounded
-/// region, which makes the transparent corners read as a rectangular
-/// blur block. Until the platform layer can expose a rounded blur
-/// region, alpha shape correctness wins over blur.
+/// Wayland keeps the native surface transparent so Con's rounded
+/// workspace clip can define the outer shape. X11 uses an opaque
+/// server-decorated window so the window manager owns rounded corners
+/// without paying for full-window alpha compositing.
 #[cfg(target_os = "linux")]
 pub fn set_linux_window_blur(window: &mut Window, _blur: bool) {
     use gpui::WindowBackgroundAppearance;
-    window.set_background_appearance(WindowBackgroundAppearance::Transparent);
+    window.set_background_appearance(if linux_uses_client_side_decorations() {
+        WindowBackgroundAppearance::Transparent
+    } else {
+        WindowBackgroundAppearance::Opaque
+    });
 }
 
 #[cfg(target_os = "macos")]
@@ -380,11 +384,14 @@ fn set_windows_backdrop(window: &mut Window, blur: bool) -> Option<()> {
 
 fn default_window_options(config: &con_core::Config, cx: &mut App) -> WindowOptions {
     let transparent = supports_transparent_main_window();
+    let window_decorations = default_window_decorations();
+    let window_background = default_window_background(config, transparent);
+
     WindowOptions {
         window_bounds: Some(default_workspace_window_bounds(cx)),
         titlebar: default_titlebar_options(transparent),
-        window_decorations: default_window_decorations(),
-        window_background: default_window_background(config, transparent),
+        window_decorations,
+        window_background,
         // macOS: disable NSWindow's native `isMovable` drag so that
         // GPUI elements (tabs, sidebar) can start their own drags
         // without the window also moving. The top_bar renders an
@@ -529,18 +536,13 @@ fn default_titlebar_options(transparent: bool) -> Option<TitlebarOptions> {
 }
 
 fn default_window_decorations() -> Option<WindowDecorations> {
-    // Linux now ships a client-side titlebar drawn in
-    // `workspace::ConWorkspace::draw_top_bar` (the same top bar Windows uses),
-    // so the GPUI app shell paints its own brand chrome instead of
-    // stacking the xfwm4 / mutter / kwin frame on top of it. The
-    // gpui_linux X11 backend gracefully falls back to server-side
-    // decorations when no compositor is present, so this is safe on
-    // headless / minimal sessions too. macOS continues to use the
-    // default (system traffic-light cluster over an in-app top bar
-    // with `leading_pad = 78px`).
     #[cfg(target_os = "linux")]
     {
-        Some(WindowDecorations::Client)
+        if linux_uses_client_side_decorations() {
+            Some(WindowDecorations::Client)
+        } else {
+            Some(WindowDecorations::Server)
+        }
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -563,50 +565,28 @@ pub(crate) fn open_con_window(
                 .new(|cx| ConWorkspace::from_session(config.clone(), restored_session, window, cx));
             #[cfg(target_os = "windows")]
             let mica_applied = apply_windows_backdrop(window, config.appearance.terminal_blur);
-            #[cfg(not(target_os = "windows"))]
-            let mica_applied = false;
 
             #[cfg(target_os = "linux")]
             set_linux_window_blur(window, config.appearance.terminal_blur);
             cx.new(|cx| {
-                // On Windows we want the DWM-provided backdrop (Mica)
-                // to shine through wherever the app isn't painting —
-                // most importantly, the terminal area when the child
-                // pane HWND is hidden behind a modal. That requires a
-                // transparent Root. If Mica isn't available (Win10,
-                // RDP, older Win11), fall back to an opaque theme fill
-                // so the window doesn't look "see-through to desktop".
-                //
-                // On macOS 12 and older we still need the window itself
-                // to be opaque, but the GPUI root above the embedded
-                // Ghostty NSView must stay transparent. Making both the
-                // window and the root opaque fixed the desktop leak but
-                // painted the fallback theme background over the terminal
-                // surface, leaving Monterey users with a blank beige pane.
-                let background = if cfg!(target_os = "windows") {
-                    if mica_applied {
-                        cx.theme().transparent
-                    } else {
-                        cx.theme().background
-                    }
-                } else if cfg!(target_os = "macos") {
-                    // The window background policy decides whether the
-                    // desktop can bleed through. On macOS the root
-                    // itself must remain transparent so the embedded
-                    // Ghostty NSView below GPUI stays visible, even on
-                    // Monterey where the top-level window falls back to
-                    // opaque.
-                    cx.theme().transparent
-                } else if cfg!(target_os = "linux") {
-                    // Linux relies on a transparent top-level Root so
-                    // the workspace's rounded `overflow_hidden` clip
-                    // exposes the compositor at the outer corners.
-                    // Painting the Root with the theme background here
-                    // makes the clipped workspace look square again.
+                #[cfg(target_os = "windows")]
+                let background = if mica_applied {
                     cx.theme().transparent
                 } else {
                     cx.theme().background
                 };
+                #[cfg(target_os = "macos")]
+                let background = cx.theme().transparent;
+                #[cfg(target_os = "linux")]
+                let background = {
+                    if matches!(window.window_decorations(), Decorations::Client { .. }) {
+                        cx.theme().transparent
+                    } else {
+                        cx.theme().background
+                    }
+                };
+                #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+                let background = cx.theme().background;
                 gpui_component::Root::new(view, window, cx).bg(background)
             })
         }) {

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -1092,6 +1092,10 @@ impl SettingsPanel {
         cx: &mut Context<Self>,
     ) -> Self {
         let mut config = config.clone();
+        #[cfg(target_os = "linux")]
+        {
+            config.appearance.terminal_blur = false;
+        }
         let active_provider = Self::provider_for_saved_transport(&config, &config.agent.provider);
         config.agent.provider = active_provider;
         let agent = &config.agent;
@@ -1690,7 +1694,15 @@ impl SettingsPanel {
                 cx,
             );
         });
-        self.terminal_blur = self.config.appearance.terminal_blur;
+        self.terminal_blur = if cfg!(target_os = "linux") {
+            false
+        } else {
+            self.config.appearance.terminal_blur
+        };
+        #[cfg(target_os = "linux")]
+        {
+            self.config.appearance.terminal_blur = false;
+        }
         self.ui_opacity_slider.update(cx, |slider, cx| {
             slider.set_value(
                 Self::clamp_ui_opacity(self.config.appearance.ui_opacity),

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -220,6 +220,14 @@ impl SettingsPanel {
         value.clamp(0.35, 1.0)
     }
 
+    fn terminal_blur_supported() -> bool {
+        !cfg!(target_os = "linux")
+    }
+
+    fn effective_terminal_blur(value: bool) -> bool {
+        value && Self::terminal_blur_supported()
+    }
+
     fn terminal_opacity_value(&self) -> f32 {
         Self::clamp_terminal_opacity(self.config.appearance.terminal_opacity)
     }
@@ -1092,10 +1100,8 @@ impl SettingsPanel {
         cx: &mut Context<Self>,
     ) -> Self {
         let mut config = config.clone();
-        #[cfg(target_os = "linux")]
-        {
-            config.appearance.terminal_blur = false;
-        }
+        config.appearance.terminal_blur =
+            Self::effective_terminal_blur(config.appearance.terminal_blur);
         let active_provider = Self::provider_for_saved_transport(&config, &config.agent.provider);
         config.agent.provider = active_provider;
         let agent = &config.agent;
@@ -1537,7 +1543,7 @@ impl SettingsPanel {
             font_size_input,
             ui_font_size_input,
             terminal_opacity_slider,
-            terminal_blur: config.appearance.terminal_blur,
+            terminal_blur: Self::effective_terminal_blur(config.appearance.terminal_blur),
             ui_opacity_slider,
             tab_accent_inactive_alpha_slider,
             tab_accent_inactive_hover_alpha_slider,
@@ -1694,15 +1700,8 @@ impl SettingsPanel {
                 cx,
             );
         });
-        self.terminal_blur = if cfg!(target_os = "linux") {
-            false
-        } else {
-            self.config.appearance.terminal_blur
-        };
-        #[cfg(target_os = "linux")]
-        {
-            self.config.appearance.terminal_blur = false;
-        }
+        self.terminal_blur = Self::effective_terminal_blur(self.config.appearance.terminal_blur);
+        self.config.appearance.terminal_blur = self.terminal_blur;
         self.ui_opacity_slider.update(cx, |slider, cx| {
             slider.set_value(
                 Self::clamp_ui_opacity(self.config.appearance.ui_opacity),
@@ -2341,7 +2340,8 @@ impl SettingsPanel {
         self.config.appearance.ui_font_size = Self::clamp_ui_font_size(parsed_ui_font_size);
         self.config.appearance.terminal_opacity =
             Self::clamp_terminal_opacity(self.terminal_opacity_slider.read(cx).value().end());
-        self.config.appearance.terminal_blur = self.terminal_blur;
+        self.config.appearance.terminal_blur = Self::effective_terminal_blur(self.terminal_blur);
+        self.terminal_blur = self.config.appearance.terminal_blur;
         self.config.appearance.ui_opacity =
             Self::clamp_ui_opacity(self.ui_opacity_slider.read(cx).value().end());
         self.config.appearance.tab_accent_inactive_alpha = Self::clamp_tab_accent_inactive_alpha(
@@ -3582,9 +3582,9 @@ impl SettingsPanel {
                                 "Blur the desktop behind transparent terminal surfaces."
                             },
                             {
-                                let terminal_blur_supported = !cfg!(target_os = "linux");
+                                let terminal_blur_supported = Self::terminal_blur_supported();
                                 let mut toggle = Switch::new("terminal-blur-toggle")
-                                    .checked(self.terminal_blur && terminal_blur_supported)
+                                    .checked(Self::effective_terminal_blur(self.terminal_blur))
                                     .small()
                                     .disabled(!terminal_blur_supported);
 

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -3564,16 +3564,31 @@ impl SettingsPanel {
                         .child(row_separator(theme))
                         .child(toggle_row(
                             "Terminal Blur",
-                            "Blur the desktop behind transparent terminal surfaces.",
-                            Switch::new("terminal-blur-toggle")
-                                .checked(self.terminal_blur)
-                                .small()
-                                .on_click(cx.listener(|this, checked: &bool, _, cx| {
-                                    this.terminal_blur = *checked;
-                                    this.config.appearance.terminal_blur = *checked;
-                                    cx.emit(AppearancePreview);
-                                    cx.notify();
-                                })),
+                            if cfg!(target_os = "linux") {
+                                "Disabled on Linux until rounded compositor blur regions are available."
+                            } else {
+                                "Blur the desktop behind transparent terminal surfaces."
+                            },
+                            {
+                                let terminal_blur_supported = !cfg!(target_os = "linux");
+                                let mut toggle = Switch::new("terminal-blur-toggle")
+                                    .checked(self.terminal_blur && terminal_blur_supported)
+                                    .small()
+                                    .disabled(!terminal_blur_supported);
+
+                                if terminal_blur_supported {
+                                    toggle = toggle.on_click(cx.listener(
+                                        |this, checked: &bool, _, cx| {
+                                            this.terminal_blur = *checked;
+                                            this.config.appearance.terminal_blur = *checked;
+                                            cx.emit(AppearancePreview);
+                                            cx.notify();
+                                        },
+                                    ));
+                                }
+
+                                toggle
+                            },
                             theme,
                         ))
                         .child(row_separator(theme))

--- a/crates/con-app/src/workspace/caption.rs
+++ b/crates/con-app/src/workspace/caption.rs
@@ -149,14 +149,14 @@ pub(super) fn caption_buttons(
 
         #[cfg(target_os = "linux")]
         if close {
-            el = el.relative().rounded_tr(px(14.0)).overflow_hidden().child(
+            el = el.relative().child(
                 div()
                     .absolute()
-                    .top_0()
-                    .bottom_0()
-                    .left_0()
-                    .right_0()
-                    .rounded_tr(px(14.0))
+                    .top(px(4.0))
+                    .bottom(px(4.0))
+                    .left(px(4.0))
+                    .right(px(4.0))
+                    .rounded(px(8.0))
                     .bg(close_red)
                     .opacity(0.0)
                     .group_hover(id, |s| s.opacity(1.0)),

--- a/crates/con-app/src/workspace/caption.rs
+++ b/crates/con-app/src/workspace/caption.rs
@@ -155,7 +155,7 @@ pub(super) fn caption_buttons(
             );
         #[cfg(target_os = "linux")]
         if close {
-            el = el.rounded_tr(px(12.0));
+            el = el.rounded_tr(px(14.0)).overflow_hidden();
         }
 
         // Linux: GPUI's X11 hit-test doesn't fire `WindowControlArea`

--- a/crates/con-app/src/workspace/caption.rs
+++ b/crates/con-app/src/workspace/caption.rs
@@ -129,8 +129,7 @@ pub(super) fn caption_buttons(
         // a `group(id)` so the svg's `.group_hover(id, ...)` fires when
         // the 36px hit-target is hovered, not just the 10px icon ink.
         let hover_fg = if close { gpui::white() } else { hover_fg };
-        let linux_close_button = cfg!(target_os = "linux") && close;
-        let mut el = div()
+        let el = div()
             .id(id)
             .group(id)
             .flex()
@@ -145,33 +144,15 @@ pub(super) fn caption_buttons(
             .w(px(36.0))
             .h(px(height))
             .flex_shrink_0()
-            .window_control_area(area);
-
-        #[cfg(target_os = "linux")]
-        if close {
-            el = el.relative().child(
-                div()
-                    .absolute()
-                    .top(px(4.0))
-                    .bottom(px(4.0))
-                    .left(px(4.0))
-                    .right(px(4.0))
-                    .rounded(px(8.0))
-                    .bg(close_red)
-                    .opacity(0.0)
-                    .group_hover(id, |s| s.opacity(1.0)),
+            .window_control_area(area)
+            .hover(move |s| s.bg(hover))
+            .child(
+                svg()
+                    .path(icon)
+                    .size(px(10.0))
+                    .text_color(fg)
+                    .group_hover(id, move |s| s.text_color(hover_fg)),
             );
-        }
-        if !linux_close_button {
-            el = el.hover(move |s| s.bg(hover));
-        }
-        el = el.child(
-            svg()
-                .path(icon)
-                .size(px(10.0))
-                .text_color(fg)
-                .group_hover(id, move |s| s.text_color(hover_fg)),
-        );
 
         // Linux: GPUI's X11 hit-test doesn't fire `WindowControlArea`
         // dispatchers, so wire each button to its `Window` action by

--- a/crates/con-app/src/workspace/caption.rs
+++ b/crates/con-app/src/workspace/caption.rs
@@ -129,7 +129,7 @@ pub(super) fn caption_buttons(
         // a `group(id)` so the svg's `.group_hover(id, ...)` fires when
         // the 36px hit-target is hovered, not just the 10px icon ink.
         let hover_fg = if close { gpui::white() } else { hover_fg };
-        let el = div()
+        let mut el = div()
             .id(id)
             .group(id)
             .flex()
@@ -153,6 +153,10 @@ pub(super) fn caption_buttons(
                     .text_color(fg)
                     .group_hover(id, move |s| s.text_color(hover_fg)),
             );
+        #[cfg(target_os = "linux")]
+        if close {
+            el = el.rounded_tr(px(12.0));
+        }
 
         // Linux: GPUI's X11 hit-test doesn't fire `WindowControlArea`
         // dispatchers, so wire each button to its `Window` action by

--- a/crates/con-app/src/workspace/caption.rs
+++ b/crates/con-app/src/workspace/caption.rs
@@ -129,6 +129,7 @@ pub(super) fn caption_buttons(
         // a `group(id)` so the svg's `.group_hover(id, ...)` fires when
         // the 36px hit-target is hovered, not just the 10px icon ink.
         let hover_fg = if close { gpui::white() } else { hover_fg };
+        let linux_close_button = cfg!(target_os = "linux") && close;
         let mut el = div()
             .id(id)
             .group(id)
@@ -144,19 +145,33 @@ pub(super) fn caption_buttons(
             .w(px(36.0))
             .h(px(height))
             .flex_shrink_0()
-            .window_control_area(area)
-            .hover(move |s| s.bg(hover))
-            .child(
-                svg()
-                    .path(icon)
-                    .size(px(10.0))
-                    .text_color(fg)
-                    .group_hover(id, move |s| s.text_color(hover_fg)),
-            );
+            .window_control_area(area);
+
         #[cfg(target_os = "linux")]
         if close {
-            el = el.rounded_tr(px(14.0)).overflow_hidden();
+            el = el.relative().rounded_tr(px(14.0)).overflow_hidden().child(
+                div()
+                    .absolute()
+                    .top_0()
+                    .bottom_0()
+                    .left_0()
+                    .right_0()
+                    .rounded_tr(px(14.0))
+                    .bg(close_red)
+                    .opacity(0.0)
+                    .group_hover(id, |s| s.opacity(1.0)),
+            );
         }
+        if !linux_close_button {
+            el = el.hover(move |s| s.bg(hover));
+        }
+        el = el.child(
+            svg()
+                .path(icon)
+                .size(px(10.0))
+                .text_color(fg)
+                .group_hover(id, move |s| s.text_color(hover_fg)),
+        );
 
         // Linux: GPUI's X11 hit-test doesn't fire `WindowControlArea`
         // dispatchers, so wire each button to its `Window` action by

--- a/crates/con-app/src/workspace/lifecycle.rs
+++ b/crates/con-app/src/workspace/lifecycle.rs
@@ -864,14 +864,6 @@ impl ConWorkspace {
     }
 
     pub(super) fn current_top_bar_height(&self) -> f32 {
-        #[cfg(target_os = "linux")]
-        if std::env::var_os("DISPLAY").is_some() && std::env::var_os("WAYLAND_DISPLAY").is_none() {
-            if self.tab_strip_motion.is_animating() || self.horizontal_tabs_visible() {
-                return TOP_BAR_TABS_HEIGHT;
-            }
-            return 0.0;
-        }
-
         if self.tab_strip_motion.is_animating() || self.horizontal_tabs_visible() {
             TOP_BAR_TABS_HEIGHT
         } else {

--- a/crates/con-app/src/workspace/lifecycle.rs
+++ b/crates/con-app/src/workspace/lifecycle.rs
@@ -864,6 +864,14 @@ impl ConWorkspace {
     }
 
     pub(super) fn current_top_bar_height(&self) -> f32 {
+        #[cfg(target_os = "linux")]
+        if std::env::var_os("DISPLAY").is_some() && std::env::var_os("WAYLAND_DISPLAY").is_none() {
+            if self.tab_strip_motion.is_animating() || self.horizontal_tabs_visible() {
+                return TOP_BAR_TABS_HEIGHT;
+            }
+            return 0.0;
+        }
+
         if self.tab_strip_motion.is_animating() || self.horizontal_tabs_visible() {
             TOP_BAR_TABS_HEIGHT
         } else {

--- a/crates/con-app/src/workspace/lifecycle.rs
+++ b/crates/con-app/src/workspace/lifecycle.rs
@@ -712,6 +712,8 @@ impl ConWorkspace {
             input_bar_release_cover_until: None,
             #[cfg(target_os = "macos")]
             top_chrome_release_cover_until: None,
+            #[cfg(target_os = "linux")]
+            linux_window_shape_signature: None,
             pending_create_pane_requests: Vec::new(),
             pending_window_control_requests: Vec::new(),
             pending_surface_control_requests: Vec::new(),

--- a/crates/con-app/src/workspace/mod.rs
+++ b/crates/con-app/src/workspace/mod.rs
@@ -207,7 +207,7 @@ pub struct ConWorkspace {
     #[cfg(target_os = "macos")]
     top_chrome_release_cover_until: Option<Instant>,
     #[cfg(target_os = "linux")]
-    linux_window_shape_signature: Option<(u32, u32, u32, bool)>,
+    linux_window_shape_signature: Option<(u32, u32, crate::LinuxWindowShapeRadii)>,
     /// Pending create-pane requests that need a window context to process.
     pending_create_pane_requests: Vec<PendingCreatePane>,
     /// Pending window-aware control requests such as tab lifecycle mutations.

--- a/crates/con-app/src/workspace/mod.rs
+++ b/crates/con-app/src/workspace/mod.rs
@@ -206,6 +206,8 @@ pub struct ConWorkspace {
     input_bar_release_cover_until: Option<Instant>,
     #[cfg(target_os = "macos")]
     top_chrome_release_cover_until: Option<Instant>,
+    #[cfg(target_os = "linux")]
+    linux_window_shape_signature: Option<(u32, u32, u32, bool)>,
     /// Pending create-pane requests that need a window context to process.
     pending_create_pane_requests: Vec<PendingCreatePane>,
     /// Pending window-aware control requests such as tab lifecycle mutations.

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -1582,11 +1582,13 @@ impl Render for ConWorkspace {
             let decorations = window.window_decorations();
             let is_maximized = window.is_maximized();
             let is_fullscreen = window.is_fullscreen();
+            let mut x11_shape_round = false;
 
             if let Decorations::Client { tiling } = decorations
                 && !is_maximized
                 && !is_fullscreen
             {
+                x11_shape_round = !(tiling.top || tiling.left || tiling.right || tiling.bottom);
                 if !(tiling.top || tiling.left) {
                     workspace_frame = workspace_frame.rounded_tl(LINUX_WINDOW_CORNER_RADIUS);
                 }
@@ -1600,6 +1602,26 @@ impl Render for ConWorkspace {
                     workspace_frame = workspace_frame.rounded_br(LINUX_WINDOW_CORNER_RADIUS);
                 }
                 workspace_frame = workspace_frame.overflow_hidden();
+            }
+
+            let scale = window.scale_factor().max(f32::EPSILON);
+            let size = window.bounds().size;
+            let width_px = (size.width.as_f32() * scale).round().max(1.0) as u32;
+            let height_px = (size.height.as_f32() * scale).round().max(1.0) as u32;
+            let radius_px = if x11_shape_round {
+                LINUX_WINDOW_CORNER_RADIUS.as_f32().round().max(0.0) as u32
+            } else {
+                0
+            };
+            let shape_signature = (width_px, height_px, radius_px, x11_shape_round);
+            if self.linux_window_shape_signature != Some(shape_signature) {
+                crate::sync_linux_x11_window_shape(
+                    window,
+                    width_px,
+                    height_px,
+                    x11_shape_round.then_some(radius_px),
+                );
+                self.linux_window_shape_signature = Some(shape_signature);
             }
 
             root = div()

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -4,11 +4,7 @@ mod top_bar;
 use super::*;
 
 #[cfg(target_os = "linux")]
-<<<<<<< HEAD
 const LINUX_WINDOW_CORNER_RADIUS: Pixels = px(14.0);
-=======
-const LINUX_WINDOW_CORNER_RADIUS: Pixels = px(18.0);
->>>>>>> parent of a397d82 (Adopt Zed-style Linux client decorations)
 
 impl ConWorkspace {
     fn has_active_resize_drag(&self) -> bool {

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -3,6 +3,9 @@ mod top_bar;
 
 use super::*;
 
+#[cfg(target_os = "linux")]
+const LINUX_WINDOW_CORNER_RADIUS: Pixels = px(14.0);
+
 impl ConWorkspace {
     fn has_active_resize_drag(&self) -> bool {
         self.sidebar_drag.is_some()
@@ -983,19 +986,6 @@ impl Render for ConWorkspace {
             .font_family(theme.mono_font_family.clone())
             .track_focus(&self.workspace_focus);
 
-        // Linux: con paints its own client-side decorations, so we
-        // also have to clip the window to a rounded rectangle the
-        // same way macOS gets from NSWindow + transparent backdrop
-        // and Windows 11 gets from DWM. Wrap with `overflow_hidden`
-        // so child surfaces (top bar, terminal pane, modals) all
-        // respect the corner radius. 14px matches Mica's perceived
-        // radius on Win11 and reads as "windowed" rather than
-        // "phone-app sheet".
-        #[cfg(target_os = "linux")]
-        {
-            root = root.rounded(px(14.0)).overflow_hidden();
-        }
-
         root = root
             .key_context("ConWorkspace")
             // Pane drag-to-resize: capture mouse move/up on root so it works
@@ -1574,6 +1564,36 @@ impl Render for ConWorkspace {
         let palette_visible = self.command_palette.read(cx).is_visible();
         if palette_visible {
             root = root.child(self.command_palette.clone());
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let mut workspace_frame = root;
+
+            if let Decorations::Client { tiling } = window.window_decorations()
+                && !window.is_maximized()
+                && !window.is_fullscreen()
+            {
+                if !(tiling.top || tiling.left) {
+                    workspace_frame = workspace_frame.rounded_tl(LINUX_WINDOW_CORNER_RADIUS);
+                }
+                if !(tiling.top || tiling.right) {
+                    workspace_frame = workspace_frame.rounded_tr(LINUX_WINDOW_CORNER_RADIUS);
+                }
+                if !(tiling.bottom || tiling.left) {
+                    workspace_frame = workspace_frame.rounded_bl(LINUX_WINDOW_CORNER_RADIUS);
+                }
+                if !(tiling.bottom || tiling.right) {
+                    workspace_frame = workspace_frame.rounded_br(LINUX_WINDOW_CORNER_RADIUS);
+                }
+                workspace_frame = workspace_frame.overflow_hidden();
+            }
+
+            root = div()
+                .relative()
+                .size_full()
+                .bg(transparent_black())
+                .child(workspace_frame);
         }
 
         root.into_any_element()

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -1659,9 +1659,11 @@ impl Render for ConWorkspace {
                     )
                     .child(
                         div()
-                            .relative()
-                            .size_full()
-                            .p(LINUX_WINDOW_FRAME_PAD)
+                            .absolute()
+                            .top(LINUX_WINDOW_FRAME_PAD)
+                            .bottom(LINUX_WINDOW_FRAME_PAD)
+                            .left(LINUX_WINDOW_FRAME_PAD)
+                            .right(LINUX_WINDOW_FRAME_PAD)
                             .child(workspace_frame),
                     );
             } else {

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -1611,7 +1611,9 @@ impl Render for ConWorkspace {
             let width_px = (size.width.as_f32() * scale).round().max(1.0) as u32;
             let height_px = (size.height.as_f32() * scale).round().max(1.0) as u32;
             let radius_px = if x11_shape_round {
-                LINUX_WINDOW_CORNER_RADIUS.as_f32().round().max(0.0) as u32
+                (LINUX_WINDOW_CORNER_RADIUS.as_f32() * scale)
+                    .round()
+                    .max(0.0) as u32
             } else {
                 0
             };

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -4,11 +4,11 @@ mod top_bar;
 use super::*;
 
 #[cfg(target_os = "linux")]
-const LINUX_WINDOW_CORNER_RADIUS: Pixels = px(22.0);
+const LINUX_WINDOW_CORNER_RADIUS: Pixels = px(20.0);
 #[cfg(target_os = "linux")]
-const LINUX_WINDOW_FRAME_PAD: Pixels = px(8.0);
+const LINUX_WINDOW_FRAME_PAD: Pixels = px(12.0);
 #[cfg(target_os = "linux")]
-const LINUX_WINDOW_OUTER_RADIUS: Pixels = px(30.0);
+const LINUX_WINDOW_OUTER_RADIUS: Pixels = px(32.0);
 
 impl ConWorkspace {
     fn has_active_resize_drag(&self) -> bool {

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -1005,7 +1005,13 @@ impl Render for ConWorkspace {
                         .and_then(|guard| guard.clone())
                     {
                         let preview_size = tab_like_drag_preview_size();
-                        let leading_pad = if cfg!(target_os = "macos") { 78.0 } else { 8.0 };
+                        let leading_pad = if cfg!(target_os = "macos") {
+                            78.0
+                        } else if cfg!(target_os = "linux") {
+                            10.0
+                        } else {
+                            8.0
+                        };
                         let min_left = px(leading_pad);
                         let max_left =
                             (win.viewport_size().width - preview_size.width).max(min_left);
@@ -1279,16 +1285,16 @@ impl Render for ConWorkspace {
                     cx.stop_propagation();
                 }
             }))
-            .child(top_bar)
-            .when(show_compact_top_bar_separator, |root| {
-                root.child(
-                    div()
-                        .h(px(1.0))
-                        .flex_shrink_0()
-                        .bg(chrome_static_seam_color),
-                )
-            })
-            .child(main_area);
+            .child(top_bar);
+        if show_compact_top_bar_separator {
+            root = root.child(
+                div()
+                    .h(px(1.0))
+                    .flex_shrink_0()
+                    .bg(chrome_static_seam_color),
+            );
+        }
+        root = root.child(main_area);
 
         if let Some(preview) = self
             .tab_drag_preview
@@ -1297,7 +1303,13 @@ impl Render for ConWorkspace {
             .and_then(|guard| guard.clone())
         {
             let preview_size = tab_like_drag_preview_size();
-            let leading_pad = if cfg!(target_os = "macos") { 78.0 } else { 8.0 };
+            let leading_pad = if cfg!(target_os = "macos") {
+                78.0
+            } else if cfg!(target_os = "linux") {
+                10.0
+            } else {
+                8.0
+            };
             let min_left = px(leading_pad);
             let max_left = (window.viewport_size().width - preview_size.width).max(min_left);
             let left =
@@ -1582,24 +1594,31 @@ impl Render for ConWorkspace {
             let decorations = window.window_decorations();
             let is_maximized = window.is_maximized();
             let is_fullscreen = window.is_fullscreen();
-            let mut x11_shape_round = false;
+            let mut shape_radii = crate::LinuxWindowShapeRadii::default();
 
             if let Decorations::Client { tiling } = decorations
                 && !is_maximized
                 && !is_fullscreen
             {
-                x11_shape_round = !(tiling.top || tiling.left || tiling.right || tiling.bottom);
+                let radius_px = (LINUX_WINDOW_CORNER_RADIUS.as_f32()
+                    * window.scale_factor().max(f32::EPSILON))
+                .round()
+                .max(0.0) as u32;
                 if !(tiling.top || tiling.left) {
                     workspace_frame = workspace_frame.rounded_tl(LINUX_WINDOW_CORNER_RADIUS);
+                    shape_radii.top_left = radius_px;
                 }
                 if !(tiling.top || tiling.right) {
                     workspace_frame = workspace_frame.rounded_tr(LINUX_WINDOW_CORNER_RADIUS);
+                    shape_radii.top_right = radius_px;
                 }
                 if !(tiling.bottom || tiling.left) {
                     workspace_frame = workspace_frame.rounded_bl(LINUX_WINDOW_CORNER_RADIUS);
+                    shape_radii.bottom_left = radius_px;
                 }
                 if !(tiling.bottom || tiling.right) {
                     workspace_frame = workspace_frame.rounded_br(LINUX_WINDOW_CORNER_RADIUS);
+                    shape_radii.bottom_right = radius_px;
                 }
                 workspace_frame = workspace_frame.overflow_hidden();
             }
@@ -1610,21 +1629,9 @@ impl Render for ConWorkspace {
             let size = window.bounds().size;
             let width_px = (size.width.as_f32() * scale).round().max(1.0) as u32;
             let height_px = (size.height.as_f32() * scale).round().max(1.0) as u32;
-            let radius_px = if x11_shape_round {
-                (LINUX_WINDOW_CORNER_RADIUS.as_f32() * scale)
-                    .round()
-                    .max(0.0) as u32
-            } else {
-                0
-            };
-            let shape_signature = (width_px, height_px, radius_px, x11_shape_round);
+            let shape_signature = (width_px, height_px, shape_radii);
             if self.linux_window_shape_signature != Some(shape_signature) {
-                crate::sync_linux_x11_window_shape(
-                    window,
-                    width_px,
-                    height_px,
-                    x11_shape_round.then_some(radius_px),
-                );
+                crate::sync_linux_x11_window_shape(window, width_px, height_px, shape_radii);
                 self.linux_window_shape_signature = Some(shape_signature);
             }
 

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -4,11 +4,7 @@ mod top_bar;
 use super::*;
 
 #[cfg(target_os = "linux")]
-const LINUX_WINDOW_CORNER_RADIUS: Pixels = px(20.0);
-#[cfg(target_os = "linux")]
-const LINUX_WINDOW_FRAME_PAD: Pixels = px(12.0);
-#[cfg(target_os = "linux")]
-const LINUX_WINDOW_OUTER_RADIUS: Pixels = px(32.0);
+const LINUX_WINDOW_CORNER_RADIUS: Pixels = px(18.0);
 
 impl ConWorkspace {
     fn has_active_resize_drag(&self) -> bool {
@@ -1613,7 +1609,7 @@ impl Render for ConWorkspace {
             let width_px = (size.width.as_f32() * scale).round().max(1.0) as u32;
             let height_px = (size.height.as_f32() * scale).round().max(1.0) as u32;
             let radius_px = if x11_shape_round {
-                LINUX_WINDOW_OUTER_RADIUS.as_f32().round().max(0.0) as u32
+                LINUX_WINDOW_CORNER_RADIUS.as_f32().round().max(0.0) as u32
             } else {
                 0
             };
@@ -1628,46 +1624,11 @@ impl Render for ConWorkspace {
                 self.linux_window_shape_signature = Some(shape_signature);
             }
 
-            if x11_shape_round {
-                let linux_theme = cx.theme();
-                let outline_opacity = if linux_theme.is_dark() { 0.18 } else { 0.10 };
-                let frame_color = linux_theme.title_bar.opacity(0.98);
-                let outline_color = linux_theme.foreground.opacity(outline_opacity);
-                let linux_x11 = std::env::var_os("DISPLAY").is_some()
-                    && std::env::var_os("WAYLAND_DISPLAY").is_none();
-                let mut frame = div().relative().size_full().bg(frame_color);
-                if !linux_x11 {
-                    frame = frame.rounded(LINUX_WINDOW_OUTER_RADIUS);
-                }
-                root = frame
-                    .child(
-                        div()
-                            .absolute()
-                            .top(LINUX_WINDOW_FRAME_PAD)
-                            .bottom(LINUX_WINDOW_FRAME_PAD)
-                            .left(LINUX_WINDOW_FRAME_PAD)
-                            .right(LINUX_WINDOW_FRAME_PAD)
-                            .rounded(LINUX_WINDOW_CORNER_RADIUS)
-                            .bg(outline_color),
-                    )
-                    .child(
-                        div()
-                            .absolute()
-                            .top(LINUX_WINDOW_FRAME_PAD)
-                            .bottom(LINUX_WINDOW_FRAME_PAD)
-                            .left(LINUX_WINDOW_FRAME_PAD)
-                            .right(LINUX_WINDOW_FRAME_PAD)
-                            .rounded(LINUX_WINDOW_CORNER_RADIUS)
-                            .overflow_hidden()
-                            .child(workspace_frame),
-                    );
-            } else {
-                root = div()
-                    .relative()
-                    .size_full()
-                    .bg(transparent_black())
-                    .child(workspace_frame);
-            }
+            root = div()
+                .relative()
+                .size_full()
+                .bg(transparent_black())
+                .child(workspace_frame);
         }
 
         root.into_any_element()

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -1630,23 +1630,14 @@ impl Render for ConWorkspace {
 
             if x11_shape_round {
                 let linux_theme = cx.theme();
-                let shadow_opacity = if linux_theme.is_dark() { 0.30 } else { 0.18 };
                 let outline_opacity = if linux_theme.is_dark() { 0.18 } else { 0.10 };
+                let frame_color = linux_theme.title_bar.opacity(0.98);
                 let outline_color = linux_theme.foreground.opacity(outline_opacity);
                 root = div()
                     .relative()
                     .size_full()
-                    .bg(transparent_black())
-                    .child(
-                        div()
-                            .absolute()
-                            .top(px(2.0))
-                            .bottom(px(0.0))
-                            .left(px(2.0))
-                            .right(px(2.0))
-                            .rounded(LINUX_WINDOW_OUTER_RADIUS)
-                            .bg(gpui::black().opacity(shadow_opacity)),
-                    )
+                    .rounded(LINUX_WINDOW_OUTER_RADIUS)
+                    .bg(frame_color)
                     .child(
                         div()
                             .absolute()

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -1664,6 +1664,8 @@ impl Render for ConWorkspace {
                             .bottom(LINUX_WINDOW_FRAME_PAD)
                             .left(LINUX_WINDOW_FRAME_PAD)
                             .right(LINUX_WINDOW_FRAME_PAD)
+                            .rounded(LINUX_WINDOW_CORNER_RADIUS)
+                            .overflow_hidden()
                             .child(workspace_frame),
                     );
             } else {

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -408,8 +408,13 @@ impl Render for ConWorkspace {
         } else {
             0.0
         };
+        #[cfg(target_os = "linux")]
+        let linux_x11_native_decorated =
+            std::env::var_os("DISPLAY").is_some() && std::env::var_os("WAYLAND_DISPLAY").is_none();
+        #[cfg(not(target_os = "linux"))]
+        let linux_x11_native_decorated = false;
         let vertical_tabs_enabled = self.vertical_tabs_enabled();
-        let show_left_panel = self.left_panel_open;
+        let show_left_panel = self.left_panel_open && !linux_x11_native_decorated;
         let show_vertical_tabs = show_left_panel && vertical_tabs_enabled;
         let show_sidebar_tools =
             show_left_panel && (!vertical_tabs_enabled || self.sidebar_tools_open);

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -408,13 +408,8 @@ impl Render for ConWorkspace {
         } else {
             0.0
         };
-        #[cfg(target_os = "linux")]
-        let linux_x11_native_decorated =
-            std::env::var_os("DISPLAY").is_some() && std::env::var_os("WAYLAND_DISPLAY").is_none();
-        #[cfg(not(target_os = "linux"))]
-        let linux_x11_native_decorated = false;
         let vertical_tabs_enabled = self.vertical_tabs_enabled();
-        let show_left_panel = self.left_panel_open && !linux_x11_native_decorated;
+        let show_left_panel = self.left_panel_open;
         let show_vertical_tabs = show_left_panel && vertical_tabs_enabled;
         let show_sidebar_tools =
             show_left_panel && (!vertical_tabs_enabled || self.sidebar_tools_open);

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -1631,8 +1631,13 @@ impl Render for ConWorkspace {
             let height_px = (size.height.as_f32() * scale).round().max(1.0) as u32;
             let shape_signature = (width_px, height_px, shape_radii);
             if self.linux_window_shape_signature != Some(shape_signature) {
-                crate::sync_linux_x11_window_shape(window, width_px, height_px, shape_radii);
-                self.linux_window_shape_signature = Some(shape_signature);
+                let linux_x11 = std::env::var_os("DISPLAY").is_some()
+                    && std::env::var_os("WAYLAND_DISPLAY").is_none();
+                if !linux_x11
+                    || crate::sync_linux_x11_window_shape(window, width_px, height_px, shape_radii)
+                {
+                    self.linux_window_shape_signature = Some(shape_signature);
+                }
             }
 
             root = div()

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -975,6 +975,8 @@ impl Render for ConWorkspace {
             elevated_ui_surface_opacity,
             top_bar_surface_color,
         );
+        let show_compact_top_bar_separator =
+            cfg!(not(target_os = "macos")) && tab_strip_progress <= 0.01;
 
         let theme = cx.theme();
         let mut root = div()
@@ -1278,6 +1280,14 @@ impl Render for ConWorkspace {
                 }
             }))
             .child(top_bar)
+            .when(show_compact_top_bar_separator, |root| {
+                root.child(
+                    div()
+                        .h(px(1.0))
+                        .flex_shrink_0()
+                        .bg(chrome_static_seam_color),
+                )
+            })
             .child(main_area);
 
         if let Some(preview) = self

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -4,7 +4,9 @@ mod top_bar;
 use super::*;
 
 #[cfg(target_os = "linux")]
-const LINUX_WINDOW_CORNER_RADIUS: Pixels = px(18.0);
+const LINUX_WINDOW_CORNER_RADIUS: Pixels = px(10.0);
+#[cfg(target_os = "linux")]
+const LINUX_WINDOW_SHADOW_SIZE: Pixels = px(10.0);
 
 impl ConWorkspace {
     fn has_active_resize_drag(&self) -> bool {
@@ -1582,11 +1584,13 @@ impl Render for ConWorkspace {
             let decorations = window.window_decorations();
             let is_maximized = window.is_maximized();
             let is_fullscreen = window.is_fullscreen();
+            let tiling = match decorations {
+                Decorations::Client { tiling } => tiling,
+                Decorations::Server => Tiling::default(),
+            };
             let mut x11_shape_round = false;
 
-            if let Decorations::Client { tiling } = decorations
-                && !is_maximized
-                && !is_fullscreen
+            if matches!(decorations, Decorations::Client { .. }) && !is_maximized && !is_fullscreen
             {
                 x11_shape_round = !(tiling.top || tiling.left || tiling.right || tiling.bottom);
                 if !(tiling.top || tiling.left) {
@@ -1602,6 +1606,12 @@ impl Render for ConWorkspace {
                     workspace_frame = workspace_frame.rounded_br(LINUX_WINDOW_CORNER_RADIUS);
                 }
                 workspace_frame = workspace_frame.overflow_hidden();
+            }
+
+            if matches!(decorations, Decorations::Client { .. }) {
+                window.set_client_inset(LINUX_WINDOW_SHADOW_SIZE);
+            } else {
+                window.set_client_inset(px(0.0));
             }
 
             let scale = window.scale_factor().max(f32::EPSILON);
@@ -1624,11 +1634,59 @@ impl Render for ConWorkspace {
                 self.linux_window_shape_signature = Some(shape_signature);
             }
 
-            root = div()
-                .relative()
-                .size_full()
-                .bg(transparent_black())
-                .child(workspace_frame);
+            if matches!(decorations, Decorations::Client { .. }) && !is_maximized && !is_fullscreen
+            {
+                let border =
+                    cx.theme()
+                        .foreground
+                        .opacity(if cx.theme().is_dark() { 0.18 } else { 0.10 });
+                let backdrop = div()
+                    .relative()
+                    .size_full()
+                    .bg(transparent_black())
+                    .when(!tiling.top, |div| div.pt(LINUX_WINDOW_SHADOW_SIZE))
+                    .when(!tiling.bottom, |div| div.pb(LINUX_WINDOW_SHADOW_SIZE))
+                    .when(!tiling.left, |div| div.pl(LINUX_WINDOW_SHADOW_SIZE))
+                    .when(!tiling.right, |div| div.pr(LINUX_WINDOW_SHADOW_SIZE));
+                let mut body = div()
+                    .size_full()
+                    .border_color(border)
+                    .shadow(vec![gpui::BoxShadow {
+                        color: gpui::black().opacity(0.28),
+                        blur_radius: LINUX_WINDOW_SHADOW_SIZE / 2.,
+                        spread_radius: px(0.0),
+                        offset: point(px(0.0), px(0.0)),
+                    }])
+                    .child(workspace_frame);
+                if !(tiling.top || tiling.left) {
+                    body = body
+                        .rounded_tl(LINUX_WINDOW_CORNER_RADIUS)
+                        .border_l(px(1.0));
+                }
+                if !(tiling.top || tiling.right) {
+                    body = body
+                        .rounded_tr(LINUX_WINDOW_CORNER_RADIUS)
+                        .border_r(px(1.0));
+                }
+                if !(tiling.bottom || tiling.left) {
+                    body = body
+                        .rounded_bl(LINUX_WINDOW_CORNER_RADIUS)
+                        .border_b(px(1.0));
+                }
+                if !(tiling.bottom || tiling.right) {
+                    body = body.rounded_br(LINUX_WINDOW_CORNER_RADIUS);
+                }
+                if !tiling.top {
+                    body = body.border_t(px(1.0));
+                }
+                root = backdrop.child(body);
+            } else {
+                root = div()
+                    .relative()
+                    .size_full()
+                    .bg(transparent_black())
+                    .child(workspace_frame);
+            }
         }
 
         root.into_any_element()

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -4,11 +4,11 @@ mod top_bar;
 use super::*;
 
 #[cfg(target_os = "linux")]
-const LINUX_WINDOW_CORNER_RADIUS: Pixels = px(14.0);
+const LINUX_WINDOW_CORNER_RADIUS: Pixels = px(22.0);
 #[cfg(target_os = "linux")]
-const LINUX_WINDOW_FRAME_PAD: Pixels = px(7.0);
+const LINUX_WINDOW_FRAME_PAD: Pixels = px(8.0);
 #[cfg(target_os = "linux")]
-const LINUX_WINDOW_OUTER_RADIUS: Pixels = px(21.0);
+const LINUX_WINDOW_OUTER_RADIUS: Pixels = px(30.0);
 
 impl ConWorkspace {
     fn has_active_resize_drag(&self) -> bool {

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -1579,10 +1579,13 @@ impl Render for ConWorkspace {
         #[cfg(target_os = "linux")]
         {
             let mut workspace_frame = root;
+            let decorations = window.window_decorations();
+            let is_maximized = window.is_maximized();
+            let is_fullscreen = window.is_fullscreen();
 
-            if let Decorations::Client { tiling } = window.window_decorations()
-                && !window.is_maximized()
-                && !window.is_fullscreen()
+            if let Decorations::Client { tiling } = decorations
+                && !is_maximized
+                && !is_fullscreen
             {
                 if !(tiling.top || tiling.left) {
                     workspace_frame = workspace_frame.rounded_tl(LINUX_WINDOW_CORNER_RADIUS);

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -976,7 +976,7 @@ impl Render for ConWorkspace {
             top_bar_surface_color,
         );
         let show_compact_top_bar_separator =
-            cfg!(not(target_os = "macos")) && tab_strip_progress <= 0.01;
+            cfg!(not(target_os = "macos")) && top_bar_height > 0.5 && tab_strip_progress <= 0.01;
 
         let theme = cx.theme();
         let mut root = div()

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -4,7 +4,11 @@ mod top_bar;
 use super::*;
 
 #[cfg(target_os = "linux")]
+<<<<<<< HEAD
 const LINUX_WINDOW_CORNER_RADIUS: Pixels = px(14.0);
+=======
+const LINUX_WINDOW_CORNER_RADIUS: Pixels = px(18.0);
+>>>>>>> parent of a397d82 (Adopt Zed-style Linux client decorations)
 
 impl ConWorkspace {
     fn has_active_resize_drag(&self) -> bool {
@@ -1582,13 +1586,11 @@ impl Render for ConWorkspace {
             let decorations = window.window_decorations();
             let is_maximized = window.is_maximized();
             let is_fullscreen = window.is_fullscreen();
-            let tiling = match decorations {
-                Decorations::Client { tiling } => tiling,
-                Decorations::Server => Tiling::default(),
-            };
             let mut x11_shape_round = false;
 
-            if matches!(decorations, Decorations::Client { .. }) && !is_maximized && !is_fullscreen
+            if let Decorations::Client { tiling } = decorations
+                && !is_maximized
+                && !is_fullscreen
             {
                 x11_shape_round = !(tiling.top || tiling.left || tiling.right || tiling.bottom);
                 if !(tiling.top || tiling.left) {

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -4,9 +4,7 @@ mod top_bar;
 use super::*;
 
 #[cfg(target_os = "linux")]
-const LINUX_WINDOW_CORNER_RADIUS: Pixels = px(10.0);
-#[cfg(target_os = "linux")]
-const LINUX_WINDOW_SHADOW_SIZE: Pixels = px(10.0);
+const LINUX_WINDOW_CORNER_RADIUS: Pixels = px(14.0);
 
 impl ConWorkspace {
     fn has_active_resize_drag(&self) -> bool {
@@ -1608,11 +1606,7 @@ impl Render for ConWorkspace {
                 workspace_frame = workspace_frame.overflow_hidden();
             }
 
-            if matches!(decorations, Decorations::Client { .. }) {
-                window.set_client_inset(LINUX_WINDOW_SHADOW_SIZE);
-            } else {
-                window.set_client_inset(px(0.0));
-            }
+            window.set_client_inset(px(0.0));
 
             let scale = window.scale_factor().max(f32::EPSILON);
             let size = window.bounds().size;
@@ -1634,59 +1628,11 @@ impl Render for ConWorkspace {
                 self.linux_window_shape_signature = Some(shape_signature);
             }
 
-            if matches!(decorations, Decorations::Client { .. }) && !is_maximized && !is_fullscreen
-            {
-                let border =
-                    cx.theme()
-                        .foreground
-                        .opacity(if cx.theme().is_dark() { 0.18 } else { 0.10 });
-                let backdrop = div()
-                    .relative()
-                    .size_full()
-                    .bg(transparent_black())
-                    .when(!tiling.top, |div| div.pt(LINUX_WINDOW_SHADOW_SIZE))
-                    .when(!tiling.bottom, |div| div.pb(LINUX_WINDOW_SHADOW_SIZE))
-                    .when(!tiling.left, |div| div.pl(LINUX_WINDOW_SHADOW_SIZE))
-                    .when(!tiling.right, |div| div.pr(LINUX_WINDOW_SHADOW_SIZE));
-                let mut body = div()
-                    .size_full()
-                    .border_color(border)
-                    .shadow(vec![gpui::BoxShadow {
-                        color: gpui::black().opacity(0.28),
-                        blur_radius: LINUX_WINDOW_SHADOW_SIZE / 2.,
-                        spread_radius: px(0.0),
-                        offset: point(px(0.0), px(0.0)),
-                    }])
-                    .child(workspace_frame);
-                if !(tiling.top || tiling.left) {
-                    body = body
-                        .rounded_tl(LINUX_WINDOW_CORNER_RADIUS)
-                        .border_l(px(1.0));
-                }
-                if !(tiling.top || tiling.right) {
-                    body = body
-                        .rounded_tr(LINUX_WINDOW_CORNER_RADIUS)
-                        .border_r(px(1.0));
-                }
-                if !(tiling.bottom || tiling.left) {
-                    body = body
-                        .rounded_bl(LINUX_WINDOW_CORNER_RADIUS)
-                        .border_b(px(1.0));
-                }
-                if !(tiling.bottom || tiling.right) {
-                    body = body.rounded_br(LINUX_WINDOW_CORNER_RADIUS);
-                }
-                if !tiling.top {
-                    body = body.border_t(px(1.0));
-                }
-                root = backdrop.child(body);
-            } else {
-                root = div()
-                    .relative()
-                    .size_full()
-                    .bg(transparent_black())
-                    .child(workspace_frame);
-            }
+            root = div()
+                .relative()
+                .size_full()
+                .bg(transparent_black())
+                .child(workspace_frame);
         }
 
         root.into_any_element()

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -1633,11 +1633,13 @@ impl Render for ConWorkspace {
                 let outline_opacity = if linux_theme.is_dark() { 0.18 } else { 0.10 };
                 let frame_color = linux_theme.title_bar.opacity(0.98);
                 let outline_color = linux_theme.foreground.opacity(outline_opacity);
-                root = div()
-                    .relative()
-                    .size_full()
-                    .rounded(LINUX_WINDOW_OUTER_RADIUS)
-                    .bg(frame_color)
+                let linux_x11 = std::env::var_os("DISPLAY").is_some()
+                    && std::env::var_os("WAYLAND_DISPLAY").is_none();
+                let mut frame = div().relative().size_full().bg(frame_color);
+                if !linux_x11 {
+                    frame = frame.rounded(LINUX_WINDOW_OUTER_RADIUS);
+                }
+                root = frame
                     .child(
                         div()
                             .absolute()

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -5,6 +5,10 @@ use super::*;
 
 #[cfg(target_os = "linux")]
 const LINUX_WINDOW_CORNER_RADIUS: Pixels = px(14.0);
+#[cfg(target_os = "linux")]
+const LINUX_WINDOW_FRAME_PAD: Pixels = px(7.0);
+#[cfg(target_os = "linux")]
+const LINUX_WINDOW_OUTER_RADIUS: Pixels = px(21.0);
 
 impl ConWorkspace {
     fn has_active_resize_drag(&self) -> bool {
@@ -1609,7 +1613,7 @@ impl Render for ConWorkspace {
             let width_px = (size.width.as_f32() * scale).round().max(1.0) as u32;
             let height_px = (size.height.as_f32() * scale).round().max(1.0) as u32;
             let radius_px = if x11_shape_round {
-                LINUX_WINDOW_CORNER_RADIUS.as_f32().round().max(0.0) as u32
+                LINUX_WINDOW_OUTER_RADIUS.as_f32().round().max(0.0) as u32
             } else {
                 0
             };
@@ -1624,11 +1628,49 @@ impl Render for ConWorkspace {
                 self.linux_window_shape_signature = Some(shape_signature);
             }
 
-            root = div()
-                .relative()
-                .size_full()
-                .bg(transparent_black())
-                .child(workspace_frame);
+            if x11_shape_round {
+                let linux_theme = cx.theme();
+                let shadow_opacity = if linux_theme.is_dark() { 0.30 } else { 0.18 };
+                let outline_opacity = if linux_theme.is_dark() { 0.18 } else { 0.10 };
+                let outline_color = linux_theme.foreground.opacity(outline_opacity);
+                root = div()
+                    .relative()
+                    .size_full()
+                    .bg(transparent_black())
+                    .child(
+                        div()
+                            .absolute()
+                            .top(px(2.0))
+                            .bottom(px(0.0))
+                            .left(px(2.0))
+                            .right(px(2.0))
+                            .rounded(LINUX_WINDOW_OUTER_RADIUS)
+                            .bg(gpui::black().opacity(shadow_opacity)),
+                    )
+                    .child(
+                        div()
+                            .absolute()
+                            .top(LINUX_WINDOW_FRAME_PAD)
+                            .bottom(LINUX_WINDOW_FRAME_PAD)
+                            .left(LINUX_WINDOW_FRAME_PAD)
+                            .right(LINUX_WINDOW_FRAME_PAD)
+                            .rounded(LINUX_WINDOW_CORNER_RADIUS)
+                            .bg(outline_color),
+                    )
+                    .child(
+                        div()
+                            .relative()
+                            .size_full()
+                            .p(LINUX_WINDOW_FRAME_PAD)
+                            .child(workspace_frame),
+                    );
+            } else {
+                root = div()
+                    .relative()
+                    .size_full()
+                    .bg(transparent_black())
+                    .child(workspace_frame);
+            }
         }
 
         root.into_any_element()

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -1005,13 +1005,7 @@ impl Render for ConWorkspace {
                         .and_then(|guard| guard.clone())
                     {
                         let preview_size = tab_like_drag_preview_size();
-                        let leading_pad = if cfg!(target_os = "macos") {
-                            78.0
-                        } else if cfg!(target_os = "linux") {
-                            10.0
-                        } else {
-                            8.0
-                        };
+                        let leading_pad = top_bar::top_bar_leading_pad(win);
                         let min_left = px(leading_pad);
                         let max_left =
                             (win.viewport_size().width - preview_size.width).max(min_left);
@@ -1303,13 +1297,7 @@ impl Render for ConWorkspace {
             .and_then(|guard| guard.clone())
         {
             let preview_size = tab_like_drag_preview_size();
-            let leading_pad = if cfg!(target_os = "macos") {
-                78.0
-            } else if cfg!(target_os = "linux") {
-                10.0
-            } else {
-                8.0
-            };
+            let leading_pad = top_bar::top_bar_leading_pad(window);
             let min_left = px(leading_pad);
             let max_left = (window.viewport_size().width - preview_size.width).max(min_left);
             let left =

--- a/crates/con-app/src/workspace/render/top_bar.rs
+++ b/crates/con-app/src/workspace/render/top_bar.rs
@@ -22,6 +22,9 @@ impl ConWorkspace {
         top_bar_surface_color: Hsla,
     ) -> impl IntoElement + use<> {
         let theme = cx.theme();
+        #[cfg(target_os = "linux")]
+        let linux_client_decorated =
+            matches!(window.window_decorations(), Decorations::Client { .. });
         // macOS: leave 78px for the system traffic-light cluster that
         // the OS paints over our content. Windows / Linux: start flush
         // at the left; the Min/Max/Close cluster gets appended at the
@@ -30,20 +33,18 @@ impl ConWorkspace {
         // (GPUI's hit-test walks buttons first so child clickables
         // still work) and still lets macOS react to
         // `titlebar_double_click`.
-        let leading_pad = if cfg!(target_os = "macos") {
-            78.0
-        } else if cfg!(target_os = "linux") {
-            10.0
-        } else {
-            8.0
-        };
-        let trailing_pad = if cfg!(target_os = "windows") {
-            0.0
-        } else if cfg!(target_os = "linux") {
-            8.0
-        } else {
-            6.0
-        };
+        #[cfg(target_os = "macos")]
+        let leading_pad = 78.0;
+        #[cfg(target_os = "linux")]
+        let leading_pad = if linux_client_decorated { 10.0 } else { 8.0 };
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        let leading_pad = 8.0;
+        #[cfg(target_os = "windows")]
+        let trailing_pad = 0.0;
+        #[cfg(target_os = "linux")]
+        let trailing_pad = if linux_client_decorated { 8.0 } else { 6.0 };
+        #[cfg(not(any(target_os = "windows", target_os = "linux")))]
+        let trailing_pad = 6.0;
         let mut top_bar = div()
             .id("tab-bar")
             .flex()
@@ -1038,16 +1039,18 @@ impl ConWorkspace {
             // handler. GPUI Linux does not dispatch window-control
             // hit tests like Windows, so the draggable area must stay
             // clear of normal buttons.
-            leading_chrome = leading_chrome
-                .window_control_area(WindowControlArea::Drag)
-                .on_mouse_down(MouseButton::Left, |_, window, _cx| {
-                    window.start_window_move();
-                })
-                .on_click(|event, window, _cx| {
-                    if event.click_count() == 2 {
-                        window.titlebar_double_click();
-                    }
-                });
+            if linux_client_decorated {
+                leading_chrome = leading_chrome
+                    .window_control_area(WindowControlArea::Drag)
+                    .on_mouse_down(MouseButton::Left, |_, window, _cx| {
+                        window.start_window_move();
+                    })
+                    .on_click(|event, window, _cx| {
+                        if event.click_count() == 2 {
+                            window.titlebar_double_click();
+                        }
+                    });
+            }
         }
         // Show the tab strip when animating/visible OR when a pane is being
         // dragged to become a new tab (so the ghost tab preview is visible
@@ -1081,7 +1084,9 @@ impl ConWorkspace {
             .flex_shrink_0();
         #[cfg(target_os = "linux")]
         {
-            tab_controls = tab_controls.mr(px(4.0));
+            if linux_client_decorated {
+                tab_controls = tab_controls.mr(px(4.0));
+            }
         }
 
         let new_tab_icon_color = theme
@@ -1323,13 +1328,19 @@ impl ConWorkspace {
         {
             #[cfg(target_os = "linux")]
             let workspace_handle = cx.weak_entity();
-            top_bar = top_bar.child(caption_buttons(
-                window,
-                theme,
-                top_bar_height,
-                #[cfg(target_os = "linux")]
-                workspace_handle,
-            ));
+            #[cfg(target_os = "linux")]
+            if linux_client_decorated {
+                top_bar = top_bar.child(caption_buttons(
+                    window,
+                    theme,
+                    top_bar_height,
+                    workspace_handle,
+                ));
+            }
+            #[cfg(target_os = "windows")]
+            {
+                top_bar = top_bar.child(caption_buttons(window, theme, top_bar_height));
+            }
         }
 
         top_bar

--- a/crates/con-app/src/workspace/render/top_bar.rs
+++ b/crates/con-app/src/workspace/render/top_bar.rs
@@ -17,7 +17,7 @@ pub(super) fn top_bar_leading_pad(window: &Window) -> f32 {
     }
     #[cfg(target_os = "linux")]
     {
-        if matches!(window.window_decorations(), Decorations::Client { .. }) {
+        if linux_client_decorated(window) {
             10.0
         } else {
             8.0
@@ -30,6 +30,11 @@ pub(super) fn top_bar_leading_pad(window: &Window) -> f32 {
     }
 }
 
+#[cfg(target_os = "linux")]
+fn linux_client_decorated(window: &Window) -> bool {
+    matches!(window.window_decorations(), Decorations::Client { .. })
+}
+
 fn top_bar_trailing_pad(window: &Window) -> f32 {
     #[cfg(target_os = "windows")]
     {
@@ -38,7 +43,7 @@ fn top_bar_trailing_pad(window: &Window) -> f32 {
     }
     #[cfg(target_os = "linux")]
     {
-        if matches!(window.window_decorations(), Decorations::Client { .. }) {
+        if linux_client_decorated(window) {
             8.0
         } else {
             6.0
@@ -1068,7 +1073,7 @@ impl ConWorkspace {
             // handler. GPUI Linux does not dispatch window-control
             // hit tests like Windows, so the draggable area must stay
             // clear of normal buttons.
-            if linux_client_decorated {
+            if linux_client_decorated(window) {
                 leading_chrome = leading_chrome
                     .window_control_area(WindowControlArea::Drag)
                     .on_mouse_down(MouseButton::Left, |_, window, _cx| {
@@ -1113,7 +1118,7 @@ impl ConWorkspace {
             .flex_shrink_0();
         #[cfg(target_os = "linux")]
         {
-            if linux_client_decorated {
+            if linux_client_decorated(window) {
                 tab_controls = tab_controls.mr(px(4.0));
             }
         }
@@ -1345,7 +1350,7 @@ impl ConWorkspace {
             #[cfg(target_os = "linux")]
             let workspace_handle = cx.weak_entity();
             #[cfg(target_os = "linux")]
-            if linux_client_decorated {
+            if linux_client_decorated(window) {
                 top_bar = top_bar.child(caption_buttons(
                     window,
                     theme,

--- a/crates/con-app/src/workspace/render/top_bar.rs
+++ b/crates/con-app/src/workspace/render/top_bar.rs
@@ -30,9 +30,17 @@ impl ConWorkspace {
         // (GPUI's hit-test walks buttons first so child clickables
         // still work) and still lets macOS react to
         // `titlebar_double_click`.
-        let leading_pad = if cfg!(target_os = "macos") { 78.0 } else { 8.0 };
+        let leading_pad = if cfg!(target_os = "macos") {
+            78.0
+        } else if cfg!(target_os = "linux") {
+            10.0
+        } else {
+            8.0
+        };
         let trailing_pad = if cfg!(target_os = "windows") {
             0.0
+        } else if cfg!(target_os = "linux") {
+            8.0
         } else {
             6.0
         };
@@ -1051,6 +1059,10 @@ impl ConWorkspace {
             .gap(px(2.0))
             .mb(px(top_bar_controls_offset))
             .flex_shrink_0();
+        #[cfg(target_os = "linux")]
+        {
+            tab_controls = tab_controls.mr(px(4.0));
+        }
 
         tab_controls = tab_controls.child(
             div()

--- a/crates/con-app/src/workspace/render/top_bar.rs
+++ b/crates/con-app/src/workspace/render/top_bar.rs
@@ -9,6 +9,48 @@ fn sanitize_tab_accent_alpha(alpha: f32) -> f32 {
     }
 }
 
+pub(super) fn top_bar_leading_pad(window: &Window) -> f32 {
+    #[cfg(target_os = "macos")]
+    {
+        let _ = window;
+        78.0
+    }
+    #[cfg(target_os = "linux")]
+    {
+        if matches!(window.window_decorations(), Decorations::Client { .. }) {
+            10.0
+        } else {
+            8.0
+        }
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = window;
+        8.0
+    }
+}
+
+fn top_bar_trailing_pad(window: &Window) -> f32 {
+    #[cfg(target_os = "windows")]
+    {
+        let _ = window;
+        0.0
+    }
+    #[cfg(target_os = "linux")]
+    {
+        if matches!(window.window_decorations(), Decorations::Client { .. }) {
+            8.0
+        } else {
+            6.0
+        }
+    }
+    #[cfg(not(any(target_os = "windows", target_os = "linux")))]
+    {
+        let _ = window;
+        6.0
+    }
+}
+
 impl ConWorkspace {
     pub(super) fn render_top_bar(
         &mut self,
@@ -22,9 +64,6 @@ impl ConWorkspace {
         top_bar_surface_color: Hsla,
     ) -> impl IntoElement + use<> {
         let theme = cx.theme();
-        #[cfg(target_os = "linux")]
-        let linux_client_decorated =
-            matches!(window.window_decorations(), Decorations::Client { .. });
         // macOS: leave 78px for the system traffic-light cluster that
         // the OS paints over our content. Windows / Linux: start flush
         // at the left; the Min/Max/Close cluster gets appended at the
@@ -33,18 +72,8 @@ impl ConWorkspace {
         // (GPUI's hit-test walks buttons first so child clickables
         // still work) and still lets macOS react to
         // `titlebar_double_click`.
-        #[cfg(target_os = "macos")]
-        let leading_pad = 78.0;
-        #[cfg(target_os = "linux")]
-        let leading_pad = if linux_client_decorated { 10.0 } else { 8.0 };
-        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-        let leading_pad = 8.0;
-        #[cfg(target_os = "windows")]
-        let trailing_pad = 0.0;
-        #[cfg(target_os = "linux")]
-        let trailing_pad = if linux_client_decorated { 8.0 } else { 6.0 };
-        #[cfg(not(any(target_os = "windows", target_os = "linux")))]
-        let trailing_pad = 6.0;
+        let leading_pad = top_bar_leading_pad(window);
+        let trailing_pad = top_bar_trailing_pad(window);
         let mut top_bar = div()
             .id("tab-bar")
             .flex()

--- a/crates/con-app/src/workspace/render/top_bar.rs
+++ b/crates/con-app/src/workspace/render/top_bar.rs
@@ -91,14 +91,10 @@ impl ConWorkspace {
                 });
         }
 
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "windows")]
         {
             top_bar = top_bar
                 .window_control_area(WindowControlArea::Drag)
-                .on_mouse_down(MouseButton::Left, |_, _window, _cx| {
-                    #[cfg(target_os = "linux")]
-                    _window.start_window_move();
-                })
                 .on_click(|event, window, _cx| {
                     if event.click_count() == 2 {
                         window.titlebar_double_click();
@@ -1029,7 +1025,30 @@ impl ConWorkspace {
             }
         }
 
-        let mut leading_chrome = div().flex().flex_1().min_w_0().items_end();
+        let mut leading_chrome = div()
+            .id("top-bar-leading-chrome")
+            .flex()
+            .flex_1()
+            .min_w_0()
+            .items_end();
+        #[cfg(target_os = "linux")]
+        {
+            // Keep Linux's client-side titlebar draggable without
+            // putting the right-side controls under a parent drag
+            // handler. GPUI Linux does not dispatch window-control
+            // hit tests like Windows, so the draggable area must stay
+            // clear of normal buttons.
+            leading_chrome = leading_chrome
+                .window_control_area(WindowControlArea::Drag)
+                .on_mouse_down(MouseButton::Left, |_, window, _cx| {
+                    window.start_window_move();
+                })
+                .on_click(|event, window, _cx| {
+                    if event.click_count() == 2 {
+                        window.titlebar_double_click();
+                    }
+                });
+        }
         // Show the tab strip when animating/visible OR when a pane is being
         // dragged to become a new tab (so the ghost tab preview is visible
         // even when there is currently only one tab).

--- a/crates/con-app/src/workspace/render/top_bar.rs
+++ b/crates/con-app/src/workspace/render/top_bar.rs
@@ -1056,52 +1056,69 @@ impl ConWorkspace {
         let mut tab_controls = div()
             .flex()
             .items_center()
-            .gap(px(2.0))
+            .gap(px(3.0))
             .mb(px(top_bar_controls_offset))
+            .ml(px(if show_horizontal_tabs { 8.0 } else { 0.0 }))
             .flex_shrink_0();
         #[cfg(target_os = "linux")]
         {
             tab_controls = tab_controls.mr(px(4.0));
         }
 
-        tab_controls = tab_controls.child(
-            div()
-                .id("tab-new")
-                .flex()
-                .items_center()
-                .justify_center()
-                .size(px(22.0))
-                .rounded(px(5.0))
-                .cursor_pointer()
-                // `.occlude()` is required on Windows so the parent
-                // top_bar's `WindowControlArea::Drag` hit-test doesn't
-                // swallow this button (the OS would return HTCAPTION and
-                // start a window-drag on click instead of firing the
-                // click listener). Same treatment as the Min/Max/Close
-                // caption buttons at the top of this file.
-                .occlude()
-                .hover(|s| s.bg(theme.muted.opacity(0.10)))
-                .tooltip(|window, cx| {
-                    chrome_tooltip(
-                        "New tab",
-                        crate::keycaps::first_action_keystroke(&NewTab, window),
-                        window,
-                        cx,
-                    )
-                })
+        let new_tab_icon_color = theme
+            .muted_foreground
+            .opacity(0.45 + (0.08 * compact_titlebar_progress));
+        let mut new_tab_button = div()
+            .id("tab-new")
+            .flex()
+            .items_center()
+            .justify_center()
+            .size(px(24.0))
+            .rounded(px(6.0))
+            .cursor_pointer()
+            // `.occlude()` is required on Windows so the parent
+            // top_bar's `WindowControlArea::Drag` hit-test doesn't
+            // swallow this button (the OS would return HTCAPTION and
+            // start a window-drag on click instead of firing the
+            // click listener). Same treatment as the Min/Max/Close
+            // caption buttons at the top of this file.
+            .occlude()
+            .hover(|s| s.bg(theme.muted.opacity(0.12)))
+            .tooltip(|window, cx| {
+                chrome_tooltip(
+                    "New tab",
+                    crate::keycaps::first_action_keystroke(&NewTab, window),
+                    window,
+                    cx,
+                )
+            });
+        #[cfg(target_os = "linux")]
+        {
+            new_tab_button = new_tab_button.on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, window, cx| {
+                    cx.stop_propagation();
+                    this.new_tab(&NewTab, window, cx);
+                }),
+            );
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            new_tab_button = new_tab_button
                 .on_mouse_down(MouseButton::Left, |_, _, cx| {
                     cx.stop_propagation();
                 })
                 .on_click(cx.listener(|this, _, window, cx| {
                     this.new_tab(&NewTab, window, cx);
-                }))
-                .child(
-                    svg().path("phosphor/plus.svg").size(px(12.0)).text_color(
-                        theme
-                            .muted_foreground
-                            .opacity(0.45 + (0.08 * compact_titlebar_progress)),
-                    ),
-                ),
+                }));
+        }
+        tab_controls = tab_controls.child(
+            new_tab_button.child(
+                svg()
+                    .path("phosphor/plus.svg")
+                    .size(px(12.0))
+                    .text_color(new_tab_icon_color),
+            ),
         );
 
         let left_sidebar_tooltip = if self.left_panel_open {

--- a/crates/con-app/src/workspace/render/top_bar.rs
+++ b/crates/con-app/src/workspace/render/top_bar.rs
@@ -1092,7 +1092,7 @@ impl ConWorkspace {
         let new_tab_icon_color = theme
             .muted_foreground
             .opacity(0.45 + (0.08 * compact_titlebar_progress));
-        let mut new_tab_button = div()
+        let new_tab_button = div()
             .id("tab-new")
             .flex()
             .items_center()
@@ -1116,26 +1116,13 @@ impl ConWorkspace {
                     cx,
                 )
             });
-        #[cfg(target_os = "linux")]
-        {
-            new_tab_button = new_tab_button.on_mouse_down(
-                MouseButton::Left,
-                cx.listener(|this, _, window, cx| {
-                    cx.stop_propagation();
-                    this.new_tab(&NewTab, window, cx);
-                }),
-            );
-        }
-        #[cfg(not(target_os = "linux"))]
-        {
-            new_tab_button = new_tab_button
-                .on_mouse_down(MouseButton::Left, |_, _, cx| {
-                    cx.stop_propagation();
-                })
-                .on_click(cx.listener(|this, _, window, cx| {
-                    this.new_tab(&NewTab, window, cx);
-                }));
-        }
+        let new_tab_button = new_tab_button
+            .on_mouse_down(MouseButton::Left, |_, _, cx| {
+                cx.stop_propagation();
+            })
+            .on_click(cx.listener(|this, _, window, cx| {
+                this.new_tab(&NewTab, window, cx);
+            }));
         tab_controls = tab_controls.child(
             new_tab_button.child(
                 svg()

--- a/crates/con-app/src/workspace/tests.rs
+++ b/crates/con-app/src/workspace/tests.rs
@@ -1168,12 +1168,12 @@ fn top_bar_clickables_explicitly_consume_left_mouse_down() {
             .find(&marker)
             .unwrap_or_else(|| panic!("missing top bar control {control_id}"));
         let snippet = &source[start..source.len().min(start + 1200)];
-        let consumes_mouse_down = (snippet
-            .contains(".on_mouse_down(MouseButton::Left, |_, _, cx| {")
-            || snippet.contains(
-                ".on_mouse_down(\n                MouseButton::Left,\n                cx.listener(",
-            ))
-            && snippet.contains("cx.stop_propagation();");
+        let normalized = snippet.split_whitespace().collect::<String>();
+        let has_mouse_down_handler = normalized
+            .contains(".on_mouse_down(MouseButton::Left,|_,_,cx|{")
+            || normalized.contains(".on_mouse_down(MouseButton::Left,cx.listener(");
+        let consumes_mouse_down =
+            has_mouse_down_handler && normalized.contains("cx.stop_propagation();");
         assert!(
             consumes_mouse_down,
             "top bar control {control_id} must consume left mouse-down before parent drag"

--- a/crates/con-app/src/workspace/tests.rs
+++ b/crates/con-app/src/workspace/tests.rs
@@ -1168,9 +1168,14 @@ fn top_bar_clickables_explicitly_consume_left_mouse_down() {
             .find(&marker)
             .unwrap_or_else(|| panic!("missing top bar control {control_id}"));
         let snippet = &source[start..source.len().min(start + 1200)];
+        let consumes_mouse_down = (snippet
+            .contains(".on_mouse_down(MouseButton::Left, |_, _, cx| {")
+            || snippet.contains(
+                ".on_mouse_down(\n                MouseButton::Left,\n                cx.listener(",
+            ))
+            && snippet.contains("cx.stop_propagation();");
         assert!(
-            snippet.contains(".on_mouse_down(MouseButton::Left, |_, _, cx| {")
-                && snippet.contains("cx.stop_propagation();"),
+            consumes_mouse_down,
             "top bar control {control_id} must consume left mouse-down before parent drag"
         );
     }

--- a/docs/impl/linux-port.md
+++ b/docs/impl/linux-port.md
@@ -7,7 +7,7 @@ macOS now opens on Linux with client-side decorations (no native WM
 titlebar stacked on top of the GPUI shell), a transparent ARGB
 window with rounded corners, the same caption cluster Windows
 ships, IoskeleyMono-shaped styled cells, the user's theme palette,
-and KWin Wayland backdrop blur where the compositor exposes it.
+and per-pane / per-surface opacity composited by the desktop.
 This document is the Linux single-source-of-truth equivalent of
 `docs/impl/windows-port.md`: it captures the upstream constraints,
 the recommended architecture, and the staged path from today's
@@ -74,14 +74,19 @@ What that gives you:
   relying on libghostty-vt's terminal-only stream handler, so Linux
   pane/session state can follow shell-reported directory changes
 - transparent ARGB window with rounded corners (14 px on Linux, no
-  corners from `NSWindow` or DWM here so we clip the GPUI root
-  ourselves) and per-pane / per-surface opacity that composites
+  corners from `NSWindow` or DWM here so we use a transparent GPUI
+  toplevel and clip the workspace frame itself). The top-level
+  GPUI `Root` must stay transparent; otherwise the clipped workspace
+  still sits over an opaque rectangular app fill and the outer
+  corners read as square. Per-pane / per-surface opacity composites
   through to the desktop
-- backdrop blur on KDE Plasma Wayland via `org_kde_kwin_blur` —
-  real Gaussian blur of what's behind the window. On X11 / mutter /
-  sway the blur toggle still ships but the visible result is
-  transparency only (no portable backdrop-blur protocol exists
-  outside KWin)
+- Linux backdrop blur is intentionally not enabled yet. KWin exposes
+  `org_kde_kwin_blur`, but GPUI's current Wayland hook commits blur
+  for the whole surface instead of a rounded region, which makes the
+  window look rectangular even when the app paint is clipped. Shape
+  correctness wins until the platform layer can set a rounded blur
+  region. On X11 / mutter / sway there is no portable backdrop-blur
+  protocol anyway
 - a snappy paint pipeline: redundant per-tick snapshot refreshes
   and `Vec<Cell>` deep-equality compares were removed, PTY output now
   wakes the Linux terminal view directly instead of waiting for the
@@ -287,7 +292,7 @@ can ship.
 | 2b | GPUI feasibility spike | confirm whether con needs foreign-surface embedding, texture interop, or neither | bounded GPUI worklist exists, or path is ruled out | ✅ landed |
 | 2c | Architecture decision | pick Linux backend lane | one recommended implementation path, no split-brain plan | ✅ landed |
 | 3 | Linux backend scaffold | `con-ghostty/src/linux/` plus `con-app/src/linux_view.rs` (or equivalent) with real lifecycle types | Linux no longer routes through the generic stub path conceptually | ✅ landed |
-| 4 | First real terminal surface | PTY spawn, resize, exit, `libghostty-vt` state, GPUI-owned pane paint, real product chrome (no native WM titlebar), embedded mono font, transparent + rounded window with compositor-gated blur | VT-backed Linux pane compiles and displays live shell state with SGR colors / bold / italic / underline / strikethrough / inverse, cursor block, theme palette synced from settings, IoskeleyMono shaping, client-side titlebar with min/max/close caption cluster, transparent ARGB window with rounded corners and per-pane / per-surface opacity, real KWin Wayland blur where available, fast paint pipeline (16 ms keystroke-echo round-trip), no placeholder flash on alt-screen TUIs | ✅ landed (preview) |
+| 4 | First real terminal surface | PTY spawn, resize, exit, `libghostty-vt` state, GPUI-owned pane paint, real product chrome (no native WM titlebar), embedded mono font, transparent + rounded window | VT-backed Linux pane compiles and displays live shell state with SGR colors / bold / italic / underline / strikethrough / inverse, cursor block, theme palette synced from settings, IoskeleyMono shaping, client-side titlebar with min/max/close caption cluster, transparent ARGB window with rounded corners and per-pane / per-surface opacity, fast paint pipeline (16 ms keystroke-echo round-trip), no placeholder flash on alt-screen TUIs | ✅ landed (preview) |
 | 5 | Input + selection + glyph-atlas grid renderer | keyboard, mouse, clipboard, bracketed paste, DECCKM, CJK IME text/preedit input, selection, plus the long-term GPUI-owned glyph-atlas grid renderer matching the D3D11/DirectWrite path Windows uses | vim/tmux/fzf/less usable on Linux at full speed | 🚧 in progress (DECCKM, bracketed paste, CJK IME text/preedit input, terminal-local Tab / Shift+Tab capture, and basic left-drag text selection are wired; mouse reporting, scrollback gestures, desktop IME validation matrix, and the glyph-atlas renderer remain) |
 | 6 | Packaging | one-line installer, tarball release, desktop entry, icon integration, appcast / notify-only updater, plus native artifact strategy (`.deb`, AppImage, Flatpak, etc.) | tarball installer exists; runtime Linux app id, desktop-file basename, and `StartupWMClass` are aligned as `co.nowledge.con`; native package format decision remains | 🚧 partially landed |
 
@@ -317,10 +322,9 @@ With phase 4 landed (preview), the remaining Linux tasks are:
    a terminal-local key context so shell completion and reverse focus
    traversal are not intercepted by GPUI's app-level focus navigation.
 3. Validate on hardware-accelerated native Linux desktops (Wayland
-   on KDE Plasma to confirm `org_kde_kwin_blur`; Wayland on
-   GNOME / sway and X11 on each major WM to confirm the
-   transparency / CSD / caption-cluster fallback paths). The
-   cloud-VM XFCE + llvmpipe + Xvfb-style display has covered the
+   on KDE Plasma, GNOME / sway, and X11 on each major WM to confirm
+   the transparency / rounded-CSD / caption-cluster fallback paths).
+   The cloud-VM XFCE + llvmpipe + Xvfb-style display has covered the
    software path end to end (full launch flow, styled output,
    transparent rounded chrome, htop in the alternate screen,
    keystroke-echo benchmark), but the hardware path still wants a

--- a/postmortem/2026-05-13-linux-x11-window-corners.md
+++ b/postmortem/2026-05-13-linux-x11-window-corners.md
@@ -18,9 +18,11 @@ show.
 
 Linux keeps Con's client-side chrome. Wayland still uses the transparent GPUI
 surface and rounded workspace clip; X11 additionally applies a server-side
-SHAPE mask matching the rounded workspace, updating only when window
-size/maximize/tiling state changes. This keeps the modern in-app titlebar
-without adding a second native titlebar.
+SHAPE mask matching the outer rounded frame, updating only when window
+size/maximize/tiling state changes. The Linux wrapper also reserves a small
+transparent frame and paints an opacity-based halo/outline around the rounded
+workspace body, giving the main window visible depth without adding a second
+native titlebar.
 
 ## What we learned
 

--- a/postmortem/2026-05-13-linux-x11-window-corners.md
+++ b/postmortem/2026-05-13-linux-x11-window-corners.md
@@ -1,0 +1,27 @@
+# Linux X11 Window Corners
+
+## What happened
+
+On Xfce/X11, Con opened with a sharp rectangular outer silhouette while Xfce
+Terminal on the same display had rounded window-manager corners.
+
+## Root cause
+
+Con requested GPUI client-side decorations on Linux and rendered rounded
+workspace content into a transparent top-level surface. Runtime logs confirmed
+the rounded GPUI branch was active, but on X11/Xfce the visible outer silhouette
+is owned by the window manager's server-side frame. Removing that frame meant
+there was no native rounded shape left for the compositor to show.
+
+## Fix applied
+
+Linux now chooses decorations by compositor: Wayland keeps client-side
+transparent rendering, while X11 uses server-side decorations and an opaque
+window/root. The Linux in-app caption buttons and drag titlebar behavior are
+rendered only when GPUI reports client-side decorations.
+
+## What we learned
+
+Rounded GPUI content is not the same as a rounded top-level X11 window. On X11,
+native server decorations are the performance-safe path for matching the desktop
+environment's window shape.

--- a/postmortem/2026-05-13-linux-x11-window-corners.md
+++ b/postmortem/2026-05-13-linux-x11-window-corners.md
@@ -10,18 +10,20 @@ Terminal on the same display had rounded window-manager corners.
 Con requested GPUI client-side decorations on Linux and rendered rounded
 workspace content into a transparent top-level surface. Runtime logs confirmed
 the rounded GPUI branch was active, but on X11/Xfce the visible outer silhouette
-is owned by the window manager's server-side frame. Removing that frame meant
-there was no native rounded shape left for the compositor to show.
+is the top-level X window shape, not the inner GPUI clip. Removing the native
+frame meant there was no window-manager rounded shape left for the compositor to
+show.
 
 ## Fix applied
 
-Linux now chooses decorations by compositor: Wayland keeps client-side
-transparent rendering, while X11 uses server-side decorations and an opaque
-window/root. The Linux in-app caption buttons and drag titlebar behavior are
-rendered only when GPUI reports client-side decorations.
+Linux keeps Con's client-side chrome. Wayland still uses the transparent GPUI
+surface and rounded workspace clip; X11 additionally applies a server-side
+SHAPE mask matching the rounded workspace, updating only when window
+size/maximize/tiling state changes. This keeps the modern in-app titlebar
+without adding a second native titlebar.
 
 ## What we learned
 
 Rounded GPUI content is not the same as a rounded top-level X11 window. On X11,
-native server decorations are the performance-safe path for matching the desktop
-environment's window shape.
+an explicit shape mask is the performance-safe path for matching the desktop
+environment's rounded windows while preserving client-side chrome.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Supersedes #193 by carrying forward its Linux rounded-window chrome work on top of latest `main`.
- Keeps Linux on Con-owned client-side titlebar chrome so one-tab and multi-tab states retain the same integrated controls as macOS/Windows.
- Restores visible titlebar actions (`+`, sidebar/input/agent/settings, window controls) in the one-tab state.
- Keeps tabs integrated into the themed titlebar in multi-tab mode.
- Preserves the X11 SHAPE mask path for client-decorated Linux windows, while removing the visually distracting faux frame/shadow experiment.
- Improves the Linux terminal pane by using shared cell metrics and a single pane background layer to avoid double-tinted opacity.
- Restores left sidebar/rail behavior so sidebar tools remain reachable from the integrated chrome.
- Addresses review feedback: HiDPI-scaled X11 shape radius, reusable X11 shape connection, retry-on-failure shape sync, per-corner mask state for tiling, safe large-window fallback, click-release new-tab semantics, less brittle topbar tests, and Linux blur config normalization.

### Walkthrough
[linux_integrated_titlebar_final.mp4](https://cursor.com/agents/bc-5ae2bde6-a8c3-40e9-b2d3-9f865b6ca144/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flinux_integrated_titlebar_final.mp4)

[Linux integrated titlebar single tab](https://cursor.com/agents/bc-5ae2bde6-a8c3-40e9-b2d3-9f865b6ca144/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flinux_integrated_titlebar_single_tab.webp)
[Linux integrated titlebar multi tab](https://cursor.com/agents/bc-5ae2bde6-a8c3-40e9-b2d3-9f865b6ca144/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flinux_integrated_titlebar_multi_tab.webp)
[Linux integrated titlebar sidebar](https://cursor.com/agents/bc-5ae2bde6-a8c3-40e9-b2d3-9f865b6ca144/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flinux_integrated_titlebar_sidebar.webp)

### Testing
- `cargo test -p con linux_window_shape -- --nocapture`
- `cargo test -p con ghostty_view::tests -- --nocapture`
- `cargo test -p con top_bar_clickables_explicitly_consume_left_mouse_down -- --nocapture`
- `cargo check -p con`
- Manual computer-use verification for one-tab controls, multi-tab integrated titlebar, X11 shape behavior, and sidebar open behavior.

### Notes
- #193 can be closed as superseded by this PR.
- Native-quality rounded/shadowed X11 client-side decorations likely need upstream GPUI/X11 windowing work; this PR keeps the Con UI coherent and avoids the fake-border approach.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ae2bde6-a8c3-40e9-b2d3-9f865b6ca144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ae2bde6-a8c3-40e9-b2d3-9f865b6ca144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

