### PR TITLE
Implement dynamic input bar height adjustment and auto-growing feature

### DIFF
--- a/crates/con-app/src/input_bar.rs
+++ b/crates/con-app/src/input_bar.rs
@@ -409,7 +409,6 @@ impl InputBar {
                 .placeholder("Type a command or ask AI…")
                 .code_editor("con-shell")
                 .auto_grow(1, INPUT_BAR_MAX_ROWS)
-                .folding(false)
         });
         shell_input_state.update(cx, |state, cx| {
             state.set_highlighter("con-shell", cx);

--- a/crates/con-app/src/input_bar.rs
+++ b/crates/con-app/src/input_bar.rs
@@ -7,6 +7,10 @@ use gpui_component::{
 
 use crate::ui_scale::{mono_density_scale, mono_px, mono_space_px};
 
+const INPUT_BAR_MIN_HEIGHT: f32 = 43.0;
+const INPUT_BAR_ROW_HEIGHT: f32 = 20.0;
+const INPUT_BAR_MAX_ROWS: usize = 6;
+
 actions!(
     input_bar,
     [
@@ -396,7 +400,7 @@ impl InputBar {
             InputState::new(window, cx)
                 .placeholder("Type a command or ask AI…")
                 .code_editor("con-shell")
-                .multi_line(false)
+                .auto_grow(1, INPUT_BAR_MAX_ROWS)
                 .folding(false)
         });
         shell_input_state.update(cx, |state, cx| {
@@ -794,15 +798,21 @@ impl InputBar {
     }
 
     pub fn skill_popup_offset(&self, cx: &App) -> Pixels {
-        let rows = self
-            .current_input_state()
+        px(56.0 + (self.content_rows(cx).saturating_sub(1) as f32 * INPUT_BAR_ROW_HEIGHT))
+    }
+
+    pub fn rendered_height(&self, cx: &App) -> Pixels {
+        px(INPUT_BAR_MIN_HEIGHT
+            + (self.content_rows(cx).saturating_sub(1) as f32 * INPUT_BAR_ROW_HEIGHT))
+    }
+
+    fn content_rows(&self, cx: &App) -> usize {
+        self.current_input_state()
             .read(cx)
             .value()
             .lines()
             .count()
-            .clamp(1, 6);
-
-        px(56.0 + (rows.saturating_sub(1) as f32 * 20.0))
+            .clamp(1, INPUT_BAR_MAX_ROWS)
     }
 
     pub fn cycle_mode(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -1577,7 +1587,7 @@ impl Render for InputBar {
                         .text_size(input_text_size)
                         .line_height(input_line_height)
                         .pl(px(12.0 * mono_scale))
-                        .h(control_size)
+                        .min_h(control_size)
                         .into_any_element()
                 } else {
                     Input::new(&input_state)
@@ -1591,7 +1601,7 @@ impl Render for InputBar {
                         })
                         .text_size(input_text_size)
                         .line_height(input_line_height)
-                        .h(control_size)
+                        .min_h(control_size)
                         .into_any_element()
                 },
             ));
@@ -1611,7 +1621,6 @@ impl Render for InputBar {
                     .min_h(px(44.0 * mono_scale))
                     .flex()
                     .items_center()
-                    .h(px(32.0 * mono_scale))
                     .gap(px(9.0 * mono_scale))
                     .child(mode_prefix)
                     .children(pane_row)

--- a/crates/con-app/src/input_bar.rs
+++ b/crates/con-app/src/input_bar.rs
@@ -7,9 +7,17 @@ use gpui_component::{
 
 use crate::ui_scale::{mono_density_scale, mono_px, mono_space_px};
 
-const INPUT_BAR_MIN_HEIGHT: f32 = 43.0;
+const INPUT_BAR_MIN_HEIGHT: f32 = 44.0;
 const INPUT_BAR_ROW_HEIGHT: f32 = 20.0;
 const INPUT_BAR_MAX_ROWS: usize = 6;
+
+fn input_bar_content_rows(value: &str) -> usize {
+    (value.matches('\n').count() + 1).clamp(1, INPUT_BAR_MAX_ROWS)
+}
+
+fn input_bar_rendered_height_for_rows(rows: usize, mono_scale: f32) -> f32 {
+    (INPUT_BAR_MIN_HEIGHT + rows.saturating_sub(1) as f32 * INPUT_BAR_ROW_HEIGHT) * mono_scale
+}
 
 actions!(
     input_bar,
@@ -394,7 +402,7 @@ impl InputBar {
         let agent_input_state = cx.new(|cx| {
             InputState::new(window, cx)
                 .placeholder("Ask anything…")
-                .auto_grow(1, 6)
+                .auto_grow(1, INPUT_BAR_MAX_ROWS)
         });
         let shell_input_state = cx.new(|cx| {
             InputState::new(window, cx)
@@ -798,21 +806,22 @@ impl InputBar {
     }
 
     pub fn skill_popup_offset(&self, cx: &App) -> Pixels {
-        px(56.0 + (self.content_rows(cx).saturating_sub(1) as f32 * INPUT_BAR_ROW_HEIGHT))
+        let mono_scale = mono_density_scale(cx.theme());
+        px(
+            (56.0 + (self.content_rows(cx).saturating_sub(1) as f32 * INPUT_BAR_ROW_HEIGHT))
+                * mono_scale,
+        )
     }
 
     pub fn rendered_height(&self, cx: &App) -> Pixels {
-        px(INPUT_BAR_MIN_HEIGHT
-            + (self.content_rows(cx).saturating_sub(1) as f32 * INPUT_BAR_ROW_HEIGHT))
+        px(input_bar_rendered_height_for_rows(
+            self.content_rows(cx),
+            mono_density_scale(cx.theme()),
+        ))
     }
 
     fn content_rows(&self, cx: &App) -> usize {
-        self.current_input_state()
-            .read(cx)
-            .value()
-            .lines()
-            .count()
-            .clamp(1, INPUT_BAR_MAX_ROWS)
+        input_bar_content_rows(&self.current_input_state().read(cx).value())
     }
 
     pub fn cycle_mode(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -1627,5 +1636,28 @@ impl Render for InputBar {
                     .child(div().flex_1().min_w_0().child(input_field))
                     .child(send_button),
             )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{INPUT_BAR_MAX_ROWS, input_bar_content_rows, input_bar_rendered_height_for_rows};
+
+    #[test]
+    fn content_rows_counts_trailing_newline_and_clamps() {
+        assert_eq!(input_bar_content_rows(""), 1);
+        assert_eq!(input_bar_content_rows("cmd"), 1);
+        assert_eq!(input_bar_content_rows("cmd\n"), 2);
+        assert_eq!(input_bar_content_rows("cmd\nnext"), 2);
+
+        let many_rows = "1\n2\n3\n4\n5\n6\n7\n8";
+        assert_eq!(input_bar_content_rows(many_rows), INPUT_BAR_MAX_ROWS);
+    }
+
+    #[test]
+    fn rendered_height_scales_minimum_and_extra_rows() {
+        assert_eq!(input_bar_rendered_height_for_rows(1, 1.0), 44.0);
+        assert_eq!(input_bar_rendered_height_for_rows(3, 1.0), 84.0);
+        assert_eq!(input_bar_rendered_height_for_rows(3, 1.25), 105.0);
     }
 }

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -118,7 +118,11 @@ impl ConWorkspace {
         }
 
         let top_bar_height = self.current_top_bar_height();
-        let input_bar_height = if self.input_bar_visible { 42.0 } else { 0.0 };
+        let input_bar_height = if self.input_bar_visible {
+            self.input_bar.read(cx).rendered_height(cx).as_f32()
+        } else {
+            0.0
+        };
         let win_w = f32::from(win.bounds().size.width);
         let win_h = f32::from(win.bounds().size.height);
         let effective_agent_panel_width = self.agent_panel_width.min(max_agent_panel_width(win_w));
@@ -742,10 +746,11 @@ impl Render for ConWorkspace {
             input_bar_progress > 0.01 || input_bar_snap_guard_active;
 
         if input_bar_reserved_for_layout {
+            let full_input_bar_height = self.input_bar.read(cx).rendered_height(cx).as_f32();
             let input_bar_height = if input_bar_progress > 0.01 {
-                43.0 * input_bar_progress
+                full_input_bar_height * input_bar_progress
             } else {
-                43.0
+                full_input_bar_height
             };
             let input_bar_content_opacity = if input_bar_progress > 0.01 {
                 input_bar_content_progress
@@ -761,7 +766,7 @@ impl Render for ConWorkspace {
                     .child(div().h(px(1.0)).bg(chrome_static_seam_color))
                     .child(
                         div()
-                            .h(px(42.0))
+                            .min_h(px((input_bar_height - 1.0).max(0.0)))
                             .opacity(input_bar_content_opacity)
                             .child(self.input_bar.clone()),
                     ),
@@ -1038,7 +1043,11 @@ impl Render for ConWorkspace {
                     }
 
                     let top_bar_height = this.current_top_bar_height();
-                    let input_bar_height = if this.input_bar_visible { 42.0 } else { 0.0 };
+                    let input_bar_height = if this.input_bar_visible {
+                        this.input_bar.read(cx).rendered_height(cx).as_f32()
+                    } else {
+                        0.0
+                    };
 
                     // Compute layout-dependent inputs *before* re-borrowing
                     // `this` mutably for the pane tree, otherwise we
@@ -1397,7 +1406,7 @@ impl Render for ConWorkspace {
                         .absolute()
                         .left(px(terminal_content_left))
                         .right(px(agent_panel_outer_width))
-                        .bottom(px(43.0))
+                        .bottom(self.input_bar.read(cx).rendered_height(cx))
                         .h(px(CHROME_MOTION_SEAM_OVERDRAW))
                         .bg(chrome_transition_seam_color),
                 );
@@ -1411,7 +1420,7 @@ impl Render for ConWorkspace {
                     .left(px(terminal_content_left))
                     .right(px(agent_panel_outer_width))
                     .bottom_0()
-                    .h(px(43.0))
+                    .h(self.input_bar.read(cx).rendered_height(cx))
                     .bg(chrome_transition_seam_color),
             );
         }


### PR DESCRIPTION
Resolve #232

Signed-off-by: Frost Ming <me@frostming.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Input bar now measures and clamps content rows and derives its rendered height from shared sizing constants rather than fixed pixel values.
  * Workspace layout, pane resizing, and related animations now use the input bar’s actual rendered height for positioning and transitions.
* **Tests**
  * Added unit tests validating content-row clamping and rendered-height behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->