### PR TITLE
fix(agent): skip wait_for on interactive agent-CLI panes (refs #239)

### DIFF
--- a/crates/con-agent/src/context.rs
+++ b/crates/con-agent/src/context.rs
@@ -1482,6 +1482,13 @@ pub fn derive_screen_hints(title: Option<&str>, lines: &[String]) -> Vec<PaneObs
     hints
 }
 
+/// Classifies whether recent visible pane lines appear to be an interactive agent CLI.
+///
+/// Pass the current pane title, when available, and the current visible screen or other recent
+/// pane lines. Returns `"codex"`, `"claude"`, or `"opencode"` when the marker heuristics match a
+/// known agent CLI; returns `None` for ordinary shell output or unknown TUIs. Detection is based on
+/// visible text markers, so stale scrollback, localized UI text, or future CLI UI changes can cause
+/// false positives or false negatives.
 pub fn classify_screen_agent_cli(_title: Option<&str>, lines: &[String]) -> Option<&'static str> {
     let joined = lines.join("\n").to_ascii_lowercase();
 
@@ -3390,9 +3397,24 @@ mod tests {
     #[test]
     fn classify_screen_agent_cli_detects_coding_clis_and_skips_plain_shell() {
         let claude = vec!["✻ Ideating…".to_string(), "Claude Code".to_string()];
-        assert_eq!(super::classify_screen_agent_cli(None, &claude), Some("claude"));
+        assert_eq!(
+            super::classify_screen_agent_cli(None, &claude),
+            Some("claude")
+        );
         let codex = vec!["OpenAI Codex".to_string()];
-        assert_eq!(super::classify_screen_agent_cli(None, &codex), Some("codex"));
+        assert_eq!(
+            super::classify_screen_agent_cli(None, &codex),
+            Some("codex")
+        );
+        let opencode = vec![
+            "Ask anything".to_string(),
+            "Tab agents".to_string(),
+            "Ctrl+P commands".to_string(),
+        ];
+        assert_eq!(
+            super::classify_screen_agent_cli(None, &opencode),
+            Some("opencode")
+        );
         let plain_shell = vec!["tony@host ~ %".to_string(), "ls -la".to_string()];
         assert_eq!(super::classify_screen_agent_cli(None, &plain_shell), None);
     }

--- a/crates/con-agent/src/context.rs
+++ b/crates/con-agent/src/context.rs
@@ -1482,7 +1482,7 @@ pub fn derive_screen_hints(title: Option<&str>, lines: &[String]) -> Vec<PaneObs
     hints
 }
 
-fn classify_screen_agent_cli(_title: Option<&str>, lines: &[String]) -> Option<&'static str> {
+pub fn classify_screen_agent_cli(_title: Option<&str>, lines: &[String]) -> Option<&'static str> {
     let joined = lines.join("\n").to_ascii_lowercase();
 
     if joined.contains("openai codex") {
@@ -3387,6 +3387,16 @@ impl TerminalContext {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn classify_screen_agent_cli_detects_coding_clis_and_skips_plain_shell() {
+        let claude = vec!["✻ Ideating…".to_string(), "Claude Code".to_string()];
+        assert_eq!(super::classify_screen_agent_cli(None, &claude), Some("claude"));
+        let codex = vec!["OpenAI Codex".to_string()];
+        assert_eq!(super::classify_screen_agent_cli(None, &codex), Some("codex"));
+        let plain_shell = vec!["tony@host ~ %".to_string(), "ls -la".to_string()];
+        assert_eq!(super::classify_screen_agent_cli(None, &plain_shell), None);
+    }
+
     use crate::control::{PaneControlState, TmuxControlMode, TmuxControlState};
     use crate::shell_probe::{ShellProbeResult, ShellProbeTmuxContext};
     use crate::tmux::{TmuxPaneInfo, TmuxSnapshot};

--- a/crates/con-app/src/workspace/control_agent_tools.rs
+++ b/crates/con-app/src/workspace/control_agent_tools.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+const AGENT_CLI_DETECT_LOOKBACK_LINES: usize = 80;
+
 impl ConWorkspace {
     /// Handle a visible terminal execution request from the agent.
     ///
@@ -829,19 +831,24 @@ impl ConWorkspace {
                         // Codex / OpenCode). Those TUIs never return to a settled shell prompt,
                         // so wait_for would loop until the turn hits max_turns and the panel
                         // appears hung. Short-circuit with guidance toward agent_cli_turn.
-                        let recent_for_agent_cli = pane.recent_lines(80, cx);
-                        if let Some(agent) =
-                            con_agent::context::classify_screen_agent_cli(None, &recent_for_agent_cli)
-                        {
+                        let observation =
+                            pane.observation_frame(AGENT_CLI_DETECT_LOOKBACK_LINES, cx);
+                        if let Some(agent) = con_agent::context::classify_screen_agent_cli(
+                            observation.title.as_deref(),
+                            &observation.recent_output,
+                        ) {
                             log::info!("[wait_for] → skipped: interactive agent-CLI '{agent}'");
                             let _ = response_tx.send(PaneResponse::WaitComplete {
                                 status: "skipped_agent_cli".into(),
                                 output: format!(
-                                    "This pane is running an interactive agent-CLI ('{agent}'), which never \
-                                     returns to a settled shell prompt — waiting on it would loop indefinitely. \
-                                     Do not poll it with wait_for or repeated read_pane. To drive it, use \
-                                     agent_cli_turn(agent_name=\"{agent}\", prompt=…); otherwise send one input \
-                                     and stop, or just report the current screen."
+                                    concat!(
+                                        "This pane is running an interactive agent-CLI ('{}'), which never ",
+                                        "returns to a settled shell prompt — waiting on it would loop indefinitely. ",
+                                        "Do not poll it with wait_for or repeated read_pane. To drive it, use ",
+                                        "agent_cli_turn(agent_name=\"{}\", prompt=…); otherwise send one input ",
+                                        "and stop, or just report the current screen."
+                                    ),
+                                    agent, agent
                                 ),
                             });
                             return;

--- a/crates/con-app/src/workspace/control_agent_tools.rs
+++ b/crates/con-app/src/workspace/control_agent_tools.rs
@@ -825,6 +825,28 @@ impl ConWorkspace {
                         let timeout = timeout_secs.unwrap_or(30).min(120);
                         let response_tx = req.response_tx;
 
+                        // con #239: never poll an interactive agent-CLI pane (Claude Code /
+                        // Codex / OpenCode). Those TUIs never return to a settled shell prompt,
+                        // so wait_for would loop until the turn hits max_turns and the panel
+                        // appears hung. Short-circuit with guidance toward agent_cli_turn.
+                        let recent_for_agent_cli = pane.recent_lines(80, cx);
+                        if let Some(agent) =
+                            con_agent::context::classify_screen_agent_cli(None, &recent_for_agent_cli)
+                        {
+                            log::info!("[wait_for] → skipped: interactive agent-CLI '{agent}'");
+                            let _ = response_tx.send(PaneResponse::WaitComplete {
+                                status: "skipped_agent_cli".into(),
+                                output: format!(
+                                    "This pane is running an interactive agent-CLI ('{agent}'), which never \
+                                     returns to a settled shell prompt — waiting on it would loop indefinitely. \
+                                     Do not poll it with wait_for or repeated read_pane. To drive it, use \
+                                     agent_cli_turn(agent_name=\"{agent}\", prompt=…); otherwise send one input \
+                                     and stop, or just report the current screen."
+                                ),
+                            });
+                            return;
+                        }
+
                         log::info!("[wait_for] has_si={} is_busy={}", has_si, pane.is_busy(cx),);
 
                         // Check if already in target state before spawning async task


### PR DESCRIPTION
## Problem

The built-in agent can hang for many minutes when `wait_for` targets a pane running an interactive agent-CLI (Claude Code / Codex / OpenCode). Those TUIs never return to a settled shell prompt, so the model keeps re-issuing `wait_for` until the turn hits `max_turns`, with the agent panel's "Actions, probes, and output" trace spinning the whole time.

Observed in a captured `RUST_LOG=con_agent=debug` session: ~16 `wait_for(pane)` calls over ~10 minutes on a pane running Claude Code (the model was polling for that CLI's own `⏺` / `Ideating…` markers), then a stray `send_keys` ESC — never converging.

## Fix

Before `wait_for` enters its polling loop, the `PaneQuery::WaitFor` handler now checks the target pane's screen with con's existing `classify_screen_agent_cli` detector. If the pane is an interactive agent-CLI, it short-circuits immediately with `status: "skipped_agent_cli"` and guidance to use `agent_cli_turn` — instead of polling a target that never settles.

This reuses con's own detector (no new heuristics), is placed before the idle/pattern early-returns so an agent-CLI pane is never waited on regardless of args, and enforces the existing `LOCAL_AGENT_CLI_WORK` playbook guidance at the tool layer rather than relying on prompt steering alone.

## Changes

- `con-app` (`workspace/control_agent_tools.rs`): short-circuit in the WaitFor handler.
- `con-agent` (`context.rs`): make `classify_screen_agent_cli` `pub`; add a unit test.

## Testing / local verification scope (honest disclosure)

- ✅ `cargo test -p con-agent classify_screen_agent_cli` — **passes** (detects claude/codex, returns `None` for a plain shell prompt). The detector change + new test compile and run green.
- ⚠️ `cargo check -p con` (which type-checks the `con-app` handler edit) — **could not run on my machine.** `con-ghostty`'s libghostty build fails because **Zig 0.15.2 (the repo-pinned version) cannot link against the macOS 26 SDK's libSystem** — undefined symbols for standard libc (`_isatty`, `_sigaction`, `_waitpid`, `_sysctlbyname`, `__availability_version_check`, …) in Zig's own build-runner. `SDKROOT` did not help, and there is no 0.15.x release above 0.15.2 (next is 0.16.0, which the repo pins against). This is an environment limitation on a very new macOS, **unrelated to this patch** — it blocks any local full build here.

The `con-app` change is small and uses only in-tree APIs (`pane.recent_lines(_, cx)`, `PaneResponse::WaitComplete { status, output }`, `con_agent::context::classify_screen_agent_cli`). I'd appreciate CI confirming the full build on a supported macOS/Zig combination.

## Scope

Addresses the agent-CLI `wait_for` loop from #239. The other two items in #239 — a generic consecutive-no-progress guard for `wait_for`, and throttling the tab-labeler — are intentionally left for separate PRs to keep this focused.

Refs #239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive agent-CLI terminals are now automatically detected and skipped by polling workflows
  * When skipped, the system provides guidance on recommended interaction methods instead of polling

* **Tests**
  * Added test coverage validating agent-CLI terminal detection and skip behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->