### PR TITLE
Fix Quick Terminal IME input target

### DIFF
--- a/crates/con-app/src/objc/quick_terminal_trampoline.m
+++ b/crates/con-app/src/objc/quick_terminal_trampoline.m
@@ -1,6 +1,7 @@
 #import <AppKit/AppKit.h>
 #import <QuartzCore/QuartzCore.h>
 #include <dispatch/dispatch.h>
+#include <objc/message.h>
 #include <objc/runtime.h>
 #include <unistd.h>
 
@@ -10,7 +11,17 @@ extern void con_quick_terminal_handle_resign_key(void);
 extern void con_quick_terminal_remember_active_app(int32_t pid);
 
 static char kResignKeyObserverKey;
+static char kAppResignActiveObserverKey;
+static char kImeRetryGenerationKey;
 static id gActiveAppObserver = nil;
+
+static BOOL con_quick_terminal_is_text_input_view(NSView *view) {
+    // GPUI's native view implements NSTextInputClient directly. The content
+    // view may contain plain NSView wrappers, which cannot receive IME commits.
+    return view != nil && [view respondsToSelector:@selector(hasMarkedText)] &&
+           [view respondsToSelector:@selector(insertText:replacementRange:)] &&
+           [view respondsToSelector:@selector(setMarkedText:selectedRange:replacementRange:)];
+}
 
 void con_quick_terminal_init(void) {
     if (gActiveAppObserver != nil) {
@@ -49,7 +60,109 @@ static NSRect con_quick_terminal_frame(NSWindow *window, bool visible) {
     return frame;
 }
 
+static NSView *con_quick_terminal_text_input_view(NSWindow *window) {
+    NSView *contentView = window.contentView;
+    if (contentView == nil) {
+        return nil;
+    }
+
+    id responder = window.firstResponder;
+    if ([responder isKindOfClass:NSView.class] &&
+        con_quick_terminal_is_text_input_view((NSView *)responder)) {
+        return (NSView *)responder;
+    }
+
+    NSMutableArray<NSView *> *stack = [NSMutableArray arrayWithObject:contentView];
+    while (stack.count > 0) {
+        NSView *view = stack.lastObject;
+        [stack removeLastObject];
+
+        if (con_quick_terminal_is_text_input_view(view)) {
+            return view;
+        }
+
+        for (NSView *subview in view.subviews) {
+            [stack addObject:subview];
+        }
+    }
+
+    return nil;
+}
+
+static void con_quick_terminal_focus_text_input_view(NSWindow *window) {
+    NSView *view = con_quick_terminal_text_input_view(window);
+    if (view == nil) {
+        return;
+    }
+
+    [window makeFirstResponder:view];
+}
+
+static bool con_quick_terminal_has_marked_text(NSWindow *window) {
+    id responder = window.firstResponder;
+    if (responder == nil || ![responder respondsToSelector:@selector(hasMarkedText)]) {
+        return false;
+    }
+
+    BOOL (*hasMarkedText)(id, SEL) = (BOOL (*)(id, SEL))objc_msgSend;
+    return hasMarkedText(responder, @selector(hasMarkedText));
+}
+
+static NSUInteger con_quick_terminal_ime_retry_generation(NSWindow *window) {
+    NSNumber *generation = objc_getAssociatedObject(window, &kImeRetryGenerationKey);
+    return generation.unsignedIntegerValue;
+}
+
+static void con_quick_terminal_bump_ime_retry_generation(NSWindow *window) {
+    NSUInteger generation = con_quick_terminal_ime_retry_generation(window) + 1;
+    objc_setAssociatedObject(window, &kImeRetryGenerationKey, @(generation),
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+static void con_quick_terminal_handle_resign_after_ime(NSWindow *window);
+
+static void con_quick_terminal_schedule_resign_retry(NSWindow *window) {
+    NSUInteger generation = con_quick_terminal_ime_retry_generation(window);
+    __weak NSWindow *weakWindow = window;
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.20 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        NSWindow *strongWindow = weakWindow;
+        if (strongWindow == nil ||
+            con_quick_terminal_ime_retry_generation(strongWindow) != generation) {
+            return;
+        }
+        con_quick_terminal_handle_resign_after_ime(strongWindow);
+    });
+}
+
+static void con_quick_terminal_handle_resign_after_ime(NSWindow *window) {
+    if (window == nil || window.isKeyWindow) {
+        return;
+    }
+
+    if (NSApp.isActive) {
+        NSWindow *keyWindow = NSApp.keyWindow;
+        if (keyWindow != nil && keyWindow != window) {
+            con_quick_terminal_handle_resign_key();
+            return;
+        }
+        // Some IMEs briefly move key focus during candidate handling while Con
+        // remains active. Keep the text-input view as first responder.
+        con_quick_terminal_focus_text_input_view(window);
+        return;
+    }
+
+    if (con_quick_terminal_has_marked_text(window)) {
+        con_quick_terminal_schedule_resign_retry(window);
+        return;
+    }
+
+    con_quick_terminal_handle_resign_key();
+}
+
 static void con_quick_terminal_apply_configuration(NSWindow *window) {
+    con_quick_terminal_bump_ime_retry_generation(window);
+
     // Borderless removes the visible chrome; the resizable bit keeps the
     // AppKit edge-resize behavior for the bottom edge and preserves live
     // height changes across show/hide animations.
@@ -65,6 +178,7 @@ static void con_quick_terminal_apply_configuration(NSWindow *window) {
     window.contentMinSize = NSMakeSize(320.0, CON_QUICK_TERMINAL_MIN_HEIGHT);
     [window setFrame:con_quick_terminal_frame(window, false) display:NO];
     [window orderOut:nil];
+    con_quick_terminal_focus_text_input_view(window);
 
     // Auto-hide when the window loses focus (user clicks elsewhere).
     id oldObserver = objc_getAssociatedObject(window, &kResignKeyObserverKey);
@@ -75,18 +189,45 @@ static void con_quick_terminal_apply_configuration(NSWindow *window) {
         addObserverForName:NSWindowDidResignKeyNotification
                     object:window
                      queue:NSOperationQueue.mainQueue
-                usingBlock:^(__unused NSNotification *note) {
-                    con_quick_terminal_handle_resign_key();
+                usingBlock:^(NSNotification *note) {
+                    con_quick_terminal_handle_resign_after_ime((NSWindow *)note.object);
                 }];
     objc_setAssociatedObject(window, &kResignKeyObserverKey, observer,
+                             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+
+    id oldAppObserver = objc_getAssociatedObject(window, &kAppResignActiveObserverKey);
+    if (oldAppObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:oldAppObserver];
+    }
+    __weak NSWindow *weakWindow = window;
+    id appObserver = [[NSNotificationCenter defaultCenter]
+        addObserverForName:NSApplicationDidResignActiveNotification
+                    object:NSApp
+                     queue:NSOperationQueue.mainQueue
+                usingBlock:^(__unused NSNotification *note) {
+                    NSWindow *strongWindow = weakWindow;
+                    if (strongWindow != nil) {
+                        con_quick_terminal_handle_resign_after_ime(strongWindow);
+                    }
+                }];
+    objc_setAssociatedObject(window, &kAppResignActiveObserverKey, appObserver,
                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 static void con_quick_terminal_remove_resign_observer(NSWindow *window) {
+    con_quick_terminal_bump_ime_retry_generation(window);
+
     id observer = objc_getAssociatedObject(window, &kResignKeyObserverKey);
     if (observer) {
         [[NSNotificationCenter defaultCenter] removeObserver:observer];
         objc_setAssociatedObject(window, &kResignKeyObserverKey, nil,
+                                 OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    id appObserver = objc_getAssociatedObject(window, &kAppResignActiveObserverKey);
+    if (appObserver) {
+        [[NSNotificationCenter defaultCenter] removeObserver:appObserver];
+        objc_setAssociatedObject(window, &kAppResignActiveObserverKey, nil,
                                  OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
 }
@@ -210,6 +351,7 @@ void con_quick_terminal_slide_in(void *window_ptr) {
 #pragma clang diagnostic pop
         }
         [window makeKeyAndOrderFront:nil];
+        con_quick_terminal_focus_text_input_view(window);
 
         [NSAnimationContext runAnimationGroup:^(NSAnimationContext *context) {
             context.duration = 0.18;

--- a/postmortem/2026-06-01-quick-terminal-doubao-ime.md
+++ b/postmortem/2026-06-01-quick-terminal-doubao-ime.md
@@ -1,0 +1,26 @@
+# Quick Terminal Doubao IME composition was lost
+
+## What happened
+
+In Quick Terminal mode, typing into the input bar with the Doubao input method did not show committed or composing text. The same input bar worked in normal windows, and other input methods worked in Quick Terminal.
+
+## Root cause
+
+Quick Terminal reuses the normal `ConWorkspace` and input bar, but wraps the GPUI window with extra AppKit behavior: it converts the window to a borderless transient window, orders it out, shows it again with `makeKeyAndOrderFront:`, and auto-hides on `NSWindowDidResignKeyNotification`.
+
+That made the native text-input target less stable than in a normal GPUI window. IME text is delivered through the window's first responder, which must implement `NSTextInputClient`. After the Quick Terminal show/configure path, the repair code initially tried to restore focus by selecting the first content subview, but that subview was a plain `NSView`, not GPUI's `NSTextInputClient` view. That changed the first responder from `GPUIView` to `NSView`, so printable text and IME commits had no text-input target.
+
+The resign-key observer also treated all key-window loss as an external click, even though some IME candidate/composition flows temporarily move key focus before marked text is established.
+
+Doubao appears to rely on that stricter AppKit text-input lifecycle, while other input methods tolerate the transient focus path.
+
+## Fix applied
+
+- Restore only the GPUI view that actually implements the `NSTextInputClient` selectors as first responder after Quick Terminal configuration and every slide-in.
+- Detect active marked text on the current first responder.
+- Delay Quick Terminal auto-hide while IME marked text is active, then re-check after composition settles.
+- Treat `NSWindowDidResignKeyNotification` as an auto-hide signal only when Con has actually deactivated or another Con window has become key. If Con is still active and no other app window is key, restore the GPUI view as first responder so IME candidate-window focus handoff does not interrupt composition.
+
+## What we learned
+
+Quick Terminal's native shell around GPUI must preserve AppKit text-input invariants, not only GPUI focus state. For IME compatibility, a borderless transient hotkey window still needs a stable `NSTextInputClient` first responder, and focus-loss auto-hide must distinguish real user deactivation from IME composition handoff.


### PR DESCRIPTION
## Summary
- keep Quick Terminal first responder on the GPUI NSTextInputClient view instead of a plain NSView wrapper
- make Quick Terminal auto-hide tolerate IME candidate/composition focus handoff
- add a postmortem for the Doubao IME regression

## Bug
In Quick Terminal mode, Doubao IME printable/composed input did not appear in the input bar while Tab and Enter still worked. Diagnostics showed the Quick Terminal configuration path changed first responder from `GPUIView` (`hasMarkedText`/`insertText` capable) to a plain `NSView`, leaving IME commits without an `NSTextInputClient` target.

## Testing
- `cargo check -p con`
- manually verified Doubao IME input works in Quick Terminal after preserving the GPUI text-input first responder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text input not appearing in the quick terminal with certain IMEs by better detecting text-input views and preserving first-responder focus during composition.
  * Deferred or retried resign/hide actions while IME composition is active to avoid interrupting candidate selection and ensured focus is restored when the window is shown.
  * Improved handling of resign/active transitions to reduce IME-related interruptions.

* **Documentation**
  * Added a postmortem describing the IME issue, root cause analysis, and the applied fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->