### PR TITLE
Fix ChatGPT Subscription auth refresh and model picker

### DIFF
--- a/crates/con-agent/src/lib.rs
+++ b/crates/con-agent/src/lib.rs
@@ -23,7 +23,7 @@ pub use hook::{ConHook, ToolApprovalDecision, is_dangerous};
 pub use provider::{
     AgentConfig, AgentEvent, AgentProvider, OAuthDevicePrompt, ProviderConfig, ProviderKind,
     ProviderMap, SuggestionModelConfig, authorize_oauth_provider, oauth_token_dir,
-    read_chatgpt_oauth_access_token,
+    read_chatgpt_oauth_access_token, read_synced_chatgpt_oauth_access_token,
 };
 pub use shell_probe::{ShellProbeResult, ShellProbeTmuxContext};
 pub use skills::{Skill, SkillRegistry};

--- a/crates/con-agent/src/lib.rs
+++ b/crates/con-agent/src/lib.rs
@@ -23,6 +23,7 @@ pub use hook::{ConHook, ToolApprovalDecision, is_dangerous};
 pub use provider::{
     AgentConfig, AgentEvent, AgentProvider, OAuthDevicePrompt, ProviderConfig, ProviderKind,
     ProviderMap, SuggestionModelConfig, authorize_oauth_provider, oauth_token_dir,
+    read_chatgpt_oauth_access_token,
 };
 pub use shell_probe::{ShellProbeResult, ShellProbeTmuxContext};
 pub use skills::{Skill, SkillRegistry};

--- a/crates/con-agent/src/provider.rs
+++ b/crates/con-agent/src/provider.rs
@@ -411,7 +411,7 @@ mod tests {
     }
 
     #[test]
-    fn codex_chatgpt_auth_import_writes_rig_cache_without_overwrite() {
+    fn codex_chatgpt_auth_sync_writes_rig_cache_without_clobbering_seen_source() {
         let root = std::env::temp_dir().join(format!(
             "con-agent-codex-auth-test-{}-{}",
             std::process::id(),
@@ -439,7 +439,7 @@ mod tests {
         .expect("source auth should be written");
 
         assert!(
-            import_codex_chatgpt_auth_from_file_if_needed(&source, &target)
+            sync_codex_chatgpt_auth_from_file(&source, &target)
                 .expect("codex auth import should succeed")
         );
 
@@ -454,13 +454,57 @@ mod tests {
         std::fs::write(&target, r#"{"access_token":"existing"}"#)
             .expect("target auth should be overwritten by test setup");
         assert!(
-            !import_codex_chatgpt_auth_from_file_if_needed(&source, &target)
+            !sync_codex_chatgpt_auth_from_file(&source, &target)
                 .expect("existing target should be left alone")
         );
         assert_eq!(
             std::fs::read_to_string(&target).expect("target auth should still exist"),
             r#"{"access_token":"existing"}"#
         );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn codex_chatgpt_auth_sync_updates_when_codex_source_fingerprint_changes() {
+        let root = std::env::temp_dir().join(format!(
+            "con-agent-codex-auth-update-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system clock should be after unix epoch")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&root).expect("temp root should be created");
+        let source = root.join("codex-auth.json");
+        let target = root.join("con").join("auth.json");
+        std::fs::create_dir_all(target.parent().expect("target should have a parent"))
+            .expect("target parent should be created");
+        std::fs::write(&target, r#"{"access_token":"stale"}"#)
+            .expect("target auth should be written");
+
+        std::fs::write(
+            &source,
+            serde_json::to_vec(&serde_json::json!({
+                "auth_mode": "chatgpt",
+                "tokens": {
+                    "access_token": "fresh",
+                    "refresh_token": "refresh"
+                }
+            }))
+            .expect("source json should serialize"),
+        )
+        .expect("source auth should be written");
+
+        assert!(
+            sync_codex_chatgpt_auth_from_file(&source, &target)
+                .expect("codex auth sync should succeed")
+        );
+        let imported = std::fs::read_to_string(&target).expect("target auth should exist");
+        let imported: serde_json::Value =
+            serde_json::from_str(&imported).expect("target auth should be valid json");
+        assert_eq!(imported["access_token"], "fresh");
+        assert_eq!(imported["refresh_token"], "refresh");
 
         let _ = std::fs::remove_dir_all(root);
     }
@@ -788,6 +832,11 @@ struct RigChatGptAuthRecord {
     account_id: Option<String>,
 }
 
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+struct CodexAuthSyncState {
+    source_fingerprint: String,
+}
+
 fn convert_codex_chatgpt_auth(auth: CodexAuthFile) -> Option<RigChatGptAuthRecord> {
     if auth.auth_mode.as_deref() != Some("chatgpt") {
         return None;
@@ -807,14 +856,14 @@ fn codex_auth_file() -> Option<PathBuf> {
     dirs::home_dir().map(|home| home.join(".codex").join("auth.json"))
 }
 
-fn import_codex_chatgpt_auth_from_file_if_needed(
+fn codex_auth_sync_state_file(target_auth_file: &std::path::Path) -> PathBuf {
+    target_auth_file.with_file_name("codex-auth-sync.json")
+}
+
+fn sync_codex_chatgpt_auth_from_file(
     source_auth_file: &std::path::Path,
     target_auth_file: &std::path::Path,
 ) -> Result<bool> {
-    if target_auth_file.exists() {
-        return Ok(false);
-    }
-
     if !source_auth_file.is_file() {
         return Ok(false);
     }
@@ -830,18 +879,75 @@ fn import_codex_chatgpt_auth_from_file_if_needed(
     }
 
     let bytes = serde_json::to_vec_pretty(&record)?;
-    if !write_auth_record_create_new(target_auth_file, &bytes)? {
+    let source_fingerprint = stable_fingerprint(&bytes);
+    let sync_state_file = codex_auth_sync_state_file(target_auth_file);
+    if target_auth_file.is_file()
+        && read_codex_auth_sync_state(&sync_state_file)?
+            .as_ref()
+            .is_some_and(|state| state.source_fingerprint == source_fingerprint)
+    {
         return Ok(false);
     }
 
+    if target_auth_file
+        .is_file()
+        .then(|| std::fs::read(target_auth_file))
+        .transpose()?
+        .as_deref()
+        == Some(bytes.as_slice())
+    {
+        write_codex_auth_sync_state(&sync_state_file, &source_fingerprint)?;
+        return Ok(false);
+    }
+
+    write_auth_record(target_auth_file, &bytes)?;
+    write_codex_auth_sync_state(&sync_state_file, &source_fingerprint)?;
+
     log::info!(
-        "[provider] Imported ChatGPT OAuth cache from Codex auth into {}",
+        "[provider] Synced ChatGPT OAuth cache from Codex auth into {}",
         target_auth_file.display()
     );
     Ok(true)
 }
 
-fn write_auth_record_create_new(path: &std::path::Path, bytes: &[u8]) -> Result<bool> {
+fn stable_fingerprint(bytes: &[u8]) -> String {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{hash:016x}")
+}
+
+fn read_codex_auth_sync_state(path: &std::path::Path) -> Result<Option<CodexAuthSyncState>> {
+    match std::fs::read_to_string(path) {
+        Ok(raw) => Ok(Some(serde_json::from_str(&raw)?)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn write_codex_auth_sync_state(path: &std::path::Path, source_fingerprint: &str) -> Result<()> {
+    let state = CodexAuthSyncState {
+        source_fingerprint: source_fingerprint.to_string(),
+    };
+    let bytes = serde_json::to_vec_pretty(&state)?;
+    write_auth_record(path, &bytes)
+}
+
+fn clear_auth_record_if_present(path: &std::path::Path) -> Result<bool> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn clear_codex_auth_sync_state(target_auth_file: &std::path::Path) -> Result<bool> {
+    clear_auth_record_if_present(&codex_auth_sync_state_file(target_auth_file))
+}
+
+fn write_auth_record(path: &std::path::Path, bytes: &[u8]) -> Result<()> {
     use std::io::Write;
 
     if let Some(parent) = path.parent() {
@@ -877,27 +983,42 @@ fn write_auth_record_create_new(path: &std::path::Path, bytes: &[u8]) -> Result<
         return Err(err);
     }
 
-    match std::fs::hard_link(&tmp_path, path) {
-        Ok(()) => {
-            let _ = std::fs::remove_file(&tmp_path);
-            Ok(true)
-        }
-        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
-            let _ = std::fs::remove_file(&tmp_path);
-            Ok(false)
-        }
-        Err(err) => {
-            let _ = std::fs::remove_file(&tmp_path);
-            Err(err.into())
-        }
+    if let Err(err) = std::fs::rename(&tmp_path, path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(err.into());
     }
+
+    Ok(())
 }
 
-fn import_codex_chatgpt_auth_if_needed(target_auth_file: &std::path::Path) -> Result<bool> {
+fn sync_codex_chatgpt_auth(target_auth_file: &std::path::Path) -> Result<bool> {
     let Some(source_auth_file) = codex_auth_file() else {
         return Ok(false);
     };
-    import_codex_chatgpt_auth_from_file_if_needed(&source_auth_file, target_auth_file)
+    sync_codex_chatgpt_auth_from_file(&source_auth_file, target_auth_file)
+}
+
+fn mark_codex_chatgpt_auth_source_seen(target_auth_file: &std::path::Path) -> Result<bool> {
+    let Some(source_auth_file) = codex_auth_file() else {
+        return Ok(false);
+    };
+    if !source_auth_file.is_file() {
+        return Ok(false);
+    }
+
+    let source = std::fs::read_to_string(source_auth_file)?;
+    let codex_auth: CodexAuthFile = serde_json::from_str(&source)?;
+    let Some(record) = convert_codex_chatgpt_auth(codex_auth) else {
+        return Ok(false);
+    };
+
+    let bytes = serde_json::to_vec_pretty(&record)?;
+    let source_fingerprint = stable_fingerprint(&bytes);
+    write_codex_auth_sync_state(
+        &codex_auth_sync_state_file(target_auth_file),
+        &source_fingerprint,
+    )?;
+    Ok(true)
 }
 
 pub async fn authorize_oauth_provider<F>(kind: ProviderKind, prompt_handler: F) -> Result<()>
@@ -919,12 +1040,12 @@ where
                 });
             if let Some(dir) = oauth_token_dir(&kind) {
                 let auth_file = dir.join("auth.json");
-                match import_codex_chatgpt_auth_if_needed(&auth_file) {
-                    Ok(_) => {}
-                    Err(err) => {
-                        log::warn!("[provider] Failed to import Codex ChatGPT auth cache: {err}");
-                    }
+                if clear_auth_record_if_present(&auth_file)? {
+                    log::info!(
+                        "[provider] Cleared existing ChatGPT OAuth cache before manual authorization"
+                    );
                 }
+                clear_codex_auth_sync_state(&auth_file)?;
                 builder = builder.token_dir(dir);
             }
             let client = builder
@@ -933,7 +1054,14 @@ where
             client
                 .authorize()
                 .await
-                .map_err(|e| anyhow::anyhow!("ChatGPT OAuth error: {e}"))
+                .map_err(|e| anyhow::anyhow!("ChatGPT OAuth error: {e}"))?;
+            if let Some(dir) = oauth_token_dir(&kind) {
+                let auth_file = dir.join("auth.json");
+                if let Err(err) = mark_codex_chatgpt_auth_source_seen(&auth_file) {
+                    log::warn!("[provider] Failed to mark Codex ChatGPT auth source seen: {err}");
+                }
+            }
+            Ok(())
         }
         ProviderKind::GitHubCopilot => {
             let prompt_handler = prompt_handler.clone();
@@ -1757,8 +1885,8 @@ impl AgentProvider {
                 let mut builder = builder.oauth();
                 if let Some(dir) = oauth_token_dir(&ProviderKind::ChatGPT) {
                     let auth_file = dir.join("auth.json");
-                    if let Err(err) = import_codex_chatgpt_auth_if_needed(&auth_file) {
-                        log::warn!("[provider] Failed to import Codex ChatGPT auth cache: {err}");
+                    if let Err(err) = sync_codex_chatgpt_auth(&auth_file) {
+                        log::warn!("[provider] Failed to sync Codex ChatGPT auth cache: {err}");
                     }
                     builder = builder.token_dir(dir);
                 }

--- a/crates/con-agent/src/provider.rs
+++ b/crates/con-agent/src/provider.rs
@@ -875,6 +875,13 @@ pub fn read_chatgpt_oauth_access_token(auth_file: &std::path::Path) -> Result<Op
     }
 }
 
+pub fn read_synced_chatgpt_oauth_access_token(
+    auth_file: &std::path::Path,
+) -> Result<Option<String>> {
+    sync_codex_chatgpt_auth(auth_file)?;
+    read_chatgpt_oauth_access_token(auth_file)
+}
+
 fn codex_auth_sync_state_file(target_auth_file: &std::path::Path) -> PathBuf {
     target_auth_file.with_file_name("codex-auth-sync.json")
 }

--- a/crates/con-agent/src/provider.rs
+++ b/crates/con-agent/src/provider.rs
@@ -832,6 +832,11 @@ struct RigChatGptAuthRecord {
     account_id: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct RigChatGptAuthTokenView {
+    access_token: Option<String>,
+}
+
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
 struct CodexAuthSyncState {
     source_fingerprint: String,
@@ -854,6 +859,20 @@ fn convert_codex_chatgpt_auth(auth: CodexAuthFile) -> Option<RigChatGptAuthRecor
 
 fn codex_auth_file() -> Option<PathBuf> {
     dirs::home_dir().map(|home| home.join(".codex").join("auth.json"))
+}
+
+pub fn read_chatgpt_oauth_access_token(auth_file: &std::path::Path) -> Result<Option<String>> {
+    match std::fs::read_to_string(auth_file) {
+        Ok(raw) => {
+            let record: RigChatGptAuthTokenView = serde_json::from_str(&raw)?;
+            Ok(record
+                .access_token
+                .map(|token| token.trim().to_string())
+                .filter(|token| !token.is_empty()))
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err.into()),
+    }
 }
 
 fn codex_auth_sync_state_file(target_auth_file: &std::path::Path) -> PathBuf {

--- a/crates/con-app/src/model_registry.rs
+++ b/crates/con-app/src/model_registry.rs
@@ -11,6 +11,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 const API_URL: &str = "https://models.dev/api.json";
+const CHATGPT_CODEX_API_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
 const CACHE_TTL: Duration = Duration::from_secs(3600); // 1 hour
 
 // ── Fallback model lists (used when API is unreachable) ──────────────
@@ -36,20 +37,13 @@ fn fallback_models(provider: &ProviderKind) -> &'static [&'static str] {
             "gpt-4.1-nano",
         ],
         ProviderKind::ChatGPT => &[
-            "o4-mini",
-            "o3",
-            "o3-pro",
-            "o3-mini",
-            "gpt-4o",
-            "gpt-4o-mini",
-            "gpt-4.1",
-            "gpt-4.1-mini",
-            "gpt-4.1-nano",
+            "gpt-5.5",
             "gpt-5.4",
-            "gpt-5.4-pro",
+            "gpt-5.4-mini",
+            "gpt-5.4-nano",
             "gpt-5.3-codex",
-            "gpt-5.3-chat-latest",
-            "gpt-5.3-instant",
+            "gpt-5.3-codex-spark",
+            "chat-latest",
         ],
         ProviderKind::GitHubCopilot => &[
             "gpt-5.4",
@@ -144,7 +138,7 @@ fn canonical_models_provider(provider: &ProviderKind) -> ProviderKind {
 fn models_dev_id_to_providers(id: &str) -> &'static [ProviderKind] {
     match id {
         "anthropic" => &[ProviderKind::Anthropic],
-        "openai" => &[ProviderKind::OpenAI, ProviderKind::ChatGPT],
+        "openai" => &[ProviderKind::OpenAI],
         "chatgpt" => &[ProviderKind::ChatGPT],
         "github-copilot" => &[ProviderKind::GitHubCopilot],
         "minimax" => &[ProviderKind::MiniMax, ProviderKind::MiniMaxAnthropic],
@@ -273,8 +267,7 @@ impl ModelRegistry {
         models
     }
 
-    /// Stores models discovered from a user-configured provider endpoint.
-    #[cfg(test)]
+    /// Stores models discovered from a provider-managed endpoint.
     pub fn set_provider_models(&self, provider: ProviderKind, models: Vec<String>) {
         let canonical = canonical_models_provider(&provider);
         self.custom
@@ -401,6 +394,30 @@ impl ModelRegistry {
         Ok(parsed.to_string())
     }
 
+    pub fn chatgpt_subscription_models_url(base_url: Option<&str>) -> anyhow::Result<String> {
+        let raw = base_url
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(CHATGPT_CODEX_API_BASE_URL);
+        let mut parsed = url::Url::parse(raw).context("Base URL must be an absolute URL")?;
+        if !matches!(parsed.scheme(), "http" | "https") {
+            return Err(anyhow!("Base URL must use http or https"));
+        }
+
+        let mut path = parsed.path().trim_end_matches('/').to_string();
+        if !path.ends_with("/models") {
+            if path.is_empty() || path == "/" {
+                path = "/models".to_string();
+            } else {
+                path.push_str("/models");
+            }
+        }
+
+        parsed.set_path(&path);
+        parsed.set_fragment(None);
+        Ok(parsed.to_string())
+    }
+
     fn custom_models_scope(base_url: &str) -> Option<String> {
         Self::openai_compatible_models_url(base_url).ok()
     }
@@ -453,6 +470,73 @@ impl ModelRegistry {
         models.dedup();
         Ok(models)
     }
+
+    pub async fn fetch_chatgpt_subscription_models(
+        access_token: &str,
+        base_url: Option<&str>,
+    ) -> anyhow::Result<Vec<String>> {
+        let endpoint = Self::chatgpt_subscription_models_url(base_url)?;
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(15))
+            .build()?;
+
+        let resp = client
+            .get(&endpoint)
+            .bearer_auth(access_token)
+            .send()
+            .await?;
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            let detail = body.trim();
+            let detail = if detail.chars().count() > 180 {
+                format!("{}…", detail.chars().take(180).collect::<String>())
+            } else {
+                detail.to_string()
+            };
+            return Err(anyhow!(
+                "Model list request failed with HTTP {status}{}",
+                if detail.is_empty() {
+                    String::new()
+                } else {
+                    format!(": {detail}")
+                }
+            ));
+        }
+
+        let raw: serde_json::Value = resp
+            .json()
+            .await
+            .context("Response was not a ChatGPT Subscription model list")?;
+        let mut models = extract_model_ids(&raw);
+        models.sort();
+        models.dedup();
+        Ok(models)
+    }
+}
+
+fn extract_model_ids(raw: &serde_json::Value) -> Vec<String> {
+    let entries = raw
+        .get("data")
+        .and_then(serde_json::Value::as_array)
+        .or_else(|| raw.get("models").and_then(serde_json::Value::as_array))
+        .into_iter()
+        .flatten();
+
+    entries
+        .filter_map(|entry| match entry {
+            serde_json::Value::String(value) => Some(value.as_str()),
+            serde_json::Value::Object(object) => object
+                .get("id")
+                .or_else(|| object.get("slug"))
+                .or_else(|| object.get("name"))
+                .and_then(serde_json::Value::as_str),
+            _ => None,
+        })
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
 }
 
 #[cfg(test)]
@@ -480,7 +564,11 @@ mod tests {
     fn models_dev_aliases_cover_live_provider_ids() {
         assert_eq!(
             models_dev_id_to_providers("openai"),
-            &[ProviderKind::OpenAI, ProviderKind::ChatGPT]
+            &[ProviderKind::OpenAI]
+        );
+        assert_eq!(
+            models_dev_id_to_providers("chatgpt"),
+            &[ProviderKind::ChatGPT]
         );
         assert_eq!(
             models_dev_id_to_providers("minimax"),
@@ -501,6 +589,24 @@ mod tests {
         assert_eq!(
             models_dev_id_to_providers("deepseek"),
             &[ProviderKind::DeepSeek]
+        );
+    }
+
+    #[test]
+    fn chatgpt_subscription_fallback_is_curated_not_openai_api_catalog() {
+        let registry = ModelRegistry::new();
+
+        assert_eq!(
+            registry.models_for(&ProviderKind::ChatGPT),
+            vec![
+                "gpt-5.5".to_string(),
+                "gpt-5.4".to_string(),
+                "gpt-5.4-mini".to_string(),
+                "gpt-5.4-nano".to_string(),
+                "gpt-5.3-codex".to_string(),
+                "gpt-5.3-codex-spark".to_string(),
+                "chat-latest".to_string(),
+            ]
         );
     }
 
@@ -563,6 +669,53 @@ mod tests {
         );
         assert!(ModelRegistry::openai_compatible_models_url("/chat/completions").is_err());
         assert!(ModelRegistry::openai_compatible_models_url("chat/completions").is_err());
+    }
+
+    #[test]
+    fn chatgpt_subscription_models_url_uses_codex_models_endpoint() {
+        assert_eq!(
+            ModelRegistry::chatgpt_subscription_models_url(None).unwrap(),
+            "https://chatgpt.com/backend-api/codex/models"
+        );
+        assert_eq!(
+            ModelRegistry::chatgpt_subscription_models_url(Some(
+                "https://chatgpt.com/backend-api/codex"
+            ))
+            .unwrap(),
+            "https://chatgpt.com/backend-api/codex/models"
+        );
+        assert_eq!(
+            ModelRegistry::chatgpt_subscription_models_url(Some(
+                "https://chatgpt.com/backend-api/codex/models"
+            ))
+            .unwrap(),
+            "https://chatgpt.com/backend-api/codex/models"
+        );
+    }
+
+    #[test]
+    fn extract_model_ids_accepts_data_and_models_shapes() {
+        assert_eq!(
+            extract_model_ids(&serde_json::json!({
+                "data": [
+                    {"id": "gpt-5.5"},
+                    {"slug": "gpt-5.4"},
+                    {"name": "chat-latest"},
+                    {"id": " "}
+                ]
+            })),
+            vec![
+                "gpt-5.5".to_string(),
+                "gpt-5.4".to_string(),
+                "chat-latest".to_string(),
+            ]
+        );
+        assert_eq!(
+            extract_model_ids(&serde_json::json!({
+                "models": ["gpt-5.5", {"id": "gpt-5.4-mini"}]
+            })),
+            vec!["gpt-5.5".to_string(), "gpt-5.4-mini".to_string()]
+        );
     }
 
     #[test]

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -1,7 +1,7 @@
 use con_agent::provider::{AgentPurpose, ProviderTransport};
 use con_agent::{
     OAuthDevicePrompt, ProviderConfig, ProviderKind, SuggestionModelConfig,
-    authorize_oauth_provider, oauth_token_dir, read_chatgpt_oauth_access_token,
+    authorize_oauth_provider, oauth_token_dir, read_synced_chatgpt_oauth_access_token,
 };
 use con_core::{
     Config,
@@ -2248,7 +2248,7 @@ impl SettingsPanel {
                     cx.notify();
                     return;
                 };
-                let access_token = match read_chatgpt_oauth_access_token(&auth_file) {
+                let access_token = match read_synced_chatgpt_oauth_access_token(&auth_file) {
                     Ok(Some(token)) => token,
                     Ok(None) => {
                         self.provider_model_status =
@@ -2259,7 +2259,7 @@ impl SettingsPanel {
                     }
                     Err(err) => {
                         self.provider_model_status =
-                            Some(format!("Could not read ChatGPT OAuth cache: {err}"));
+                            Some(format!("Could not refresh ChatGPT OAuth cache: {err}"));
                         self.provider_model_status_error = true;
                         cx.notify();
                         return;

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -1,7 +1,7 @@
 use con_agent::provider::{AgentPurpose, ProviderTransport};
 use con_agent::{
     OAuthDevicePrompt, ProviderConfig, ProviderKind, SuggestionModelConfig,
-    authorize_oauth_provider, oauth_token_dir,
+    authorize_oauth_provider, oauth_token_dir, read_chatgpt_oauth_access_token,
 };
 use con_core::{
     Config,
@@ -44,6 +44,59 @@ struct ProviderOAuthState {
     prompt: Option<OAuthDevicePrompt>,
     status_message: Option<String>,
     error_message: Option<String>,
+}
+
+enum ProviderModelFetchRequest {
+    OpenAICompatible {
+        base_url: String,
+        api_key: Option<String>,
+    },
+    ChatGPT {
+        access_token: String,
+        base_url: Option<String>,
+    },
+}
+
+impl ProviderModelFetchRequest {
+    async fn fetch(self) -> anyhow::Result<ProviderModelFetchResult> {
+        match self {
+            Self::OpenAICompatible { base_url, api_key } => {
+                let models =
+                    ModelRegistry::fetch_openai_compatible_models(&base_url, api_key.as_deref())
+                        .await?;
+                Ok(ProviderModelFetchResult::OpenAICompatible { base_url, models })
+            }
+            Self::ChatGPT {
+                access_token,
+                base_url,
+            } => {
+                let models = ModelRegistry::fetch_chatgpt_subscription_models(
+                    &access_token,
+                    base_url.as_deref(),
+                )
+                .await?;
+                Ok(ProviderModelFetchResult::ChatGPT { models })
+            }
+        }
+    }
+}
+
+enum ProviderModelFetchResult {
+    OpenAICompatible {
+        base_url: String,
+        models: Vec<String>,
+    },
+    ChatGPT {
+        models: Vec<String>,
+    },
+}
+
+impl ProviderModelFetchResult {
+    fn models(&self) -> &[String] {
+        match self {
+            Self::OpenAICompatible { models, .. } | Self::ChatGPT { models } => models,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -2143,39 +2196,87 @@ impl SettingsPanel {
     }
 
     fn fetch_selected_provider_models(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if self.selected_provider != ProviderKind::OpenAICompatible || self.provider_model_fetching
+        if !matches!(
+            self.selected_provider,
+            ProviderKind::OpenAICompatible | ProviderKind::ChatGPT
+        ) || self.provider_model_fetching
         {
             return;
         }
 
+        let provider = self.selected_provider.clone();
         let provider_config = self.read_provider_inputs(cx);
         self.config
             .agent
             .providers
-            .set(&self.selected_provider, provider_config.clone());
+            .set(&provider, provider_config.clone());
 
-        let Some(base_url) = provider_config
-            .base_url
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(ToOwned::to_owned)
-        else {
-            self.provider_model_status =
-                Some("Enter the provider Base URL, usually ending in /v1.".to_string());
-            self.provider_model_status_error = true;
-            cx.notify();
-            return;
-        };
+        let fetch_request = match provider {
+            ProviderKind::OpenAICompatible => {
+                let Some(base_url) = provider_config
+                    .base_url
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToOwned::to_owned)
+                else {
+                    self.provider_model_status =
+                        Some("Enter the provider Base URL, usually ending in /v1.".to_string());
+                    self.provider_model_status_error = true;
+                    cx.notify();
+                    return;
+                };
 
-        let api_key = match Self::resolve_provider_api_key(&provider_config) {
-            Ok(api_key) => api_key,
-            Err(message) => {
-                self.provider_model_status = Some(message);
-                self.provider_model_status_error = true;
-                cx.notify();
-                return;
+                let api_key = match Self::resolve_provider_api_key(&provider_config) {
+                    Ok(api_key) => api_key,
+                    Err(message) => {
+                        self.provider_model_status = Some(message);
+                        self.provider_model_status_error = true;
+                        cx.notify();
+                        return;
+                    }
+                };
+                ProviderModelFetchRequest::OpenAICompatible { base_url, api_key }
             }
+            ProviderKind::ChatGPT => {
+                let Some(auth_file) =
+                    oauth_token_dir(&ProviderKind::ChatGPT).map(|dir| dir.join("auth.json"))
+                else {
+                    self.provider_model_status =
+                        Some("ChatGPT OAuth token storage is unavailable.".to_string());
+                    self.provider_model_status_error = true;
+                    cx.notify();
+                    return;
+                };
+                let access_token = match read_chatgpt_oauth_access_token(&auth_file) {
+                    Ok(Some(token)) => token,
+                    Ok(None) => {
+                        self.provider_model_status =
+                            Some("Sign in with ChatGPT OAuth before fetching models.".to_string());
+                        self.provider_model_status_error = true;
+                        cx.notify();
+                        return;
+                    }
+                    Err(err) => {
+                        self.provider_model_status =
+                            Some(format!("Could not read ChatGPT OAuth cache: {err}"));
+                        self.provider_model_status_error = true;
+                        cx.notify();
+                        return;
+                    }
+                };
+                let base_url = provider_config
+                    .base_url
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToOwned::to_owned);
+                ProviderModelFetchRequest::ChatGPT {
+                    access_token,
+                    base_url,
+                }
+            }
+            _ => return,
         };
 
         self.provider_model_fetching = true;
@@ -2185,13 +2286,9 @@ impl SettingsPanel {
 
         let registry = self.registry.clone();
         let runtime = self.oauth_runtime.clone();
-        let base_url_for_cache = base_url.clone();
         cx.spawn_in(window, async move |this, window| {
             let result = runtime
-                .spawn(async move {
-                    ModelRegistry::fetch_openai_compatible_models(&base_url, api_key.as_deref())
-                        .await
-                })
+                .spawn(async move { fetch_request.fetch().await })
                 .await
                 .map_err(|err| anyhow::anyhow!("Model fetch task failed: {err}"))
                 .and_then(|result| result);
@@ -2200,40 +2297,47 @@ impl SettingsPanel {
                 let _ = this.update(cx, |panel, cx| {
                     panel.provider_model_fetching = false;
                     match result {
-                        Ok(models) if models.is_empty() => {
+                        Ok(result) if result.models().is_empty() => {
                             panel.provider_model_status = Some(
                                 "The endpoint responded, but returned no models. Type the model ID manually."
                                     .to_string(),
                             );
                             panel.provider_model_status_error = true;
                         }
-                        Ok(models) => {
-                            let count = models.len();
-                            if let Err(err) = registry.set_provider_models_for_base_url(
-                                ProviderKind::OpenAICompatible,
-                                &base_url_for_cache,
-                                models,
-                            ) {
-                                panel.provider_model_status = Some(err.to_string());
-                                panel.provider_model_status_error = true;
-                                cx.notify();
-                                return;
+                        Ok(result) => {
+                            let count = result.models().len();
+                            match result {
+                                ProviderModelFetchResult::OpenAICompatible { base_url, models } => {
+                                    if let Err(err) = registry.set_provider_models_for_base_url(
+                                        ProviderKind::OpenAICompatible,
+                                        &base_url,
+                                        models,
+                                    ) {
+                                        panel.provider_model_status = Some(err.to_string());
+                                        panel.provider_model_status_error = true;
+                                        cx.notify();
+                                        return;
+                                    }
+                                }
+                                ProviderModelFetchResult::ChatGPT { models } => {
+                                    registry.set_provider_models(ProviderKind::ChatGPT, models);
+                                }
                             }
-                            if panel.selected_provider == ProviderKind::OpenAICompatible {
+                            if panel.selected_provider == provider {
                                 let current_model =
                                     panel.model_input.read(cx).value().trim().to_string();
                                 let current_model =
                                     (!current_model.is_empty()).then_some(current_model);
                                 panel.model_select = Self::make_model_select(
-                                    &ProviderKind::OpenAICompatible,
+                                    &provider,
                                     &current_model,
-                                    Some(&base_url_for_cache),
+                                    Self::provider_base_url(&panel.config, &provider),
                                     &registry,
                                     window,
                                     cx,
                                 );
                             }
-                            if panel.config.agent.provider == ProviderKind::OpenAICompatible {
+                            if panel.config.agent.provider == provider {
                                 panel.active_model_select = Self::make_active_model_select(
                                     &panel.config,
                                     &registry,
@@ -2241,9 +2345,7 @@ impl SettingsPanel {
                                     cx,
                                 );
                             }
-                            if Self::effective_suggestion_provider(&panel.config)
-                                == ProviderKind::OpenAICompatible
-                            {
+                            if Self::effective_suggestion_provider(&panel.config) == provider {
                                 panel.suggestion_model_select = Self::make_suggestion_model_select(
                                     &panel.config,
                                     &registry,
@@ -4203,7 +4305,10 @@ impl SettingsPanel {
         let model_select = self.model_select.clone();
         let endpoint_preset_select = self.endpoint_preset_select.clone();
         let endpoint_presets = Self::provider_endpoint_presets(&self.selected_provider);
-        let can_fetch_models = self.selected_provider == ProviderKind::OpenAICompatible;
+        let can_fetch_models = matches!(
+            self.selected_provider,
+            ProviderKind::OpenAICompatible | ProviderKind::ChatGPT
+        );
         let protocol_switch_label = Self::protocol_switch_label(&self.selected_provider);
         let protocol_switch_hint = Self::protocol_switch_hint(&self.selected_provider);
         let anthropic_protocol_enabled = Self::uses_anthropic_protocol(&self.selected_provider);
@@ -4418,7 +4523,11 @@ impl SettingsPanel {
                                 })
                                 .child(
                                     self.provider_model_status.clone().unwrap_or_else(|| {
-                                        "Fetch /models when the provider exposes a model list. Or enter the model ID.".to_string()
+                                        if self.selected_provider == ProviderKind::ChatGPT {
+                                            "Fetch the current ChatGPT Subscription model list after OAuth sign-in. Or enter the model ID.".to_string()
+                                        } else {
+                                            "Fetch /models when the provider exposes a model list. Or enter the model ID.".to_string()
+                                        }
                                     }),
                                 ),
                         )


### PR DESCRIPTION
Fixes #243.
Refs #222.
Refs #223.

## Summary
- Track the Codex ChatGPT auth source with a sidecar fingerprint so Con can refresh its imported Rig cache when `~/.codex/auth.json` changes, without overwriting a cache that Rig or manual OAuth already refreshed locally.
- Clear stale ChatGPT Subscription OAuth cache before manual re-auth, so a reused refresh token does not keep poisoning the provider.
- Stop mapping the generic OpenAI API model catalog onto ChatGPT Subscription, add a short curated subscription fallback list, and allow Settings to fetch the current subscription model list after OAuth sign-in.

## Validation
- `rustfmt --edition 2024 --check crates/con-agent/src/provider.rs crates/con-app/src/model_registry.rs crates/con-app/src/settings_panel.rs`
- `git diff --check -- crates/con-agent/src/provider.rs crates/con-app/src/model_registry.rs crates/con-app/src/settings_panel.rs`
- `cargo test -p con-agent`
- Attempted `cargo test -p con model_registry`; this did not reach the app tests in this local environment because the `con-ghostty` build script was still downloading/building Ghostty dependencies for the macOS backend.

## Notes
- The ChatGPT Subscription model picker now has a provider-specific path instead of reusing the OpenAI API catalog. This keeps the offline fallback intentionally short and lets signed-in users fetch the server-provided list when available.
<img width="920" height="680" alt="con Beta 2026-06-12 21 29 07" src="https://github.com/user-attachments/assets/5be5ccb7-cd76-43e5-b952-f83633a99de9" />
<img width="920" height="680" alt="con Beta 2026-06-12 21 14 13" src="https://github.com/user-attachments/assets/245b6d03-a487-4bf8-ac5c-ff4ba29d46a8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ChatGPT OAuth now syncs with legacy Codex auth so subscription tokens and models are discoverable.
  * Settings panel: fetch/refresh models for ChatGPT and OpenAI-compatible providers; contextual help and UI updates for fetched results.
  * Public helpers to read (optionally synced) ChatGPT OAuth access tokens.

* **Bug Fixes / Reliability**
  * Safer token sync that avoids clobbering caches, uses atomic writes, and refreshes sync state during device login.

* **Tests**
  * Added/expanded unit tests covering auth conversion, sync behavior, and model discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->