### PR TITLE
Fix chat markdown code block copy state

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,8 +36,8 @@ env:
 
 jobs:
   e2e:
-    name: e2e (macos-latest)
-    runs-on: macos-latest
+    name: e2e (macos-15)
+    runs-on: macos-15
     timeout-minutes: 30
 
     steps:

--- a/crates/con-app/src/agent_panel.rs
+++ b/crates/con-app/src/agent_panel.rs
@@ -30,7 +30,7 @@ use std::time::Duration;
 
 use crate::chat_markdown::{
     ChatMarkdownBlockView, ChatMarkdownTone, ParsedChatMarkdown, chat_markdown_block_gap,
-    render_parsed_chat_markdown, render_parsed_chat_markdown_prefix_with_copy_namespace,
+    render_parsed_chat_markdown_prefix_with_copy_namespace,
 };
 use crate::input_bar::SkillEntry;
 use crate::motion::{MotionValue, vertical_reveal_offset};
@@ -3172,11 +3172,14 @@ fn render_assistant_message(
                 .line_height(px(18.0))
                 .text_color(theme.muted_foreground.opacity(0.54));
             if let Some(markdown) = msg.thinking_markdown.as_ref() {
-                thinking_el = thinking_el.child(render_parsed_chat_markdown(
-                    markdown,
-                    ChatMarkdownTone::Thinking,
-                    theme,
-                ));
+                thinking_el =
+                    thinking_el.child(render_parsed_chat_markdown_prefix_with_copy_namespace(
+                        markdown,
+                        ChatMarkdownTone::Thinking,
+                        theme,
+                        markdown.block_count(),
+                        format!("asst-think-{msg_idx}"),
+                    ));
             } else {
                 thinking_el = thinking_el.child(div().whitespace_normal().child(thinking.clone()));
             }

--- a/crates/con-app/src/agent_panel.rs
+++ b/crates/con-app/src/agent_panel.rs
@@ -30,7 +30,7 @@ use std::time::Duration;
 
 use crate::chat_markdown::{
     ChatMarkdownBlockView, ChatMarkdownTone, ParsedChatMarkdown, chat_markdown_block_gap,
-    render_parsed_chat_markdown, render_parsed_chat_markdown_prefix,
+    render_parsed_chat_markdown, render_parsed_chat_markdown_prefix_with_copy_namespace,
 };
 use crate::input_bar::SkillEntry;
 use crate::motion::{MotionValue, vertical_reveal_offset};
@@ -738,6 +738,7 @@ impl AssistantMessageView {
         }
 
         let gap = chat_markdown_block_gap(ChatMarkdownTone::Message, theme);
+        let copy_namespace = format!("asst-{}", self.msg_idx);
         div()
             .w_full()
             .flex()
@@ -748,12 +749,23 @@ impl AssistantMessageView {
                 let view = if let Some(view) = self.markdown_block_views[block_idx].as_ref() {
                     let view = view.clone();
                     view.update(cx, |view, cx| {
-                        view.update(document, block_idx, ChatMarkdownTone::Message, cx);
+                        view.update(
+                            document,
+                            block_idx,
+                            ChatMarkdownTone::Message,
+                            copy_namespace.clone(),
+                            cx,
+                        );
                     });
                     view
                 } else {
                     let view = cx.new(|_| {
-                        ChatMarkdownBlockView::new(document, block_idx, ChatMarkdownTone::Message)
+                        ChatMarkdownBlockView::new(
+                            document,
+                            block_idx,
+                            ChatMarkdownTone::Message,
+                            copy_namespace.clone(),
+                        )
                     });
                     self.markdown_block_views[block_idx] = Some(view.clone());
                     view
@@ -3186,12 +3198,14 @@ fn render_assistant_message(
             if let Some(rendered_markdown) = rendered_markdown {
                 content_el = content_el.child(rendered_markdown);
             } else {
-                content_el = content_el.child(render_parsed_chat_markdown_prefix(
-                    markdown,
-                    ChatMarkdownTone::Message,
-                    theme,
-                    visible_blocks,
-                ));
+                content_el =
+                    content_el.child(render_parsed_chat_markdown_prefix_with_copy_namespace(
+                        markdown,
+                        ChatMarkdownTone::Message,
+                        theme,
+                        visible_blocks,
+                        format!("asst-{msg_idx}"),
+                    ));
             }
             if let Some(suffix) = unparsed_markdown_suffix(msg) {
                 content_el = content_el.child(div().mt(ui_space_px(theme, 6.0)).child(

--- a/crates/con-app/src/chat_markdown.rs
+++ b/crates/con-app/src/chat_markdown.rs
@@ -467,7 +467,18 @@ pub fn render_parsed_chat_markdown_prefix(
     theme: &Theme,
     max_blocks: usize,
 ) -> AnyElement {
+    render_parsed_chat_markdown_prefix_with_copy_namespace(document, tone, theme, max_blocks, "")
+}
+
+pub fn render_parsed_chat_markdown_prefix_with_copy_namespace(
+    document: &ParsedChatMarkdown,
+    tone: ChatMarkdownTone,
+    theme: &Theme,
+    max_blocks: usize,
+    copy_namespace: impl Into<SharedString>,
+) -> AnyElement {
     let style = ChatMarkdownStyle::new(theme, tone);
+    let copy_namespace = copy_namespace.into();
     let block_count = document.blocks.len().min(max_blocks);
     let blocks = &document.blocks[..block_count];
 
@@ -480,12 +491,9 @@ pub fn render_parsed_chat_markdown_prefix(
         .flex()
         .flex_col()
         .gap(style.block_gap)
-        .children(
-            blocks
-                .iter()
-                .enumerate()
-                .map(|(idx, block)| render_block_with_width(block, idx, &style, None)),
-        )
+        .children(blocks.iter().enumerate().map(|(idx, block)| {
+            render_block_with_width(block, idx, &style, None, copy_namespace.as_ref())
+        }))
         .into_any_element()
 }
 
@@ -497,6 +505,7 @@ pub struct ChatMarkdownBlockView {
     document: Arc<ParsedChatMarkdown>,
     block_index: usize,
     tone: ChatMarkdownTone,
+    copy_namespace: SharedString,
     table_scroll_handle: ScrollHandle,
     rich_svg_renders: HashMap<RichSvgRenderKey, RichSvgRenderEntry>,
 }
@@ -506,11 +515,13 @@ impl ChatMarkdownBlockView {
         document: Arc<ParsedChatMarkdown>,
         block_index: usize,
         tone: ChatMarkdownTone,
+        copy_namespace: impl Into<SharedString>,
     ) -> Self {
         Self {
             document,
             block_index,
             tone,
+            copy_namespace: copy_namespace.into(),
             table_scroll_handle: ScrollHandle::new(),
             rich_svg_renders: HashMap::new(),
         }
@@ -521,20 +532,26 @@ impl ChatMarkdownBlockView {
         document: Arc<ParsedChatMarkdown>,
         block_index: usize,
         tone: ChatMarkdownTone,
+        copy_namespace: impl Into<SharedString>,
         cx: &mut gpui::Context<Self>,
     ) {
+        let copy_namespace = copy_namespace.into();
         let old_block = self.document.blocks.get(self.block_index);
         let new_block = document.blocks.get(block_index);
-        let block_changed =
-            self.block_index != block_index || self.tone != tone || old_block != new_block;
+        let block_changed = self.block_index != block_index
+            || self.tone != tone
+            || self.copy_namespace != copy_namespace
+            || old_block != new_block;
 
         if self.block_index != block_index
             || self.tone != tone
+            || self.copy_namespace != copy_namespace
             || !Arc::ptr_eq(&self.document, &document)
         {
             self.document = document;
             self.block_index = block_index;
             self.tone = tone;
+            self.copy_namespace = copy_namespace;
             if block_changed {
                 self.table_scroll_handle = ScrollHandle::new();
                 self.rich_svg_renders.clear();
@@ -683,13 +700,21 @@ impl ChatMarkdownBlockView {
         match block {
             MarkdownBlock::Mermaid { .. } | MarkdownBlock::MathBlock { .. } => self
                 .render_rich_svg_block(path, block, style, cx)
-                .unwrap_or_else(|| render_block(block, index, style, table_scroll_handle)),
+                .unwrap_or_else(|| {
+                    render_block(
+                        block,
+                        index,
+                        style,
+                        table_scroll_handle,
+                        self.copy_namespace.as_ref(),
+                    )
+                }),
             MarkdownBlock::CodeBlock {
                 language,
                 code,
                 highlight_cache,
             } => render_code_block(
-                code_block_copy_id(path, code),
+                code_block_copy_id(self.copy_namespace.as_ref(), path, code),
                 language,
                 code,
                 highlight_cache,
@@ -766,7 +791,13 @@ impl ChatMarkdownBlockView {
 
                 render_list_children(*ordered, *start, items.len(), item_children, style)
             }
-            _ => render_block(block, index, style, table_scroll_handle),
+            _ => render_block(
+                block,
+                index,
+                style,
+                table_scroll_handle,
+                self.copy_namespace.as_ref(),
+            ),
         }
     }
 
@@ -1149,9 +1180,10 @@ fn render_block(
     index: usize,
     style: &ChatMarkdownStyle<'_>,
     table_scroll_handle: Option<&ScrollHandle>,
+    copy_namespace: &str,
 ) -> AnyElement {
     let mut path = vec![index];
-    render_block_at_path(block, &mut path, style, table_scroll_handle)
+    render_block_at_path(block, &mut path, style, table_scroll_handle, copy_namespace)
 }
 
 fn render_block_at_path(
@@ -1159,6 +1191,7 @@ fn render_block_at_path(
     path: &mut Vec<usize>,
     style: &ChatMarkdownStyle<'_>,
     table_scroll_handle: Option<&ScrollHandle>,
+    copy_namespace: &str,
 ) -> AnyElement {
     let index = path.last().copied().unwrap_or(0);
     match block {
@@ -1193,7 +1226,7 @@ fn render_block_at_path(
             code,
             highlight_cache,
         } => render_code_block(
-            code_block_copy_id(path, code),
+            code_block_copy_id(copy_namespace, path, code),
             language,
             code,
             highlight_cache,
@@ -1209,7 +1242,7 @@ fn render_block_at_path(
                 .enumerate()
                 .map(|(idx, block)| {
                     path.push(idx);
-                    let rendered = render_block_at_path(block, path, style, None);
+                    let rendered = render_block_at_path(block, path, style, None, copy_namespace);
                     path.pop();
                     rendered
                 })
@@ -1232,7 +1265,13 @@ fn render_block_at_path(
                         .map(|(nested_idx, nested_block)| {
                             path.push(item_idx);
                             path.push(nested_idx);
-                            let rendered = render_block_at_path(nested_block, path, style, None);
+                            let rendered = render_block_at_path(
+                                nested_block,
+                                path,
+                                style,
+                                None,
+                                copy_namespace,
+                            );
                             path.pop();
                             path.pop();
                             rendered
@@ -1261,6 +1300,7 @@ fn render_block_with_width(
     index: usize,
     style: &ChatMarkdownStyle<'_>,
     table_scroll_handle: Option<&ScrollHandle>,
+    copy_namespace: &str,
 ) -> AnyElement {
     let mut wrapper = div().w_full();
     if !matches!(
@@ -1273,7 +1313,13 @@ fn render_block_with_width(
     }
 
     wrapper
-        .child(render_block(block, index, style, table_scroll_handle))
+        .child(render_block(
+            block,
+            index,
+            style,
+            table_scroll_handle,
+            copy_namespace,
+        ))
         .into_any_element()
 }
 
@@ -2053,11 +2099,13 @@ fn rich_svg_render_id(path: &[usize], key: &RichSvgRenderKey) -> SharedString {
     SharedString::from(format!("chat-md-{kind}-{path}-{:x}", hasher.finish()))
 }
 
-fn code_block_copy_id(path: &[usize], code: &str) -> String {
+fn code_block_copy_id(copy_namespace: &str, path: &[usize], code: &str) -> String {
     let mut hasher = DefaultHasher::new();
+    copy_namespace.hash(&mut hasher);
     code.hash(&mut hasher);
     format!(
-        "copy-code-block-{}-{:x}",
+        "copy-code-block-{}-{}-{:x}",
+        copy_namespace,
         markdown_path_id(path),
         hasher.finish()
     )
@@ -3068,12 +3116,24 @@ mod tests {
     fn code_block_copy_ids_include_nested_block_path() {
         let code = "brew services start lizardbyte/homebrew/sunshine";
 
-        let first = code_block_copy_id(&[0, 0, 1], code);
-        let second = code_block_copy_id(&[0, 1, 1], code);
+        let first = code_block_copy_id("asst-1", &[0, 0, 1], code);
+        let second = code_block_copy_id("asst-1", &[0, 1, 1], code);
 
         assert_ne!(first, second);
         assert!(first.contains("0.0.1"));
         assert!(second.contains("0.1.1"));
+    }
+
+    #[test]
+    fn code_block_copy_ids_include_message_namespace() {
+        let code = "brew services start lizardbyte/homebrew/sunshine";
+
+        let first = code_block_copy_id("asst-1", &[0, 0, 1], code);
+        let second = code_block_copy_id("asst-2", &[0, 0, 1], code);
+
+        assert_ne!(first, second);
+        assert!(first.contains("asst-1"));
+        assert!(second.contains("asst-2"));
     }
 
     #[test]

--- a/crates/con-app/src/chat_markdown.rs
+++ b/crates/con-app/src/chat_markdown.rs
@@ -453,23 +453,6 @@ impl ParsedChatMarkdown {
     }
 }
 
-pub fn render_parsed_chat_markdown(
-    document: &ParsedChatMarkdown,
-    tone: ChatMarkdownTone,
-    theme: &Theme,
-) -> AnyElement {
-    render_parsed_chat_markdown_prefix(document, tone, theme, document.blocks.len())
-}
-
-pub fn render_parsed_chat_markdown_prefix(
-    document: &ParsedChatMarkdown,
-    tone: ChatMarkdownTone,
-    theme: &Theme,
-    max_blocks: usize,
-) -> AnyElement {
-    render_parsed_chat_markdown_prefix_with_copy_namespace(document, tone, theme, max_blocks, "")
-}
-
 pub fn render_parsed_chat_markdown_prefix_with_copy_namespace(
     document: &ParsedChatMarkdown,
     tone: ChatMarkdownTone,

--- a/crates/con-app/src/chat_markdown.rs
+++ b/crates/con-app/src/chat_markdown.rs
@@ -684,6 +684,17 @@ impl ChatMarkdownBlockView {
             MarkdownBlock::Mermaid { .. } | MarkdownBlock::MathBlock { .. } => self
                 .render_rich_svg_block(path, block, style, cx)
                 .unwrap_or_else(|| render_block(block, index, style, table_scroll_handle)),
+            MarkdownBlock::CodeBlock {
+                language,
+                code,
+                highlight_cache,
+            } => render_code_block(
+                code_block_copy_id(path, code),
+                language,
+                code,
+                highlight_cache,
+                style,
+            ),
             MarkdownBlock::Paragraph {
                 inlines,
                 inline_cache,
@@ -1139,6 +1150,17 @@ fn render_block(
     style: &ChatMarkdownStyle<'_>,
     table_scroll_handle: Option<&ScrollHandle>,
 ) -> AnyElement {
+    let mut path = vec![index];
+    render_block_at_path(block, &mut path, style, table_scroll_handle)
+}
+
+fn render_block_at_path(
+    block: &MarkdownBlock,
+    path: &mut Vec<usize>,
+    style: &ChatMarkdownStyle<'_>,
+    table_scroll_handle: Option<&ScrollHandle>,
+) -> AnyElement {
+    let index = path.last().copied().unwrap_or(0);
     match block {
         MarkdownBlock::Paragraph {
             inlines,
@@ -1170,7 +1192,13 @@ fn render_block(
             language,
             code,
             highlight_cache,
-        } => render_code_block(index, language, code, highlight_cache, style),
+        } => render_code_block(
+            code_block_copy_id(path, code),
+            language,
+            code,
+            highlight_cache,
+            style,
+        ),
         MarkdownBlock::Mermaid { code, scale } => {
             render_mermaid_code_fallback(index, code, *scale, style)
         }
@@ -1179,7 +1207,12 @@ fn render_block(
             let children = blocks
                 .iter()
                 .enumerate()
-                .map(|(idx, block)| render_block(block, idx, style, None))
+                .map(|(idx, block)| {
+                    path.push(idx);
+                    let rendered = render_block_at_path(block, path, style, None);
+                    path.pop();
+                    rendered
+                })
                 .collect::<Vec<_>>();
 
             render_blockquote_children(children, style)
@@ -1191,12 +1224,18 @@ fn render_block(
         } => {
             let item_children = items
                 .iter()
-                .map(|item_blocks| {
+                .enumerate()
+                .map(|(item_idx, item_blocks)| {
                     item_blocks
                         .iter()
                         .enumerate()
                         .map(|(nested_idx, nested_block)| {
-                            render_block(nested_block, nested_idx, style, None)
+                            path.push(item_idx);
+                            path.push(nested_idx);
+                            let rendered = render_block_at_path(nested_block, path, style, None);
+                            path.pop();
+                            path.pop();
+                            rendered
                         })
                         .collect::<Vec<_>>()
                 })
@@ -1463,7 +1502,7 @@ fn render_table_block(
 }
 
 fn render_code_block(
-    _index: usize,
+    copy_id: String,
     language: &Option<String>,
     code: &str,
     highlight_cache: &RefCell<Option<CachedCodeHighlightRuns>>,
@@ -1489,10 +1528,7 @@ fn render_code_block(
                 .child(header_label),
         )
         .child(div().h(px(1.0)).flex_1().bg(style.rule_color.opacity(0.36)))
-        .child(
-            Clipboard::new(format!("copy-code-block-{_index}"))
-                .value(SharedString::from(code.to_string())),
-        );
+        .child(Clipboard::new(copy_id).value(SharedString::from(code.to_string())));
 
     let block = div()
         .w_full()
@@ -2013,12 +2049,29 @@ fn rich_svg_render_id(path: &[usize], key: &RichSvgRenderKey) -> SharedString {
         RichSvgRenderKind::Math => "math",
         RichSvgRenderKind::InlineMath => "inline-math",
     };
-    let path = path
-        .iter()
+    let path = markdown_path_id(path);
+    SharedString::from(format!("chat-md-{kind}-{path}-{:x}", hasher.finish()))
+}
+
+fn code_block_copy_id(path: &[usize], code: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    code.hash(&mut hasher);
+    format!(
+        "copy-code-block-{}-{:x}",
+        markdown_path_id(path),
+        hasher.finish()
+    )
+}
+
+fn markdown_path_id(path: &[usize]) -> String {
+    if path.is_empty() {
+        return "root".to_string();
+    }
+
+    path.iter()
         .map(usize::to_string)
         .collect::<Vec<_>>()
-        .join(".");
-    SharedString::from(format!("chat-md-{kind}-{path}-{:x}", hasher.finish()))
+        .join(".")
 }
 
 fn rich_svg_render_scale(key: &RichSvgRenderKey) -> f32 {
@@ -3009,6 +3062,18 @@ mod tests {
         let first = rich_svg_render_id(&[0, 0, 0], &key);
         let second = rich_svg_render_id(&[1, 0, 0], &key);
         assert_ne!(first, second);
+    }
+
+    #[test]
+    fn code_block_copy_ids_include_nested_block_path() {
+        let code = "brew services start lizardbyte/homebrew/sunshine";
+
+        let first = code_block_copy_id(&[0, 0, 1], code);
+        let second = code_block_copy_id(&[0, 1, 1], code);
+
+        assert_ne!(first, second);
+        assert!(first.contains("0.0.1"));
+        assert!(second.contains("0.1.1"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Scope chat markdown code block copy IDs by message, markdown block path, and code content.
- Preserve that copy namespace through nested blockquotes/lists and the cached `ChatMarkdownBlockView` render path.
- Pin the e2e workflow to `macos-15` so it does not drift onto the `macos-26-arm64` runner image that fails the Zig/libghostty build.

## Evidence

Reported screenshot showing multiple copy buttons entering the copied state together:

![Screenshot evidence](https://raw.githubusercontent.com/hhh2210/con-terminal/23fa294fe650b6e1d2720d9f2dc7fe74655c0dbf/evidence/chat-markdown-copy-buttons.png)

## Validation

- `RUSTFLAGS='-D warnings' cargo test -p con code_block_copy_ids_include`
- `RUSTFLAGS='-D warnings' cargo check -p con`

GitHub checks pass on commit `18e7961`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown rendering for fenced code blocks, including nested content like quotes and lists.
  * Made code-block copy behavior more consistent so copied content is identified correctly in different positions.
  * Updated embedded SVG rendering to use more stable identifiers for Markdown content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
