### PR TITLE
Fix multiline command input text visibility

### DIFF
--- a/crates/con-app/src/input_bar.rs
+++ b/crates/con-app/src/input_bar.rs
@@ -1162,6 +1162,10 @@ impl InputBar {
 
         Some(runs.into_iter().filter(|run| run.len > 0).collect())
     }
+
+    fn should_hide_native_command_text(input: &str, has_command_overlay: bool) -> bool {
+        !input.is_empty() && has_command_overlay
+    }
 }
 
 fn syntax_color(theme: &gpui_component::Theme, name: &str) -> Option<Hsla> {
@@ -1399,6 +1403,8 @@ impl Render for InputBar {
         } else {
             None
         };
+        let hide_native_command_text =
+            Self::should_hide_native_command_text(&input_value, command_overlay_runs.is_some());
 
         let input_field = div()
             .flex_1()
@@ -1602,7 +1608,7 @@ impl Render for InputBar {
                         .appearance(false)
                         .cleanable(false)
                         .font_family(input_font)
-                        .text_color(if !input_value.is_empty() {
+                        .text_color(if hide_native_command_text {
                             gpui::transparent_black()
                         } else {
                             theme.foreground
@@ -1640,7 +1646,10 @@ impl Render for InputBar {
 
 #[cfg(test)]
 mod tests {
-    use super::{INPUT_BAR_MAX_ROWS, input_bar_content_rows, input_bar_rendered_height_for_rows};
+    use super::{
+        INPUT_BAR_MAX_ROWS, InputBar, input_bar_content_rows,
+        input_bar_rendered_height_for_rows,
+    };
 
     #[test]
     fn content_rows_counts_trailing_newline_and_clamps() {
@@ -1658,5 +1667,15 @@ mod tests {
         assert_eq!(input_bar_rendered_height_for_rows(1, 1.0), 44.0);
         assert_eq!(input_bar_rendered_height_for_rows(3, 1.0), 84.0);
         assert_eq!(input_bar_rendered_height_for_rows(3, 1.25), 105.0);
+    }
+
+    #[test]
+    fn native_command_text_stays_visible_when_multiline_overlay_is_unavailable() {
+        assert!(!InputBar::should_hide_native_command_text("echo one\necho two", false));
+    }
+
+    #[test]
+    fn native_command_text_hides_when_single_line_overlay_is_available() {
+        assert!(InputBar::should_hide_native_command_text("echo one", true));
     }
 }

--- a/postmortem/2026-06-08-multiline-input-text-hidden.md
+++ b/postmortem/2026-06-08-multiline-input-text-hidden.md
@@ -1,0 +1,15 @@
+## What happened
+
+After the dynamic input bar height change, pressing Shift+Enter in the command input grew the bar but made typed shell text invisible.
+
+## Root cause
+
+Shell input renders a colored single-line command overlay and hides the native `Input` text underneath to avoid double text. The auto-grow change allowed multiline shell input, but `command_overlay_runs` intentionally returns `None` for values containing `\n`. The native input text still became transparent for any non-empty shell input, so multiline values had no visible text renderer.
+
+## Fix applied
+
+Native shell text is now hidden only when the command overlay is actually present. Multiline shell input falls back to the native `Input` text, while single-line command overlay rendering keeps its previous behavior.
+
+## What we learned
+
+When a visual overlay replaces native text, the visibility condition must be tied to overlay availability, not just to input non-emptiness.


### PR DESCRIPTION
## Summary
- Keep native command input text visible when multiline input disables the single-line command overlay.
- Preserve existing single-line overlay behavior so colored command rendering still avoids double text.
- Add a postmortem for the Shift+Enter multiline visibility regression.

## Test Plan
- [x] cargo test -p con input_bar::tests
- [x] cargo check -p con
- [x] git diff --check