### PR TITLE
Reveal vertical tab rail when creating tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ con is still pre-release, so entries may group related beta work while the produ
   [#212](https://github.com/nowledge-co/con-terminal/pull/212) by
   [@wey-gu](https://github.com/wey-gu))_
 
+**Terminal**
+
+- Hardened startup environment handling so terminals launched from wrapper
+  shells do not inherit Conductor's temporary zsh integration directory as
+  their own `ZDOTDIR`, preserving the user's normal prompt and shell rc loading.
+  _(PR [#212](https://github.com/nowledge-co/con-terminal/pull/212) by
+  [@wey-gu](https://github.com/wey-gu))_
+
 ---
 
 ## `v0.1.0-beta.73` - 2026-05-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
-## `v0.1.0-beta.73` - Unreleased
+## `v0.1.0-beta.74` - Unreleased
+
+### Fixed
+
+**Sidebar**
+
+- In vertical tabs mode, creating or duplicating a tab while the left sidebar is
+  hidden now reveals the compact tab rail, keeping existing tabs visible without
+  opening the Files/Search drawer or the full session panel. _(PR
+  [#212](https://github.com/nowledge-co/con-terminal/pull/212) by
+  [@wey-gu](https://github.com/wey-gu))_
 
 ---
 

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -69,6 +69,7 @@ mod sidebar_search_view;
 mod tab_colors;
 mod tab_context_menu;
 mod terminal_context_menu;
+mod terminal_env;
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 mod terminal_ime;
 mod terminal_keys;
@@ -2176,6 +2177,7 @@ fn main() {
     // Critical on Windows where double-clicking the exe detaches
     // stderr and a panic produces a silent exit.
     install_panic_hook();
+    terminal_env::sanitize_inherited_terminal_environment();
 
     // Catch C-level access violations / stack overflows / etc. from
     // FFI libraries (libghostty-vt, GPU driver shims) that bypass
@@ -2220,6 +2222,7 @@ fn main() {
     // get PATH, GOPATH, HTTP_PROXY, etc. from shell rc files.
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     inherit_shell_env();
+    terminal_env::sanitize_inherited_terminal_environment();
 
     log::info!("con starting (pid {})", std::process::id());
     if let Some(path) = log_file_path.as_ref() {

--- a/crates/con-app/src/sidebar.rs
+++ b/crates/con-app/src/sidebar.rs
@@ -252,6 +252,10 @@ pub struct SessionSidebar {
     /// vertical tabs. The sidebar then becomes the single icon rail so
     /// tools and sessions share one left-navigation surface.
     tools_panel_open: bool,
+    /// Render-only compact rail override used when the workspace reveals
+    /// hidden vertical tabs after explicit tab creation. This must not mutate
+    /// `mode`: pinned/collapsed is a user preference persisted in sessions.
+    rail_only_override: bool,
     active_tool_slot: ActivitySlot,
     tab_accent_inactive_alpha: f32,
     tab_accent_inactive_hover_alpha: f32,
@@ -340,6 +344,7 @@ impl SessionSidebar {
             drag_preview: Rc::new(RefCell::new(None)),
             ui_opacity: 0.92,
             tools_panel_open: false,
+            rail_only_override: false,
             active_tool_slot: ActivitySlot::Files,
             tab_accent_inactive_alpha: crate::tab_colors::TAB_ACCENT_INACTIVE_ALPHA,
             tab_accent_inactive_hover_alpha: crate::tab_colors::TAB_ACCENT_INACTIVE_HOVER_ALPHA,
@@ -373,6 +378,8 @@ impl SessionSidebar {
     }
 
     pub fn set_pinned(&mut self, pinned: bool, cx: &mut Context<Self>) {
+        let had_rail_only_override = self.rail_only_override;
+        self.rail_only_override = false;
         let new_mode = if pinned {
             PanelMode::Pinned
         } else {
@@ -384,6 +391,8 @@ impl SessionSidebar {
             self.hovered_rail = None;
             let target = if pinned { 1.0 } else { 0.0 };
             self.width_motion.set_target(target, PANEL_TWEEN);
+            cx.notify();
+        } else if had_rail_only_override {
             cx.notify();
         }
     }
@@ -397,7 +406,7 @@ impl SessionSidebar {
     }
 
     pub fn rendered_width(&self) -> f32 {
-        if self.tools_panel_open {
+        if self.renders_rail_only() {
             return RAIL_WIDTH;
         }
         match self.mode {
@@ -410,8 +419,29 @@ impl SessionSidebar {
         if self.tools_panel_open != open {
             self.tools_panel_open = open;
             self.hovered_rail = None;
+            if open {
+                self.rail_only_override = false;
+            }
         }
         self.active_tool_slot = active_slot;
+    }
+
+    pub fn show_rail_only_preserving_pinned(&mut self, cx: &mut Context<Self>) {
+        if self.rail_only_override {
+            return;
+        }
+        self.rail_only_override = true;
+        self.hovered_rail = None;
+        cx.notify();
+    }
+
+    pub fn clear_rail_only_override(&mut self, cx: &mut Context<Self>) {
+        if !self.rail_only_override {
+            return;
+        }
+        self.rail_only_override = false;
+        self.hovered_rail = None;
+        cx.notify();
     }
 
     pub fn set_panel_width(&mut self, width: f32, cx: &mut Context<Self>) {
@@ -540,6 +570,12 @@ impl SessionSidebar {
         Self::clamped_panel_width(self.panel_width, self.effective_panel_max_width)
     }
 
+    fn renders_rail_only(&self) -> bool {
+        self.tools_panel_open
+            || self.rail_only_override
+            || matches!(self.mode, PanelMode::Collapsed)
+    }
+
     pub fn toggle_pinned(&mut self, cx: &mut Context<Self>) {
         let now_pinned = !self.is_pinned();
         self.set_pinned(now_pinned, cx);
@@ -657,12 +693,13 @@ impl SessionSidebar {
         let theme = cx.theme();
         let rail_bg = sidebar_surface(theme, self.ui_opacity, 0.035);
         let session_count = self.sessions.len();
-        let mode_icon = if self.tools_panel_open || self.is_pinned() {
+        let mode_icon = if self.tools_panel_open || (self.is_pinned() && !self.rail_only_override) {
             "phosphor/caret-line-left.svg"
         } else {
             "phosphor/caret-line-right.svg"
         };
-        let mode_color = if self.tools_panel_open || self.is_pinned() {
+        let mode_color = if self.tools_panel_open || (self.is_pinned() && !self.rail_only_override)
+        {
             theme.foreground.opacity(0.74)
         } else {
             theme.muted_foreground.opacity(0.78)
@@ -832,6 +869,10 @@ impl SessionSidebar {
                     if this.tools_panel_open {
                         this.set_pinned(false, cx);
                         cx.emit(SidebarShowSessions);
+                    } else if this.rail_only_override {
+                        this.rail_only_override = false;
+                        this.hovered_rail = None;
+                        cx.notify();
                     } else {
                         this.toggle_pinned(cx);
                     }
@@ -1023,7 +1064,7 @@ impl SessionSidebar {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<AnyElement> {
-        if !matches!(self.mode, PanelMode::Collapsed) {
+        if !self.renders_rail_only() {
             return None;
         }
         let i = self.hovered_rail?;
@@ -1720,7 +1761,7 @@ impl Render for SessionSidebar {
         // Drive the width-tween animation frame.
         let _progress = self.width_motion.value(window);
 
-        if self.tools_panel_open {
+        if self.tools_panel_open || self.rail_only_override {
             let mut rail = div()
                 .relative()
                 .h_full()

--- a/crates/con-app/src/sidebar.rs
+++ b/crates/con-app/src/sidebar.rs
@@ -82,6 +82,14 @@ enum PanelMode {
     Pinned,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RailModeButtonAction {
+    ShowSessionsFromToolPanel,
+    RestorePinnedPanelFromRail,
+    ExpandCollapsedPanelFromOverride,
+    TogglePinned,
+}
+
 /// Per-tab transient state — the inline-rename input.
 struct RenameState {
     index: usize,
@@ -321,6 +329,10 @@ impl EventEmitter<SidebarShowSessions> for SessionSidebar {}
 
 impl SessionSidebar {
     pub fn new(_cx: &mut Context<Self>) -> Self {
+        Self::default_state()
+    }
+
+    fn default_state() -> Self {
         Self {
             mode: PanelMode::Collapsed,
             sessions: Vec::new(),
@@ -349,6 +361,11 @@ impl SessionSidebar {
             tab_accent_inactive_alpha: crate::tab_colors::TAB_ACCENT_INACTIVE_ALPHA,
             tab_accent_inactive_hover_alpha: crate::tab_colors::TAB_ACCENT_INACTIVE_HOVER_ALPHA,
         }
+    }
+
+    #[cfg(test)]
+    fn new_for_test() -> Self {
+        Self::default_state()
     }
 
     pub fn set_ui_opacity(&mut self, opacity: f32, cx: &mut Context<Self>) {
@@ -427,6 +444,10 @@ impl SessionSidebar {
     }
 
     pub fn show_rail_only_preserving_pinned(&mut self, cx: &mut Context<Self>) {
+        if matches!(self.mode, PanelMode::Collapsed) {
+            self.hovered_rail = None;
+            return;
+        }
         if self.rail_only_override {
             return;
         }
@@ -574,6 +595,20 @@ impl SessionSidebar {
         self.tools_panel_open
             || self.rail_only_override
             || matches!(self.mode, PanelMode::Collapsed)
+    }
+
+    fn rail_mode_button_action(&self) -> RailModeButtonAction {
+        if self.tools_panel_open {
+            return RailModeButtonAction::ShowSessionsFromToolPanel;
+        }
+        if self.rail_only_override {
+            return if self.is_pinned() {
+                RailModeButtonAction::RestorePinnedPanelFromRail
+            } else {
+                RailModeButtonAction::ExpandCollapsedPanelFromOverride
+            };
+        }
+        RailModeButtonAction::TogglePinned
     }
 
     pub fn toggle_pinned(&mut self, cx: &mut Context<Self>) {
@@ -865,15 +900,19 @@ impl SessionSidebar {
                 mode_icon,
                 mode_color,
                 theme,
-                cx.listener(|this, _, _, cx| {
-                    if this.tools_panel_open {
+                cx.listener(|this, _, _, cx| match this.rail_mode_button_action() {
+                    RailModeButtonAction::ShowSessionsFromToolPanel => {
                         this.set_pinned(false, cx);
                         cx.emit(SidebarShowSessions);
-                    } else if this.rail_only_override {
-                        this.rail_only_override = false;
-                        this.hovered_rail = None;
-                        cx.notify();
-                    } else {
+                    }
+                    RailModeButtonAction::RestorePinnedPanelFromRail => {
+                        this.clear_rail_only_override(cx);
+                    }
+                    RailModeButtonAction::ExpandCollapsedPanelFromOverride => {
+                        this.clear_rail_only_override(cx);
+                        this.set_pinned(true, cx);
+                    }
+                    RailModeButtonAction::TogglePinned => {
                         this.toggle_pinned(cx);
                     }
                 }),
@@ -2239,7 +2278,8 @@ fn normalize_sidebar_rename_label(value: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        SidebarDragPreviewState, begin_rename_after_cancel_lifecycle, begin_rename_lifecycle,
+        PanelMode, RailModeButtonAction, SessionSidebar, SidebarDragPreviewState,
+        begin_rename_after_cancel_lifecycle, begin_rename_lifecycle,
         blur_should_commit_for_lifecycle, cancel_rename_lifecycle, normalize_sidebar_rename_label,
         vertical_drag_overlay_probe_position, vertical_slot_from_bounds,
     };
@@ -2315,6 +2355,37 @@ mod tests {
         assert_eq!(
             normalize_sidebar_rename_label("  hello  "),
             Some("hello".to_string())
+        );
+    }
+
+    #[test]
+    fn rail_mode_button_expands_on_first_click_from_collapsed_override() {
+        let mut sidebar = SessionSidebar {
+            mode: PanelMode::Collapsed,
+            rail_only_override: true,
+            ..SessionSidebar::new_for_test()
+        };
+
+        assert_eq!(
+            sidebar.rail_mode_button_action(),
+            RailModeButtonAction::ExpandCollapsedPanelFromOverride
+        );
+
+        sidebar.mode = PanelMode::Pinned;
+        assert_eq!(
+            sidebar.rail_mode_button_action(),
+            RailModeButtonAction::RestorePinnedPanelFromRail
+        );
+
+        sidebar.rail_only_override = false;
+        assert_eq!(
+            sidebar.rail_mode_button_action(),
+            RailModeButtonAction::TogglePinned
+        );
+        sidebar.tools_panel_open = true;
+        assert_eq!(
+            sidebar.rail_mode_button_action(),
+            RailModeButtonAction::ShowSessionsFromToolPanel
         );
     }
 

--- a/crates/con-app/src/terminal_env.rs
+++ b/crates/con-app/src/terminal_env.rs
@@ -47,8 +47,8 @@ fn conductor_zdotdir_update(
     }
 
     conductor_user_zdotdir
-        .or(conductor_original_zdotdir)
         .filter(|value| !value.is_empty())
+        .or_else(|| conductor_original_zdotdir.filter(|value| !value.is_empty()))
         .map(|value| {
             if value == current {
                 EnvUpdate::Remove
@@ -101,6 +101,15 @@ mod tests {
                 Some(OsStr::new("/tmp/integration")),
                 Some(OsStr::new("/tmp/integration")),
                 None,
+                Some(OsStr::new("/original"))
+            ),
+            EnvUpdate::Set("/original".into())
+        );
+        assert_eq!(
+            conductor_zdotdir_update(
+                Some(OsStr::new("/tmp/integration")),
+                Some(OsStr::new("/tmp/integration")),
+                Some(OsStr::new("")),
                 Some(OsStr::new("/original"))
             ),
             EnvUpdate::Set("/original".into())

--- a/crates/con-app/src/terminal_env.rs
+++ b/crates/con-app/src/terminal_env.rs
@@ -1,0 +1,118 @@
+use std::ffi::{OsStr, OsString};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum EnvUpdate {
+    Set(OsString),
+    Remove,
+    Unchanged,
+}
+
+pub fn sanitize_inherited_terminal_environment() {
+    let update = conductor_zdotdir_update(
+        std::env::var_os("ZDOTDIR").as_deref(),
+        std::env::var_os("CONDUCTOR_INTEGRATION_ZDOTDIR").as_deref(),
+        std::env::var_os("CONDUCTOR_USER_ZDOTDIR").as_deref(),
+        std::env::var_os("CONDUCTOR_ORIGINAL_ZDOTDIR").as_deref(),
+    );
+
+    match update {
+        EnvUpdate::Set(value) => {
+            // SAFETY: callers run this during app startup, before GPUI and
+            // terminal worker threads are created.
+            unsafe { std::env::set_var("ZDOTDIR", value) };
+        }
+        EnvUpdate::Remove => {
+            // SAFETY: callers run this during app startup, before GPUI and
+            // terminal worker threads are created.
+            unsafe { std::env::remove_var("ZDOTDIR") };
+        }
+        EnvUpdate::Unchanged => {}
+    }
+}
+
+fn conductor_zdotdir_update(
+    zdotdir: Option<&OsStr>,
+    conductor_integration_zdotdir: Option<&OsStr>,
+    conductor_user_zdotdir: Option<&OsStr>,
+    conductor_original_zdotdir: Option<&OsStr>,
+) -> EnvUpdate {
+    let Some(current) = zdotdir else {
+        return EnvUpdate::Unchanged;
+    };
+    let Some(integration) = conductor_integration_zdotdir else {
+        return EnvUpdate::Unchanged;
+    };
+    if current != integration {
+        return EnvUpdate::Unchanged;
+    }
+
+    conductor_user_zdotdir
+        .or(conductor_original_zdotdir)
+        .filter(|value| !value.is_empty())
+        .map(|value| {
+            if value == current {
+                EnvUpdate::Remove
+            } else {
+                EnvUpdate::Set(value.to_os_string())
+            }
+        })
+        .unwrap_or(EnvUpdate::Remove)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{EnvUpdate, conductor_zdotdir_update};
+    use std::ffi::OsStr;
+
+    #[test]
+    fn leaves_absent_or_non_conductor_zdotdir_unchanged() {
+        assert_eq!(
+            conductor_zdotdir_update(None, Some(OsStr::new("/tmp/integration")), None, None),
+            EnvUpdate::Unchanged
+        );
+        assert_eq!(
+            conductor_zdotdir_update(
+                Some(OsStr::new("/custom/zsh")),
+                Some(OsStr::new("/tmp/integration")),
+                Some(OsStr::new("/Users/example")),
+                None
+            ),
+            EnvUpdate::Unchanged
+        );
+    }
+
+    #[test]
+    fn restores_user_zdotdir_when_conductor_integration_leaks_in() {
+        assert_eq!(
+            conductor_zdotdir_update(
+                Some(OsStr::new("/tmp/integration")),
+                Some(OsStr::new("/tmp/integration")),
+                Some(OsStr::new("/Users/example")),
+                Some(OsStr::new("/fallback"))
+            ),
+            EnvUpdate::Set("/Users/example".into())
+        );
+    }
+
+    #[test]
+    fn falls_back_to_original_zdotdir_or_removes_when_no_user_value_exists() {
+        assert_eq!(
+            conductor_zdotdir_update(
+                Some(OsStr::new("/tmp/integration")),
+                Some(OsStr::new("/tmp/integration")),
+                None,
+                Some(OsStr::new("/original"))
+            ),
+            EnvUpdate::Set("/original".into())
+        );
+        assert_eq!(
+            conductor_zdotdir_update(
+                Some(OsStr::new("/tmp/integration")),
+                Some(OsStr::new("/tmp/integration")),
+                None,
+                None
+            ),
+            EnvUpdate::Remove
+        );
+    }
+}

--- a/crates/con-app/src/terminal_env.rs
+++ b/crates/con-app/src/terminal_env.rs
@@ -51,7 +51,7 @@ fn conductor_zdotdir_update(
         .or_else(|| conductor_original_zdotdir.filter(|value| !value.is_empty()))
         .map(|value| {
             if value == current {
-                EnvUpdate::Remove
+                EnvUpdate::Unchanged
             } else {
                 EnvUpdate::Set(value.to_os_string())
             }
@@ -122,6 +122,28 @@ mod tests {
                 None
             ),
             EnvUpdate::Remove
+        );
+    }
+
+    #[test]
+    fn leaves_matching_conductor_fallback_unchanged() {
+        assert_eq!(
+            conductor_zdotdir_update(
+                Some(OsStr::new("/tmp/integration")),
+                Some(OsStr::new("/tmp/integration")),
+                Some(OsStr::new("/tmp/integration")),
+                Some(OsStr::new("/original"))
+            ),
+            EnvUpdate::Unchanged
+        );
+        assert_eq!(
+            conductor_zdotdir_update(
+                Some(OsStr::new("/tmp/integration")),
+                Some(OsStr::new("/tmp/integration")),
+                None,
+                Some(OsStr::new("/tmp/integration"))
+            ),
+            EnvUpdate::Unchanged
         );
     }
 }

--- a/crates/con-app/src/workspace/chrome_actions.rs
+++ b/crates/con-app/src/workspace/chrome_actions.rs
@@ -98,6 +98,29 @@ impl ConWorkspace {
         cx.notify();
     }
 
+    pub(super) fn reveal_vertical_tab_rail_for_new_tab_if_needed(
+        &mut self,
+        cx: &mut Context<Self>,
+    ) {
+        if !should_reveal_vertical_tab_rail_for_new_tab(
+            self.vertical_tabs_enabled(),
+            self.left_panel_open,
+        ) {
+            return;
+        }
+
+        self.left_panel_open = true;
+        self.sidebar_tools_open = false;
+        self.sidebar.update(cx, |sidebar, cx| {
+            sidebar.set_pinned(false, cx);
+        });
+        self.activity_bar.update(cx, |bar, cx| {
+            bar.left_panel_open = false;
+            cx.notify();
+        });
+        cx.notify();
+    }
+
     pub(super) fn collapse_sidebar(
         &mut self,
         _: &CollapseSidebar,

--- a/crates/con-app/src/workspace/chrome_actions.rs
+++ b/crates/con-app/src/workspace/chrome_actions.rs
@@ -85,6 +85,10 @@ impl ConWorkspace {
         self.left_panel_open = !self.left_panel_open;
         if !self.vertical_tabs_enabled() {
             self.sidebar_tools_open = self.left_panel_open;
+        } else if !self.left_panel_open {
+            self.sidebar.update(cx, |sidebar, cx| {
+                sidebar.clear_rail_only_override(cx);
+            });
         }
         self.activity_bar.update(cx, |bar, cx| {
             bar.left_panel_open = if self.vertical_tabs_enabled() {
@@ -112,7 +116,7 @@ impl ConWorkspace {
         self.left_panel_open = true;
         self.sidebar_tools_open = false;
         self.sidebar.update(cx, |sidebar, cx| {
-            sidebar.set_pinned(false, cx);
+            sidebar.show_rail_only_preserving_pinned(cx);
         });
         self.activity_bar.update(cx, |bar, cx| {
             bar.left_panel_open = false;
@@ -131,6 +135,9 @@ impl ConWorkspace {
             return;
         }
         self.left_panel_open = false;
+        self.sidebar.update(cx, |sidebar, cx| {
+            sidebar.clear_rail_only_override(cx);
+        });
         self.activity_bar.update(cx, |bar, cx| {
             bar.left_panel_open = false;
             cx.notify();

--- a/crates/con-app/src/workspace/helpers.rs
+++ b/crates/con-app/src/workspace/helpers.rs
@@ -450,6 +450,13 @@ pub(super) fn rebase_active_tab_for_insert(active_tab: usize, insert_index: usiz
     }
 }
 
+pub(super) fn should_reveal_vertical_tab_rail_for_new_tab(
+    vertical_tabs_enabled: bool,
+    left_panel_open: bool,
+) -> bool {
+    vertical_tabs_enabled && !left_panel_open
+}
+
 #[cfg(test)]
 pub(super) struct NewTabSyncPolicy {
     pub(super) activates_new_tab: bool,

--- a/crates/con-app/src/workspace/tab_actions.rs
+++ b/crates/con-app/src/workspace/tab_actions.rs
@@ -717,6 +717,7 @@ impl ConWorkspace {
             shell_history: HashMap::new(),
         };
         let insert_at = index + 1;
+        self.reveal_vertical_tab_rail_for_new_tab_if_needed(cx);
         self.tabs.insert(insert_at, new_tab);
         if self.active_tab >= insert_at {
             self.active_tab += 1;

--- a/crates/con-app/src/workspace/tests.rs
+++ b/crates/con-app/src/workspace/tests.rs
@@ -4,8 +4,8 @@ use super::{
     FileTreeFocusSource, WorkspaceCloseIntent, activation_focus_target_for_reassertion,
     active_pane_focus_target, editor_file_close_outcome, editor_line_boundary_for_key,
     file_tree_root_for_focus, focused_editor_pane_key_fallback_allowed,
-    resize_drag_should_continue, should_show_activity_bar, workspace_close_intent,
-    workspace_close_intent_for_close_tab,
+    resize_drag_should_continue, should_reveal_vertical_tab_rail_for_new_tab,
+    should_show_activity_bar, workspace_close_intent, workspace_close_intent_for_close_tab,
 };
 use super::{
     ConWorkspace, SPLIT_PREVIEW_SEAM_THICKNESS, SplitDirection, SplitPlacement,
@@ -1238,6 +1238,14 @@ fn new_tab_requires_immediate_ui_sync() {
     assert!(policy.notifies_ui);
     assert!(policy.syncs_native_visibility);
     assert!(policy.reuses_shared_tab_activation_flow);
+}
+
+#[test]
+fn new_tab_reveals_hidden_vertical_tab_rail_only() {
+    assert!(should_reveal_vertical_tab_rail_for_new_tab(true, false));
+    assert!(!should_reveal_vertical_tab_rail_for_new_tab(true, true));
+    assert!(!should_reveal_vertical_tab_rail_for_new_tab(false, false));
+    assert!(!should_reveal_vertical_tab_rail_for_new_tab(false, true));
 }
 
 #[test]

--- a/crates/con-app/src/workspace/window_actions.rs
+++ b/crates/con-app/src/workspace/window_actions.rs
@@ -359,6 +359,7 @@ impl ConWorkspace {
     }
 
     pub(super) fn new_tab(&mut self, _: &NewTab, window: &mut Window, cx: &mut Context<Self>) {
+        self.reveal_vertical_tab_rail_for_new_tab_if_needed(cx);
         let cwd = self
             .has_active_tab()
             .then(|| self.try_active_terminal().and_then(|t| t.current_dir(cx)))

--- a/postmortem/2026-05-13-conductor-zdotdir-prompt-leak.md
+++ b/postmortem/2026-05-13-conductor-zdotdir-prompt-leak.md
@@ -1,0 +1,30 @@
+# Conductor ZDOTDIR Prompt Leak
+
+## What happened
+
+A development build of Con launched from a Conductor-managed environment opened
+new terminal panes with the bare zsh `%` prompt instead of the user's configured
+prompt. Restarting the app from a clean environment restored normal behavior.
+
+## Root cause
+
+The app process inherited Conductor's temporary zsh integration `ZDOTDIR`. Con
+then loads the login-shell environment during startup and Ghostty child shells
+inherit the resulting process environment. That allowed a wrapper app's shell
+bootstrap directory to become Con's terminal `ZDOTDIR`, so new panes could start
+with the wrong shell initialization context.
+
+## Fix applied
+
+Con now sanitizes only this specific inherited Conductor `ZDOTDIR` case during
+startup, before and after login-shell environment loading. When
+`ZDOTDIR == CONDUCTOR_INTEGRATION_ZDOTDIR`, Con restores
+`CONDUCTOR_USER_ZDOTDIR` or `CONDUCTOR_ORIGINAL_ZDOTDIR`; if neither exists, it
+removes `ZDOTDIR`. A user's intentional custom `ZDOTDIR` is left untouched.
+
+## What we learned
+
+Loading a GUI app's login-shell environment is useful, but terminal apps must be
+careful about inheriting shell-integration variables from the launcher itself.
+Wrapper-owned bootstrap paths are control-plane state, not user shell
+configuration, and should not be propagated into terminal child shells.


### PR DESCRIPTION
## Summary
- reveal the compact vertical tab rail when an explicit tab creation happens while the left sidebar is hidden
- keep Files/Search closed and force the session panel to the rail state so the clean view is only minimally interrupted
- cover the reveal policy with workspace tests

## Tests
- cargo test -p con workspace::tests::new_tab
- cargo test --workspace

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes workspace/sidebar state transitions around tab creation and mutates `ZDOTDIR` at startup, which could affect shell initialization if the detection logic is wrong.
> 
> **Overview**
> **Vertical tabs UX:** When vertical tabs are enabled and the left panel is hidden, explicit tab creation (new/duplicate) now *reveals only the compact tab rail* (not Files/Search or the full sessions panel) via a new rail-only override that preserves the user’s pinned/collapsed preference.
> 
> **Startup environment hardening:** Adds `terminal_env::sanitize_inherited_terminal_environment()` and runs it before/after login-shell env inheritance to restore/remove `ZDOTDIR` when it matches Conductor’s integration path, preventing wrapper-shell state from altering terminal prompts/rc loading.
> 
> Also updates the `CHANGELOG` for `v0.1.0-beta.74`, adds targeted unit tests for the new reveal policy/rail button behavior, and includes a postmortem documenting the `ZDOTDIR` incident and fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0891eeb79ce4c258518735b99a7965ada679aa35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed sidebar behavior when creating or duplicating tabs with vertical tabs enabled and hidden left panel—now reveals the compact tab rail instead of opening other panels
* Fixed terminal startup environment handling to prevent inherited launcher shell variables from affecting terminal prompts and shell configuration loading

## Documentation
* Added incident postmortem documenting terminal environment handling improvements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/con-terminal/pull/212)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->