### PR TITLE
Fix IME committed text not appearing in terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ con is still pre-release, so entries may group related beta work while the produ
   [#211](https://github.com/nowledge-co/con-terminal/issues/211), PR
   [#214](https://github.com/nowledge-co/con-terminal/pull/214) by
   [@wey-gu](https://github.com/wey-gu))_
+- Fixed macOS IME commits in Ghostty terminal panes so Chinese/Pinyin and
+  WeChat IME text repaints immediately, candidate windows stay anchored to the
+  current cursor bounds, and marked preedit text is rendered at the terminal
+  cursor. _(Issue
+  [#210](https://github.com/nowledge-co/con-terminal/issues/210), PR
+  [#213](https://github.com/nowledge-co/con-terminal/pull/213) by
+  [@sundy-li](https://github.com/sundy-li))_
 
 ---
 

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -1548,7 +1548,9 @@ impl InputHandler for GhosttyInputHandler {
                 if !had_marked_text && should_send_ime_insert_as_key_event(text) {
                     send_ime_insert_as_key_events(terminal, text);
                 } else {
-                    terminal.send_text(text);
+                    // Use key event path (not ghostty_surface_text) to avoid
+                    // bracketed-paste wrapping and post-paste selection highlight.
+                    terminal.send_text_as_key_event(text);
                 }
                 terminal.refresh();
             }
@@ -1572,6 +1574,8 @@ impl InputHandler for GhosttyInputHandler {
                 Some(new_text.to_string())
             };
             if let Some(terminal) = &view.terminal {
+                let ime = terminal.ime_point();
+
                 terminal.refresh();
             }
             cx.notify();
@@ -1784,8 +1788,58 @@ impl Render for GhosttyView {
         let context_focus = focus.clone();
         let menu_focus = focus.clone();
         let ui_font = cx.theme().font_family.clone();
+        let mono_font = cx.theme().mono_font_family.clone();
+        let mono_font_size = cx.theme().mono_font_size;
         let entity = cx.entity().downgrade();
         let show_layout_fallback = self.show_layout_fallback();
+
+        // Preedit overlay: render IME composition text at the cursor position.
+        let preedit_overlay: Option<gpui::AnyElement> = self
+            .ime_marked_text
+            .as_deref()
+            .filter(|t| !t.is_empty())
+            .and_then(|preedit_text| {
+                let terminal = self.terminal.as_ref()?;
+                let bounds = self.last_bounds?;
+                let ime = terminal.ime_point();
+                let fg = self
+                    .app
+                    .foreground_rgb()
+                    .map(|rgb| {
+                        Rgba { r: rgb[0] as f32 / 255.0, g: rgb[1] as f32 / 255.0, b: rgb[2] as f32 / 255.0, a: 1.0 }.into()
+                    })
+                    .unwrap_or(cx.theme().foreground);
+                let bg = self
+                    .app
+                    .background_rgb()
+                    .map(|rgb| {
+                        // Force opaque so the overlay covers ghostty's real cursor.
+                        Rgba { r: rgb[0] as f32 / 255.0, g: rgb[1] as f32 / 255.0, b: rgb[2] as f32 / 255.0, a: 1.0 }.into()
+                    })
+                    .unwrap_or(cx.theme().background);
+                let left = px(ime.x as f32).min(bounds.size.width - px(1.0)).max(px(0.0));
+                // ime_point y is the bottom of the cursor cell (candidate anchor).
+                // Subtract cell height to align the overlay with the cursor row.
+                let cell_height = if ime.height > 0.0 { ime.height as f32 } else { f32::from(mono_font_size) };
+                let top = px(ime.y as f32 - cell_height)
+                    .min(bounds.size.height - mono_font_size)
+                    .max(px(0.0));
+                let text = preedit_text.to_string();
+                Some(
+                    div()
+                        .absolute()
+                        .left(left)
+                        .top(top)
+                        .bg(bg)
+                        .text_color(fg)
+                        .font_family(mono_font.clone())
+                        .text_size(mono_font_size)
+                        .underline()
+                        .child(text)
+                        .into_any_element(),
+                )
+            });
+
         let layout_fallback_bg = self
             .app
             .background_rgb()
@@ -2000,6 +2054,7 @@ impl Render for GhosttyView {
                 )
                 .size_full(),
             )
+            .children(preedit_overlay)
             .context_menu(move |menu, window, cx| {
                 crate::terminal_context_menu::terminal_context_menu(
                     menu.action_context(menu_focus.clone()),

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -1536,13 +1536,13 @@ impl InputHandler for GhosttyInputHandler {
         &mut self,
         _replacement_range: Option<Range<usize>>,
         text: &str,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut App,
     ) {
         if text.is_empty() {
             return;
         }
-        let _ = self.view.update(cx, |view, _| {
+        let _ = self.view.update(cx, |view, cx| {
             let had_marked_text = view.ime_marked_text.take().is_some();
             if let Some(terminal) = &view.terminal {
                 if !had_marked_text && should_send_ime_insert_as_key_event(text) {
@@ -1552,7 +1552,9 @@ impl InputHandler for GhosttyInputHandler {
                 }
                 terminal.refresh();
             }
+            cx.notify();
         });
+        window.invalidate_character_coordinates();
     }
 
     fn replace_and_mark_text_in_range(
@@ -1560,10 +1562,10 @@ impl InputHandler for GhosttyInputHandler {
         _range_utf16: Option<Range<usize>>,
         new_text: &str,
         _new_selected_range: Option<Range<usize>>,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut App,
     ) {
-        let _ = self.view.update(cx, |view, _| {
+        let _ = self.view.update(cx, |view, cx| {
             view.ime_marked_text = if new_text.is_empty() {
                 None
             } else {
@@ -1572,16 +1574,20 @@ impl InputHandler for GhosttyInputHandler {
             if let Some(terminal) = &view.terminal {
                 terminal.refresh();
             }
+            cx.notify();
         });
+        window.invalidate_character_coordinates();
     }
 
-    fn unmark_text(&mut self, _window: &mut Window, cx: &mut App) {
-        let _ = self.view.update(cx, |view, _| {
+    fn unmark_text(&mut self, window: &mut Window, cx: &mut App) {
+        let _ = self.view.update(cx, |view, cx| {
             view.ime_marked_text = None;
             if let Some(terminal) = &view.terminal {
                 terminal.refresh();
             }
+            cx.notify();
         });
+        window.invalidate_character_coordinates();
     }
 
     fn bounds_for_range(

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -1574,8 +1574,6 @@ impl InputHandler for GhosttyInputHandler {
                 Some(new_text.to_string())
             };
             if let Some(terminal) = &view.terminal {
-                let ime = terminal.ime_point();
-
                 terminal.refresh();
             }
             cx.notify();
@@ -1806,7 +1804,13 @@ impl Render for GhosttyView {
                     .app
                     .foreground_rgb()
                     .map(|rgb| {
-                        Rgba { r: rgb[0] as f32 / 255.0, g: rgb[1] as f32 / 255.0, b: rgb[2] as f32 / 255.0, a: 1.0 }.into()
+                        Rgba {
+                            r: rgb[0] as f32 / 255.0,
+                            g: rgb[1] as f32 / 255.0,
+                            b: rgb[2] as f32 / 255.0,
+                            a: 1.0,
+                        }
+                        .into()
                     })
                     .unwrap_or(cx.theme().foreground);
                 let bg = self
@@ -1814,13 +1818,25 @@ impl Render for GhosttyView {
                     .background_rgb()
                     .map(|rgb| {
                         // Force opaque so the overlay covers ghostty's real cursor.
-                        Rgba { r: rgb[0] as f32 / 255.0, g: rgb[1] as f32 / 255.0, b: rgb[2] as f32 / 255.0, a: 1.0 }.into()
+                        Rgba {
+                            r: rgb[0] as f32 / 255.0,
+                            g: rgb[1] as f32 / 255.0,
+                            b: rgb[2] as f32 / 255.0,
+                            a: 1.0,
+                        }
+                        .into()
                     })
                     .unwrap_or(cx.theme().background);
-                let left = px(ime.x as f32).min(bounds.size.width - px(1.0)).max(px(0.0));
+                let left = px(ime.x as f32)
+                    .min(bounds.size.width - px(1.0))
+                    .max(px(0.0));
                 // ime_point y is the bottom of the cursor cell (candidate anchor).
                 // Subtract cell height to align the overlay with the cursor row.
-                let cell_height = if ime.height > 0.0 { ime.height as f32 } else { f32::from(mono_font_size) };
+                let cell_height = if ime.height > 0.0 {
+                    ime.height as f32
+                } else {
+                    f32::from(mono_font_size)
+                };
                 let top = px(ime.y as f32 - cell_height)
                     .min(bounds.size.height - mono_font_size)
                     .max(px(0.0));

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -551,6 +551,15 @@ impl GhosttyApp {
             .map(|colors| colors.background)
     }
 
+    /// Current configured terminal foreground color.
+    pub fn foreground_rgb(&self) -> Option<[u8; 3]> {
+        self.appearance
+            .lock()
+            .colors
+            .as_ref()
+            .map(|colors| colors.foreground)
+    }
+
     /// Current configured terminal background opacity. This lets the macOS
     /// embedding layer keep short-lived AppKit backing mattes visually aligned
     /// with Ghostty's own transparent terminal background.

--- a/postmortem/2026-05-13-ime-commit-no-repaint.md
+++ b/postmortem/2026-05-13-ime-commit-no-repaint.md
@@ -1,0 +1,55 @@
+# IME committed text reached PTY but terminal did not repaint
+
+## What happened
+
+On macOS, Chinese IME input (both system Pinyin and WeChat IME) showed the
+candidate window correctly but committed text never appeared in the terminal.
+The characters were silently dropped from the user's perspective.
+
+## Root cause
+
+`GhosttyInputHandler::replace_text_in_range` and
+`replace_and_mark_text_in_range` both called `self.view.update(cx, |view, _|
+{ ... })` — discarding the `&mut Context<GhosttyView>` closure argument — so
+`cx.notify()` was never called after the IME commit.
+
+When the user selects a candidate word, AppKit calls `insertText:` →
+`replace_text_in_range`. The handler correctly called `terminal.send_text()`
+and `terminal.refresh()`, so the bytes reached the PTY. But without
+`cx.notify()`, GPUI did not schedule a redraw, so the terminal surface never
+repainted and the committed text was invisible.
+
+The same omission in `replace_and_mark_text_in_range` meant the preedit
+(marked text) phase also did not trigger a repaint, though this was less
+noticeable because Ghostty renders the composition inline.
+
+`window.invalidate_character_coordinates()` was also missing from all three
+callbacks (`replace_text_in_range`, `replace_and_mark_text_in_range`,
+`unmark_text`), which could cause the IME candidate window to appear at a
+stale position after the cursor moved.
+
+## Fix applied
+
+In all three `GhosttyInputHandler` callbacks:
+
+- Changed `|view, _|` to `|view, cx|` and added `cx.notify()` so GPUI
+  schedules a repaint after every IME state change.
+- Changed `_window` to `window` and added
+  `window.invalidate_character_coordinates()` so the candidate window
+  position is refreshed each time.
+
+## What we learned
+
+`InputHandler` callbacks receive `&mut Window` and (via `view.update`) a
+`&mut Context<V>`. Both must be used:
+
+- `cx.notify()` — required after any state change that should be visible on
+  screen. Without it GPUI will not redraw even if the underlying PTY state
+  changed.
+- `window.invalidate_character_coordinates()` — required after any IME state
+  change so the platform can re-query `bounds_for_range` for candidate window
+  placement.
+
+The pattern `self.view.update(cx, |view, _| { ... })` silently discards the
+context and is a footgun in input handler callbacks. Always name the second
+closure argument and call `cx.notify()` when state changes.


### PR DESCRIPTION
## Problem

Fixes #210

On macOS, Chinese IME input (system Pinyin and WeChat IME) showed the candidate window correctly but committed text did not reliably appear in the Ghostty-backed terminal.

## Root cause

`GhosttyInputHandler`'s IME callbacks updated terminal/IME state but did not notify GPUI after those changes, so the bytes could reach the PTY while the terminal view failed to repaint.

The callbacks also did not invalidate character coordinates after IME state changes, which could leave the candidate window positioned from stale cursor bounds.

## Fix

In `replace_text_in_range`, `replace_and_mark_text_in_range`, and `unmark_text`:

- call `cx.notify()` after IME state changes so GPUI schedules a repaint
- call `window.invalidate_character_coordinates()` so AppKit re-queries candidate-window bounds
- send committed IME text through Ghostty's key-event path rather than `ghostty_surface_text`, avoiding bracketed-paste wrapping and the post-paste selection highlight for committed IME text
- preserve direct ASCII IME inserts as per-character key events when there was no active marked text, keeping shell key handling and suggestions on the normal typed-key path

This PR also renders marked IME preedit text as a lightweight GPUI overlay at the terminal cursor so composition remains visible while Ghostty owns the native terminal surface. The overlay uses Ghostty's configured foreground/background colors for contrast; `GhosttyApp::foreground_rgb()` was added for that terminal-surface integration point, matching the existing `background_rgb()` accessor.

## Notes

The earlier surface-shortcut change was dropped during rebase because #214 already fixed that issue on `main`.

<img width="1864" height="186" alt="image" src="https://github.com/user-attachments/assets/30d02587-836b-4e1e-8a32-63ac2bc2dfe9" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where macOS Chinese IME committed text reached the terminal but did not properly repaint.
  * Fixed IME candidate position updates following cursor movement.

* **New Features**
  * Added visual preedit overlay displaying IME marked text at the correct terminal location.

* **Documentation**
  * Added postmortem document detailing IME behavior improvements and lessons learned.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nowledge-co/con-terminal/pull/213)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
