### PR TITLE
Fix stale provider activation after credentials are cleared

### DIFF
--- a/crates/con-app/src/agent_panel.rs
+++ b/crates/con-app/src/agent_panel.rs
@@ -5152,6 +5152,40 @@ mod tests {
     }
 
     #[test]
+    fn provider_api_key_env_is_treated_as_configured() {
+        let mut config = AgentConfig::default();
+        config.providers.set(
+            &ProviderKind::Anthropic,
+            ProviderConfig {
+                api_key_env: Some("ANTHROPIC_API_KEY".to_string()),
+                ..ProviderConfig::default()
+            },
+        );
+
+        assert!(AgentPanel::provider_is_configured(
+            &config,
+            &ProviderKind::Anthropic
+        ));
+    }
+
+    #[test]
+    fn provider_whitespace_api_key_is_not_configured() {
+        let mut config = AgentConfig::default();
+        config.providers.set(
+            &ProviderKind::OpenAI,
+            ProviderConfig {
+                api_key: Some("   ".to_string()),
+                ..ProviderConfig::default()
+            },
+        );
+
+        assert!(!AgentPanel::provider_is_configured(
+            &config,
+            &ProviderKind::OpenAI
+        ));
+    }
+
+    #[test]
     fn openai_compatible_base_url_only_is_treated_as_configured() {
         let mut config = AgentConfig::default();
         config.providers.set(

--- a/crates/con-app/src/agent_panel.rs
+++ b/crates/con-app/src/agent_panel.rs
@@ -852,39 +852,43 @@ impl AgentPanel {
             return true;
         }
 
-        let has_meaningful_config = |kind: &ProviderKind| {
+        let has_auth_config = |kind: &ProviderKind| {
             config.providers.get(kind).is_some_and(|provider| {
-                provider
-                    .model
+                let has_api_key = provider
+                    .api_key
                     .as_ref()
                     .is_some_and(|v| !v.trim().is_empty())
                     || provider
-                        .api_key
-                        .as_ref()
-                        .is_some_and(|v| !v.trim().is_empty())
-                    || provider
                         .api_key_env
                         .as_ref()
-                        .is_some_and(|v| !v.trim().is_empty())
-                    || provider
+                        .is_some_and(|v| !v.trim().is_empty());
+                if has_api_key {
+                    return true;
+                }
+
+                *kind == ProviderKind::OpenAICompatible
+                    && provider
                         .base_url
                         .as_ref()
                         .is_some_and(|v| !v.trim().is_empty())
-                    || provider.max_tokens.is_some()
             })
         };
 
-        has_meaningful_config(&sidebar_provider)
+        has_auth_config(&sidebar_provider)
             || match sidebar_provider {
-                ProviderKind::MiniMax => has_meaningful_config(&ProviderKind::MiniMaxAnthropic),
-                ProviderKind::Moonshot => has_meaningful_config(&ProviderKind::MoonshotAnthropic),
-                ProviderKind::ZAI => has_meaningful_config(&ProviderKind::ZAIAnthropic),
+                ProviderKind::MiniMax => has_auth_config(&ProviderKind::MiniMaxAnthropic),
+                ProviderKind::Moonshot => has_auth_config(&ProviderKind::MoonshotAnthropic),
+                ProviderKind::ZAI => has_auth_config(&ProviderKind::ZAIAnthropic),
                 _ => false,
             }
     }
 
     pub fn configured_session_providers(config: &AgentConfig) -> Vec<ProviderKind> {
-        let mut providers = vec![Self::session_sidebar_provider_kind(&config.provider)];
+        let current_provider = Self::session_sidebar_provider_kind(&config.provider);
+        let mut providers = Vec::new();
+        if Self::provider_is_configured(config, &current_provider) {
+            providers.push(current_provider.clone());
+        }
         for provider in [
             ProviderKind::Anthropic,
             ProviderKind::OpenAI,
@@ -904,6 +908,9 @@ impl AgentPanel {
             if Self::provider_is_configured(config, &provider) && !providers.contains(&provider) {
                 providers.push(provider);
             }
+        }
+        if providers.is_empty() {
+            providers.push(current_provider);
         }
         providers
     }
@@ -5056,10 +5063,14 @@ fn humanize_model_name(model: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{AgentPanel, PanelState, StepStatus, humanize_model_name};
+    use con_agent::{AgentConfig, ProviderConfig, ProviderKind};
 
     #[test]
     fn humanize_strips_date_suffix() {
-        assert_eq!(humanize_model_name("claude-sonnet-4-5-20250929"), "Sonnet 4.5");
+        assert_eq!(
+            humanize_model_name("claude-sonnet-4-5-20250929"),
+            "Sonnet 4.5"
+        );
         assert_eq!(humanize_model_name("claude-opus-4-1-20250805"), "Opus 4.1");
         assert_eq!(humanize_model_name("claude-sonnet-4-6"), "Sonnet 4.6");
         assert_eq!(humanize_model_name(""), "No model");
@@ -5104,6 +5115,83 @@ mod tests {
             text.chars().count() as u32,
             false,
         ));
+    }
+
+    #[test]
+    fn provider_model_only_is_not_treated_as_configured() {
+        let mut config = AgentConfig::default();
+        config.providers.set(
+            &ProviderKind::OpenAI,
+            ProviderConfig {
+                model: Some("gpt-4o".to_string()),
+                ..ProviderConfig::default()
+            },
+        );
+
+        assert!(!AgentPanel::provider_is_configured(
+            &config,
+            &ProviderKind::OpenAI
+        ));
+    }
+
+    #[test]
+    fn provider_api_key_is_treated_as_configured() {
+        let mut config = AgentConfig::default();
+        config.providers.set(
+            &ProviderKind::OpenAI,
+            ProviderConfig {
+                api_key: Some("sk-test".to_string()),
+                ..ProviderConfig::default()
+            },
+        );
+
+        assert!(AgentPanel::provider_is_configured(
+            &config,
+            &ProviderKind::OpenAI
+        ));
+    }
+
+    #[test]
+    fn openai_compatible_base_url_only_is_treated_as_configured() {
+        let mut config = AgentConfig::default();
+        config.providers.set(
+            &ProviderKind::OpenAICompatible,
+            ProviderConfig {
+                base_url: Some("http://127.0.0.1:11434/v1".to_string()),
+                ..ProviderConfig::default()
+            },
+        );
+
+        assert!(AgentPanel::provider_is_configured(
+            &config,
+            &ProviderKind::OpenAICompatible
+        ));
+    }
+
+    #[test]
+    fn configured_provider_list_excludes_model_only_entries() {
+        let mut config = AgentConfig {
+            provider: ProviderKind::Anthropic,
+            ..AgentConfig::default()
+        };
+        config.providers.set(
+            &ProviderKind::OpenAI,
+            ProviderConfig {
+                model: Some("gpt-4.1".to_string()),
+                ..ProviderConfig::default()
+            },
+        );
+        config.providers.set(
+            &ProviderKind::Anthropic,
+            ProviderConfig {
+                api_key: Some("sk-ant-test".to_string()),
+                ..ProviderConfig::default()
+            },
+        );
+
+        let providers = AgentPanel::configured_session_providers(&config);
+        assert!(providers.contains(&ProviderKind::Anthropic));
+        assert!(!providers.contains(&ProviderKind::OpenAI));
     }
 
     #[test]

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -504,16 +504,11 @@ impl SettingsPanel {
             return true;
         }
 
-        let current_provider =
-            Self::sidebar_provider_kind(&self.selected_provider) == sidebar_provider;
-        if current_provider {
-            let current = self.read_provider_inputs(cx);
-            if Self::provider_config_has_auth_signal(&sidebar_provider, &current) {
-                return true;
-            }
-        }
-
         let has_config = |kind: &ProviderKind| {
+            if *kind == self.selected_provider {
+                let current = self.read_provider_inputs(cx);
+                return Self::provider_config_has_auth_signal(kind, &current);
+            }
             self.config
                 .agent
                 .providers

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -472,21 +472,24 @@ impl SettingsPanel {
         }
     }
 
-    fn provider_config_is_meaningful(config: &ProviderConfig) -> bool {
-        config.model.as_ref().is_some_and(|v| !v.trim().is_empty())
-            || config
-                .api_key
-                .as_ref()
-                .is_some_and(|v| !v.trim().is_empty())
+    fn provider_config_has_auth_signal(provider: &ProviderKind, config: &ProviderConfig) -> bool {
+        let has_api_key = config
+            .api_key
+            .as_ref()
+            .is_some_and(|v| !v.trim().is_empty())
             || config
                 .api_key_env
                 .as_ref()
-                .is_some_and(|v| !v.trim().is_empty())
-            || config
+                .is_some_and(|v| !v.trim().is_empty());
+        if has_api_key {
+            return true;
+        }
+
+        *provider == ProviderKind::OpenAICompatible
+            && config
                 .base_url
                 .as_ref()
                 .is_some_and(|v| !v.trim().is_empty())
-            || config.max_tokens.is_some()
     }
 
     fn provider_is_configured(&self, provider: &ProviderKind, cx: &App) -> bool {
@@ -505,7 +508,7 @@ impl SettingsPanel {
             Self::sidebar_provider_kind(&self.selected_provider) == sidebar_provider;
         if current_provider {
             let current = self.read_provider_inputs(cx);
-            if Self::provider_config_is_meaningful(&current) {
+            if Self::provider_config_has_auth_signal(&sidebar_provider, &current) {
                 return true;
             }
         }
@@ -515,7 +518,7 @@ impl SettingsPanel {
                 .agent
                 .providers
                 .get(kind)
-                .is_some_and(Self::provider_config_is_meaningful)
+                .is_some_and(|config| Self::provider_config_has_auth_signal(kind, config))
         };
 
         has_config(&sidebar_provider)

--- a/crates/con-app/src/workspace/control_agent_tools.rs
+++ b/crates/con-app/src/workspace/control_agent_tools.rs
@@ -820,12 +820,21 @@ impl ConWorkspace {
 
                 match self.resolve_pane_target_for_tab(tab_idx, target) {
                     Ok(resolved) => {
+                        let pane_index = resolved.pane_index;
+                        let pane_id = resolved.pane_id;
+                        let pane_target = con_agent::tools::PaneSelector::new(None, Some(pane_id));
                         let pane = resolved.pane;
                         let has_si = pane.has_shell_integration(cx);
                         let timeout = timeout_secs.unwrap_or(30).min(120);
                         let response_tx = req.response_tx;
 
-                        log::info!("[wait_for] has_si={} is_busy={}", has_si, pane.is_busy(cx),);
+                        log::info!(
+                            "[wait_for] pane_index={} pane_id={} has_si={} is_busy={}",
+                            pane_index,
+                            pane_id,
+                            has_si,
+                            pane.is_busy(cx),
+                        );
 
                         // Check if already in target state before spawning async task
                         if pattern.is_none() && has_si && !pane.is_busy(cx) {
@@ -874,7 +883,15 @@ impl ConWorkspace {
                         // long enough to avoid false positives from progress output.
                         const QUIET_THRESHOLD: u32 = 4;
                         let mut last_snapshot = if use_quiescence {
-                            match this.update(cx, |_, cx| normalize_output(pane.recent_lines(50, cx))) {
+                            match this.update(cx, |workspace, cx| {
+                                workspace
+                                    .resolve_pane_target_for_tab(tab_idx, pane_target)
+                                    .ok()
+                                    .map(|resolved| {
+                                        normalize_output(resolved.pane.recent_lines(50, cx))
+                                    })
+                                    .unwrap_or_default()
+                            }) {
                                 Ok(s) if !s.is_empty() => s,
                                 _ => {
                                     // Terminal not ready yet — use sentinel that won't match real output.
@@ -895,7 +912,13 @@ impl ConWorkspace {
 
                             if std::time::Instant::now() >= deadline {
                                 let output = this
-                                    .update(cx, |_, cx| pane.recent_lines(50, cx).join("\n"))
+                                    .update(cx, |workspace, cx| {
+                                        workspace
+                                            .resolve_pane_target_for_tab(tab_idx, pane_target)
+                                            .ok()
+                                            .map(|resolved| resolved.pane.recent_lines(50, cx).join("\n"))
+                                            .unwrap_or_default()
+                                    })
                                     .unwrap_or_default();
                                 let _ = response_tx.send(PaneResponse::WaitComplete {
                                     status: "timeout".into(),
@@ -904,25 +927,48 @@ impl ConWorkspace {
                                 return;
                             }
 
-                            let done = this
-                                .update(cx, |_, cx| {
+                            enum WaitPoll {
+                                Continue,
+                                Done {
+                                    status: String,
+                                    output: String,
+                                },
+                                Error(String),
+                            }
+
+                            let poll = this
+                                .update(cx, |workspace, cx| {
+                                    let resolved = match workspace
+                                        .resolve_pane_target_for_tab(tab_idx, pane_target)
+                                    {
+                                        Ok(resolved) => resolved,
+                                        Err(err) => return WaitPoll::Error(err),
+                                    };
+                                    let pane = resolved.pane;
+                                    let has_si = pane.has_shell_integration(cx);
+
                                     if let Some(ref pat) = pattern {
                                         // Pattern mode
                                         let content = pane.recent_lines(50, cx).join("\n");
                                         if content.contains(pat.as_str()) {
-                                            Some(("matched".to_string(), content))
+                                            WaitPoll::Done {
+                                                status: "matched".to_string(),
+                                                output: content,
+                                            }
                                         } else {
-                                            None
+                                            WaitPoll::Continue
                                         }
                                     } else if has_si {
                                         // Shell integration idle mode
                                         if pane.take_command_finished(cx).is_some()
                                             || !pane.is_busy(cx)
                                         {
-                                            let output = pane.recent_lines(50, cx).join("\n");
-                                            Some(("idle".to_string(), output))
+                                            WaitPoll::Done {
+                                                status: "idle".to_string(),
+                                                output: pane.recent_lines(50, cx).join("\n"),
+                                            }
                                         } else {
-                                            None
+                                            WaitPoll::Continue
                                         }
                                     } else {
                                         // Quiescence mode: output unchanged for QUIET_THRESHOLD polls
@@ -933,44 +979,54 @@ impl ConWorkspace {
                                             // Never report quiescent-idle until the pane is both alive and ready.
                                             last_snapshot.clear();
                                             stable_count = 0;
-                                            None
+                                            WaitPoll::Continue
                                         } else {
                                             let current = normalize_output(pane.recent_lines(50, cx));
                                             if current.is_empty() {
                                                 // Terminal not producing output yet — don't count as stable
-                                                None
+                                                WaitPoll::Continue
                                             } else if last_snapshot.is_empty() {
                                                 // First non-empty snapshot — set baseline, start counting
                                                 log::info!("[wait_for] quiescence: baseline set ({} bytes)", current.len());
                                                 last_snapshot = current;
                                                 stable_count = 0;
-                                                None
+                                                WaitPoll::Continue
                                             } else if current == last_snapshot {
                                                 stable_count += 1;
                                                 log::info!("[wait_for] quiescence: stable {}/{}", stable_count, QUIET_THRESHOLD);
                                                 if stable_count >= QUIET_THRESHOLD {
-                                                    Some(("idle".to_string(), current))
+                                                    WaitPoll::Done {
+                                                        status: "idle".to_string(),
+                                                        output: current,
+                                                    }
                                                 } else {
-                                                    None
+                                                    WaitPoll::Continue
                                                 }
                                             } else {
                                                 log::info!("[wait_for] quiescence: output changed, resetting (stable was {})", stable_count);
                                                 last_snapshot = current;
                                                 stable_count = 0;
-                                                None
+                                                WaitPoll::Continue
                                             }
                                         }
                                     }
                                 })
-                                .ok()
-                                .flatten();
+                                .ok();
 
-                            if let Some((status, output)) = done {
-                                let _ = response_tx.send(PaneResponse::WaitComplete {
-                                    status,
-                                    output,
-                                });
-                                return;
+                            match poll {
+                                Some(WaitPoll::Done { status, output }) => {
+                                    let _ = response_tx.send(PaneResponse::WaitComplete {
+                                        status,
+                                        output,
+                                    });
+                                    return;
+                                }
+                                Some(WaitPoll::Error(err)) => {
+                                    let _ = response_tx.send(PaneResponse::Error(err));
+                                    return;
+                                }
+                                Some(WaitPoll::Continue) => {}
+                                None => return,
                             }
                         }
                     })

--- a/crates/con-app/src/workspace/control_agent_tools.rs
+++ b/crates/con-app/src/workspace/control_agent_tools.rs
@@ -926,29 +926,39 @@ impl ConWorkspace {
                                         }
                                     } else {
                                         // Quiescence mode: output unchanged for QUIET_THRESHOLD polls
-                                        let current = normalize_output(pane.recent_lines(50, cx));
-                                        if current.is_empty() {
-                                            // Terminal not producing output yet — don't count as stable
-                                            None
-                                        } else if last_snapshot.is_empty() {
-                                            // First non-empty snapshot — set baseline, start counting
-                                            log::info!("[wait_for] quiescence: baseline set ({} bytes)", current.len());
-                                            last_snapshot = current;
+                                        let is_alive = pane.is_alive(cx);
+                                        let surface_ready = pane.surface_ready(cx);
+                                        if !is_alive || !surface_ready {
+                                            // A pane can exist before its terminal surface is bootstrapped.
+                                            // Never report quiescent-idle until the pane is both alive and ready.
+                                            last_snapshot.clear();
                                             stable_count = 0;
                                             None
-                                        } else if current == last_snapshot {
-                                            stable_count += 1;
-                                            log::info!("[wait_for] quiescence: stable {}/{}", stable_count, QUIET_THRESHOLD);
-                                            if stable_count >= QUIET_THRESHOLD {
-                                                Some(("idle".to_string(), current))
+                                        } else {
+                                            let current = normalize_output(pane.recent_lines(50, cx));
+                                            if current.is_empty() {
+                                                // Terminal not producing output yet — don't count as stable
+                                                None
+                                            } else if last_snapshot.is_empty() {
+                                                // First non-empty snapshot — set baseline, start counting
+                                                log::info!("[wait_for] quiescence: baseline set ({} bytes)", current.len());
+                                                last_snapshot = current;
+                                                stable_count = 0;
+                                                None
+                                            } else if current == last_snapshot {
+                                                stable_count += 1;
+                                                log::info!("[wait_for] quiescence: stable {}/{}", stable_count, QUIET_THRESHOLD);
+                                                if stable_count >= QUIET_THRESHOLD {
+                                                    Some(("idle".to_string(), current))
+                                                } else {
+                                                    None
+                                                }
                                             } else {
+                                                log::info!("[wait_for] quiescence: output changed, resetting (stable was {})", stable_count);
+                                                last_snapshot = current;
+                                                stable_count = 0;
                                                 None
                                             }
-                                        } else {
-                                            log::info!("[wait_for] quiescence: output changed, resetting (stable was {})", stable_count);
-                                            last_snapshot = current;
-                                            stable_count = 0;
-                                            None
                                         }
                                     }
                                 })

--- a/crates/con-test/testdata/panes/split.test
+++ b/crates/con-test/testdata/panes/split.test
@@ -12,7 +12,7 @@ con-cli --json panes list --tab 1  # now have 2 panes
 ---- contains
 "index":2
 
-con-cli --json panes wait --tab 1 --pane-index 2 --timeout 5  # wait for new pane to become alive
+con-cli --json panes wait --tab 1 --pane-index 2 --timeout 15  # wait for new pane to become alive
 ---- ok
 
 con-cli --json panes list --tab 1  # both panes are alive


### PR DESCRIPTION
## Summary
- treat provider configured state as auth-backed instead of any override field
- keep OpenAI-compatible providers configurable via base_url-only setups
- update session provider filtering so model-only providers do not stay in the picker
- add unit tests for configured-state behavior

Fixes #227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Provider configuration now requires real auth signals (API key/env or OpenAI‑compatible base URL); model-only entries are no longer treated as configured.
  * Configured-provider lists never return empty — the current provider is used as a fallback.

* **Improvements**
  * Pane waiting delays "idle" detection until a pane is alive and its terminal surface is ready, restarting stability checks when readiness changes.

* **Tests**
  * Updated and added unit tests; an integration wait timeout was increased.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->