### PR TITLE
Polish sidebar chrome and harden Zig release builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## `v0.1.0-beta.76` - 2026-05-14
+
+### Changed
+
+**Sidebar**
+
+- Polished the Files/Search sidebar controls, file-tree hover treatment, and
+  dark-mode chrome affordances so sidebar tools stay readable without adding
+  extra visual weight. _(PR
+  [#215](https://github.com/nowledge-co/con-terminal/pull/215) by
+  [@wey-gu](https://github.com/wey-gu))_
+
+### Fixed
+
+**Sidebar**
+
+- Fixed a sidebar hover performance regression by keeping file-tree hover state
+  on stable row elements and explicitly occluding sidebar surfaces from the
+  embedded terminal underneath. _(PR
+  [#215](https://github.com/nowledge-co/con-terminal/pull/215) by
+  [@wey-gu](https://github.com/wey-gu))_
+
+**Settings**
+
+- Corrected the Settings unsaved-state colors in light and dark themes so the
+  warning status uses the semantic warning color instead of the foreground color
+  intended for text on warning backgrounds. _(PR
+  [#215](https://github.com/nowledge-co/con-terminal/pull/215) by
+  [@wey-gu](https://github.com/wey-gu))_
+
+---
+
 ## `v0.1.0-beta.75` - 2026-05-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ### Fixed
 
+**Build**
+
+- Hardened Windows and Linux libghostty-vt builds against transient Zig package
+  fetch failures during both `zig build -h` probing and the actual VT build, so
+  release builds retry after prewarming Zig's package cache instead of
+  misreporting a package-fetch error as a missing libghostty-vt build knob.
+  _(PR [#215](https://github.com/nowledge-co/con-terminal/pull/215) by
+  [@wey-gu](https://github.com/wey-gu))_
+
 **Sidebar**
 
 - Fixed a sidebar hover performance regression by keeping file-tree hover state

--- a/crates/con-app/src/activity_bar.rs
+++ b/crates/con-app/src/activity_bar.rs
@@ -6,16 +6,16 @@
 //! Visual rules
 //! ---
 //! - Fixed height: 32 px while the left sidebar is visible.
-//! - Active slot: accent-colored icon.
-//! - Inactive slots: muted_foreground icon.
-//! - No text labels — icons only.
+//! - Active slot: quiet filled tab with foreground icon + label.
+//! - Inactive slots: muted foreground; hover stays subtle to avoid a jumpy bubble.
 //! - Surface separation via bg opacity, no borders.
 
 use gpui::{
-    Context, EventEmitter, IntoElement, ParentElement, Render, Styled, Window, div, prelude::*, px,
+    Context, EventEmitter, FontWeight, IntoElement, ParentElement, Render, Styled, Window, div,
+    prelude::*, px, svg,
 };
 use gpui_component::{
-    ActiveTheme, Icon, Selectable, Sizable as _,
+    ActiveTheme, Icon, Sizable as _,
     button::{Button, ButtonVariants as _},
 };
 
@@ -103,16 +103,14 @@ impl Render for ActivityBar {
             .flex_row()
             .items_center()
             .justify_between()
-            .px(px(10.0))
+            .pl(px(8.0))
+            .pr(px(8.0))
             .flex_shrink_0()
             .child(
                 div()
                     .flex()
                     .items_center()
                     .gap(px(3.0))
-                    .p(px(1.0))
-                    .rounded(px(6.0))
-                    .bg(theme.foreground.opacity(0.038))
                     .child(activity_slot_button(
                         "activity-files",
                         "phosphor/folder.svg",
@@ -138,9 +136,13 @@ impl Render for ActivityBar {
                 Button::new("activity-close")
                     .icon(Icon::default().path("phosphor/x.svg"))
                     .ghost()
-                    .text_color(theme.muted_foreground)
+                    .text_color(theme.muted_foreground.opacity(if theme.is_dark() {
+                        0.82
+                    } else {
+                        0.70
+                    }))
                     .rounded(px(5.0))
-                    .with_size(px(22.0))
+                    .with_size(px(20.0))
                     .cursor_pointer()
                     .on_click(cx.listener(|this, _: &gpui::ClickEvent, _window, cx| {
                         this.close_panel(cx);
@@ -156,23 +158,57 @@ fn activity_slot_button<F>(
     active: bool,
     theme: &gpui_component::Theme,
     handler: F,
-) -> impl IntoElement
+) -> impl IntoElement + use<F>
 where
     F: Fn(&gpui::ClickEvent, &mut Window, &mut gpui::App) + 'static,
 {
     let icon_color = if active {
-        theme.primary
+        theme.foreground
     } else {
-        theme.muted_foreground
+        theme
+            .muted_foreground
+            .opacity(if theme.is_dark() { 0.82 } else { 0.72 })
     };
-    Button::new(id)
-        .icon(Icon::default().path(icon))
-        .ghost()
-        .selected(active)
-        .text_color(icon_color)
+    let label_color = if active {
+        theme.foreground
+    } else {
+        theme
+            .muted_foreground
+            .opacity(if theme.is_dark() { 0.78 } else { 0.66 })
+    };
+    let active_bg = theme
+        .foreground
+        .opacity(if theme.is_dark() { 0.105 } else { 0.052 });
+    let hover_bg = theme
+        .foreground
+        .opacity(if theme.is_dark() { 0.060 } else { 0.034 });
+
+    div()
+        .id(id)
+        .flex()
+        .items_center()
+        .justify_center()
+        .h(px(24.0))
+        .px(px(6.0))
+        .gap(px(4.5))
         .rounded(px(5.0))
-        .with_size(px(24.0))
-        .tooltip(tooltip)
+        .bg(if active { active_bg } else { theme.transparent })
+        .text_color(label_color)
+        .hover(move |s| s.bg(if active { active_bg } else { hover_bg }))
         .cursor_pointer()
+        .occlude()
         .on_click(handler)
+        .child(svg().path(icon).size(px(12.5)).text_color(icon_color))
+        .child(
+            div()
+                .text_size(px(11.0))
+                .line_height(px(14.0))
+                .font_weight(if active {
+                    FontWeight::MEDIUM
+                } else {
+                    FontWeight::NORMAL
+                })
+                .text_color(label_color)
+                .child(tooltip),
+        )
 }

--- a/crates/con-app/src/file_tree_view.rs
+++ b/crates/con-app/src/file_tree_view.rs
@@ -254,8 +254,12 @@ impl Render for FileTreeView {
         }
 
         let active_path = self.active_path.clone();
-        let accent_bg = theme.primary.opacity(0.10);
-        let hover_bg = theme.foreground.opacity(0.055);
+        let accent_bg = theme
+            .primary
+            .opacity(if theme.is_dark() { 0.12 } else { 0.075 });
+        let hover_bg = theme
+            .foreground
+            .opacity(if theme.is_dark() { 0.046 } else { 0.026 });
 
         let entries = self.entries.clone();
         let entry_count = entries.len();
@@ -316,11 +320,11 @@ impl Render for FileTreeView {
                     div()
                         .id(("file-row", idx))
                         .h(px(ROW_HEIGHT))
+                        .w_full()
                         .flex()
                         .items_center()
-                        .mx(px(6.0))
-                        .rounded(px(6.0))
                         .pl(px(indent))
+                        .pr(px(8.0))
                         .gap(px(5.0))
                         .bg(row_bg)
                         .cursor_pointer()
@@ -380,6 +384,7 @@ impl Render for FileTreeView {
             .size_full()
             .flex()
             .flex_col()
+            .occlude()
             .child(list)
             .into_any_element()
     }

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -5439,8 +5439,12 @@ impl Render for SettingsPanel {
         let save_button_tint = theme.foreground.opacity(if has_unsaved_changes {
             if theme.is_dark() { 0.88 } else { 0.82 }
         } else {
-            0.48
+            if theme.is_dark() { 0.62 } else { 0.52 }
         });
+        let config_button_tone =
+            theme
+                .foreground
+                .opacity(if theme.is_dark() { 0.66 } else { 0.54 });
         let save_button_style = ButtonCustomVariant::new(cx)
             .color(save_button_tint.opacity(if has_unsaved_changes { 0.11 } else { 0.04 }))
             .foreground(save_button_tint)
@@ -5556,13 +5560,17 @@ impl Render for SettingsPanel {
                                             (
                                                 "phosphor/warning.svg",
                                                 "Unsaved",
-                                                theme.foreground.opacity(0.54),
+                                                theme
+                                                    .warning
+                                                    .opacity(if theme.is_dark() { 0.96 } else { 0.92 }),
                                             )
                                         } else {
                                             (
                                                 "phosphor/check-circle-fill.svg",
                                                 "Saved",
-                                                theme.muted_foreground.opacity(0.46),
+                                                theme
+                                                    .foreground
+                                                    .opacity(if theme.is_dark() { 0.52 } else { 0.42 }),
                                             )
                                         };
                                         div()
@@ -5571,6 +5579,18 @@ impl Render for SettingsPanel {
                                             .gap(px(5.0))
                                             .min_w(px(64.0))
                                             .justify_end()
+                                            .px(px(7.0))
+                                            .h(px(24.0))
+                                            .rounded(px(6.0))
+                                            .bg(if has_unsaved_changes {
+                                                theme.warning.opacity(if theme.is_dark() {
+                                                    0.095
+                                                } else {
+                                                    0.070
+                                                })
+                                            } else {
+                                                theme.transparent
+                                            })
                                             .child(
                                                 svg()
                                                     .path(icon)
@@ -5600,9 +5620,7 @@ impl Render for SettingsPanel {
                                                 svg()
                                                     .path("phosphor/file-text.svg")
                                                     .size(px(15.0 * header_density))
-                                                    .text_color(
-                                                        theme.muted_foreground.opacity(0.68),
-                                                    ),
+                                                    .text_color(config_button_tone),
                                             )
                                             .on_click(|_, _, cx| {
                                                 let path = Config::config_path();
@@ -5669,7 +5687,11 @@ impl Render for SettingsPanel {
                             .gap(px(12.0))
                             .min_h(px(42.0))
                             .px(px(20.0))
-                            .bg(theme.foreground.opacity(0.048))
+                            .bg(theme.warning.opacity(if theme.is_dark() {
+                                0.075
+                            } else {
+                                0.055
+                            }))
                             .child(
                                 div()
                                     .flex()
@@ -5680,14 +5702,22 @@ impl Render for SettingsPanel {
                                         svg()
                                             .path("phosphor/warning.svg")
                                             .size(px(14.0))
-                                            .text_color(theme.foreground.opacity(0.64)),
+                                            .text_color(theme.warning.opacity(if theme.is_dark() {
+                                                0.96
+                                            } else {
+                                                0.90
+                                            })),
                                     )
                                     .child(
                                         div()
                                             .text_size(px(12.0))
                                             .line_height(px(16.0))
                                             .font_weight(FontWeight::MEDIUM)
-                                            .text_color(theme.foreground.opacity(0.72))
+                                            .text_color(theme.foreground.opacity(if theme.is_dark() {
+                                                0.84
+                                            } else {
+                                                0.76
+                                            }))
                                             .whitespace_nowrap()
                                             .child("Save changes before closing?"),
                                     ),

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -785,6 +785,7 @@ impl Render for ConWorkspace {
                 .flex_row()
                 .flex_shrink_0()
                 .overflow_hidden()
+                .occlude()
                 .bg(elevated_panel_surface_color);
             if show_vertical_tabs {
                 left_sidebar = left_sidebar.child(
@@ -806,7 +807,8 @@ impl Render for ConWorkspace {
                     .flex()
                     .flex_col()
                     .flex_shrink_0()
-                    .overflow_hidden();
+                    .overflow_hidden()
+                    .occlude();
                 if !vertical_tabs_enabled {
                     sidebar_panel = sidebar_panel.child(self.activity_bar.clone());
                 }

--- a/crates/con-app/src/workspace/render/top_bar.rs
+++ b/crates/con-app/src/workspace/render/top_bar.rs
@@ -56,6 +56,37 @@ fn top_bar_trailing_pad(window: &Window) -> f32 {
     }
 }
 
+fn chrome_icon_tone(theme: &gpui_component::Theme, compact_titlebar_progress: f32) -> Hsla {
+    let base = if theme.is_dark() { 0.62 } else { 0.52 };
+    theme
+        .foreground
+        .opacity(base + (0.08 * compact_titlebar_progress))
+}
+
+fn chrome_toggle_tone(
+    theme: &gpui_component::Theme,
+    active: bool,
+    compact_titlebar_progress: f32,
+) -> Hsla {
+    if active {
+        theme.primary
+    } else {
+        chrome_icon_tone(theme, compact_titlebar_progress)
+    }
+}
+
+fn chrome_control_hover_bg(theme: &gpui_component::Theme) -> Hsla {
+    theme
+        .foreground
+        .opacity(if theme.is_dark() { 0.12 } else { 0.075 })
+}
+
+fn chrome_control_active_bg(theme: &gpui_component::Theme) -> Hsla {
+    theme
+        .primary
+        .opacity(if theme.is_dark() { 0.14 } else { 0.09 })
+}
+
 impl ConWorkspace {
     pub(super) fn render_top_bar(
         &mut self,
@@ -1123,9 +1154,9 @@ impl ConWorkspace {
             }
         }
 
-        let new_tab_icon_color = theme
-            .muted_foreground
-            .opacity(0.45 + (0.08 * compact_titlebar_progress));
+        let new_tab_icon_color = chrome_icon_tone(theme, compact_titlebar_progress);
+        let chrome_hover_bg = chrome_control_hover_bg(theme);
+        let chrome_active_bg = chrome_control_active_bg(theme);
         let new_tab_button = div()
             .id("tab-new")
             .flex()
@@ -1141,7 +1172,7 @@ impl ConWorkspace {
             // click listener). Same treatment as the Min/Max/Close
             // caption buttons at the top of this file.
             .occlude()
-            .hover(|s| s.bg(theme.muted.opacity(0.12)))
+            .hover(move |s| s.bg(chrome_hover_bg))
             .tooltip(|window, cx| {
                 chrome_tooltip(
                     "New tab",
@@ -1181,7 +1212,12 @@ impl ConWorkspace {
                 .rounded(px(5.0))
                 .cursor_pointer()
                 .occlude()
-                .hover(|s| s.bg(theme.muted.opacity(0.10)))
+                .bg(if self.left_panel_open {
+                    chrome_active_bg
+                } else {
+                    theme.transparent
+                })
+                .hover(move |s| s.bg(chrome_hover_bg))
                 .tooltip(move |window, cx| {
                     chrome_tooltip(
                         left_sidebar_tooltip,
@@ -1200,11 +1236,11 @@ impl ConWorkspace {
                     svg()
                         .path("phosphor/sidebar.svg")
                         .size(px(12.0))
-                        .text_color(if self.left_panel_open {
-                            theme.primary
-                        } else {
-                            theme.muted_foreground.opacity(0.4)
-                        }),
+                        .text_color(chrome_toggle_tone(
+                            theme,
+                            self.left_panel_open,
+                            compact_titlebar_progress,
+                        )),
                 ),
         );
 
@@ -1224,7 +1260,12 @@ impl ConWorkspace {
                 .rounded(px(5.0))
                 .cursor_pointer()
                 .occlude()
-                .hover(|s| s.bg(theme.muted.opacity(0.10)))
+                .bg(if self.input_bar_visible {
+                    chrome_active_bg
+                } else {
+                    theme.transparent
+                })
+                .hover(move |s| s.bg(chrome_hover_bg))
                 .tooltip(move |window, cx| {
                     chrome_tooltip(
                         input_bar_tooltip,
@@ -1243,11 +1284,11 @@ impl ConWorkspace {
                     svg()
                         .path("phosphor/square-half-bottom-fill.svg")
                         .size(px(12.0))
-                        .text_color(if self.input_bar_visible {
-                            theme.primary
-                        } else {
-                            theme.muted_foreground.opacity(0.4)
-                        }),
+                        .text_color(chrome_toggle_tone(
+                            theme,
+                            self.input_bar_visible,
+                            compact_titlebar_progress,
+                        )),
                 ),
         );
 
@@ -1267,7 +1308,12 @@ impl ConWorkspace {
                 .rounded(px(5.0))
                 .cursor_pointer()
                 .occlude()
-                .hover(|s| s.bg(theme.muted.opacity(0.10)))
+                .bg(if self.agent_panel_open {
+                    chrome_active_bg
+                } else {
+                    theme.transparent
+                })
+                .hover(move |s| s.bg(chrome_hover_bg))
                 .tooltip(move |window, cx| {
                     chrome_tooltip(
                         agent_panel_tooltip,
@@ -1286,11 +1332,11 @@ impl ConWorkspace {
                     svg()
                         .path("phosphor/square-half-fill.svg")
                         .size(px(12.0))
-                        .text_color(if self.agent_panel_open {
-                            theme.primary
-                        } else {
-                            theme.muted_foreground.opacity(0.4)
-                        }),
+                        .text_color(chrome_toggle_tone(
+                            theme,
+                            self.agent_panel_open,
+                            compact_titlebar_progress,
+                        )),
                 ),
         );
 
@@ -1311,7 +1357,7 @@ impl ConWorkspace {
                     .rounded(px(5.0))
                     .cursor_pointer()
                     .occlude()
-                    .hover(|s| s.bg(theme.muted.opacity(0.10)))
+                    .hover(move |s| s.bg(chrome_hover_bg))
                     .tooltip(|window, cx| {
                         chrome_tooltip(
                             "Settings",
@@ -1330,11 +1376,10 @@ impl ConWorkspace {
                         this.toggle_settings(&settings_panel::ToggleSettings, window, cx);
                     }))
                     .child(
-                        svg().path("phosphor/gear.svg").size(px(12.0)).text_color(
-                            theme
-                                .muted_foreground
-                                .opacity(0.45 + (0.08 * compact_titlebar_progress)),
-                        ),
+                        svg()
+                            .path("phosphor/gear.svg")
+                            .size(px(12.0))
+                            .text_color(chrome_icon_tone(theme, compact_titlebar_progress)),
                     ),
             );
         }

--- a/crates/con-ghostty/build.rs
+++ b/crates/con-ghostty/build.rs
@@ -301,12 +301,10 @@ fn build_vt_backend(target_os: &str) {
     let optimize = ghostty_optimize();
     let zig_target = ghostty_vt_zig_target();
 
-    let mut cmd = Command::new(&zig_bin);
-    cmd.current_dir(&ghostty_dir);
-    configure_zig_command(&mut cmd, zig_global_cache_dir.as_deref());
-    cmd.arg("build");
+    let mut build_args = Vec::new();
+    build_args.push("build".to_string());
     for arg in &invocation {
-        cmd.arg(arg);
+        build_args.push(arg.clone());
     }
     if let Some(zig_target) = &zig_target {
         // Do not let Zig default to the build machine's native CPU for
@@ -314,27 +312,47 @@ fn build_vt_backend(target_os: &str) {
         // that WSL / older x86_64 hosts do not support, and a native-built
         // static lib can SIGILL even when the Rust binary itself is generic.
         println!("cargo:warning=building libghostty-vt for Zig target {zig_target}");
-        cmd.arg(format!("-Dtarget={zig_target}"));
+        build_args.push(format!("-Dtarget={zig_target}"));
     } else {
         println!(
             "cargo:warning=building libghostty-vt without explicit Zig target; \
              set {GHOSTTY_VT_TARGET_ENV} to avoid native CPU codegen"
         );
     }
-    cmd.args([&format!("-Doptimize={optimize}"), simd_flag]);
+    build_args.push(format!("-Doptimize={optimize}"));
+    build_args.push(simd_flag.to_string());
 
-    let status = cmd
-        .status()
-        .expect("failed to run zig build for libghostty-vt");
+    let status = run_zig_command_status(
+        &zig_bin,
+        &ghostty_dir,
+        zig_global_cache_dir.as_deref(),
+        &build_args,
+    )
+    .expect("failed to run zig build for libghostty-vt");
 
     if !status.success() {
-        panic!(
-            "zig build {:?} failed; see output above.\n\
-             If this Ghostty revision doesn't expose libghostty-vt,\n\
-             bump GHOSTTY_REV in crates/con-ghostty/build.rs or set\n\
-             CON_GHOSTTY_VT_STEP to the correct step name.",
-            invocation
+        println!(
+            "cargo:warning=zig build failed for libghostty-vt; prefetching Zig package cache and retrying"
         );
+        prefetch_zig_dependencies(&zig_bin, &ghostty_dir, zig_global_cache_dir.as_deref());
+
+        let retry_status = run_zig_command_status(
+            &zig_bin,
+            &ghostty_dir,
+            zig_global_cache_dir.as_deref(),
+            &build_args,
+        )
+        .expect("failed to retry zig build for libghostty-vt");
+
+        if !retry_status.success() {
+            panic!(
+                "zig build {:?} failed after package-cache prefetch; see output above.\n\
+                 If this Ghostty revision doesn't expose libghostty-vt,\n\
+                 bump GHOSTTY_REV in crates/con-ghostty/build.rs or set\n\
+                 CON_GHOSTTY_VT_STEP to the correct step name.",
+                invocation
+            );
+        }
     }
 
     // Zig produces both a shared library (`ghostty-vt.dll` +
@@ -422,22 +440,7 @@ fn pick_vt_invocation(
         }
     }
 
-    let mut cmd = Command::new(zig_bin);
-    cmd.args(["build", "-h"]).current_dir(ghostty_dir);
-    configure_zig_command(&mut cmd, zig_global_cache_dir);
-    let output = cmd.output();
-
-    let help_text = match output {
-        Ok(out) => {
-            let mut text = String::new();
-            text.push_str(&String::from_utf8_lossy(&out.stdout));
-            text.push_str(&String::from_utf8_lossy(&out.stderr));
-            text
-        }
-        Err(err) => {
-            panic!("failed to run `zig build -h` in Ghostty checkout: {err}");
-        }
-    };
+    let help_text = zig_build_help_text(zig_bin, ghostty_dir, zig_global_cache_dir);
 
     // Preferred: current Ghostty exposes `-Demit-lib-vt=[bool]` which
     // configures the default `install` step to produce only
@@ -479,6 +482,68 @@ fn pick_vt_invocation(
 }
 
 // ── Shared helpers ─────────────────────────────────────────────────────
+
+fn run_zig_command_status(
+    zig_bin: &OsStr,
+    dir: &Path,
+    zig_global_cache_dir: Option<&Path>,
+    args: &[String],
+) -> std::io::Result<std::process::ExitStatus> {
+    let mut cmd = Command::new(zig_bin);
+    configure_zig_command(&mut cmd, zig_global_cache_dir);
+    cmd.args(args).current_dir(dir).status()
+}
+
+fn zig_build_help_text(
+    zig_bin: &OsStr,
+    ghostty_dir: &Path,
+    zig_global_cache_dir: Option<&Path>,
+) -> String {
+    let args = vec!["build".to_string(), "-h".to_string()];
+
+    for attempt in 0..2 {
+        let mut cmd = Command::new(zig_bin);
+        configure_zig_command(&mut cmd, zig_global_cache_dir);
+        let output = cmd.args(&args).current_dir(ghostty_dir).output();
+
+        let out = match output {
+            Ok(out) => out,
+            Err(err) => {
+                panic!("failed to run `zig build -h` in Ghostty checkout: {err}");
+            }
+        };
+
+        let mut text = String::new();
+        text.push_str(&String::from_utf8_lossy(&out.stdout));
+        text.push_str(&String::from_utf8_lossy(&out.stderr));
+
+        if out.status.success() {
+            return text;
+        }
+
+        if attempt == 0 {
+            println!(
+                "cargo:warning=`zig build -h` failed while probing libghostty-vt; prefetching Zig package cache and retrying"
+            );
+            prefetch_zig_dependencies(zig_bin, ghostty_dir, zig_global_cache_dir);
+            continue;
+        }
+
+        panic!(
+            "\n========================================================\n\
+             con-ghostty: `zig build -h` failed while probing the\n\
+             libghostty-vt build surface, even after Zig package-cache\n\
+             prefetch. This usually means Zig could not resolve an\n\
+             upstream package dependency, not that libghostty-vt is\n\
+             missing from the pinned Ghostty checkout.\n\n\
+             `zig build -h` output:\n{help}\n\
+             ========================================================\n",
+            help = text,
+        );
+    }
+
+    unreachable!("two-attempt zig build help loop must return or panic")
+}
 
 fn ghostty_vt_zig_target() -> Option<String> {
     if let Some(target) = env::var_os(GHOSTTY_VT_TARGET_ENV) {

--- a/postmortem/2026-05-14-windows-release-zig-help-prefetch.md
+++ b/postmortem/2026-05-14-windows-release-zig-help-prefetch.md
@@ -1,0 +1,45 @@
+# Windows release Zig help probe package fetch failure
+
+## What happened
+
+The `v0.1.0-beta.75` Windows release workflow failed while building
+`con-ghostty`. The build script ran `zig build -h` to detect the pinned
+Ghostty checkout's libghostty-vt build surface, but Zig attempted to resolve a
+package dependency during help generation and failed with:
+
+```text
+invalid HTTP response: HttpConnectionClosing
+```
+
+The build script then treated the failed help output as normal help text,
+could not find the libghostty-vt option/step, and panicked with the misleading
+"couldn't find a libghostty-vt build knob" message.
+
+## Root Cause
+
+`pick_vt_invocation` only handled spawn failures for `zig build -h`; it did not
+check whether the command exited successfully. Any non-zero help probe output
+was parsed as if it were valid help. That made transient Zig package-fetch
+failures look like upstream Ghostty had removed or renamed the VT build knob.
+
+The macOS full-libghostty build already retried after prefetching Zig package
+dependencies, but the Windows/Linux libghostty-vt path did not use that retry
+strategy for either the help probe or the actual VT build.
+
+## Fix Applied
+
+- `zig build -h` now checks the exit status.
+- A failed help probe prefetches Zig package dependencies into the active global
+  cache, then retries once.
+- If the retry still fails, the panic now reports a help-probe/package
+  resolution failure instead of claiming the VT build knob is missing.
+- Windows/Linux libghostty-vt builds now also retry once after the same package
+  cache prefetch.
+
+## What We Learned
+
+Zig help generation can touch package resolution for upstream projects, so
+release build probes must be treated as real build-system commands with
+network/cache failure modes. Probe failures should be classified before parsing
+their output; otherwise a transient dependency fetch turns into a false design
+diagnosis and blocks release triage.


### PR DESCRIPTION
## Summary
- improve dark-mode contrast for titlebar chrome and settings controls
- polish Files/Search sidebar controls and file-tree hover states
- fix the sidebar/file-tree hover performance regression by keeping hover state on stable row elements and occluding the terminal surface
- fix the beta.75 Windows release failure mode: libghostty-vt now retries Zig package-fetch failures during both `zig build -h` probing and the actual VT build after prewarming Zig's package cache, instead of misreporting the transient fetch error as a missing build knob

## Failure addressed
The previous Windows release failed because `zig build -h` tried to resolve a Ghostty Zig package and hit `invalid HTTP response: HttpConnectionClosing`. The build script parsed that failed output as normal help text and panicked with a misleading missing-libghostty-vt-build-knob message.

This PR checks the help probe exit status, prefetches Zig package dependencies, retries, and gives a correct failure if retry still cannot resolve packages.

## Validation
- `cargo check -p con-ghostty`
- `cargo check -p con`
- `cargo test -p con workspace::tests::activity_bar_visibility_tracks_left_sidebar_visibility -- --nocapture`
- `git diff --check`
- `cargo run -p con` boot smoke
- PR CI: Ubuntu, Windows, and macOS e2e passed
