### PR TITLE
Fix terminal input responsiveness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ con is still pre-release, so entries may group related beta work while the produ
 
 - Improved terminal input responsiveness by keeping normal keypresses out of
   workspace focus-change handling, making input-bar pane metadata sync
-  idempotent, and moving skill discovery filesystem work off the render path.
-  _(PR [#208](https://github.com/nowledge-co/con-terminal/pull/208) by
+  idempotent, reasserting the active input target when returning to a Con
+  window from another app, and moving skill discovery filesystem work off the
+  render path. _(PR
+  [#208](https://github.com/nowledge-co/con-terminal/pull/208) by
   [@wey-gu](https://github.com/wey-gu))_
 
 ## `v0.1.0-beta.72` - 2026-05-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## `v0.1.0-beta.73`
+
+### Fixed
+
+**Terminal**
+
+- Improved terminal input responsiveness by keeping normal keypresses out of
+  workspace focus-change handling, making input-bar pane metadata sync
+  idempotent, and moving skill discovery filesystem work off the render path.
+  _(PR [#208](https://github.com/nowledge-co/con-terminal/pull/208) by
+  [@wey-gu](https://github.com/wey-gu))_
+
 ## `v0.1.0-beta.72` - 2026-05-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
-## `v0.1.0-beta.73`
+## `v0.1.0-beta.73` - Unreleased
 
 ### Fixed
 

--- a/crates/con-agent/src/skills.rs
+++ b/crates/con-agent/src/skills.rs
@@ -139,15 +139,20 @@ impl SkillRegistry {
     }
 
     pub fn names(&self) -> Vec<String> {
-        self.skills.keys().cloned().collect()
+        let mut names: Vec<_> = self.skills.keys().cloned().collect();
+        names.sort();
+        names
     }
 
     /// Return (name, description) pairs for all registered skills.
     pub fn summaries(&self) -> Vec<(String, String)> {
-        self.skills
+        let mut summaries: Vec<_> = self
+            .skills
             .values()
             .map(|s| (s.name.clone(), s.description.clone()))
-            .collect()
+            .collect();
+        summaries.sort_by(|a, b| a.0.cmp(&b.0));
+        summaries
     }
 
     pub fn is_empty(&self) -> bool {
@@ -270,6 +275,36 @@ mod tests {
         let (fm, body) = parse_frontmatter(content).unwrap();
         assert_eq!(fm["name"], "empty");
         assert!(body.trim().is_empty());
+    }
+
+    #[test]
+    fn registry_names_and_summaries_are_sorted_by_name() {
+        let mut registry = SkillRegistry::new();
+        for name in ["zeta", "alpha", "middle"] {
+            registry.register(Skill {
+                name: name.to_string(),
+                description: format!("{name} description"),
+                prompt_template: format!("{name} prompt"),
+                source: SkillSource::Global(PathBuf::from("/tmp")),
+            });
+        }
+
+        assert_eq!(
+            registry.names(),
+            vec![
+                "alpha".to_string(),
+                "middle".to_string(),
+                "zeta".to_string()
+            ]
+        );
+        assert_eq!(
+            registry.summaries(),
+            vec![
+                ("alpha".to_string(), "alpha description".to_string()),
+                ("middle".to_string(), "middle description".to_string()),
+                ("zeta".to_string(), "zeta description".to_string())
+            ]
+        );
     }
 
     #[test]

--- a/crates/con-agent/src/skills.rs
+++ b/crates/con-agent/src/skills.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 /// A skill is a named capability with a prompt template.
@@ -50,7 +50,7 @@ impl std::fmt::Display for SkillSource {
 /// Registry of available skills, populated by scanning the filesystem.
 #[derive(Debug, Clone, Default)]
 pub struct SkillRegistry {
-    skills: HashMap<String, Skill>,
+    skills: BTreeMap<String, Skill>,
 }
 
 impl SkillRegistry {
@@ -139,20 +139,15 @@ impl SkillRegistry {
     }
 
     pub fn names(&self) -> Vec<String> {
-        let mut names: Vec<_> = self.skills.keys().cloned().collect();
-        names.sort();
-        names
+        self.skills.keys().cloned().collect()
     }
 
     /// Return (name, description) pairs for all registered skills.
     pub fn summaries(&self) -> Vec<(String, String)> {
-        let mut summaries: Vec<_> = self
-            .skills
+        self.skills
             .values()
             .map(|s| (s.name.clone(), s.description.clone()))
-            .collect();
-        summaries.sort_by(|a, b| a.0.cmp(&b.0));
-        summaries
+            .collect()
     }
 
     pub fn is_empty(&self) -> bool {

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -1967,7 +1967,6 @@ impl Render for GhosttyView {
                 // Force repaint — some ghostty key bindings (e.g. cmd-k clear screen)
                 // modify the terminal without emitting GHOSTTY_ACTION_RENDER.
                 cx.notify();
-                cx.emit(GhosttyFocusChanged);
             }))
             .child(
                 canvas(

--- a/crates/con-app/src/input_bar.rs
+++ b/crates/con-app/src/input_bar.rs
@@ -530,7 +530,7 @@ impl InputBar {
         cx.notify();
     }
 
-    pub fn set_recent_commands(&mut self, commands: Vec<String>) {
+    pub fn set_recent_commands(&mut self, commands: Vec<String>, cx: &mut Context<Self>) {
         let commands = commands
             .into_iter()
             .filter(|command| !command.contains('\n'))
@@ -542,6 +542,7 @@ impl InputBar {
         self.recent_commands = commands;
         self.history_nav_index = None;
         self.history_nav_draft = None;
+        cx.notify();
     }
 
     pub fn current_text(&self, cx: &App) -> String {

--- a/crates/con-app/src/input_bar.rs
+++ b/crates/con-app/src/input_bar.rs
@@ -86,7 +86,7 @@ pub struct PaneInfo {
 }
 
 /// A skill available for slash-command completion.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct SkillEntry {
     pub name: String,
     pub description: String,
@@ -471,11 +471,12 @@ impl InputBar {
         self.effective_target_ids()
     }
 
-    pub fn set_cwd(&mut self, cwd: String) {
+    pub fn set_cwd(&mut self, cwd: String, cx: &mut Context<Self>) {
         if self.cwd == cwd {
             return;
         }
         self.cwd = cwd;
+        cx.notify();
     }
 
     pub fn set_panes(
@@ -521,8 +522,12 @@ impl InputBar {
         cx.notify();
     }
 
-    pub fn set_skills(&mut self, skills: Vec<SkillEntry>) {
+    pub fn set_skills(&mut self, skills: Vec<SkillEntry>, cx: &mut Context<Self>) {
+        if self.skills == skills {
+            return;
+        }
         self.skills = skills;
+        cx.notify();
     }
 
     pub fn set_recent_commands(&mut self, commands: Vec<String>) {

--- a/crates/con-app/src/input_bar.rs
+++ b/crates/con-app/src/input_bar.rs
@@ -72,7 +72,7 @@ impl InputMode {
 }
 
 /// Pane info for the pane selector
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct PaneInfo {
     pub id: usize,
     /// Display name (title, or cwd basename, or "Pane N")
@@ -472,6 +472,9 @@ impl InputBar {
     }
 
     pub fn set_cwd(&mut self, cwd: String) {
+        if self.cwd == cwd {
+            return;
+        }
         self.cwd = cwd;
     }
 
@@ -482,6 +485,10 @@ impl InputBar {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if self.focused_pane_id == focused_id && self.panes == panes {
+            return;
+        }
+
         let was_multi_pane = self.panes.len() > 1;
         let previous_focused_id = self.focused_pane_id;
         self.panes = panes;

--- a/crates/con-app/src/workspace/helpers.rs
+++ b/crates/con-app/src/workspace/helpers.rs
@@ -51,6 +51,14 @@ pub(super) enum ActivePaneFocusTarget {
     Workspace,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ActivationFocusTarget {
+    InputBar,
+    AgentInlineInput,
+    ActiveEditor,
+    Terminal,
+}
+
 pub(super) fn active_pane_focus_target(
     has_focused_terminal: bool,
     has_focused_editor: bool,
@@ -61,6 +69,23 @@ pub(super) fn active_pane_focus_target(
         ActivePaneFocusTarget::Editor
     } else {
         ActivePaneFocusTarget::Workspace
+    }
+}
+
+pub(super) fn activation_focus_target_for_reassertion(
+    input_bar_focused: bool,
+    agent_inline_refocused: bool,
+    editor_has_keyboard_focus: bool,
+    active_pane_is_editor: bool,
+) -> ActivationFocusTarget {
+    if input_bar_focused {
+        ActivationFocusTarget::InputBar
+    } else if agent_inline_refocused {
+        ActivationFocusTarget::AgentInlineInput
+    } else if editor_has_keyboard_focus || active_pane_is_editor {
+        ActivationFocusTarget::ActiveEditor
+    } else {
+        ActivationFocusTarget::Terminal
     }
 }
 

--- a/crates/con-app/src/workspace/input_events.rs
+++ b/crates/con-app/src/workspace/input_events.rs
@@ -76,7 +76,7 @@ impl ConWorkspace {
 
         self.record_input_history(&content);
         let recent_inputs = self.recent_input_history(80);
-        input_bar.update(cx, |bar, _cx| bar.set_recent_commands(recent_inputs));
+        input_bar.update(cx, |bar, cx| bar.set_recent_commands(recent_inputs, cx));
 
         match mode {
             InputMode::Shell => {

--- a/crates/con-app/src/workspace/lifecycle.rs
+++ b/crates/con-app/src/workspace/lifecycle.rs
@@ -83,6 +83,7 @@ impl ConWorkspace {
         let (control_request_tx, control_request_rx) = crossbeam_channel::unbounded();
         let (shell_suggestion_tx, shell_suggestion_rx) = crossbeam_channel::unbounded();
         let (tab_summary_tx, tab_summary_rx) = crossbeam_channel::unbounded();
+        let (skill_scan_tx, skill_scan_rx) = crossbeam_channel::unbounded();
         let control_socket = match con_core::spawn_control_socket_server(
             harness.runtime_handle(),
             control_request_tx,
@@ -579,6 +580,13 @@ impl ConWorkspace {
                         workspace.apply_tab_summary(generation, summary_epoch, summary, cx);
                     }
 
+                    while let Ok(result) = workspace.skill_scan_rx.try_recv() {
+                        got_event = true;
+                        if workspace.harness.complete_skill_scan(result) {
+                            cx.notify();
+                        }
+                    }
+
                     if workspace.pump_ghostty_views(cx) {
                         got_event = true;
                         // Output flowed — ask the AI summarizer to
@@ -652,7 +660,7 @@ impl ConWorkspace {
         let last_ghostty_wake_generation = ghostty_app.wake_generation();
         let next_tab_summary_id_init = tabs.len() as u64;
 
-        Self {
+        let mut workspace = Self {
             config: config.clone(),
             sidebar,
             tabs,
@@ -724,6 +732,8 @@ impl ConWorkspace {
             tab_summary_engine,
             tab_summary_rx,
             tab_summary_tx,
+            skill_scan_rx,
+            skill_scan_tx,
             tab_summary_generation: 0,
             next_tab_summary_id: next_tab_summary_id_init,
             next_control_agent_request_id: 1,
@@ -757,7 +767,16 @@ impl ConWorkspace {
             file_tree_view: file_tree_entity,
             search_view: search_view_entity,
             workspace_focus: cx.focus_handle(),
+        };
+
+        if let Some(cwd) = workspace
+            .try_active_terminal()
+            .and_then(|t| t.current_dir(cx))
+        {
+            workspace.request_skill_scan_for_cwd(cwd);
         }
+
+        workspace
     }
 
     /// Create a new Ghostty terminal pane.
@@ -1072,6 +1091,24 @@ impl ConWorkspace {
             return;
         }
         self.sync_active_tab_native_view_visibility_after_layout(window, cx);
+    }
+
+    pub(super) fn request_skill_scan_for_cwd(&mut self, cwd: String) {
+        let Some(job) = self.harness.request_skill_scan(&cwd) else {
+            return;
+        };
+
+        let tx = self.skill_scan_tx.clone();
+        self.harness.spawn_detached(async move {
+            match tokio::task::spawn_blocking(move || job.scan()).await {
+                Ok(result) => {
+                    let _ = tx.send(result);
+                }
+                Err(err) => {
+                    log::warn!("Skill scan task failed: {}", err);
+                }
+            }
+        });
     }
 
     pub(super) fn pump_ghostty_views(&mut self, cx: &mut Context<Self>) -> bool {

--- a/crates/con-app/src/workspace/lifecycle.rs
+++ b/crates/con-app/src/workspace/lifecycle.rs
@@ -584,7 +584,12 @@ impl ConWorkspace {
 
                     while let Ok(result) = workspace.skill_scan_rx.try_recv() {
                         got_event = true;
-                        if workspace.harness.complete_skill_scan(result) {
+                        let completion = workspace.harness.complete_skill_scan(result);
+                        let applied = completion.applied();
+                        if let Some(job) = completion.follow_up_job() {
+                            workspace.spawn_skill_scan_job(job);
+                        }
+                        if applied {
                             cx.notify();
                         }
                     }
@@ -1100,6 +1105,10 @@ impl ConWorkspace {
             return;
         };
 
+        self.spawn_skill_scan_job(job);
+    }
+
+    pub(super) fn spawn_skill_scan_job(&self, job: SkillScanJob) {
         let failed_result = job.failed_result();
         let tx = self.skill_scan_tx.clone();
         self.harness.spawn_detached(async move {

--- a/crates/con-app/src/workspace/lifecycle.rs
+++ b/crates/con-app/src/workspace/lifecycle.rs
@@ -775,7 +775,7 @@ impl ConWorkspace {
             .try_active_terminal()
             .and_then(|t| t.current_dir(cx))
         {
-            workspace.request_skill_scan_for_cwd(cwd);
+            workspace.request_skill_scan_for_cwd(&cwd);
         }
 
         workspace
@@ -1095,8 +1095,8 @@ impl ConWorkspace {
         self.sync_active_tab_native_view_visibility_after_layout(window, cx);
     }
 
-    pub(super) fn request_skill_scan_for_cwd(&mut self, cwd: String) {
-        let Some(job) = self.harness.request_skill_scan(&cwd) else {
+    pub(super) fn request_skill_scan_for_cwd(&mut self, cwd: &str) {
+        let Some(job) = self.harness.request_skill_scan(cwd) else {
             return;
         };
 

--- a/crates/con-app/src/workspace/lifecycle.rs
+++ b/crates/con-app/src/workspace/lifecycle.rs
@@ -375,6 +375,8 @@ impl ConWorkspace {
             cx.notify();
         })
         .detach();
+        cx.observe_window_activation(window, Self::on_window_activation_changed)
+            .detach();
 
         // Activity bar: sync file/search drawer state back to workspace on click.
         let activity_bar_entity = cx.new(|_cx| ActivityBar::new());

--- a/crates/con-app/src/workspace/lifecycle.rs
+++ b/crates/con-app/src/workspace/lifecycle.rs
@@ -289,9 +289,9 @@ impl ConWorkspace {
             panel.set_ui_opacity(effective_ui_opacity);
             panel.set_recent_inputs(initial_recent_inputs.clone());
         });
-        input_bar.update(cx, |bar, _cx| {
+        input_bar.update(cx, |bar, cx| {
             bar.set_ui_opacity(effective_ui_opacity);
-            bar.set_recent_commands(initial_recent_inputs);
+            bar.set_recent_commands(initial_recent_inputs, cx);
         });
         sidebar.update(cx, |s, cx| s.set_ui_opacity(effective_ui_opacity, cx));
         command_palette.update(cx, |palette, _cx| {

--- a/crates/con-app/src/workspace/lifecycle.rs
+++ b/crates/con-app/src/workspace/lifecycle.rs
@@ -1098,6 +1098,7 @@ impl ConWorkspace {
             return;
         };
 
+        let failed_result = job.failed_result();
         let tx = self.skill_scan_tx.clone();
         self.harness.spawn_detached(async move {
             match tokio::task::spawn_blocking(move || job.scan()).await {
@@ -1106,6 +1107,7 @@ impl ConWorkspace {
                 }
                 Err(err) => {
                     log::warn!("Skill scan task failed: {}", err);
+                    let _ = tx.send(failed_result);
                 }
             }
         });

--- a/crates/con-app/src/workspace/mod.rs
+++ b/crates/con-app/src/workspace/mod.rs
@@ -92,7 +92,7 @@ use con_core::control::{
     AgentAskResult, ControlCommand, ControlError, ControlRequestEnvelope, ControlResult,
     SystemIdentifyResult, TabInfo,
 };
-use con_core::harness::{AgentHarness, AgentSession, HarnessEvent, InputKind};
+use con_core::harness::{AgentHarness, AgentSession, HarnessEvent, InputKind, SkillScanResult};
 use con_core::session::{
     AgentModelOverrideState, AgentRoutingState, GlobalHistoryState, PaneLayoutState,
     PaneSplitDirection, Session, TabState,
@@ -228,6 +228,8 @@ pub struct ConWorkspace {
     tab_summary_engine: TabSummaryEngine,
     tab_summary_rx: crossbeam_channel::Receiver<(u64, u64, TabSummary)>,
     tab_summary_tx: crossbeam_channel::Sender<(u64, u64, TabSummary)>,
+    skill_scan_rx: crossbeam_channel::Receiver<SkillScanResult>,
+    skill_scan_tx: crossbeam_channel::Sender<SkillScanResult>,
     /// Bumped whenever summary-model settings change so late async
     /// responses from the old configuration are ignored.
     tab_summary_generation: u64,

--- a/crates/con-app/src/workspace/mod.rs
+++ b/crates/con-app/src/workspace/mod.rs
@@ -92,7 +92,9 @@ use con_core::control::{
     AgentAskResult, ControlCommand, ControlError, ControlRequestEnvelope, ControlResult,
     SystemIdentifyResult, TabInfo,
 };
-use con_core::harness::{AgentHarness, AgentSession, HarnessEvent, InputKind, SkillScanResult};
+use con_core::harness::{
+    AgentHarness, AgentSession, HarnessEvent, InputKind, SkillScanJob, SkillScanResult,
+};
 use con_core::session::{
     AgentModelOverrideState, AgentRoutingState, GlobalHistoryState, PaneLayoutState,
     PaneSplitDirection, Session, TabState,

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -230,12 +230,6 @@ impl Render for ConWorkspace {
             .collect();
 
         let cwd = active_terminal.as_ref().and_then(|t| t.current_dir(cx));
-        // Schedule skill discovery when cwd changes. The actual filesystem scan
-        // runs off the UI thread; rendering must stay non-blocking for terminal
-        // input latency.
-        if let Some(ref raw_cwd) = cwd {
-            self.request_skill_scan_for_cwd(raw_cwd);
-        }
         if self.file_tree_view.read(cx).root().is_none() {
             self.sync_file_tree_from_active_focus(cx);
         }

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -230,9 +230,11 @@ impl Render for ConWorkspace {
             .collect();
 
         let cwd = active_terminal.as_ref().and_then(|t| t.current_dir(cx));
-        // Scan skills when cwd changes (project-local + platform global skills path).
+        // Schedule skill discovery when cwd changes. The actual filesystem scan
+        // runs off the UI thread; rendering must stay non-blocking for terminal
+        // input latency.
         if let Some(ref raw_cwd) = cwd {
-            self.harness.scan_skills(raw_cwd);
+            self.request_skill_scan_for_cwd(raw_cwd.clone());
         }
         if self.file_tree_view.read(cx).root().is_none() {
             self.sync_file_tree_from_active_focus(cx);

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -265,7 +265,7 @@ impl Render for ConWorkspace {
         // backed by the global submitted-input history across all modes.
         let recent_commands = self.recent_input_history(80);
         self.input_bar
-            .update(cx, |bar, _cx| bar.set_recent_commands(recent_commands));
+            .update(cx, |bar, cx| bar.set_recent_commands(recent_commands, cx));
 
         // Sync model name, inline input, and skills to agent panel
         let active_agent_config = self.active_tab_agent_config();

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -234,7 +234,7 @@ impl Render for ConWorkspace {
         // runs off the UI thread; rendering must stay non-blocking for terminal
         // input latency.
         if let Some(ref raw_cwd) = cwd {
-            self.request_skill_scan_for_cwd(raw_cwd.clone());
+            self.request_skill_scan_for_cwd(raw_cwd);
         }
         if self.file_tree_view.read(cx).root().is_none() {
             self.sync_file_tree_from_active_focus(cx);
@@ -264,8 +264,8 @@ impl Render for ConWorkspace {
             .collect();
         self.input_bar.update(cx, |bar, cx| {
             bar.set_panes(pane_infos, focused_pane_id, window, cx);
-            bar.set_cwd(display_cwd);
-            bar.set_skills(skill_entries);
+            bar.set_cwd(display_cwd, cx);
+            bar.set_skills(skill_entries, cx);
         });
         // Up/Down is command-bar recall, not shell suggestion ranking. Keep it
         // backed by the global submitted-input history across all modes.

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -265,7 +265,7 @@ impl Render for ConWorkspace {
         self.input_bar.update(cx, |bar, cx| {
             bar.set_panes(pane_infos, focused_pane_id, window, cx);
             bar.set_cwd(display_cwd, cx);
-            bar.set_skills(skill_entries, cx);
+            bar.set_skills(skill_entries.clone(), cx);
         });
         // Up/Down is command-bar recall, not shell suggestion ranking. Keep it
         // backed by the global submitted-input history across all modes.
@@ -279,15 +279,6 @@ impl Render for ConWorkspace {
         let provider = active_agent_config.provider.clone();
         let available_models = self.provider_models_for_config(&active_agent_config);
         let show_inline = !self.input_bar_visible && self.agent_panel_open;
-        let panel_skills: Vec<crate::input_bar::SkillEntry> = self
-            .harness
-            .skill_summaries()
-            .into_iter()
-            .map(|(name, desc)| crate::input_bar::SkillEntry {
-                name,
-                description: desc,
-            })
-            .collect();
         self.agent_panel.update(cx, |panel, cx| {
             panel.set_session_provider_options(
                 AgentPanel::configured_session_providers(&active_agent_config),
@@ -298,7 +289,7 @@ impl Render for ConWorkspace {
             panel.set_model_name(model_name);
             panel.set_session_model_options(available_models, window, cx);
             panel.set_show_inline_input(show_inline);
-            panel.set_skills(panel_skills, cx);
+            panel.set_skills(skill_entries, cx);
             panel.set_recent_inputs(self.recent_input_history(80));
         });
 

--- a/crates/con-app/src/workspace/sidebar_settings.rs
+++ b/crates/con-app/src/workspace/sidebar_settings.rs
@@ -876,7 +876,7 @@ impl ConWorkspace {
         self.harness.update_skills_config(skills_config);
         if self.has_active_tab() {
             if let Some(cwd) = self.try_active_terminal().and_then(|t| t.current_dir(cx)) {
-                self.harness.scan_skills(&cwd);
+                self.request_skill_scan_for_cwd(cwd);
             }
         }
 

--- a/crates/con-app/src/workspace/sidebar_settings.rs
+++ b/crates/con-app/src/workspace/sidebar_settings.rs
@@ -876,7 +876,7 @@ impl ConWorkspace {
         self.harness.update_skills_config(skills_config);
         if self.has_active_tab() {
             if let Some(cwd) = self.try_active_terminal().and_then(|t| t.current_dir(cx)) {
-                self.request_skill_scan_for_cwd(cwd);
+                self.request_skill_scan_for_cwd(&cwd);
             }
         }
 

--- a/crates/con-app/src/workspace/tab_actions.rs
+++ b/crates/con-app/src/workspace/tab_actions.rs
@@ -570,13 +570,12 @@ impl ConWorkspace {
             .tabs
             .get(self.active_tab)
             .and_then(|tab| tab.pane_tree.focused_terminal_entity_id());
-        if active_focused_terminal == Some(entity_id)
-            && let Some(cwd) = event
-                .0
-                .clone()
-                .or_else(|| self.try_active_terminal().and_then(|t| t.current_dir(cx)))
-        {
-            self.request_skill_scan_for_cwd(&cwd);
+        if active_focused_terminal == Some(entity_id) {
+            if let Some(cwd) = event.0.as_deref() {
+                self.request_skill_scan_for_cwd(cwd);
+            } else if let Some(cwd) = self.try_active_terminal().and_then(|t| t.current_dir(cx)) {
+                self.request_skill_scan_for_cwd(&cwd);
+            }
         }
         cx.notify();
     }

--- a/crates/con-app/src/workspace/tab_actions.rs
+++ b/crates/con-app/src/workspace/tab_actions.rs
@@ -566,10 +566,11 @@ impl ConWorkspace {
         self.request_tab_summaries(cx);
         // Keep file tree root in sync with the active focused pane.
         self.sync_file_tree_from_active_focus(cx);
-        if self.tabs[self.active_tab]
-            .pane_tree
-            .focused_terminal_entity_id()
-            == Some(entity_id)
+        let active_focused_terminal = self
+            .tabs
+            .get(self.active_tab)
+            .and_then(|tab| tab.pane_tree.focused_terminal_entity_id());
+        if active_focused_terminal == Some(entity_id)
             && let Some(cwd) = event
                 .0
                 .clone()

--- a/crates/con-app/src/workspace/tab_actions.rs
+++ b/crates/con-app/src/workspace/tab_actions.rs
@@ -58,6 +58,12 @@ impl ConWorkspace {
         }
 
         self.sync_file_tree_from_active_focus(cx);
+        let active_cwd = self
+            .try_active_terminal()
+            .and_then(|terminal| terminal.current_dir(cx));
+        if let Some(cwd) = active_cwd {
+            self.request_skill_scan_for_cwd(&cwd);
+        }
 
         self.sync_sidebar(cx);
         // Activating a tab is a strong signal the user cares about

--- a/crates/con-app/src/workspace/tab_actions.rs
+++ b/crates/con-app/src/workspace/tab_actions.rs
@@ -566,6 +566,17 @@ impl ConWorkspace {
         self.request_tab_summaries(cx);
         // Keep file tree root in sync with the active focused pane.
         self.sync_file_tree_from_active_focus(cx);
+        if self.tabs[self.active_tab]
+            .pane_tree
+            .focused_terminal_entity_id()
+            == Some(entity_id)
+            && let Some(cwd) = event
+                .0
+                .clone()
+                .or_else(|| self.try_active_terminal().and_then(|t| t.current_dir(cx)))
+        {
+            self.request_skill_scan_for_cwd(cwd);
+        }
         cx.notify();
     }
 

--- a/crates/con-app/src/workspace/tab_actions.rs
+++ b/crates/con-app/src/workspace/tab_actions.rs
@@ -575,7 +575,7 @@ impl ConWorkspace {
                 .clone()
                 .or_else(|| self.try_active_terminal().and_then(|t| t.current_dir(cx)))
         {
-            self.request_skill_scan_for_cwd(cwd);
+            self.request_skill_scan_for_cwd(&cwd);
         }
         cx.notify();
     }

--- a/crates/con-app/src/workspace/tests.rs
+++ b/crates/con-app/src/workspace/tests.rs
@@ -1,10 +1,11 @@
 use super::chrome::agent_panel_motion_target_for_agent_request;
 use super::{
-    ActivePaneFocusTarget, EditorFileCloseOutcome, EditorLineBoundary, FileTreeFocusSource,
-    WorkspaceCloseIntent, active_pane_focus_target, editor_file_close_outcome,
-    editor_line_boundary_for_key, file_tree_root_for_focus,
-    focused_editor_pane_key_fallback_allowed, resize_drag_should_continue,
-    should_show_activity_bar, workspace_close_intent, workspace_close_intent_for_close_tab,
+    ActivationFocusTarget, ActivePaneFocusTarget, EditorFileCloseOutcome, EditorLineBoundary,
+    FileTreeFocusSource, WorkspaceCloseIntent, activation_focus_target_for_reassertion,
+    active_pane_focus_target, editor_file_close_outcome, editor_line_boundary_for_key,
+    file_tree_root_for_focus, focused_editor_pane_key_fallback_allowed,
+    resize_drag_should_continue, should_show_activity_bar, workspace_close_intent,
+    workspace_close_intent_for_close_tab,
 };
 use super::{
     ConWorkspace, SPLIT_PREVIEW_SEAM_THICKNESS, SplitDirection, SplitPlacement,
@@ -145,6 +146,30 @@ fn editor_only_tabs_focus_editor_when_no_terminal_exists() {
     assert_eq!(
         active_pane_focus_target(false, false),
         ActivePaneFocusTarget::Workspace
+    );
+}
+
+#[test]
+fn window_activation_focus_prefers_input_bar_then_agent_then_editor_then_terminal() {
+    assert_eq!(
+        activation_focus_target_for_reassertion(true, true, true, true),
+        ActivationFocusTarget::InputBar
+    );
+    assert_eq!(
+        activation_focus_target_for_reassertion(false, true, true, true),
+        ActivationFocusTarget::AgentInlineInput
+    );
+    assert_eq!(
+        activation_focus_target_for_reassertion(false, false, true, false),
+        ActivationFocusTarget::ActiveEditor
+    );
+    assert_eq!(
+        activation_focus_target_for_reassertion(false, false, false, true),
+        ActivationFocusTarget::ActiveEditor
+    );
+    assert_eq!(
+        activation_focus_target_for_reassertion(false, false, false, false),
+        ActivationFocusTarget::Terminal
     );
 }
 

--- a/crates/con-app/src/workspace/window_actions.rs
+++ b/crates/con-app/src/workspace/window_actions.rs
@@ -1,6 +1,60 @@
 use super::*;
 
 impl ConWorkspace {
+    pub(super) fn on_window_activation_changed(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !window.is_window_active() || self.is_modal_open(cx) {
+            return;
+        }
+
+        self.reassert_keyboard_focus_after_activation(window, cx);
+    }
+
+    fn reassert_keyboard_focus_after_activation(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.input_bar_visible && self.input_bar.focus_handle(cx).is_focused(window) {
+            self.input_bar.focus_handle(cx).focus(window, cx);
+            return;
+        }
+
+        if self.agent_panel_open {
+            let inline_focused = self
+                .agent_panel
+                .read(cx)
+                .inline_input_is_focused(window, cx);
+            if inline_focused
+                && self
+                    .agent_panel
+                    .update(cx, |panel, cx| panel.focus_inline_input(window, cx))
+            {
+                return;
+            }
+        }
+
+        if self.editor_has_keyboard_focus(window, cx) {
+            self.focus_active_editor_or_workspace(window, cx);
+            return;
+        }
+
+        let active_pane_is_editor = self.has_active_tab() && {
+            let pane_tree = &self.tabs[self.active_tab].pane_tree;
+            pane_tree
+                .editor_view_for_pane(pane_tree.focused_pane_id())
+                .is_some()
+        };
+        if active_pane_is_editor {
+            self.focus_active_editor_or_workspace(window, cx);
+        } else {
+            self.focus_first_terminal(window, cx);
+        }
+    }
+
     pub(super) fn minimize(&mut self, _: &Minimize, window: &mut Window, _cx: &mut Context<Self>) {
         window.minimize_window();
     }

--- a/crates/con-app/src/workspace/window_actions.rs
+++ b/crates/con-app/src/workspace/window_actions.rs
@@ -18,40 +18,47 @@ impl ConWorkspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.input_bar_visible && self.input_bar.focus_handle(cx).is_focused(window) {
-            self.input_bar.focus_handle(cx).focus(window, cx);
-            return;
-        }
-
-        if self.agent_panel_open {
+        let input_bar_focused =
+            self.input_bar_visible && self.input_bar.focus_handle(cx).is_focused(window);
+        let agent_inline_refocused = if !input_bar_focused && self.agent_panel_open {
             let inline_focused = self
                 .agent_panel
                 .read(cx)
                 .inline_input_is_focused(window, cx);
-            if inline_focused
+            inline_focused
                 && self
                     .agent_panel
                     .update(cx, |panel, cx| panel.focus_inline_input(window, cx))
-            {
-                return;
-            }
-        }
+        } else {
+            false
+        };
 
-        if self.editor_has_keyboard_focus(window, cx) {
-            self.focus_active_editor_or_workspace(window, cx);
-            return;
-        }
-
-        let active_pane_is_editor = self.has_active_tab() && {
+        let check_editor_or_terminal = !input_bar_focused && !agent_inline_refocused;
+        let editor_has_keyboard_focus =
+            check_editor_or_terminal && self.editor_has_keyboard_focus(window, cx);
+        let active_pane_is_editor = check_editor_or_terminal && self.has_active_tab() && {
             let pane_tree = &self.tabs[self.active_tab].pane_tree;
             pane_tree
                 .editor_view_for_pane(pane_tree.focused_pane_id())
                 .is_some()
         };
-        if active_pane_is_editor {
-            self.focus_active_editor_or_workspace(window, cx);
-        } else {
-            self.focus_first_terminal(window, cx);
+
+        match activation_focus_target_for_reassertion(
+            input_bar_focused,
+            agent_inline_refocused,
+            editor_has_keyboard_focus,
+            active_pane_is_editor,
+        ) {
+            ActivationFocusTarget::InputBar => {
+                self.input_bar.focus_handle(cx).focus(window, cx);
+            }
+            ActivationFocusTarget::AgentInlineInput => {}
+            ActivationFocusTarget::ActiveEditor => {
+                self.focus_active_editor_or_workspace(window, cx);
+            }
+            ActivationFocusTarget::Terminal => {
+                self.focus_first_terminal(window, cx);
+            }
         }
     }
 

--- a/crates/con-core/src/harness.rs
+++ b/crates/con-core/src/harness.rs
@@ -176,13 +176,13 @@ pub struct AgentHarness {
     config: con_agent::AgentConfig,
     skills_config: crate::config::SkillsConfig,
     skills: SkillRegistry,
-    /// Last candidate skill roots successfully scanned. Repeating the same cwd
-    /// is skipped, but cwd/config changes rebuild the registry off the UI thread
-    /// so skill edits are still picked up at the same points as the old
-    /// synchronous scanner.
-    last_skill_scan_candidates: Option<SkillScanCandidateDirs>,
-    latest_requested_skill_scan: Option<SkillScanCandidateDirs>,
-    in_flight_skill_scans: HashSet<SkillScanCandidateDirs>,
+    /// Last skill scan request successfully applied. Repeating the exact same
+    /// cwd and resolved roots is skipped, but cwd/config changes rebuild the
+    /// registry off the UI thread so skill edits are still picked up at the
+    /// same points as the old synchronous scanner.
+    last_skill_scan_request: Option<SkillScanRequest>,
+    latest_requested_skill_scan: Option<SkillScanRequest>,
+    in_flight_skill_scans: HashSet<SkillScanRequest>,
     runtime: Arc<Runtime>,
 }
 
@@ -192,15 +192,19 @@ struct SkillScanCandidateDirs {
     project: Vec<PathBuf>,
 }
 
-#[must_use = "skill scan jobs must be scanned or completed with failed_result to clear in-flight state"]
-pub struct SkillScanJob {
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct SkillScanRequest {
     cwd: String,
     candidates: SkillScanCandidateDirs,
 }
 
+#[must_use = "skill scan job results must be delivered to AgentHarness::complete_skill_scan, including failed_result, to clear in-flight state"]
+pub struct SkillScanJob {
+    request: SkillScanRequest,
+}
+
 pub struct SkillScanResult {
-    cwd: String,
-    candidates: SkillScanCandidateDirs,
+    request: SkillScanRequest,
     registry: Option<SkillRegistry>,
     count: usize,
 }
@@ -208,22 +212,20 @@ pub struct SkillScanResult {
 impl SkillScanJob {
     pub fn failed_result(&self) -> SkillScanResult {
         SkillScanResult {
-            cwd: self.cwd.clone(),
-            candidates: self.candidates.clone(),
+            request: self.request.clone(),
             registry: None,
             count: 0,
         }
     }
 
     pub fn scan(self) -> SkillScanResult {
-        let global_dirs = existing_skill_dirs(&self.candidates.global);
-        let project_dirs = existing_skill_dirs(&self.candidates.project);
+        let global_dirs = existing_skill_dirs(&self.request.candidates.global);
+        let project_dirs = existing_skill_dirs(&self.request.candidates.project);
 
         let mut registry = SkillRegistry::new();
         let count = registry.scan(&global_dirs, &project_dirs);
         SkillScanResult {
-            cwd: self.cwd,
-            candidates: self.candidates,
+            request: self.request,
             registry: Some(registry),
             count,
         }
@@ -243,7 +245,7 @@ impl AgentHarness {
             config: config.agent.clone(),
             skills_config: config.skills.clone(),
             skills: SkillRegistry::new(),
-            last_skill_scan_candidates: None,
+            last_skill_scan_request: None,
             latest_requested_skill_scan: None,
             in_flight_skill_scans: HashSet::new(),
             runtime,
@@ -614,30 +616,36 @@ impl AgentHarness {
             project: self.skills_config.resolved_project_paths(cwd_path),
         };
 
-        if self.last_skill_scan_candidates.as_ref() == Some(&candidates) {
-            return None;
-        }
-
-        if !self.in_flight_skill_scans.insert(candidates.clone()) {
-            return None;
-        }
-        self.latest_requested_skill_scan = Some(candidates.clone());
-
-        Some(SkillScanJob {
+        let request = SkillScanRequest {
             cwd: cwd.to_string(),
             candidates,
-        })
+        };
+
+        if self.last_skill_scan_request.as_ref() == Some(&request) {
+            return None;
+        }
+
+        if !self.in_flight_skill_scans.insert(request.clone()) {
+            self.latest_requested_skill_scan = Some(request);
+            return None;
+        }
+        self.latest_requested_skill_scan = Some(request.clone());
+
+        Some(SkillScanJob { request })
     }
 
     pub fn complete_skill_scan(&mut self, result: SkillScanResult) -> bool {
-        self.in_flight_skill_scans.remove(&result.candidates);
-        if self.latest_requested_skill_scan.as_ref() != Some(&result.candidates) {
+        self.in_flight_skill_scans.remove(&result.request);
+        if self.latest_requested_skill_scan.as_ref() != Some(&result.request) {
             return false;
         }
         self.latest_requested_skill_scan = None;
 
         if result.registry.is_none() {
-            log::warn!("Skill scan for {} failed before completion", result.cwd);
+            log::warn!(
+                "Skill scan for {} failed before completion",
+                result.request.cwd
+            );
             return false;
         }
 
@@ -645,7 +653,7 @@ impl AgentHarness {
     }
 
     fn apply_skill_scan_result(&mut self, result: SkillScanResult) -> bool {
-        self.last_skill_scan_candidates = Some(result.candidates);
+        self.last_skill_scan_request = Some(result.request.clone());
 
         let Some(registry) = result.registry else {
             return false;
@@ -654,7 +662,7 @@ impl AgentHarness {
         self.skills = registry;
         log::info!(
             "Skill scan for {}: {} skill(s) found",
-            result.cwd,
+            result.request.cwd,
             result.count
         );
         true
@@ -664,7 +672,7 @@ impl AgentHarness {
     pub fn update_skills_config(&mut self, config: crate::config::SkillsConfig) {
         self.skills_config = config;
         // Force rescan on next cwd check
-        self.last_skill_scan_candidates = None;
+        self.last_skill_scan_request = None;
         self.latest_requested_skill_scan = None;
         self.in_flight_skill_scans.clear();
     }
@@ -753,6 +761,15 @@ mod tests {
         AgentHarness::new(&config).unwrap()
     }
 
+    fn harness_with_global_skill_paths_only(global: &Path) -> AgentHarness {
+        let mut config = Config::default();
+        config.skills = SkillsConfig {
+            project_paths: Vec::new(),
+            global_paths: vec![global.display().to_string()],
+        };
+        AgentHarness::new(&config).unwrap()
+    }
+
     #[test]
     fn async_skill_scan_reloads_when_candidates_change_even_if_existing_roots_do_not() {
         let root = TempDir::new("skill-scan-candidate-change");
@@ -777,6 +794,30 @@ mod tests {
         let second_result = second.scan();
         assert!(second_result.registry.is_some());
         assert!(harness.complete_skill_scan(second_result));
+
+        let names = harness.skill_names();
+        assert!(names.contains(&"global-skill".to_string()));
+        assert!(names.contains(&"new-global-skill".to_string()));
+    }
+
+    #[test]
+    fn async_skill_scan_reloads_when_cwd_changes_even_if_candidate_roots_do_not() {
+        let root = TempDir::new("skill-scan-cwd-change");
+        let global = root.path().join("global");
+        let cwd_a = root.path().join("a");
+        let cwd_b = root.path().join("b");
+        fs::create_dir_all(&cwd_a).unwrap();
+        fs::create_dir_all(&cwd_b).unwrap();
+        write_skill(&global, "global-skill");
+
+        let mut harness = harness_with_global_skill_paths_only(&global);
+        let first = harness.request_skill_scan(cwd_a.to_str().unwrap()).unwrap();
+        assert!(harness.complete_skill_scan(first.scan()));
+
+        write_skill(&global, "new-global-skill");
+
+        let second = harness.request_skill_scan(cwd_b.to_str().unwrap()).unwrap();
+        assert!(harness.complete_skill_scan(second.scan()));
 
         let names = harness.skill_names();
         assert!(names.contains(&"global-skill".to_string()));
@@ -838,7 +879,7 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_in_flight_scan_does_not_replace_latest_request() {
+    fn duplicate_in_flight_scan_can_become_latest_request_again() {
         let root = TempDir::new("skill-scan-duplicate-in-flight");
         let global = root.path().join("global");
         let cwd_a = root.path().join("a");
@@ -859,13 +900,13 @@ mod tests {
                 .is_none()
         );
 
-        assert!(harness.complete_skill_scan(scan_b.scan()));
-        assert!(!harness.complete_skill_scan(scan_a.scan()));
+        assert!(!harness.complete_skill_scan(scan_b.scan()));
+        assert!(harness.complete_skill_scan(scan_a.scan()));
 
         let names = harness.skill_names();
         assert!(names.contains(&"global-skill".to_string()));
-        assert!(names.contains(&"b-skill".to_string()));
-        assert!(!names.contains(&"a-skill".to_string()));
+        assert!(names.contains(&"a-skill".to_string()));
+        assert!(!names.contains(&"b-skill".to_string()));
     }
 
     #[test]

--- a/crates/con-core/src/harness.rs
+++ b/crates/con-core/src/harness.rs
@@ -183,6 +183,7 @@ pub struct AgentHarness {
     last_skill_scan_request: Option<SkillScanRequest>,
     latest_requested_skill_scan: Option<SkillScanRequest>,
     in_flight_skill_scans: HashSet<SkillScanRequest>,
+    pending_skill_rescans: HashSet<SkillScanRequest>,
     runtime: Arc<Runtime>,
 }
 
@@ -207,6 +208,21 @@ pub struct SkillScanResult {
     request: SkillScanRequest,
     registry: Option<SkillRegistry>,
     count: usize,
+}
+
+pub struct SkillScanCompletion {
+    applied: bool,
+    follow_up: Option<SkillScanJob>,
+}
+
+impl SkillScanCompletion {
+    pub fn applied(&self) -> bool {
+        self.applied
+    }
+
+    pub fn follow_up_job(self) -> Option<SkillScanJob> {
+        self.follow_up
+    }
 }
 
 impl SkillScanJob {
@@ -248,6 +264,7 @@ impl AgentHarness {
             last_skill_scan_request: None,
             latest_requested_skill_scan: None,
             in_flight_skill_scans: HashSet::new(),
+            pending_skill_rescans: HashSet::new(),
             runtime,
         })
     }
@@ -626,6 +643,7 @@ impl AgentHarness {
         }
 
         if !self.in_flight_skill_scans.insert(request.clone()) {
+            self.pending_skill_rescans.insert(request.clone());
             self.latest_requested_skill_scan = Some(request);
             return None;
         }
@@ -634,11 +652,26 @@ impl AgentHarness {
         Some(SkillScanJob { request })
     }
 
-    pub fn complete_skill_scan(&mut self, result: SkillScanResult) -> bool {
+    pub fn complete_skill_scan(&mut self, result: SkillScanResult) -> SkillScanCompletion {
         self.in_flight_skill_scans.remove(&result.request);
+        let should_rescan = self.pending_skill_rescans.remove(&result.request);
         if self.latest_requested_skill_scan.as_ref() != Some(&result.request) {
-            return false;
+            return SkillScanCompletion {
+                applied: false,
+                follow_up: None,
+            };
         }
+
+        if should_rescan {
+            let request = result.request;
+            self.in_flight_skill_scans.insert(request.clone());
+            self.latest_requested_skill_scan = Some(request.clone());
+            return SkillScanCompletion {
+                applied: false,
+                follow_up: Some(SkillScanJob { request }),
+            };
+        }
+
         self.latest_requested_skill_scan = None;
 
         if result.registry.is_none() {
@@ -646,10 +679,16 @@ impl AgentHarness {
                 "Skill scan for {} failed before completion",
                 result.request.cwd
             );
-            return false;
+            return SkillScanCompletion {
+                applied: false,
+                follow_up: None,
+            };
         }
 
-        self.apply_skill_scan_result(result)
+        SkillScanCompletion {
+            applied: self.apply_skill_scan_result(result),
+            follow_up: None,
+        }
     }
 
     fn apply_skill_scan_result(&mut self, result: SkillScanResult) -> bool {
@@ -675,6 +714,7 @@ impl AgentHarness {
         self.last_skill_scan_request = None;
         self.latest_requested_skill_scan = None;
         self.in_flight_skill_scans.clear();
+        self.pending_skill_rescans.clear();
     }
 
     pub fn config(&self) -> &con_agent::AgentConfig {
@@ -785,7 +825,7 @@ mod tests {
         let first = harness.request_skill_scan(cwd_a.to_str().unwrap()).unwrap();
         let first_result = first.scan();
         assert!(first_result.registry.is_some());
-        assert!(harness.complete_skill_scan(first_result));
+        assert!(harness.complete_skill_scan(first_result).applied());
         assert_eq!(harness.skill_summaries().len(), 1);
 
         write_skill(&global, "new-global-skill");
@@ -793,7 +833,7 @@ mod tests {
         let second = harness.request_skill_scan(cwd_b.to_str().unwrap()).unwrap();
         let second_result = second.scan();
         assert!(second_result.registry.is_some());
-        assert!(harness.complete_skill_scan(second_result));
+        assert!(harness.complete_skill_scan(second_result).applied());
 
         let names = harness.skill_names();
         assert!(names.contains(&"global-skill".to_string()));
@@ -812,12 +852,12 @@ mod tests {
 
         let mut harness = harness_with_global_skill_paths_only(&global);
         let first = harness.request_skill_scan(cwd_a.to_str().unwrap()).unwrap();
-        assert!(harness.complete_skill_scan(first.scan()));
+        assert!(harness.complete_skill_scan(first.scan()).applied());
 
         write_skill(&global, "new-global-skill");
 
         let second = harness.request_skill_scan(cwd_b.to_str().unwrap()).unwrap();
-        assert!(harness.complete_skill_scan(second.scan()));
+        assert!(harness.complete_skill_scan(second.scan()).applied());
 
         let names = harness.skill_names();
         assert!(names.contains(&"global-skill".to_string()));
@@ -836,7 +876,7 @@ mod tests {
 
         let mut harness = harness_with_skill_paths(&global);
         let first = harness.request_skill_scan(cwd_a.to_str().unwrap()).unwrap();
-        assert!(harness.complete_skill_scan(first.scan()));
+        assert!(harness.complete_skill_scan(first.scan()).applied());
 
         let project_skills = cwd_b.join(".con/skills");
         write_skill(&project_skills, "project-skill");
@@ -844,7 +884,7 @@ mod tests {
         let second = harness.request_skill_scan(cwd_b.to_str().unwrap()).unwrap();
         let second_result = second.scan();
         assert!(second_result.registry.is_some());
-        assert!(harness.complete_skill_scan(second_result));
+        assert!(harness.complete_skill_scan(second_result).applied());
 
         let names = harness.skill_names();
         assert!(names.contains(&"global-skill".to_string()));
@@ -868,10 +908,10 @@ mod tests {
         let scan_a = harness.request_skill_scan(cwd_a.to_str().unwrap()).unwrap();
         let scan_b = harness.request_skill_scan(cwd_b.to_str().unwrap()).unwrap();
 
-        assert!(!harness.complete_skill_scan(scan_a.scan()));
+        assert!(!harness.complete_skill_scan(scan_a.scan()).applied());
         assert!(harness.skill_names().is_empty());
 
-        assert!(harness.complete_skill_scan(scan_b.scan()));
+        assert!(harness.complete_skill_scan(scan_b.scan()).applied());
         let names = harness.skill_names();
         assert!(names.contains(&"global-skill".to_string()));
         assert!(names.contains(&"b-skill".to_string()));
@@ -894,18 +934,24 @@ mod tests {
 
         let scan_a = harness.request_skill_scan(cwd_a.to_str().unwrap()).unwrap();
         let scan_b = harness.request_skill_scan(cwd_b.to_str().unwrap()).unwrap();
+        let stale_a_result = scan_a.scan();
         assert!(
             harness
                 .request_skill_scan(cwd_a.to_str().unwrap())
                 .is_none()
         );
+        write_skill(&cwd_a.join(".con/skills"), "new-a-skill");
 
-        assert!(!harness.complete_skill_scan(scan_b.scan()));
-        assert!(harness.complete_skill_scan(scan_a.scan()));
+        assert!(!harness.complete_skill_scan(scan_b.scan()).applied());
+        let completion = harness.complete_skill_scan(stale_a_result);
+        assert!(!completion.applied());
+        let follow_up = completion.follow_up_job().unwrap();
+        assert!(harness.complete_skill_scan(follow_up.scan()).applied());
 
         let names = harness.skill_names();
         assert!(names.contains(&"global-skill".to_string()));
         assert!(names.contains(&"a-skill".to_string()));
+        assert!(names.contains(&"new-a-skill".to_string()));
         assert!(!names.contains(&"b-skill".to_string()));
     }
 
@@ -920,10 +966,10 @@ mod tests {
         let mut harness = harness_with_skill_paths(&global);
 
         let scan = harness.request_skill_scan(cwd.to_str().unwrap()).unwrap();
-        assert!(!harness.complete_skill_scan(scan.failed_result()));
+        assert!(!harness.complete_skill_scan(scan.failed_result()).applied());
 
         let retry = harness.request_skill_scan(cwd.to_str().unwrap()).unwrap();
-        assert!(harness.complete_skill_scan(retry.scan()));
+        assert!(harness.complete_skill_scan(retry.scan()).applied());
         assert_eq!(harness.skill_names(), vec!["global-skill".to_string()]);
     }
 }

--- a/crates/con-core/src/harness.rs
+++ b/crates/con-core/src/harness.rs
@@ -176,13 +176,11 @@ pub struct AgentHarness {
     config: con_agent::AgentConfig,
     skills_config: crate::config::SkillsConfig,
     skills: SkillRegistry,
-    /// Last candidate skill roots requested. This preserves the old contract:
-    /// skill edits in the same cwd are picked up after a cwd/config change, not
-    /// by repeatedly polling the filesystem while rendering.
+    /// Last candidate skill roots successfully scanned. Repeating the same cwd
+    /// is skipped, but cwd/config changes rebuild the registry off the UI thread
+    /// so skill edits are still picked up at the same points as the old
+    /// synchronous scanner.
     last_skill_scan_candidates: Option<SkillScanCandidateDirs>,
-    /// Last existing skill roots scanned. Background jobs compute this so the
-    /// UI thread never has to stat skill directories during render.
-    last_skill_scan_dirs: Option<SkillScanDirs>,
     latest_requested_skill_scan: Option<SkillScanCandidateDirs>,
     in_flight_skill_scans: HashSet<SkillScanCandidateDirs>,
     runtime: Arc<Runtime>,
@@ -194,49 +192,37 @@ struct SkillScanCandidateDirs {
     project: Vec<PathBuf>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct SkillScanDirs {
-    global: Vec<PathBuf>,
-    project: Vec<PathBuf>,
-}
-
 pub struct SkillScanJob {
     cwd: String,
     candidates: SkillScanCandidateDirs,
-    previous_dirs: Option<SkillScanDirs>,
 }
 
 pub struct SkillScanResult {
     cwd: String,
     candidates: SkillScanCandidateDirs,
-    dirs: SkillScanDirs,
     registry: Option<SkillRegistry>,
     count: usize,
 }
 
 impl SkillScanJob {
-    pub fn scan(self) -> SkillScanResult {
-        let dirs = SkillScanDirs {
-            global: existing_skill_dirs(self.candidates.global.clone()),
-            project: existing_skill_dirs(self.candidates.project.clone()),
-        };
-
-        if self.previous_dirs.as_ref() == Some(&dirs) {
-            return SkillScanResult {
-                cwd: self.cwd,
-                candidates: self.candidates,
-                dirs,
-                registry: None,
-                count: 0,
-            };
+    pub fn failed_result(&self) -> SkillScanResult {
+        SkillScanResult {
+            cwd: self.cwd.clone(),
+            candidates: self.candidates.clone(),
+            registry: None,
+            count: 0,
         }
+    }
+
+    pub fn scan(self) -> SkillScanResult {
+        let global_dirs = existing_skill_dirs(self.candidates.global.clone());
+        let project_dirs = existing_skill_dirs(self.candidates.project.clone());
 
         let mut registry = SkillRegistry::new();
-        let count = registry.scan(&dirs.global, &dirs.project);
+        let count = registry.scan(&global_dirs, &project_dirs);
         SkillScanResult {
             cwd: self.cwd,
             candidates: self.candidates,
-            dirs,
             registry: Some(registry),
             count,
         }
@@ -257,7 +243,6 @@ impl AgentHarness {
             skills_config: config.skills.clone(),
             skills: SkillRegistry::new(),
             last_skill_scan_candidates: None,
-            last_skill_scan_dirs: None,
             latest_requested_skill_scan: None,
             in_flight_skill_scans: HashSet::new(),
             runtime,
@@ -638,7 +623,6 @@ impl AgentHarness {
         let result = SkillScanJob {
             cwd: cwd.to_string(),
             candidates,
-            previous_dirs: self.last_skill_scan_dirs.clone(),
         }
         .scan();
         self.apply_skill_scan_result(result)
@@ -663,7 +647,6 @@ impl AgentHarness {
         Some(SkillScanJob {
             cwd: cwd.to_string(),
             candidates,
-            previous_dirs: self.last_skill_scan_dirs.clone(),
         })
     }
 
@@ -673,12 +656,17 @@ impl AgentHarness {
             return false;
         }
         self.latest_requested_skill_scan = None;
+
+        if result.registry.is_none() {
+            log::warn!("Skill scan for {} failed before completion", result.cwd);
+            return false;
+        }
+
         self.apply_skill_scan_result(result)
     }
 
     fn apply_skill_scan_result(&mut self, result: SkillScanResult) -> bool {
         self.last_skill_scan_candidates = Some(result.candidates);
-        self.last_skill_scan_dirs = Some(result.dirs);
 
         let Some(registry) = result.registry else {
             return false;
@@ -698,7 +686,6 @@ impl AgentHarness {
         self.skills_config = config;
         // Force rescan on next cwd check
         self.last_skill_scan_candidates = None;
-        self.last_skill_scan_dirs = None;
         self.latest_requested_skill_scan = None;
         self.in_flight_skill_scans.clear();
     }
@@ -789,8 +776,8 @@ mod tests {
     }
 
     #[test]
-    fn async_skill_scan_skips_registry_reload_when_existing_roots_do_not_change() {
-        let root = TempDir::new("skill-scan-same-roots");
+    fn async_skill_scan_reloads_when_candidates_change_even_if_existing_roots_do_not() {
+        let root = TempDir::new("skill-scan-candidate-change");
         let global = root.path().join("global");
         let cwd_a = root.path().join("a");
         let cwd_b = root.path().join("b");
@@ -806,11 +793,16 @@ mod tests {
         assert!(harness.complete_skill_scan(first_result));
         assert_eq!(harness.skill_summaries().len(), 1);
 
+        write_skill(&global, "new-global-skill");
+
         let second = harness.request_skill_scan(cwd_b.to_str().unwrap()).unwrap();
         let second_result = second.scan();
-        assert!(second_result.registry.is_none());
-        assert!(!harness.complete_skill_scan(second_result));
-        assert_eq!(harness.skill_summaries().len(), 1);
+        assert!(second_result.registry.is_some());
+        assert!(harness.complete_skill_scan(second_result));
+
+        let names = harness.skill_names();
+        assert!(names.contains(&"global-skill".to_string()));
+        assert!(names.contains(&"new-global-skill".to_string()));
     }
 
     #[test]
@@ -865,6 +857,24 @@ mod tests {
         assert!(names.contains(&"global-skill".to_string()));
         assert!(names.contains(&"b-skill".to_string()));
         assert!(!names.contains(&"a-skill".to_string()));
+    }
+
+    #[test]
+    fn failed_async_skill_scan_clears_in_flight_candidate() {
+        let root = TempDir::new("skill-scan-failed-result");
+        let global = root.path().join("global");
+        let cwd = root.path().join("cwd");
+        fs::create_dir_all(&cwd).unwrap();
+        write_skill(&global, "global-skill");
+
+        let mut harness = harness_with_skill_paths(&global);
+
+        let scan = harness.request_skill_scan(cwd.to_str().unwrap()).unwrap();
+        assert!(!harness.complete_skill_scan(scan.failed_result()));
+
+        let retry = harness.request_skill_scan(cwd.to_str().unwrap()).unwrap();
+        assert!(harness.complete_skill_scan(retry.scan()));
+        assert_eq!(harness.skill_names(), vec!["global-skill".to_string()]);
     }
 }
 

--- a/crates/con-core/src/harness.rs
+++ b/crates/con-core/src/harness.rs
@@ -643,8 +643,10 @@ impl AgentHarness {
         }
 
         if !self.in_flight_skill_scans.insert(request.clone()) {
-            self.pending_skill_rescans.insert(request.clone());
-            self.latest_requested_skill_scan = Some(request);
+            if self.latest_requested_skill_scan.as_ref() != Some(&request) {
+                self.pending_skill_rescans.insert(request.clone());
+                self.latest_requested_skill_scan = Some(request);
+            }
             return None;
         }
         self.latest_requested_skill_scan = Some(request.clone());
@@ -953,6 +955,26 @@ mod tests {
         assert!(names.contains(&"a-skill".to_string()));
         assert!(names.contains(&"new-a-skill".to_string()));
         assert!(!names.contains(&"b-skill".to_string()));
+    }
+
+    #[test]
+    fn exact_duplicate_in_flight_scan_stays_noop() {
+        let root = TempDir::new("skill-scan-exact-duplicate-in-flight");
+        let global = root.path().join("global");
+        let cwd = root.path().join("cwd");
+        fs::create_dir_all(&cwd).unwrap();
+        write_skill(&global, "global-skill");
+
+        let mut harness = harness_with_skill_paths(&global);
+
+        let scan = harness.request_skill_scan(cwd.to_str().unwrap()).unwrap();
+        assert!(harness.request_skill_scan(cwd.to_str().unwrap()).is_none());
+
+        let completion = harness.complete_skill_scan(scan.scan());
+        assert!(completion.applied());
+        assert!(completion.follow_up_job().is_none());
+
+        assert_eq!(harness.skill_names(), vec!["global-skill".to_string()]);
     }
 
     #[test]

--- a/crates/con-core/src/harness.rs
+++ b/crates/con-core/src/harness.rs
@@ -192,6 +192,7 @@ struct SkillScanCandidateDirs {
     project: Vec<PathBuf>,
 }
 
+#[must_use = "skill scan jobs must be scanned or completed with failed_result to clear in-flight state"]
 pub struct SkillScanJob {
     cwd: String,
     candidates: SkillScanCandidateDirs,
@@ -215,8 +216,8 @@ impl SkillScanJob {
     }
 
     pub fn scan(self) -> SkillScanResult {
-        let global_dirs = existing_skill_dirs(self.candidates.global.clone());
-        let project_dirs = existing_skill_dirs(self.candidates.project.clone());
+        let global_dirs = existing_skill_dirs(&self.candidates.global);
+        let project_dirs = existing_skill_dirs(&self.candidates.project);
 
         let mut registry = SkillRegistry::new();
         let count = registry.scan(&global_dirs, &project_dirs);
@@ -720,8 +721,8 @@ impl AgentHarness {
     }
 }
 
-fn existing_skill_dirs(dirs: Vec<PathBuf>) -> Vec<PathBuf> {
-    dirs.into_iter().filter(|dir| dir.is_dir()).collect()
+fn existing_skill_dirs(dirs: &[PathBuf]) -> Vec<PathBuf> {
+    dirs.iter().filter(|dir| dir.is_dir()).cloned().collect()
 }
 
 #[cfg(test)]
@@ -729,18 +730,17 @@ mod tests {
     use super::*;
     use crate::config::{Config, SkillsConfig};
     use std::fs;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     struct TempDir(PathBuf);
 
     impl TempDir {
         fn new(name: &str) -> Self {
-            let nanos = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_nanos();
+            let id = TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
             let path = std::env::temp_dir()
-                .join(format!("con-harness-{name}-{}-{nanos}", std::process::id()));
+                .join(format!("con-harness-{name}-{}-{id}", std::process::id()));
             fs::create_dir_all(&path).unwrap();
             Self(path)
         }

--- a/crates/con-core/src/harness.rs
+++ b/crates/con-core/src/harness.rs
@@ -607,28 +607,6 @@ impl AgentHarness {
         None
     }
 
-    /// Scan for skills from configured filesystem paths.
-    /// Only rescans if the candidate roots changed since the last completed
-    /// request. This is synchronous and intended for tests or non-UI callers;
-    /// UI code should use `request_skill_scan` and `complete_skill_scan`.
-    /// Returns true if skills were (re)loaded.
-    pub fn scan_skills(&mut self, cwd: &str) -> bool {
-        let cwd_path = Path::new(cwd);
-        let candidates = SkillScanCandidateDirs {
-            global: self.skills_config.resolved_global_paths(),
-            project: self.skills_config.resolved_project_paths(cwd_path),
-        };
-        if self.last_skill_scan_candidates.as_ref() == Some(&candidates) {
-            return false;
-        }
-        let result = SkillScanJob {
-            cwd: cwd.to_string(),
-            candidates,
-        }
-        .scan();
-        self.apply_skill_scan_result(result)
-    }
-
     pub fn request_skill_scan(&mut self, cwd: &str) -> Option<SkillScanJob> {
         let cwd_path = Path::new(cwd);
         let candidates = SkillScanCandidateDirs {
@@ -640,10 +618,10 @@ impl AgentHarness {
             return None;
         }
 
-        self.latest_requested_skill_scan = Some(candidates.clone());
         if !self.in_flight_skill_scans.insert(candidates.clone()) {
             return None;
         }
+        self.latest_requested_skill_scan = Some(candidates.clone());
 
         Some(SkillScanJob {
             cwd: cwd.to_string(),
@@ -853,6 +831,37 @@ mod tests {
         assert!(harness.skill_names().is_empty());
 
         assert!(harness.complete_skill_scan(scan_b.scan()));
+        let names = harness.skill_names();
+        assert!(names.contains(&"global-skill".to_string()));
+        assert!(names.contains(&"b-skill".to_string()));
+        assert!(!names.contains(&"a-skill".to_string()));
+    }
+
+    #[test]
+    fn duplicate_in_flight_scan_does_not_replace_latest_request() {
+        let root = TempDir::new("skill-scan-duplicate-in-flight");
+        let global = root.path().join("global");
+        let cwd_a = root.path().join("a");
+        let cwd_b = root.path().join("b");
+        fs::create_dir_all(&cwd_a).unwrap();
+        fs::create_dir_all(&cwd_b).unwrap();
+        write_skill(&global, "global-skill");
+        write_skill(&cwd_a.join(".con/skills"), "a-skill");
+        write_skill(&cwd_b.join(".con/skills"), "b-skill");
+
+        let mut harness = harness_with_skill_paths(&global);
+
+        let scan_a = harness.request_skill_scan(cwd_a.to_str().unwrap()).unwrap();
+        let scan_b = harness.request_skill_scan(cwd_b.to_str().unwrap()).unwrap();
+        assert!(
+            harness
+                .request_skill_scan(cwd_a.to_str().unwrap())
+                .is_none()
+        );
+
+        assert!(harness.complete_skill_scan(scan_b.scan()));
+        assert!(!harness.complete_skill_scan(scan_a.scan()));
+
         let names = harness.skill_names();
         assert!(names.contains(&"global-skill".to_string()));
         assert!(names.contains(&"b-skill".to_string()));

--- a/crates/con-core/src/harness.rs
+++ b/crates/con-core/src/harness.rs
@@ -184,6 +184,7 @@ pub struct AgentHarness {
     latest_requested_skill_scan: Option<SkillScanRequest>,
     in_flight_skill_scans: HashSet<SkillScanRequest>,
     pending_skill_rescans: HashSet<SkillScanRequest>,
+    skill_scan_generation: u64,
     runtime: Arc<Runtime>,
 }
 
@@ -195,6 +196,7 @@ struct SkillScanCandidateDirs {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct SkillScanRequest {
+    generation: u64,
     cwd: String,
     candidates: SkillScanCandidateDirs,
 }
@@ -265,6 +267,7 @@ impl AgentHarness {
             latest_requested_skill_scan: None,
             in_flight_skill_scans: HashSet::new(),
             pending_skill_rescans: HashSet::new(),
+            skill_scan_generation: 0,
             runtime,
         })
     }
@@ -634,6 +637,7 @@ impl AgentHarness {
         };
 
         let request = SkillScanRequest {
+            generation: self.skill_scan_generation,
             cwd: cwd.to_string(),
             candidates,
         };
@@ -717,6 +721,7 @@ impl AgentHarness {
         self.latest_requested_skill_scan = None;
         self.in_flight_skill_scans.clear();
         self.pending_skill_rescans.clear();
+        self.skill_scan_generation = self.skill_scan_generation.wrapping_add(1);
     }
 
     pub fn config(&self) -> &con_agent::AgentConfig {
@@ -975,6 +980,29 @@ mod tests {
         assert!(completion.follow_up_job().is_none());
 
         assert_eq!(harness.skill_names(), vec!["global-skill".to_string()]);
+    }
+
+    #[test]
+    fn config_update_makes_old_skill_scan_result_stale_without_disturbing_new_scan() {
+        let root = TempDir::new("skill-scan-config-generation");
+        let global = root.path().join("global");
+        let cwd = root.path().join("cwd");
+        fs::create_dir_all(&cwd).unwrap();
+        write_skill(&global, "global-skill");
+
+        let mut harness = harness_with_skill_paths(&global);
+
+        let old_scan = harness.request_skill_scan(cwd.to_str().unwrap()).unwrap();
+        harness.update_skills_config(harness.skills_config.clone());
+        write_skill(&global, "new-global-skill");
+        let new_scan = harness.request_skill_scan(cwd.to_str().unwrap()).unwrap();
+
+        assert!(!harness.complete_skill_scan(old_scan.scan()).applied());
+        assert!(harness.complete_skill_scan(new_scan.scan()).applied());
+
+        let names = harness.skill_names();
+        assert!(names.contains(&"global-skill".to_string()));
+        assert!(names.contains(&"new-global-skill".to_string()));
     }
 
     #[test]

--- a/crates/con-core/src/harness.rs
+++ b/crates/con-core/src/harness.rs
@@ -6,7 +6,7 @@ use crossbeam_channel::{Receiver, Sender};
 use parking_lot::Mutex;
 use std::collections::HashSet;
 use std::future::Future;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 use tokio::runtime::Runtime;
@@ -176,9 +176,71 @@ pub struct AgentHarness {
     config: con_agent::AgentConfig,
     skills_config: crate::config::SkillsConfig,
     skills: SkillRegistry,
-    /// Last cwd used for skill scanning, to avoid redundant rescans.
-    last_skills_cwd: Option<String>,
+    /// Last candidate skill roots requested. This preserves the old contract:
+    /// skill edits in the same cwd are picked up after a cwd/config change, not
+    /// by repeatedly polling the filesystem while rendering.
+    last_skill_scan_candidates: Option<SkillScanCandidateDirs>,
+    /// Last existing skill roots scanned. Background jobs compute this so the
+    /// UI thread never has to stat skill directories during render.
+    last_skill_scan_dirs: Option<SkillScanDirs>,
+    latest_requested_skill_scan: Option<SkillScanCandidateDirs>,
+    in_flight_skill_scans: HashSet<SkillScanCandidateDirs>,
     runtime: Arc<Runtime>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct SkillScanCandidateDirs {
+    global: Vec<PathBuf>,
+    project: Vec<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct SkillScanDirs {
+    global: Vec<PathBuf>,
+    project: Vec<PathBuf>,
+}
+
+pub struct SkillScanJob {
+    cwd: String,
+    candidates: SkillScanCandidateDirs,
+    previous_dirs: Option<SkillScanDirs>,
+}
+
+pub struct SkillScanResult {
+    cwd: String,
+    candidates: SkillScanCandidateDirs,
+    dirs: SkillScanDirs,
+    registry: Option<SkillRegistry>,
+    count: usize,
+}
+
+impl SkillScanJob {
+    pub fn scan(self) -> SkillScanResult {
+        let dirs = SkillScanDirs {
+            global: existing_skill_dirs(self.candidates.global.clone()),
+            project: existing_skill_dirs(self.candidates.project.clone()),
+        };
+
+        if self.previous_dirs.as_ref() == Some(&dirs) {
+            return SkillScanResult {
+                cwd: self.cwd,
+                candidates: self.candidates,
+                dirs,
+                registry: None,
+                count: 0,
+            };
+        }
+
+        let mut registry = SkillRegistry::new();
+        let count = registry.scan(&dirs.global, &dirs.project);
+        SkillScanResult {
+            cwd: self.cwd,
+            candidates: self.candidates,
+            dirs,
+            registry: Some(registry),
+            count,
+        }
+    }
 }
 
 impl AgentHarness {
@@ -194,7 +256,10 @@ impl AgentHarness {
             config: config.agent.clone(),
             skills_config: config.skills.clone(),
             skills: SkillRegistry::new(),
-            last_skills_cwd: None,
+            last_skill_scan_candidates: None,
+            last_skill_scan_dirs: None,
+            latest_requested_skill_scan: None,
+            in_flight_skill_scans: HashSet::new(),
             runtime,
         })
     }
@@ -557,18 +622,74 @@ impl AgentHarness {
     }
 
     /// Scan for skills from configured filesystem paths.
-    /// Only rescans if the cwd has changed since the last scan.
+    /// Only rescans if the candidate roots changed since the last completed
+    /// request. This is synchronous and intended for tests or non-UI callers;
+    /// UI code should use `request_skill_scan` and `complete_skill_scan`.
     /// Returns true if skills were (re)loaded.
     pub fn scan_skills(&mut self, cwd: &str) -> bool {
-        if self.last_skills_cwd.as_deref() == Some(cwd) {
+        let cwd_path = Path::new(cwd);
+        let candidates = SkillScanCandidateDirs {
+            global: self.skills_config.resolved_global_paths(),
+            project: self.skills_config.resolved_project_paths(cwd_path),
+        };
+        if self.last_skill_scan_candidates.as_ref() == Some(&candidates) {
             return false;
         }
-        self.last_skills_cwd = Some(cwd.to_string());
+        let result = SkillScanJob {
+            cwd: cwd.to_string(),
+            candidates,
+            previous_dirs: self.last_skill_scan_dirs.clone(),
+        }
+        .scan();
+        self.apply_skill_scan_result(result)
+    }
+
+    pub fn request_skill_scan(&mut self, cwd: &str) -> Option<SkillScanJob> {
         let cwd_path = Path::new(cwd);
-        let global_dirs = self.skills_config.resolved_global_paths();
-        let project_dirs = self.skills_config.resolved_project_paths(cwd_path);
-        let count = self.skills.scan(&global_dirs, &project_dirs);
-        log::info!("Skill scan for {}: {} skill(s) found", cwd, count);
+        let candidates = SkillScanCandidateDirs {
+            global: self.skills_config.resolved_global_paths(),
+            project: self.skills_config.resolved_project_paths(cwd_path),
+        };
+
+        if self.last_skill_scan_candidates.as_ref() == Some(&candidates) {
+            return None;
+        }
+
+        self.latest_requested_skill_scan = Some(candidates.clone());
+        if !self.in_flight_skill_scans.insert(candidates.clone()) {
+            return None;
+        }
+
+        Some(SkillScanJob {
+            cwd: cwd.to_string(),
+            candidates,
+            previous_dirs: self.last_skill_scan_dirs.clone(),
+        })
+    }
+
+    pub fn complete_skill_scan(&mut self, result: SkillScanResult) -> bool {
+        self.in_flight_skill_scans.remove(&result.candidates);
+        if self.latest_requested_skill_scan.as_ref() != Some(&result.candidates) {
+            return false;
+        }
+        self.latest_requested_skill_scan = None;
+        self.apply_skill_scan_result(result)
+    }
+
+    fn apply_skill_scan_result(&mut self, result: SkillScanResult) -> bool {
+        self.last_skill_scan_candidates = Some(result.candidates);
+        self.last_skill_scan_dirs = Some(result.dirs);
+
+        let Some(registry) = result.registry else {
+            return false;
+        };
+
+        self.skills = registry;
+        log::info!(
+            "Skill scan for {}: {} skill(s) found",
+            result.cwd,
+            result.count
+        );
         true
     }
 
@@ -576,7 +697,10 @@ impl AgentHarness {
     pub fn update_skills_config(&mut self, config: crate::config::SkillsConfig) {
         self.skills_config = config;
         // Force rescan on next cwd check
-        self.last_skills_cwd = None;
+        self.last_skill_scan_candidates = None;
+        self.last_skill_scan_dirs = None;
+        self.latest_requested_skill_scan = None;
+        self.in_flight_skill_scans.clear();
     }
 
     pub fn config(&self) -> &con_agent::AgentConfig {
@@ -606,6 +730,141 @@ impl AgentHarness {
 
     pub fn skill_summaries(&self) -> Vec<(String, String)> {
         self.skills.summaries()
+    }
+}
+
+fn existing_skill_dirs(dirs: Vec<PathBuf>) -> Vec<PathBuf> {
+    dirs.into_iter().filter(|dir| dir.is_dir()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Config, SkillsConfig};
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(name: &str) -> Self {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = std::env::temp_dir()
+                .join(format!("con-harness-{name}-{}-{nanos}", std::process::id()));
+            fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn write_skill(root: &Path, name: &str) {
+        let dir = root.join(name);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: Test skill\n---\n\nUse {name}."),
+        )
+        .unwrap();
+    }
+
+    fn harness_with_skill_paths(global: &Path) -> AgentHarness {
+        let mut config = Config::default();
+        config.skills = SkillsConfig {
+            project_paths: vec![".con/skills".into()],
+            global_paths: vec![global.display().to_string()],
+        };
+        AgentHarness::new(&config).unwrap()
+    }
+
+    #[test]
+    fn async_skill_scan_skips_registry_reload_when_existing_roots_do_not_change() {
+        let root = TempDir::new("skill-scan-same-roots");
+        let global = root.path().join("global");
+        let cwd_a = root.path().join("a");
+        let cwd_b = root.path().join("b");
+        fs::create_dir_all(&cwd_a).unwrap();
+        fs::create_dir_all(&cwd_b).unwrap();
+        write_skill(&global, "global-skill");
+
+        let mut harness = harness_with_skill_paths(&global);
+
+        let first = harness.request_skill_scan(cwd_a.to_str().unwrap()).unwrap();
+        let first_result = first.scan();
+        assert!(first_result.registry.is_some());
+        assert!(harness.complete_skill_scan(first_result));
+        assert_eq!(harness.skill_summaries().len(), 1);
+
+        let second = harness.request_skill_scan(cwd_b.to_str().unwrap()).unwrap();
+        let second_result = second.scan();
+        assert!(second_result.registry.is_none());
+        assert!(!harness.complete_skill_scan(second_result));
+        assert_eq!(harness.skill_summaries().len(), 1);
+    }
+
+    #[test]
+    fn async_skill_scan_reloads_when_project_skill_root_appears() {
+        let root = TempDir::new("skill-scan-project-root");
+        let global = root.path().join("global");
+        let cwd_a = root.path().join("a");
+        let cwd_b = root.path().join("b");
+        fs::create_dir_all(&cwd_a).unwrap();
+        fs::create_dir_all(&cwd_b).unwrap();
+        write_skill(&global, "global-skill");
+
+        let mut harness = harness_with_skill_paths(&global);
+        let first = harness.request_skill_scan(cwd_a.to_str().unwrap()).unwrap();
+        assert!(harness.complete_skill_scan(first.scan()));
+
+        let project_skills = cwd_b.join(".con/skills");
+        write_skill(&project_skills, "project-skill");
+
+        let second = harness.request_skill_scan(cwd_b.to_str().unwrap()).unwrap();
+        let second_result = second.scan();
+        assert!(second_result.registry.is_some());
+        assert!(harness.complete_skill_scan(second_result));
+
+        let names = harness.skill_names();
+        assert!(names.contains(&"global-skill".to_string()));
+        assert!(names.contains(&"project-skill".to_string()));
+    }
+
+    #[test]
+    fn async_skill_scan_ignores_stale_results() {
+        let root = TempDir::new("skill-scan-stale-result");
+        let global = root.path().join("global");
+        let cwd_a = root.path().join("a");
+        let cwd_b = root.path().join("b");
+        fs::create_dir_all(&cwd_a).unwrap();
+        fs::create_dir_all(&cwd_b).unwrap();
+        write_skill(&global, "global-skill");
+        write_skill(&cwd_a.join(".con/skills"), "a-skill");
+        write_skill(&cwd_b.join(".con/skills"), "b-skill");
+
+        let mut harness = harness_with_skill_paths(&global);
+
+        let scan_a = harness.request_skill_scan(cwd_a.to_str().unwrap()).unwrap();
+        let scan_b = harness.request_skill_scan(cwd_b.to_str().unwrap()).unwrap();
+
+        assert!(!harness.complete_skill_scan(scan_a.scan()));
+        assert!(harness.skill_names().is_empty());
+
+        assert!(harness.complete_skill_scan(scan_b.scan()));
+        let names = harness.skill_names();
+        assert!(names.contains(&"global-skill".to_string()));
+        assert!(names.contains(&"b-skill".to_string()));
+        assert!(!names.contains(&"a-skill".to_string()));
     }
 }
 

--- a/postmortem/2026-05-13-terminal-input-workspace-rerender.md
+++ b/postmortem/2026-05-13-terminal-input-workspace-rerender.md
@@ -36,7 +36,7 @@ appeared to do nothing until the user clicked the terminal.
   does not notify the input bar again.
 - Moved skill discovery to a background request/result path. Rendering now only
   schedules a deduped scan; the filesystem work runs off the UI thread.
-- Kept skill-scan deduplication at the request level, but rebuild the registry
+- Kept skill-scan deduplication at the request level, but rebuilt the registry
   in the background whenever candidate roots change. This preserves the old
   behavior where skill edits are picked up after cwd/config changes without
   putting the rebuild back on the render path.

--- a/postmortem/2026-05-13-terminal-input-workspace-rerender.md
+++ b/postmortem/2026-05-13-terminal-input-workspace-rerender.md
@@ -1,0 +1,48 @@
+# Terminal input caused workspace rerenders
+
+## What happened
+
+Terminal typing could occasionally feel unresponsive even when the shell itself
+was not blocked. The issue was most visible in terminal-focused workflows with
+the surrounding workspace chrome enabled.
+
+## Root cause
+
+The macOS terminal key handler emitted `GhosttyFocusChanged` after every handled
+key. The workspace treats that event as a pane focus change, so normal typing
+could trigger a full workspace notification path: pane focus sync, terminal
+focus-state sync, pane metadata rebuild, and input-bar/sidebar/agent-panel state
+sync.
+
+The input bar also notified on every pane metadata sync even when the pane list
+and focused pane were unchanged.
+
+A second issue was subtler: render-time skill discovery still touched the
+filesystem. Even with caching, cwd changes could synchronously stat or rescan
+skill roots from the workspace render path. That made terminal-adjacent chrome
+capable of blocking the same UI thread that needs to accept keystrokes.
+
+## Fix applied
+
+- Stopped terminal keypresses from emitting `GhosttyFocusChanged`; mouse/drop
+  focus events still emit it.
+- Made input-bar pane and cwd sync idempotent so unchanged render-time metadata
+  does not notify the input bar again.
+- Moved skill discovery to a background request/result path. Rendering now only
+  schedules a deduped scan; the filesystem work runs off the UI thread.
+- Changed skill-scan caching to key by existing skill roots instead of raw cwd.
+  Moving between directories without project-local skill roots no longer reloads
+  the same global registry, while project-local roots still trigger a reload when
+  they appear.
+
+## What we learned
+
+Terminal input should invalidate only the terminal view unless the interaction
+actually changes workspace focus or chrome state. Render-time state sync must be
+idempotent, especially for terminal-adjacent UI, because a small notification in
+the hot path can fan out into expensive parent/child rerenders.
+
+The render path should also be treated as latency-sensitive infrastructure.
+Filesystem discovery, parsing, and other potentially unbounded work must run
+through an async or background handoff, even when a cache makes the common case
+look cheap.

--- a/postmortem/2026-05-13-terminal-input-workspace-rerender.md
+++ b/postmortem/2026-05-13-terminal-input-workspace-rerender.md
@@ -4,7 +4,8 @@
 
 Terminal typing could occasionally feel unresponsive even when the shell itself
 was not blocked. The issue was most visible in terminal-focused workflows with
-the surrounding workspace chrome enabled.
+the surrounding workspace chrome enabled, and when returning to Con from another
+application.
 
 ## Root cause
 
@@ -22,6 +23,11 @@ filesystem. Even with caching, cwd changes could synchronously stat or rescan
 skill roots from the workspace render path. That made terminal-adjacent chrome
 capable of blocking the same UI thread that needs to accept keystrokes.
 
+A separate focus-loss path could make the symptom look identical to input
+latency: after switching away from Con and back, the OS window could be active
+while no terminal/editor/input focus target had been reasserted. Typing then
+appeared to do nothing until the user clicked the terminal.
+
 ## Fix applied
 
 - Stopped terminal keypresses from emitting `GhosttyFocusChanged`; mouse/drop
@@ -34,6 +40,10 @@ capable of blocking the same UI thread that needs to accept keystrokes.
   in the background whenever candidate roots change. This preserves the old
   behavior where skill edits are picked up after cwd/config changes without
   putting the rebuild back on the render path.
+- Reassert the logical keyboard focus target when a Con window becomes active.
+  Existing input/editor focus is preserved when GPUI still knows it; otherwise
+  focus falls back to the active pane so an active terminal can accept input
+  immediately after app switching.
 
 ## What we learned
 
@@ -46,3 +56,7 @@ The render path should also be treated as latency-sensitive infrastructure.
 Filesystem discovery, parsing, and other potentially unbounded work must run
 through an async or background handoff, even when a cache makes the common case
 look cheap.
+
+Responsiveness bugs are not always compute bugs. The app must also maintain a
+clear keyboard-focus owner after OS-level activation changes; otherwise a
+healthy terminal can look frozen because key events have nowhere useful to go.

--- a/postmortem/2026-05-13-terminal-input-workspace-rerender.md
+++ b/postmortem/2026-05-13-terminal-input-workspace-rerender.md
@@ -30,10 +30,10 @@ capable of blocking the same UI thread that needs to accept keystrokes.
   does not notify the input bar again.
 - Moved skill discovery to a background request/result path. Rendering now only
   schedules a deduped scan; the filesystem work runs off the UI thread.
-- Changed skill-scan caching to key by existing skill roots instead of raw cwd.
-  Moving between directories without project-local skill roots no longer reloads
-  the same global registry, while project-local roots still trigger a reload when
-  they appear.
+- Kept skill-scan deduplication at the request level, but rebuild the registry
+  in the background whenever candidate roots change. This preserves the old
+  behavior where skill edits are picked up after cwd/config changes without
+  putting the rebuild back on the render path.
 
 ## What we learned
 


### PR DESCRIPTION
## Summary

- stop macOS terminal keypresses from emitting workspace focus-change events on every handled key
- make input-bar pane/cwd sync idempotent so unchanged render metadata does not fan out into extra notifications
- move skill discovery off the workspace render path with a deduped background request/result flow
- add regression coverage for unchanged skill roots, project-local skill root appearance, and stale async scan results
- document the root cause and latency invariant in a postmortem

## Why

Typing in a terminal should only invalidate the terminal surface unless the interaction actually changes focus or chrome state. The previous path let normal keypresses trigger workspace focus handling, and render-time skill discovery could still touch the filesystem during cwd churn. Both behaviors could make terminal input feel unresponsive even when the shell was not blocked.

## Validation

- cargo fmt --check
- cargo check -p con
- cargo test -p con-core
- cargo test --workspace
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal input/focus propagation and moves skill discovery to an async background flow; regressions could show up as missing focus or stale skill completions across tabs/cwd changes.
> 
> **Overview**
> Improves terminal typing responsiveness by **stopping ordinary macOS keypress handling from emitting workspace-level `GhosttyFocusChanged` events**, reducing unnecessary focus/pane sync work.
> 
> Makes input-bar metadata updates (`panes`, `cwd`, `skills`) idempotent (adds equality checks + explicit `cx.notify()` only on change) to prevent render-time state sync from fanning out into extra rerenders.
> 
> Moves skill discovery off the workspace render path by introducing an async, deduped skill scan request/result pipeline in `AgentHarness` (`request_skill_scan`/`complete_skill_scan`) and wiring scans to cwd/tab activation events; adds sorting guarantees in `SkillRegistry` plus targeted regression tests. Also adds window-activation focus reassertion so the previous input target is restored when returning to an active Con window, and documents the incident/fix in a new postmortem + changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fbf070c5e68d1b7f3a5d2632e624a0f961ed7fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved terminal input responsiveness by reducing redundant UI updates during typing
  * Fixed keyboard focus reassertion when the application window becomes active
  * Made focus synchronization idempotent to prevent unnecessary UI notifications
  * Moved skill discovery operations to background tasks for better overall performance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/con-terminal/pull/208)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->