### PR TITLE
fix(agent-panel): keep model picker from pushing header icons

### DIFF
--- a/crates/con-app/src/agent_panel.rs
+++ b/crates/con-app/src/agent_panel.rs
@@ -4472,9 +4472,9 @@ impl Render for AgentPanel {
         let model_label = if self.model_name.is_empty() {
             SharedString::from("Model")
         } else {
-            SharedString::from(self.model_name.clone())
+            SharedString::from(humanize_model_name(&self.model_name))
         };
-        let model_picker = div().w(px(156.0)).child(
+        let model_picker = div().w(px(156.0)).flex_shrink_0().overflow_hidden().child(
             Button::new("agent-model-picker")
                 .ghost()
                 .xsmall()
@@ -5020,14 +5020,20 @@ impl Render for AgentPanel {
 
 /// Convert model ID to a human-readable short name.
 fn humanize_model_name(model: &str) -> String {
-    // Common patterns: "claude-sonnet-4-6" → "Sonnet 4.6"
+    // Common patterns: "claude-sonnet-4-6" → "Sonnet 4.6",
+    // "claude-sonnet-4-5-20250929" → "Sonnet 4.5"
     if model.contains("claude") {
         if let Some(rest) = model.strip_prefix("claude-") {
-            // "sonnet-4-6" → "Sonnet 4.6", "opus-4-6" → "Opus 4.6"
-            let parts: Vec<&str> = rest.splitn(2, '-').collect();
-            if parts.len() >= 2 {
-                let family = parts[0];
-                let version = parts[1].replace('-', ".");
+            let mut segments: Vec<&str> = rest.split('-').collect();
+            // Strip trailing date stamp (8+ contiguous digits, e.g. 20250929).
+            if let Some(last) = segments.last() {
+                if last.len() >= 8 && last.chars().all(|c| c.is_ascii_digit()) {
+                    segments.pop();
+                }
+            }
+            if segments.len() >= 2 {
+                let family = segments[0];
+                let version = segments[1..].join(".");
                 let family_cap = if let Some(first) = family.chars().next() {
                     format!("{}{}", first.to_uppercase(), &family[first.len_utf8()..])
                 } else {
@@ -5044,12 +5050,20 @@ fn humanize_model_name(model: &str) -> String {
         return "No model".to_string();
     }
     // Fallback: show as-is but truncated
-    truncate_str(model, 24)
+    truncate_str(model, 18)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{AgentPanel, PanelState, StepStatus};
+    use super::{AgentPanel, PanelState, StepStatus, humanize_model_name};
+
+    #[test]
+    fn humanize_strips_date_suffix() {
+        assert_eq!(humanize_model_name("claude-sonnet-4-5-20250929"), "Sonnet 4.5");
+        assert_eq!(humanize_model_name("claude-opus-4-1-20250805"), "Opus 4.1");
+        assert_eq!(humanize_model_name("claude-sonnet-4-6"), "Sonnet 4.6");
+        assert_eq!(humanize_model_name(""), "No model");
+    }
 
     #[test]
     fn multiline_drafts_disable_inline_history_navigation() {

--- a/crates/con-app/src/agent_panel.rs
+++ b/crates/con-app/src/agent_panel.rs
@@ -5066,6 +5066,20 @@ mod tests {
     }
 
     #[test]
+    fn humanize_unknown_model_truncates_at_eighteen_chars() {
+        // Unknown provider/family hits the fallback `truncate_str(model, 18)` branch.
+        let short = "kimi-k2-0905";
+        assert_eq!(humanize_model_name(short), short);
+
+        let long = "some-unknown-model-name-2026";
+        let result = humanize_model_name(long);
+        assert!(result.ends_with('…'), "expected ellipsis, got {result:?}");
+        // 18-char prefix + the ellipsis character.
+        assert_eq!(result.chars().count(), 19);
+        assert!(result.starts_with(&long[..18]));
+    }
+
+    #[test]
     fn multiline_drafts_disable_inline_history_navigation() {
         let text = "first line\nsecond line\nthird line";
 


### PR DESCRIPTION
## Summary
- The agent panel header rendered the raw model id (e.g. `claude-sonnet-4-5-20250929`) inside a fixed 156px slot with no overflow clipping, so long ids dislodged the right‑aligned icon cluster.
- Run the picker label through `humanize_model_name`, and teach `humanize_model_name` to drop trailing 8+ digit date stamps so `claude-sonnet-4-5-20250929` → `Sonnet 4.5` and `claude-opus-4-1-20250805` → `Opus 4.1`.
- Add `flex_shrink_0().overflow_hidden()` on the picker slot as a layout fence — any future long label is clipped instead of overflowing the row.
- Generic fallback truncation tightened from 24 → 18 chars; unit test pinned.

## Before / After
Before: `claude-sonnet-4-5-20250929` overlapped the history + new‑chat icons.
After: picker reads `Sonnet 4.5`; header icons stay anchored.

## Test plan
- [x] `cargo test -p con --bin con humanize` — new `humanize_strips_date_suffix` passes
- [x] `cargo build -p con` clean
- [ ] Manual: launch app, switch to a dated Anthropic model (`claude-sonnet-4-5-20250929`), confirm chip reads "Sonnet 4.5" and right‑side controls stay in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout change plus small string-formatting tweak for model labels; only affects how model IDs are displayed/truncated in the agent panel header.
> 
> **Overview**
> **Improves the agent panel header model picker layout** by rendering a human-friendly model label and preventing the 156px picker slot from pushing the right-aligned header icons.
> 
> Updates `humanize_model_name` to strip trailing date suffixes from Anthropic model IDs (e.g. `claude-sonnet-4-5-20250929` → `Sonnet 4.5`), tightens fallback truncation (24 → 18 chars), and adds a unit test covering these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c139e0af3cc787ad648a3b91764e3b76d6280e9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->