### PR TITLE
Fix terminal state handling on child exit and improve SSH disconnect recovery

### DIFF
--- a/crates/con-app/src/workspace/lifecycle.rs
+++ b/crates/con-app/src/workspace/lifecycle.rs
@@ -1141,12 +1141,19 @@ impl ConWorkspace {
 
         let generation = self.ghostty_app.wake_generation();
         if generation == self.last_ghostty_wake_generation {
+            for tab in &self.tabs {
+                for terminal in tab.pane_tree.all_surface_terminals() {
+                    drain_count += 1;
+                    changed |= terminal.drain_surface_state_with_native_scroll(false, cx);
+                }
+            }
             if let Some(started) = started {
                 if changed {
                     log::info!(
                         target: "con::perf",
-                        "pump_ghostty_views generation_unchanged terminals={} changed=1 elapsed_ms={:.3}",
+                        "pump_ghostty_views generation_unchanged terminals={} drains={} changed=1 elapsed_ms={:.3}",
                         terminal_count,
+                        drain_count,
                         started.elapsed().as_secs_f64() * 1000.0
                     );
                 }

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -110,6 +110,20 @@ impl SessionShared {
         self.needs_render.store(true, Ordering::Release);
         self.wake();
     }
+
+    fn mark_exited(&self, exit_code: Option<i32>, duration: Duration) {
+        if !self.alive.swap(false, Ordering::AcqRel) {
+            return;
+        }
+        *self.last_exit_code.lock() = exit_code;
+        *self.last_duration.lock() = Some(duration);
+        *self.finished_signal.lock() = Some(CommandFinishedSignal {
+            exit_code,
+            duration,
+        });
+        self.needs_render.store(true, Ordering::Release);
+        self.wake();
+    }
 }
 
 impl LinuxPtySession {
@@ -181,7 +195,8 @@ impl LinuxPtySession {
         {
             shared.transcript.lock().push(text);
         }
-        spawn_reader_thread(reader, shared.clone());
+        let started_at = Instant::now();
+        spawn_reader_thread(reader, shared.clone(), started_at);
 
         Ok(Self {
             master: Mutex::new(pair.master),
@@ -195,7 +210,7 @@ impl LinuxPtySession {
             )),
             current_dir: options.cwd.map(|cwd| cwd.to_string_lossy().to_string()),
             input_generation: AtomicU64::new(0),
-            started_at: Instant::now(),
+            started_at,
         })
     }
 
@@ -366,17 +381,9 @@ impl LinuxPtySession {
             return;
         };
 
-        self.shared.alive.store(false, Ordering::Release);
         let exit_code = i32::try_from(status.exit_code()).unwrap_or(i32::MAX);
-        let duration = self.started_at.elapsed();
-        *self.shared.last_exit_code.lock() = Some(exit_code);
-        *self.shared.last_duration.lock() = Some(duration);
-        *self.shared.finished_signal.lock() = Some(CommandFinishedSignal {
-            exit_code: Some(exit_code),
-            duration,
-        });
-        self.shared.needs_render.store(true, Ordering::Release);
-        self.shared.wake();
+        self.shared
+            .mark_exited(Some(exit_code), self.started_at.elapsed());
     }
 }
 
@@ -391,14 +398,21 @@ impl Drop for LinuxPtySession {
     }
 }
 
-fn spawn_reader_thread(mut reader: Box<dyn Read + Send>, shared: Arc<SessionShared>) {
+fn spawn_reader_thread(
+    mut reader: Box<dyn Read + Send>,
+    shared: Arc<SessionShared>,
+    started_at: Instant,
+) {
     std::thread::Builder::new()
         .name("con-linux-pty-reader".into())
         .spawn(move || {
             let mut buffer = [0_u8; 8192];
             loop {
                 match reader.read(&mut buffer) {
-                    Ok(0) => break,
+                    Ok(0) => {
+                        shared.mark_exited(None, started_at.elapsed());
+                        break;
+                    }
                     Ok(read) => {
                         shared.screen.feed(&buffer[..read]);
                         let chunk = String::from_utf8_lossy(&buffer[..read]);
@@ -407,6 +421,7 @@ fn spawn_reader_thread(mut reader: Box<dyn Read + Send>, shared: Arc<SessionShar
                     Err(err) if err.kind() == ErrorKind::Interrupted => continue,
                     Err(err) => {
                         log::debug!("linux pty reader terminated: {err}");
+                        shared.mark_exited(None, started_at.elapsed());
                         break;
                     }
                 }

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -113,6 +113,32 @@ impl SessionShared {
 
     fn mark_exited(&self, exit_code: Option<i32>, duration: Duration) {
         if !self.alive.swap(false, Ordering::AcqRel) {
+            if exit_code.is_some() {
+                let mut backfilled = false;
+                let mut last_exit_code = self.last_exit_code.lock();
+                if last_exit_code.is_none() {
+                    *last_exit_code = exit_code;
+                    *self.last_duration.lock() = Some(duration);
+                    backfilled = true;
+                }
+
+                let mut finished_signal = self.finished_signal.lock();
+                if finished_signal
+                    .as_ref()
+                    .map_or(true, |signal| signal.exit_code.is_none())
+                {
+                    *finished_signal = Some(CommandFinishedSignal {
+                        exit_code,
+                        duration,
+                    });
+                    backfilled = true;
+                }
+
+                if backfilled {
+                    self.needs_render.store(true, Ordering::Release);
+                    self.wake();
+                }
+            }
             return;
         }
         *self.last_exit_code.lock() = exit_code;
@@ -497,7 +523,13 @@ fn pty_size_from_surface(size: &SurfaceSize) -> PtySize {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
     use crate::transcript::{TranscriptBuffer, sanitize_terminal_output};
+    use crate::vt::VtScreen;
+
+    use super::SessionShared;
 
     #[test]
     fn transcript_buffer_returns_recent_lines_in_order() {
@@ -532,5 +564,37 @@ mod tests {
     #[test]
     fn sanitize_terminal_output_honors_carriage_return_rewrites() {
         assert_eq!(sanitize_terminal_output("loading\rready"), "ready");
+    }
+
+    #[test]
+    fn mark_exited_backfills_exit_code_after_eof() {
+        let shared = SessionShared::new(
+            Arc::new(VtScreen::new(80, 24, None).expect("create vt screen")),
+            None,
+            None,
+        );
+
+        shared.mark_exited(None, Duration::from_millis(10));
+        shared
+            .needs_render
+            .store(false, std::sync::atomic::Ordering::Release);
+        shared.mark_exited(Some(7), Duration::from_millis(20));
+
+        assert_eq!(*shared.last_exit_code.lock(), Some(7));
+        assert_eq!(
+            *shared.last_duration.lock(),
+            Some(Duration::from_millis(20))
+        );
+        assert!(
+            shared
+                .needs_render
+                .load(std::sync::atomic::Ordering::Acquire)
+        );
+        let finished = shared
+            .finished_signal
+            .lock()
+            .expect("exit signal should be backfilled");
+        assert_eq!(finished.exit_code, Some(7));
+        assert_eq!(finished.duration, Duration::from_millis(20));
     }
 }

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -1385,6 +1385,14 @@ unsafe extern "C" fn wakeup_callback(userdata: *mut c_void) {
     });
 }
 
+fn mark_child_exited_state(state: &StateRef) {
+    let mut s = state.lock();
+    s.child_exited = true;
+    s.needs_render = true;
+    s.is_busy = false;
+    s.last_command_finished_input_generation = s.input_generation;
+}
+
 unsafe extern "C" fn action_callback(
     _app: ffi::ghostty_app_t,
     target: ffi::ghostty_target_s,
@@ -1495,7 +1503,7 @@ unsafe extern "C" fn action_callback(
                 true
             }
             ffi::ghostty_action_tag_e::GHOSTTY_ACTION_SHOW_CHILD_EXITED => {
-                state.lock().child_exited = true;
+                mark_child_exited_state(&state);
                 true
             }
             ffi::ghostty_action_tag_e::GHOSTTY_ACTION_COLOR_CHANGE => {
@@ -1638,12 +1646,19 @@ unsafe extern "C" fn close_surface_callback(userdata: *mut c_void, _process_aliv
         return;
     }
     let state = unsafe { &*(userdata as *const StateRef) };
-    state.lock().child_exited = true;
+    mark_child_exited_state(state);
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{GhosttyConfigPatch, TerminalColors, installed_app_ghostty_resources_dir_for_exe};
+    use std::sync::Arc;
+
+    use parking_lot::Mutex;
+
+    use super::{
+        GhosttyConfigPatch, TerminalColors, TerminalState,
+        installed_app_ghostty_resources_dir_for_exe, mark_child_exited_state,
+    };
 
     fn sample_colors(seed: u8) -> TerminalColors {
         TerminalColors {
@@ -1655,6 +1670,24 @@ mod tests {
             ],
             palette: [[seed; 3]; 16],
         }
+    }
+
+    #[test]
+    fn mark_child_exited_state_clears_busy_and_marks_input_finished() {
+        let state = Arc::new(Mutex::new(TerminalState {
+            is_busy: true,
+            input_generation: 7,
+            last_command_finished_input_generation: 3,
+            ..TerminalState::default()
+        }));
+
+        mark_child_exited_state(&state);
+
+        let state = state.lock();
+        assert!(state.child_exited);
+        assert!(state.needs_render);
+        assert!(!state.is_busy);
+        assert_eq!(state.last_command_finished_input_generation, 7);
     }
 
     #[test]

--- a/postmortem/2026-06-05-ssh-disconnect-dead-pane.md
+++ b/postmortem/2026-06-05-ssh-disconnect-dead-pane.md
@@ -1,0 +1,42 @@
+# SSH disconnect left a dead terminal pane interactive
+
+## What happened
+
+When an SSH session disconnected abruptly, the terminal could remain on the old
+screen and appear frozen. Keystrokes and control-plane writes targeted the same
+pane, but there was no live child process or shell-ready state behind it.
+
+## Root cause
+
+The macOS workspace pump only drained Ghostty surface state after
+`wake_generation` changed. That was correct for render work, but process exit is
+a lifecycle event: if Ghostty did not emit a wake for a disconnect path, the
+workspace did not call `is_alive()` and therefore did not emit
+`GhosttyProcessExited`.
+
+The command busy bit had a similar failure mode. `write_to_pty()` marked input
+containing a newline as busy, and only the shell-integration
+`COMMAND_FINISHED` action cleared it. Abrupt SSH disconnects can skip that
+normal completion path, so command/control logic could keep treating the dead
+pane as busy.
+
+On Linux, the PTY reader treated EOF as a local thread exit only. The shared
+session state was updated later only if another caller happened to poll child
+status.
+
+## Fix applied
+
+- Child-exit actions now clear the busy bit, refresh the finished input
+  generation, and mark the terminal as needing render.
+- Linux PTY reader EOF and read errors now publish a session-exited state and
+  wake the UI directly.
+- The workspace pump drains lightweight surface state even when Ghostty's
+  render wake generation has not changed, while still skipping native scroll
+  synchronization on that fallback path.
+
+## What we learned
+
+Render wakeups are not a reliable carrier for lifecycle state. A terminal pane
+must be able to observe child death independently of repaint scheduling, and
+abnormal exits must clear optimistic shell-integration state because the normal
+prompt/completion protocol is best-effort across SSH and PTY boundaries.


### PR DESCRIPTION
Signed-off-by: Frost Ming <me@frostming.com>

Fix #233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminals becoming unresponsive after abrupt SSH disconnects by clearing busy state on child-exit, publishing session-exited on PTY EOF/read errors, and ensuring lightweight surface state is drained so UI updates correctly.
* **Documentation**
  * Added a postmortem detailing the disconnect issue, root causes, and applied fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->