### PR TITLE
refactor(agent): migrate to Rig 0.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## `v0.1.0-beta.79` - unreleased
+
+### Changed
+
+**Agent**
+
+- Updated Con's built-in agent to Rig 0.40 while preserving live responses,
+  tool approvals, conversation history, and existing turn limits. The agent now
+  follows Rig's published release instead of an interim source revision. _(PR
+  [#250](https://github.com/nowledge-co/con-terminal/pull/250) by
+  [@wey-gu](https://github.com/wey-gu))_
+
+---
+
 ## `v0.1.0-beta.78` - 2026-07-15
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ con is an open-source, GPU-accelerated terminal emulator with a built-in AI agen
 - **Terminal runtime**: libghostty — full Ghostty terminal via C API, Metal GPU rendering, embedded as native NSView. macOS uses the full embedded libghostty; Windows and Linux consume the carved-out `libghostty-vt` parser instead and pair it with their own renderers (D3D11/DirectWrite on Windows, GPUI per-row `StyledText` on the Linux preview today / GPUI-owned glyph-atlas grid renderer in the long term).
 - **Terminal FFI**: con-ghostty crate — thin Rust wrapper over libghostty C API on macOS (surface lifecycle, action callbacks, clipboard, key/mouse input). On Windows + Linux it wraps `libghostty-vt` plus per-platform PTY (`ConPTY` / Unix PTY) and renderer plumbing. Per-platform code lives in `con-ghostty/src/{terminal,windows,linux}/`; the workspace consumes the same `GhosttyApp` / `GhosttyTerminal` / `TerminalColors` type names from each.
 - **Terminal support crate**: con-terminal — theme and palette helpers only
-- **AI agent**: Rig v0.34.0 (from crates.io, 13 providers, Tool trait)
+- **AI agent**: Rig v0.40.0 (from crates.io, multi-provider clients, Tool and AgentHook traits)
 - **Socket API**: JSON-RPC 2.0 with a platform-specific transport — Unix domain sockets on Unix, Windows Named Pipes (`\\.\pipe\con`) on Windows. Served by the app and consumed first by `con-cli`.
 
 ## Repository Layout
@@ -32,7 +32,7 @@ kingston/
 │   ├── con-core/      # Shared logic (harness, config, session)
 │   ├── con-terminal/  # Terminal themes and palette helpers
 │   ├── con-ghostty/   # Ghostty FFI wrapper — primary macOS backend (libghostty C API)
-│   ├── con-agent/     # AI harness (Rig 0.34, tools, conversation)
+│   ├── con-agent/     # AI harness (Rig 0.40, tools, conversation)
 │   └── con-cli/       # CLI + socket client for the live local control plane
 ├── assets/            # Themes, fonts, icons
 └── 3pp/               # Third-party source (READ-ONLY reference, .gitignored)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-lite 2.6.1",
- "gloo-timers",
+ "gloo-timers 0.3.0",
  "kv-log-macro",
  "log",
  "memchr",
@@ -2533,6 +2533,10 @@ name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+dependencies = [
+ "gloo-timers 0.2.6",
+ "send_wrapper",
+]
 
 [[package]]
 name = "futures-util"
@@ -2676,6 +2680,18 @@ dependencies = [
  "bitflags 1.3.2",
  "ignore",
  "walkdir",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4466,15 +4482,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nanoid"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
-dependencies = [
- "rand 0.8.5",
-]
-
-[[package]]
 name = "nanorand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5930,8 +5937,9 @@ dependencies = [
 
 [[package]]
 name = "rig-core"
-version = "0.36.0"
-source = "git+https://github.com/0xPlaygrounds/rig.git?rev=f4ad17cd8730b32c0a36302921b3554cef0f370c#f4ad17cd8730b32c0a36302921b3554cef0f370c"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8731dd5532b3a12ce1613af73073fb2051ef750f50c504778c21d55ae933cac"
 dependencies = [
  "as-any",
  "async-stream",
@@ -5943,9 +5951,9 @@ dependencies = [
  "futures-timer",
  "glob",
  "http",
+ "indexmap",
  "mime",
  "mime_guess",
- "nanoid",
  "ordered-float",
  "pin-project-lite",
  "reqwest 0.13.2",
@@ -6414,6 +6422,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6475,9 +6489,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap",
  "itoa",
@@ -7330,9 +7344,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -7380,9 +7394,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.23.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -8026,21 +8040,20 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.23.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "utf-8",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ gpui-component-macros = { git = "https://github.com/longbridge/gpui-component.gi
 gpui-component-assets = { git = "https://github.com/longbridge/gpui-component.git", branch = "main", package = "gpui-component-assets" }
 
 # AI Agent
-rig = { package = "rig-core", git = "https://github.com/0xPlaygrounds/rig.git", rev = "f4ad17cd8730b32c0a36302921b3554cef0f370c", default-features = false, features = ["rustls"] }
+rig = { package = "rig-core", version = "0.40.0", default-features = false, features = ["rustls"] }
 
 # Async
 tokio = { version = "1", features = ["full"] }

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -88,12 +88,12 @@ kingston/
 │   │       ├── ffi.rs         # C API bindings (libghostty types, functions)
 │   │       └── terminal.rs    # GhosttyApp, GhosttyTerminal, TerminalState, action callbacks
 │   │
-│   ├── con-agent/             # AI agent harness (Rig 0.34)
+│   ├── con-agent/             # AI agent harness (Rig 0.40)
 │   │   └── src/
 │   │       ├── lib.rs
-│   │       ├── provider.rs    # Multi-provider Rig Agent (13 providers)
-│   │       ├── hook.rs        # ConHook — PromptHook lifecycle bridge
-│   │       ├── tools.rs       # Rig Tool trait impls (terminal_exec, shell, file, edit, list, search)
+│   │       ├── provider.rs    # Multi-provider Rig agent construction and streaming
+│   │       ├── hook.rs        # ConHook — AgentHook lifecycle bridge
+│   │       ├── tools.rs       # Rig Tool impls for terminals, tmux, files, and workspaces
 │   │       ├── context.rs     # terminal context extraction for agent
 │   │       ├── conversation.rs # conversation state + Rig Message conversion
 │   │       └── skills.rs      # skill registry + AGENTS.md parser
@@ -231,14 +231,14 @@ See `docs/study/terminal-control-plane.md`.
 
 - `CompletionClient::agent()` builder — preamble + tools + model config in one chain
 - `Tool` trait — type-safe tool definitions with `Args` (Deserialize), `Output` (Serialize), `Error`
-- `Chat` trait — multi-turn conversation with `Vec<Message>` history
-- `PromptHook` trait — lifecycle callbacks (on_text_delta, on_tool_call, on_tool_result) for streaming UI
+- streaming prompt requests with explicit `Vec<Message>` history
+- `AgentHook` events for text deltas, tool approval, and tool results
 - `anthropic::Client::new(api_key)` — direct Anthropic provider with model constants (`CLAUDE_4_SONNET`)
 - Agent loop with automatic tool calling (up to N turns)
 
-**Current integration:** con-agent implements 7 tools as Rig `Tool` impls (terminal_exec, shell_exec, file_read, file_write, edit_file, list_files, search), supports 13 providers (Anthropic, OpenAI, OpenAI-compatible, DeepSeek, Groq, Gemini, Ollama, OpenRouter, Mistral, Together, Cohere, Perplexity, xAI) with custom base_url for proxy endpoints. The harness runs on a shared tokio runtime. Provider settings are configurable via Cmd+, settings panel.
+**Current integration:** con-agent implements 34 Rig tools spanning visible terminal control, tmux, local files, remote workspaces, and agent CLI orchestration. Provider-native clients and OpenAI-compatible endpoints share one harness path, with configurable models, credentials, and base URLs. The harness runs on a shared tokio runtime. Provider settings are configurable from the settings window.
 
-**Agent lifecycle (PromptHook):** Each agent request uses `agent.prompt().with_hook(hook).with_history(history)` instead of `agent.chat()`. The `ConHook` struct implements Rig's `PromptHook<M>` trait, emitting `AgentEvent`s for every tool call start/result and text delta. For dangerous tools (`shell_exec`, `terminal_exec`, `file_write`, `edit_file`), the hook blocks on a per-request approval channel — the UI must explicitly allow or deny execution before the agent proceeds. Safe tools (`file_read`, `list_files`, `search`) execute immediately. A 5-minute timeout prevents indefinite hangs if the UI becomes unresponsive.
+**Agent lifecycle (AgentHook):** Each agent request builds a streaming prompt with its conversation history and a `ConHook` registered on the agent. The hook maps Rig's typed lifecycle events into Con's UI events for tool-call start, tool result, and text deltas. For dangerous tools (`shell_exec`, `terminal_exec`, `file_write`, `edit_file`), the hook waits on a per-request approval channel before execution. Safe tools (`file_read`, `list_files`, `search`) execute immediately. A 5-minute timeout prevents indefinite hangs if the UI becomes unresponsive. Rig 0.40 uses an exact total model-call budget; Con converts its existing `max_turns` setting through a compatibility function that preserves the previously shipped ceiling.
 
 **Visible terminal tool:** The `terminal_exec` tool is con's core differentiator. Instead of running commands in a hidden subprocess, it writes commands to the user's visible Ghostty pane. Output is captured via Ghostty's command-finished signal, with a bounded recent-output fallback when shell integration is unavailable. The user sees every command the agent runs in real time — full transparency.
 
@@ -313,14 +313,14 @@ Important consequence:
 - [x] Side panel for AI chat (Cmd+L to toggle)
 - [x] Terminal context injection (last N lines, current command, cwd)
 - [x] Tool execution: agent can run shell commands in terminal
-- [x] Multi-provider config (13 providers via Rig 0.34)
+- [x] Multi-provider config via Rig 0.40
 - [x] Settings panel (Cmd+,) with provider selector and model config
 - [x] Smart input bar (shell/agent/smart modes)
 - [x] Agent notification system (blue dot on tab when agent responds)
 
 ### Phase 3: Agent Lifecycle & Tool Transparency
 
-- [x] PromptHook integration — tool calls visible in agent panel
+- [x] AgentHook integration — tool calls visible in agent panel
 - [x] Tool danger classification (safe: file_read, search; dangerous: shell_exec, file_write)
 - [x] Per-request approval channels (no cross-request interference)
 - [x] Approval timeout (5 minutes, denies on expiry)
@@ -375,7 +375,7 @@ Important consequence:
 
 ### Phase 7: Agent Capabilities & Terminal Polish
 
-- [x] Rig 0.32 → 0.34 upgrade (stable API, `rustls` feature rename)
+- [x] Rig 0.36 → 0.40 migration (hooks v2, structured tool metadata, unified prompt responses)
 - [x] Rich context injection (git diff, project structure, XML-tagged system prompt)
 - [x] Visible terminal tool (terminal_exec — commands execute in user's visible PTY)
 - [x] Surgical file editing tool (edit_file — find & replace, not full overwrite)

--- a/crates/con-agent/src/conversation.rs
+++ b/crates/con-agent/src/conversation.rs
@@ -192,17 +192,15 @@ impl Conversation {
             match msg.role {
                 MessageRole::User => {
                     history.push(RigMessage::User {
-                        content: OneOrMany::one(UserContent::Text(Text {
-                            text: msg.content.clone(),
-                        })),
+                        content: OneOrMany::one(UserContent::Text(Text::new(msg.content.clone()))),
                     });
                 }
                 MessageRole::Assistant => {
                     history.push(RigMessage::Assistant {
                         id: None,
-                        content: OneOrMany::one(AssistantContent::Text(Text {
-                            text: msg.content.clone(),
-                        })),
+                        content: OneOrMany::one(AssistantContent::Text(Text::new(
+                            msg.content.clone(),
+                        ))),
                     });
                 }
                 // System and Tool messages are handled separately

--- a/crates/con-agent/src/hook.rs
+++ b/crates/con-agent/src/hook.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crossbeam_channel::Sender;
-use rig::agent::{HookAction, PromptHook, ToolCallHookAction};
+use rig::agent::{AgentHook, Flow, HookContext, StepEvent, StepEventKind};
 use rig::completion::CompletionModel;
 
 use crate::provider::AgentEvent;
@@ -61,6 +61,86 @@ impl ConHook {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hook(
+        auto_approve: bool,
+        cancelled: bool,
+    ) -> (
+        ConHook,
+        crossbeam_channel::Receiver<AgentEvent>,
+        crossbeam_channel::Sender<ToolApprovalDecision>,
+    ) {
+        let (event_tx, event_rx) = crossbeam_channel::unbounded();
+        let (approval_tx, approval_rx) = crossbeam_channel::unbounded();
+        (
+            ConHook::new(
+                event_tx,
+                approval_rx,
+                auto_approve,
+                Arc::new(AtomicBool::new(cancelled)),
+            ),
+            event_rx,
+            approval_tx,
+        )
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn safe_tool_continues_without_approval() {
+        let (hook, event_rx, _approval_tx) = hook(false, false);
+
+        let flow = hook.on_tool_call("read_pane", "call-1", "{}").await;
+
+        assert_eq!(flow, Flow::Continue);
+        assert!(matches!(
+            event_rx.try_recv(),
+            Ok(AgentEvent::ToolCallStart { call_id, tool_name, .. })
+                if call_id == "call-1" && tool_name == "read_pane"
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dangerous_tool_honors_denial_reason() {
+        let (hook, event_rx, approval_tx) = hook(false, false);
+        approval_tx
+            .send(ToolApprovalDecision {
+                call_id: "call-2".into(),
+                allowed: false,
+                reason: Some("Not approved".into()),
+            })
+            .unwrap();
+
+        let flow = hook.on_tool_call("terminal_exec", "call-2", "{}").await;
+
+        assert_eq!(
+            flow,
+            Flow::Skip {
+                reason: "Not approved".into()
+            }
+        );
+        assert!(matches!(
+            event_rx.try_recv(),
+            Ok(AgentEvent::ToolCallStart { call_id, .. }) if call_id == "call-2"
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancellation_releases_pending_approval() {
+        let (hook, _event_rx, _approval_tx) = hook(false, true);
+
+        let flow = hook.on_tool_call("file_write", "call-3", "{}").await;
+
+        assert_eq!(
+            flow,
+            Flow::Skip {
+                reason: "Tool approval timed out or cancelled".into()
+            }
+        );
+    }
+}
+
 pub fn is_dangerous(tool_name: &str) -> bool {
     matches!(
         tool_name,
@@ -86,14 +166,43 @@ const APPROVAL_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_mi
 /// Total approval timeout: 5 minutes.
 const APPROVAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
 
-impl<M: CompletionModel> PromptHook<M> for ConHook {
-    fn on_tool_call(
-        &self,
-        tool_name: &str,
-        _tool_call_id: Option<String>,
-        internal_call_id: &str,
-        args: &str,
-    ) -> impl Future<Output = ToolCallHookAction> + Send {
+impl<M: CompletionModel> AgentHook<M> for ConHook {
+    async fn on_event(&self, _ctx: &HookContext, event: StepEvent<'_, M>) -> Flow {
+        match event {
+            StepEvent::ToolCall {
+                tool_name,
+                internal_call_id,
+                args,
+                ..
+            } => self.on_tool_call(tool_name, internal_call_id, args).await,
+            StepEvent::ToolResult {
+                tool_name,
+                internal_call_id,
+                result,
+                ..
+            } => {
+                let _ = self.event_tx.send(AgentEvent::ToolCallComplete {
+                    call_id: internal_call_id.to_string(),
+                    tool_name: tool_name.to_string(),
+                    result: result.to_string(),
+                });
+                Flow::cont()
+            }
+            StepEvent::TextDelta { delta, .. } => {
+                let _ = self.event_tx.send(AgentEvent::Token(delta.to_string()));
+                Flow::cont()
+            }
+            _ => Flow::cont(),
+        }
+    }
+
+    fn observes(&self, kind: StepEventKind) -> bool {
+        matches!(kind, StepEventKind::TextDelta)
+    }
+}
+
+impl ConHook {
+    async fn on_tool_call(&self, tool_name: &str, internal_call_id: &str, args: &str) -> Flow {
         let call_id = internal_call_id.to_string();
         let tool_name = tool_name.to_string();
         let args = args.to_string();
@@ -110,7 +219,7 @@ impl<M: CompletionModel> PromptHook<M> for ConHook {
             });
 
             if !is_dangerous(&tool_name) || auto_approve {
-                return ToolCallHookAction::cont();
+                return Flow::cont();
             }
 
             // Poll for approval with short intervals so we can respond
@@ -138,40 +247,14 @@ impl<M: CompletionModel> PromptHook<M> for ConHook {
             });
 
             match decision {
-                Some(d) if d.allowed => ToolCallHookAction::cont(),
-                Some(d) => ToolCallHookAction::skip(
+                Some(d) if d.allowed => Flow::cont(),
+                Some(d) => Flow::skip(
                     d.reason
                         .unwrap_or_else(|| "User denied tool execution".to_string()),
                 ),
-                None => ToolCallHookAction::skip("Tool approval timed out or cancelled"),
+                None => Flow::skip("Tool approval timed out or cancelled"),
             }
         }
-    }
-
-    fn on_tool_result(
-        &self,
-        tool_name: &str,
-        _tool_call_id: Option<String>,
-        internal_call_id: &str,
-        _args: &str,
-        result: &str,
-    ) -> impl Future<Output = HookAction> + Send {
-        let _ = self.event_tx.send(AgentEvent::ToolCallComplete {
-            call_id: internal_call_id.to_string(),
-            tool_name: tool_name.to_string(),
-            result: result.to_string(),
-        });
-        async { HookAction::cont() }
-    }
-
-    fn on_text_delta(
-        &self,
-        text_delta: &str,
-        _aggregated_text: &str,
-    ) -> impl Future<Output = HookAction> + Send {
-        let _ = self
-            .event_tx
-            .send(AgentEvent::Token(text_delta.to_string()));
-        async { HookAction::cont() }
+        .await
     }
 }

--- a/crates/con-agent/src/hook.rs
+++ b/crates/con-agent/src/hook.rs
@@ -61,86 +61,6 @@ impl ConHook {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn hook(
-        auto_approve: bool,
-        cancelled: bool,
-    ) -> (
-        ConHook,
-        crossbeam_channel::Receiver<AgentEvent>,
-        crossbeam_channel::Sender<ToolApprovalDecision>,
-    ) {
-        let (event_tx, event_rx) = crossbeam_channel::unbounded();
-        let (approval_tx, approval_rx) = crossbeam_channel::unbounded();
-        (
-            ConHook::new(
-                event_tx,
-                approval_rx,
-                auto_approve,
-                Arc::new(AtomicBool::new(cancelled)),
-            ),
-            event_rx,
-            approval_tx,
-        )
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn safe_tool_continues_without_approval() {
-        let (hook, event_rx, _approval_tx) = hook(false, false);
-
-        let flow = hook.on_tool_call("read_pane", "call-1", "{}").await;
-
-        assert_eq!(flow, Flow::Continue);
-        assert!(matches!(
-            event_rx.try_recv(),
-            Ok(AgentEvent::ToolCallStart { call_id, tool_name, .. })
-                if call_id == "call-1" && tool_name == "read_pane"
-        ));
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn dangerous_tool_honors_denial_reason() {
-        let (hook, event_rx, approval_tx) = hook(false, false);
-        approval_tx
-            .send(ToolApprovalDecision {
-                call_id: "call-2".into(),
-                allowed: false,
-                reason: Some("Not approved".into()),
-            })
-            .unwrap();
-
-        let flow = hook.on_tool_call("terminal_exec", "call-2", "{}").await;
-
-        assert_eq!(
-            flow,
-            Flow::Skip {
-                reason: "Not approved".into()
-            }
-        );
-        assert!(matches!(
-            event_rx.try_recv(),
-            Ok(AgentEvent::ToolCallStart { call_id, .. }) if call_id == "call-2"
-        ));
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn cancellation_releases_pending_approval() {
-        let (hook, _event_rx, _approval_tx) = hook(false, true);
-
-        let flow = hook.on_tool_call("file_write", "call-3", "{}").await;
-
-        assert_eq!(
-            flow,
-            Flow::Skip {
-                reason: "Tool approval timed out or cancelled".into()
-            }
-        );
-    }
-}
-
 pub fn is_dangerous(tool_name: &str) -> bool {
     matches!(
         tool_name,
@@ -256,5 +176,85 @@ impl ConHook {
             }
         }
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hook(
+        auto_approve: bool,
+        cancelled: bool,
+    ) -> (
+        ConHook,
+        crossbeam_channel::Receiver<AgentEvent>,
+        crossbeam_channel::Sender<ToolApprovalDecision>,
+    ) {
+        let (event_tx, event_rx) = crossbeam_channel::unbounded();
+        let (approval_tx, approval_rx) = crossbeam_channel::unbounded();
+        (
+            ConHook::new(
+                event_tx,
+                approval_rx,
+                auto_approve,
+                Arc::new(AtomicBool::new(cancelled)),
+            ),
+            event_rx,
+            approval_tx,
+        )
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn safe_tool_continues_without_approval() {
+        let (hook, event_rx, _approval_tx) = hook(false, false);
+
+        let flow = hook.on_tool_call("read_pane", "call-1", "{}").await;
+
+        assert_eq!(flow, Flow::Continue);
+        assert!(matches!(
+            event_rx.try_recv(),
+            Ok(AgentEvent::ToolCallStart { call_id, tool_name, .. })
+                if call_id == "call-1" && tool_name == "read_pane"
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dangerous_tool_honors_denial_reason() {
+        let (hook, event_rx, approval_tx) = hook(false, false);
+        approval_tx
+            .send(ToolApprovalDecision {
+                call_id: "call-2".into(),
+                allowed: false,
+                reason: Some("Not approved".into()),
+            })
+            .unwrap();
+
+        let flow = hook.on_tool_call("terminal_exec", "call-2", "{}").await;
+
+        assert_eq!(
+            flow,
+            Flow::Skip {
+                reason: "Not approved".into()
+            }
+        );
+        assert!(matches!(
+            event_rx.try_recv(),
+            Ok(AgentEvent::ToolCallStart { call_id, .. }) if call_id == "call-2"
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancellation_releases_pending_approval() {
+        let (hook, _event_rx, _approval_tx) = hook(false, true);
+
+        let flow = hook.on_tool_call("file_write", "call-3", "{}").await;
+
+        assert_eq!(
+            flow,
+            Flow::Skip {
+                reason: "Tool approval timed out or cancelled".into()
+            }
+        );
     }
 }

--- a/crates/con-agent/src/provider.rs
+++ b/crates/con-agent/src/provider.rs
@@ -358,6 +358,14 @@ mod tests {
     use super::*;
 
     #[test]
+    fn rig_budget_preserves_the_previous_model_call_ceiling() {
+        assert_eq!(rig_model_call_budget(0), 2);
+        assert_eq!(rig_model_call_budget(1), 3);
+        assert_eq!(rig_model_call_budget(30), 32);
+        assert_eq!(rig_model_call_budget(usize::MAX), usize::MAX);
+    }
+
+    #[test]
     fn codex_chatgpt_auth_converter_flattens_codex_token_shape() {
         let auth = serde_json::from_value::<CodexAuthFile>(serde_json::json!({
             "auth_mode": "chatgpt",
@@ -2125,7 +2133,7 @@ macro_rules! build_and_stream {
             .tool(CreatePaneTool::new($pane_tx.clone()))
             .tool(WaitForTool::new($pane_tx, $cancelled.clone()))
             .tool(BatchExecTool::new($terminal_exec_tx))
-            .default_max_turns($cfg.max_turns);
+            .default_max_turns(rig_model_call_budget($cfg.max_turns));
 
         if let Some(max_tokens) = $cfg.effective_max_tokens(&$kind) {
             builder = builder.max_tokens(max_tokens);
@@ -2133,6 +2141,7 @@ macro_rules! build_and_stream {
         if let Some(temp) = $cfg.temperature {
             builder = builder.temperature(temp);
         }
+        builder = builder.add_hook($hook);
 
         let agent = builder.build();
 
@@ -2153,14 +2162,16 @@ macro_rules! build_and_stream {
             }
         }
 
-        let stream = agent
-            .stream_prompt($prompt)
-            .with_hook($hook)
-            .with_history($history)
-            .await;
+        let stream = agent.stream_prompt($prompt).history($history).await;
 
         consume_stream(stream, $event_tx, $cancelled).await
     }};
+}
+
+/// Rig 0.36 allowed two model calls beyond an explicit `max_turns` value. Rig
+/// 0.40 makes the model-call budget exact, so retain Con's shipped ceiling.
+fn rig_model_call_budget(tool_turns: usize) -> usize {
+    tool_turns.saturating_add(2)
 }
 
 // ── Provider ────────────────────────────────────────────────────────
@@ -2655,14 +2666,13 @@ impl AgentProvider {
             }};
         }
 
-        async fn drive_streaming_completion<M, P>(
-            agent: &rig::agent::Agent<M, P>,
+        async fn drive_streaming_completion<M>(
+            agent: &rig::agent::Agent<M>,
             prompt: &str,
         ) -> Result<String>
         where
             M: rig::completion::CompletionModel + 'static,
             M::StreamingResponse: rig::completion::GetTokenUsage,
-            P: rig::agent::PromptHook<M> + 'static,
         {
             let mut stream = agent.stream_prompt(prompt.to_owned()).await;
             // Most models emit answers to `content`; some reasoning
@@ -2690,7 +2700,7 @@ impl AgentProvider {
                         _ => {}
                     },
                     Ok(MultiTurnStreamItem::FinalResponse(fin)) => {
-                        let resp = fin.response();
+                        let resp = fin.output.as_str();
                         if !resp.is_empty() {
                             final_response_text = Some(resp.to_string());
                         }
@@ -2905,17 +2915,17 @@ async fn consume_stream<R: Send + 'static>(
                 log::info!(
                     "[agent] Stream: final response ({} chars accumulated, {} chars in FinalResponse)",
                     response_text.len(),
-                    final_resp.response().len(),
+                    final_resp.output.len(),
                 );
                 // Use FinalResponse text if we somehow missed streaming deltas.
                 // FinalResponse contains the last turn's text; response_text has
                 // all turns. Prefer response_text when available.
-                if response_text.is_empty() && !final_resp.response().is_empty() {
+                if response_text.is_empty() && !final_resp.output.is_empty() {
                     let _ = apply_stream_text_chunk(
                         &mut think_parser,
                         &mut response_text,
                         event_tx,
-                        final_resp.response(),
+                        &final_resp.output,
                         !had_reasoning_deltas,
                     );
                 }

--- a/crates/con-agent/src/provider.rs
+++ b/crates/con-agent/src/provider.rs
@@ -365,6 +365,42 @@ mod tests {
         assert_eq!(rig_model_call_budget(usize::MAX), usize::MAX);
     }
 
+    #[tokio::test]
+    async fn unified_final_response_backfills_missing_text_deltas() {
+        let final_item = MultiTurnStreamItem::<()>::final_response(
+            rig::OneOrMany::one(rig::message::AssistantContent::text("final answer")),
+            rig::completion::Usage::new(),
+        );
+        let stream: StreamingResult<()> = Box::pin(futures::stream::iter([Ok(final_item)]));
+        let (event_tx, _event_rx) = crossbeam_channel::unbounded();
+
+        let response = consume_stream(stream, &event_tx, &AtomicBool::new(false))
+            .await
+            .unwrap();
+
+        assert_eq!(response, "final answer");
+    }
+
+    #[tokio::test]
+    async fn unified_final_response_does_not_duplicate_live_text() {
+        let text_item = MultiTurnStreamItem::StreamAssistantItem(
+            StreamedAssistantContent::<()>::Text(rig::message::Text::new("live answer")),
+        );
+        let final_item = MultiTurnStreamItem::<()>::final_response(
+            rig::OneOrMany::one(rig::message::AssistantContent::text("live answer")),
+            rig::completion::Usage::new(),
+        );
+        let stream: StreamingResult<()> =
+            Box::pin(futures::stream::iter([Ok(text_item), Ok(final_item)]));
+        let (event_tx, _event_rx) = crossbeam_channel::unbounded();
+
+        let response = consume_stream(stream, &event_tx, &AtomicBool::new(false))
+            .await
+            .unwrap();
+
+        assert_eq!(response, "live answer");
+    }
+
     #[test]
     fn codex_chatgpt_auth_converter_flattens_codex_token_shape() {
         let auth = serde_json::from_value::<CodexAuthFile>(serde_json::json!({

--- a/crates/con-agent/src/tools.rs
+++ b/crates/con-agent/src/tools.rs
@@ -1,5 +1,4 @@
 use crossbeam_channel::Sender;
-use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -191,29 +190,29 @@ impl Tool for TerminalExecTool {
     type Args = TerminalExecArgs;
     type Output = ShellExecOutput;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Execute a command visibly in a con terminal pane only when that pane's control_capabilities include exec_visible_shell. Use pane_id from list_panes for stable follow-up targeting; pane_index is only a positional snapshot. These selectors refer to a con pane, not a tmux pane/window/editor target. For tmux, agent CLIs, and other TUIs, inspect first and use tmux-native tools or send_keys intentionally.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "command": {
-                        "type": "string",
-                        "description": "The shell command to execute"
-                    },
-                    "pane_index": {
-                        "type": "integer",
-                        "description": "Target pane index from the latest list_panes snapshot. Positional only; it can change when panes are added or removed."
-                    },
-                    "pane_id": {
-                        "type": "integer",
-                        "description": "Stable target pane id from list_panes. Prefer this for follow-up work."
-                    }
+    fn description(&self) -> String {
+        "Execute a command visibly in a con terminal pane only when that pane's control_capabilities include exec_visible_shell. Use pane_id from list_panes for stable follow-up targeting; pane_index is only a positional snapshot. These selectors refer to a con pane, not a tmux pane/window/editor target. For tmux, agent CLIs, and other TUIs, inspect first and use tmux-native tools or send_keys intentionally.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "The shell command to execute"
                 },
-                "required": ["command"]
-            }),
-        }
+                "pane_index": {
+                    "type": "integer",
+                    "description": "Target pane index from the latest list_panes snapshot. Positional only; it can change when panes are added or removed."
+                },
+                "pane_id": {
+                    "type": "integer",
+                    "description": "Stable target pane id from list_panes. Prefer this for follow-up work."
+                }
+            },
+            "required": ["command"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -271,25 +270,25 @@ impl Tool for ShellExecTool {
     type Args = ShellExecArgs;
     type Output = ShellExecOutput;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Execute a shell command in a hidden LOCAL background process on the con workspace machine. Output is captured but not shown in the terminal. Never use this for remote SSH/tmux inspection or remote mutations.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "command": {
-                        "type": "string",
-                        "description": "The shell command to execute"
-                    },
-                    "working_dir": {
-                        "type": "string",
-                        "description": "Optional working directory"
-                    }
+    fn description(&self) -> String {
+        "Execute a shell command in a hidden LOCAL background process on the con workspace machine. Output is captured but not shown in the terminal. Never use this for remote SSH/tmux inspection or remote mutations.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "The shell command to execute"
                 },
-                "required": ["command"]
-            }),
-        }
+                "working_dir": {
+                    "type": "string",
+                    "description": "Optional working directory"
+                }
+            },
+            "required": ["command"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -333,29 +332,29 @@ impl Tool for FileReadTool {
     type Args = FileReadArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Read a LOCAL file on the workspace machine. This tool CANNOT read files on remote SSH hosts. For remote files, use read_pane to see editor content or send_keys to run cat in a remote shell.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Path to the file to read"
-                    },
-                    "start_line": {
-                        "type": "integer",
-                        "description": "Optional start line (1-indexed)"
-                    },
-                    "end_line": {
-                        "type": "integer",
-                        "description": "Optional end line (1-indexed)"
-                    }
+    fn description(&self) -> String {
+        "Read a LOCAL file on the workspace machine. This tool CANNOT read files on remote SSH hosts. For remote files, use read_pane to see editor content or send_keys to run cat in a remote shell.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the file to read"
                 },
-                "required": ["path"]
-            }),
-        }
+                "start_line": {
+                    "type": "integer",
+                    "description": "Optional start line (1-indexed)"
+                },
+                "end_line": {
+                    "type": "integer",
+                    "description": "Optional end line (1-indexed)"
+                }
+            },
+            "required": ["path"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -400,26 +399,26 @@ impl Tool for FileWriteTool {
     type Args = FileWriteArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Write content to a LOCAL file on the workspace machine. Creates the file if it doesn't exist. CANNOT write to remote SSH hosts — use send_keys to operate remote editors or shell redirects instead."
-                .to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Path to the file to write"
-                    },
-                    "content": {
-                        "type": "string",
-                        "description": "Content to write"
-                    }
+    fn description(&self) -> String {
+        "Write content to a LOCAL file on the workspace machine. Creates the file if it doesn't exist. CANNOT write to remote SSH hosts — use send_keys to operate remote editors or shell redirects instead."
+                .to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the file to write"
                 },
-                "required": ["path", "content"]
-            }),
-        }
+                "content": {
+                    "type": "string",
+                    "description": "Content to write"
+                }
+            },
+            "required": ["path", "content"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -460,29 +459,29 @@ impl Tool for EditFileTool {
     type Args = EditFileArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Edit a LOCAL file on the workspace machine by replacing a specific text snippet. CANNOT edit files on remote SSH hosts — use send_keys with editor commands instead.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Path to the file to edit"
-                    },
-                    "old_text": {
-                        "type": "string",
-                        "description": "The exact text to find and replace (must match exactly)"
-                    },
-                    "new_text": {
-                        "type": "string",
-                        "description": "The replacement text"
-                    }
+    fn description(&self) -> String {
+        "Edit a LOCAL file on the workspace machine by replacing a specific text snippet. CANNOT edit files on remote SSH hosts — use send_keys with editor commands instead.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Path to the file to edit"
                 },
-                "required": ["path", "old_text", "new_text"]
-            }),
-        }
+                "old_text": {
+                    "type": "string",
+                    "description": "The exact text to find and replace (must match exactly)"
+                },
+                "new_text": {
+                    "type": "string",
+                    "description": "The replacement text"
+                }
+            },
+            "required": ["path", "old_text", "new_text"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -541,28 +540,28 @@ impl Tool for ListFilesTool {
     type Args = ListFilesArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "List LOCAL files and directories on the workspace machine. CANNOT list files on remote SSH hosts.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Directory to list (defaults to cwd)"
-                    },
-                    "pattern": {
-                        "type": "string",
-                        "description": "Glob pattern to filter (e.g. '*.rs', '**/*.toml')"
-                    },
-                    "max_depth": {
-                        "type": "integer",
-                        "description": "Maximum directory depth (default: 3)"
-                    }
+    fn description(&self) -> String {
+        "List LOCAL files and directories on the workspace machine. CANNOT list files on remote SSH hosts.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Directory to list (defaults to cwd)"
+                },
+                "pattern": {
+                    "type": "string",
+                    "description": "Glob pattern to filter (e.g. '*.rs', '**/*.toml')"
+                },
+                "max_depth": {
+                    "type": "integer",
+                    "description": "Maximum directory depth (default: 3)"
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -668,29 +667,29 @@ impl Tool for SearchTool {
     type Args = SearchArgs;
     type Output = SearchOutput;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Search for text in LOCAL files on the workspace machine using grep. CANNOT search remote SSH hosts. Returns matching lines with file paths and line numbers.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "pattern": {
-                        "type": "string",
-                        "description": "Search pattern (passed to grep -rn)"
-                    },
-                    "path": {
-                        "type": "string",
-                        "description": "Directory to search in (defaults to cwd)"
-                    },
-                    "file_pattern": {
-                        "type": "string",
-                        "description": "Glob pattern for files (e.g. '*.rs')"
-                    }
+    fn description(&self) -> String {
+        "Search for text in LOCAL files on the workspace machine using grep. CANNOT search remote SSH hosts. Returns matching lines with file paths and line numbers.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Search pattern (passed to grep -rn)"
                 },
-                "required": ["pattern"]
-            }),
-        }
+                "path": {
+                    "type": "string",
+                    "description": "Directory to search in (defaults to cwd)"
+                },
+                "file_pattern": {
+                    "type": "string",
+                    "description": "Glob pattern for files (e.g. '*.rs')"
+                }
+            },
+            "required": ["pattern"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -2498,15 +2497,15 @@ impl Tool for ListPanesTool {
     type Args = ListPanesArgs;
     type Output = serde_json::Value;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "List all terminal panes currently open. Returns each pane's index, title, working directory, dimensions, current verified front-state, current runtime_stack, last_verified_runtime_stack, backend-support flags, typed shell context, recent con actions, current visible-screen observation hints, and control state: address space, visible target, nested target_stack, explicit control_attachments, control channels, control capabilities, and notes. Use this before acting in tmux/TUI panes so you do not confuse a con pane with a tmux pane or over-trust stale shell metadata. If a pane exposes query_tmux, exec_tmux_command, or send_tmux_keys, prefer tmux-native tools over outer-pane send_keys.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {}
-            }),
-        }
+    fn description(&self) -> String {
+        "List all terminal panes currently open. Returns each pane's index, title, working directory, dimensions, current verified front-state, current runtime_stack, last_verified_runtime_stack, backend-support flags, typed shell context, recent con actions, current visible-screen observation hints, and control state: address space, visible target, nested target_stack, explicit control_attachments, control channels, control capabilities, and notes. Use this before acting in tmux/TUI panes so you do not confuse a con pane with a tmux pane or over-trust stale shell metadata. If a pane exposes query_tmux, exec_tmux_command, or send_tmux_keys, prefer tmux-native tools over outer-pane send_keys.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {}
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -2561,15 +2560,15 @@ impl Tool for ListTabWorkspacesTool {
     type Args = ListTabWorkspacesArgs;
     type Output = serde_json::Value;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Summarize the current tab as typed workspaces. Returns stable pane ids, current pane indices, hosts, tmux sessions, workspace kinds, and lifecycle states such as ready, needs_inspection, disconnected, or interactive. Use this for questions like 'what panes do you have?', 'which pane is the real remote shell?', or 'which SSH pane got disconnected?'.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {}
-            }),
-        }
+    fn description(&self) -> String {
+        "Summarize the current tab as typed workspaces. Returns stable pane ids, current pane indices, hosts, tmux sessions, workspace kinds, and lifecycle states such as ready, needs_inspection, disconnected, or interactive. Use this for questions like 'what panes do you have?', 'which pane is the real remote shell?', or 'which SSH pane got disconnected?'.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {}
+        })
     }
 
     async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -2603,25 +2602,25 @@ impl Tool for TmuxInspectTool {
     type Args = TmuxInspectArgs;
     type Output = serde_json::Value;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Inspect the tmux adapter state for a specific con pane. Returns tmux adapter details only when tmux has been authoritatively detected for that pane, including the explicit reason native tmux pane/window control is or is not available. Use this when a pane's target_stack includes tmux.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "pane_index": {
-                        "type": "integer",
-                        "description": "Target con pane index from list_panes. Positional only."
-                    },
-                    "pane_id": {
-                        "type": "integer",
-                        "description": "Stable target pane id from list_panes. Prefer this for follow-up work."
-                    }
+    fn description(&self) -> String {
+        "Inspect the tmux adapter state for a specific con pane. Returns tmux adapter details only when tmux has been authoritatively detected for that pane, including the explicit reason native tmux pane/window control is or is not available. Use this when a pane's target_stack includes tmux.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pane_index": {
+                    "type": "integer",
+                    "description": "Target con pane index from list_panes. Positional only."
                 },
-                "required": []
-            }),
-        }
+                "pane_id": {
+                    "type": "integer",
+                    "description": "Stable target pane id from list_panes. Prefer this for follow-up work."
+                }
+            },
+            "required": []
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -2674,25 +2673,25 @@ impl Tool for TmuxListTool {
     type Args = TmuxListArgs;
     type Output = serde_json::Value;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "List tmux panes across the current tmux session using a proven same-session tmux control anchor from the given con pane. This is the preferred first step whenever list_panes shows tmux native control. Returns tmux session/window/pane ids plus pane_current_command and pane_current_path so the agent can target Codex CLI, Claude Code, OpenCode, or shell panes inside tmux explicitly.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "pane_index": {
-                        "type": "integer",
-                        "description": "Target con pane index from list_panes. Positional only; it can change."
-                    },
-                    "pane_id": {
-                        "type": "integer",
-                        "description": "Stable target pane id from list_panes. Prefer this for follow-up tmux work."
-                    }
+    fn description(&self) -> String {
+        "List tmux panes across the current tmux session using a proven same-session tmux control anchor from the given con pane. This is the preferred first step whenever list_panes shows tmux native control. Returns tmux session/window/pane ids plus pane_current_command and pane_current_path so the agent can target Codex CLI, Claude Code, OpenCode, or shell panes inside tmux explicitly.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pane_index": {
+                    "type": "integer",
+                    "description": "Target con pane index from list_panes. Positional only; it can change."
                 },
-                "required": []
-            }),
-        }
+                "pane_id": {
+                    "type": "integer",
+                    "description": "Stable target pane id from list_panes. Prefer this for follow-up tmux work."
+                }
+            },
+            "required": []
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -2752,33 +2751,33 @@ impl Tool for TmuxCaptureTool {
     type Args = TmuxCaptureArgs;
     type Output = serde_json::Value;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Capture scrollback from a tmux pane through a proven same-session tmux control anchor. This is the correct way to inspect a tmux pane's content without confusing it with the outer con pane. If target is omitted, captures the current tmux pane of the anchor shell.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "pane_index": {
-                        "type": "integer",
-                        "description": "Target con pane index from list_panes. Positional only; it can change."
-                    },
-                    "pane_id": {
-                        "type": "integer",
-                        "description": "Stable target pane id from list_panes. Prefer this for follow-up tmux work."
-                    },
-                    "target": {
-                        "type": ["string", "null"],
-                        "description": "Optional tmux target such as %17, @3, or session:window.pane. When omitted, captures the current tmux pane of the anchor shell."
-                    },
-                    "lines": {
-                        "type": "integer",
-                        "description": "Number of recent lines to capture from the tmux pane (default: 120)."
-                    }
+    fn description(&self) -> String {
+        "Capture scrollback from a tmux pane through a proven same-session tmux control anchor. This is the correct way to inspect a tmux pane's content without confusing it with the outer con pane. If target is omitted, captures the current tmux pane of the anchor shell.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pane_index": {
+                    "type": "integer",
+                    "description": "Target con pane index from list_panes. Positional only; it can change."
                 },
-                "required": []
-            }),
-        }
+                "pane_id": {
+                    "type": "integer",
+                    "description": "Stable target pane id from list_panes. Prefer this for follow-up tmux work."
+                },
+                "target": {
+                    "type": ["string", "null"],
+                    "description": "Optional tmux target such as %17, @3, or session:window.pane. When omitted, captures the current tmux pane of the anchor shell."
+                },
+                "lines": {
+                    "type": "integer",
+                    "description": "Number of recent lines to capture from the tmux pane (default: 120)."
+                }
+            },
+            "required": []
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -2841,42 +2840,42 @@ impl Tool for TmuxSendKeysTool {
     type Args = TmuxSendKeysArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Send text or tmux key names to a specific tmux pane through a proven same-session tmux control anchor. This is the preferred interaction path for Codex CLI, Claude Code, OpenCode, or shell panes inside tmux. Use this instead of raw outer-pane input whenever tmux native control is available. Provide literal_text for typed text, key_names for tmux key tokens like Enter, Escape, C-c, Up, Down, or both.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "pane_index": {
-                        "type": "integer",
-                        "description": "Target con pane index from list_panes. Positional only; it can change."
-                    },
-                    "pane_id": {
-                        "type": "integer",
-                        "description": "Stable target pane id from list_panes. Prefer this for follow-up tmux work."
-                    },
-                    "target": {
-                        "type": "string",
-                        "description": "tmux target such as %17, @3, or session:window.pane."
-                    },
-                    "literal_text": {
-                        "type": ["string", "null"],
-                        "description": "Optional literal text to send into the tmux target."
-                    },
-                    "key_names": {
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "description": "Optional tmux key names such as Enter, Escape, C-c, Up, Down."
-                    },
-                    "append_enter": {
-                        "type": "boolean",
-                        "description": "Whether to send Enter after literal_text and key_names. Defaults to false."
-                    }
+    fn description(&self) -> String {
+        "Send text or tmux key names to a specific tmux pane through a proven same-session tmux control anchor. This is the preferred interaction path for Codex CLI, Claude Code, OpenCode, or shell panes inside tmux. Use this instead of raw outer-pane input whenever tmux native control is available. Provide literal_text for typed text, key_names for tmux key tokens like Enter, Escape, C-c, Up, Down, or both.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pane_index": {
+                    "type": "integer",
+                    "description": "Target con pane index from list_panes. Positional only; it can change."
                 },
-                "required": ["target"]
-            }),
-        }
+                "pane_id": {
+                    "type": "integer",
+                    "description": "Stable target pane id from list_panes. Prefer this for follow-up tmux work."
+                },
+                "target": {
+                    "type": "string",
+                    "description": "tmux target such as %17, @3, or session:window.pane."
+                },
+                "literal_text": {
+                    "type": ["string", "null"],
+                    "description": "Optional literal text to send into the tmux target."
+                },
+                "key_names": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Optional tmux key names such as Enter, Escape, C-c, Up, Down."
+                },
+                "append_enter": {
+                    "type": "boolean",
+                    "description": "Whether to send Enter after literal_text and key_names. Defaults to false."
+                }
+            },
+            "required": ["target"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -2944,50 +2943,50 @@ impl Tool for TmuxRunCommandTool {
     type Args = TmuxRunCommandArgs;
     type Output = serde_json::Value;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Run a command through tmux itself by creating a new tmux window or split pane from a proven same-session tmux control anchor. This is the preferred way to launch a fresh shell, Codex CLI, Claude Code, OpenCode, or any long-running command inside tmux without typing through the currently visible app.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "pane_index": {
-                        "type": "integer",
-                        "description": "Target con pane index from list_panes. Positional only; it can change."
-                    },
-                    "pane_id": {
-                        "type": "integer",
-                        "description": "Stable target pane id from list_panes. Prefer this for follow-up tmux work."
-                    },
-                    "location": {
-                        "type": "string",
-                        "enum": ["new_window", "split_horizontal", "split_vertical"],
-                        "description": "Where to create the tmux target."
-                    },
-                    "command": {
-                        "type": "string",
-                        "description": "Command to run inside the new tmux target."
-                    },
-                    "target": {
-                        "type": ["string", "null"],
-                        "description": "Optional tmux target for placement, such as a session for new_window or an existing pane/window for split operations."
-                    },
-                    "window_name": {
-                        "type": ["string", "null"],
-                        "description": "Optional tmux window name. Only used for new_window."
-                    },
-                    "cwd": {
-                        "type": ["string", "null"],
-                        "description": "Optional working directory for the new tmux target."
-                    },
-                    "detached": {
-                        "type": "boolean",
-                        "description": "Whether the new tmux target should start detached. Defaults to true."
-                    }
+    fn description(&self) -> String {
+        "Run a command through tmux itself by creating a new tmux window or split pane from a proven same-session tmux control anchor. This is the preferred way to launch a fresh shell, Codex CLI, Claude Code, OpenCode, or any long-running command inside tmux without typing through the currently visible app.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pane_index": {
+                    "type": "integer",
+                    "description": "Target con pane index from list_panes. Positional only; it can change."
                 },
-                "required": ["location", "command"]
-            }),
-        }
+                "pane_id": {
+                    "type": "integer",
+                    "description": "Stable target pane id from list_panes. Prefer this for follow-up tmux work."
+                },
+                "location": {
+                    "type": "string",
+                    "enum": ["new_window", "split_horizontal", "split_vertical"],
+                    "description": "Where to create the tmux target."
+                },
+                "command": {
+                    "type": "string",
+                    "description": "Command to run inside the new tmux target."
+                },
+                "target": {
+                    "type": ["string", "null"],
+                    "description": "Optional tmux target for placement, such as a session for new_window or an existing pane/window for split operations."
+                },
+                "window_name": {
+                    "type": ["string", "null"],
+                    "description": "Optional tmux window name. Only used for new_window."
+                },
+                "cwd": {
+                    "type": ["string", "null"],
+                    "description": "Optional working directory for the new tmux target."
+                },
+                "detached": {
+                    "type": "boolean",
+                    "description": "Whether the new tmux target should start detached. Defaults to true."
+                }
+            },
+            "required": ["location", "command"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -3058,42 +3057,42 @@ impl Tool for TmuxFindTargetsTool {
     type Args = TmuxFindTargetsArgs;
     type Output = serde_json::Value;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Find useful tmux pane targets through a proven same-session tmux control anchor. Use this helper instead of hand-filtering tmux_list_targets when you need a shell pane, an agent CLI pane, or a command/path match inside tmux.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "pane_index": {
-                        "type": "integer",
-                        "description": "Target con pane index from list_panes. Positional only; it can change."
-                    },
-                    "pane_id": {
-                        "type": "integer",
-                        "description": "Stable target pane id from list_panes. Prefer this for follow-up tmux work."
-                    },
-                    "kind": {
-                        "type": ["string", "null"],
-                        "enum": ["any", "shell", "agent_cli", null],
-                        "description": "Optional target class filter."
-                    },
-                    "command_contains": {
-                        "type": ["string", "null"],
-                        "description": "Optional case-insensitive substring match against tmux pane_current_command."
-                    },
-                    "path_contains": {
-                        "type": ["string", "null"],
-                        "description": "Optional case-insensitive substring match against tmux pane_current_path."
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "description": "Maximum number of matches to return. Defaults to 8."
-                    }
+    fn description(&self) -> String {
+        "Find useful tmux pane targets through a proven same-session tmux control anchor. Use this helper instead of hand-filtering tmux_list_targets when you need a shell pane, an agent CLI pane, or a command/path match inside tmux.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pane_index": {
+                    "type": "integer",
+                    "description": "Target con pane index from list_panes. Positional only; it can change."
                 },
-                "required": []
-            }),
-        }
+                "pane_id": {
+                    "type": "integer",
+                    "description": "Stable target pane id from list_panes. Prefer this for follow-up tmux work."
+                },
+                "kind": {
+                    "type": ["string", "null"],
+                    "enum": ["any", "shell", "agent_cli", null],
+                    "description": "Optional target class filter."
+                },
+                "command_contains": {
+                    "type": ["string", "null"],
+                    "description": "Optional case-insensitive substring match against tmux pane_current_command."
+                },
+                "path_contains": {
+                    "type": ["string", "null"],
+                    "description": "Optional case-insensitive substring match against tmux pane_current_path."
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of matches to return. Defaults to 8."
+                }
+            },
+            "required": []
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -3192,50 +3191,50 @@ impl Tool for TmuxEnsureShellTargetTool {
     type Args = TmuxEnsureShellTargetArgs;
     type Output = serde_json::Value;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Return a tmux pane that is suitable for shell work. Reuses an existing shell pane when one already matches, otherwise creates a fresh tmux shell target through the native tmux control channel. Use this before writing files remotely, launching commands away from a visible TUI, or preparing a clean shell workspace in tmux.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "pane_index": {
-                        "type": "integer",
-                        "description": "Target con pane index from list_panes. Positional only; it can change."
-                    },
-                    "pane_id": {
-                        "type": "integer",
-                        "description": "Stable target pane id from list_panes. Prefer this for follow-up tmux work."
-                    },
-                    "session_name": {
-                        "type": ["string", "null"],
-                        "description": "Optional tmux session to constrain shell-target reuse. Defaults to the pane's active tmux workspace session when con already knows it."
-                    },
-                    "cwd": {
-                        "type": ["string", "null"],
-                        "description": "Optional path hint. Existing tmux shell panes whose pane_current_path contains this value are preferred, and new shell targets inherit it when created."
-                    },
-                    "window_name": {
-                        "type": ["string", "null"],
-                        "description": "Optional name for a newly created tmux window."
-                    },
-                    "shell_command": {
-                        "type": ["string", "null"],
-                        "description": "Optional command for a newly created shell target. Defaults to an interactive login shell based on $SHELL."
-                    },
-                    "location": {
-                        "type": "string",
-                        "enum": ["new_window", "split_horizontal", "split_vertical"],
-                        "description": "Where to create a new shell target if none already exists."
-                    },
-                    "detached": {
-                        "type": "boolean",
-                        "description": "Whether a newly created target should start detached. Defaults to true."
-                    }
+    fn description(&self) -> String {
+        "Return a tmux pane that is suitable for shell work. Reuses an existing shell pane when one already matches, otherwise creates a fresh tmux shell target through the native tmux control channel. Use this before writing files remotely, launching commands away from a visible TUI, or preparing a clean shell workspace in tmux.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pane_index": {
+                    "type": "integer",
+                    "description": "Target con pane index from list_panes. Positional only; it can change."
                 },
-                "required": []
-            }),
-        }
+                "pane_id": {
+                    "type": "integer",
+                    "description": "Stable target pane id from list_panes. Prefer this for follow-up tmux work."
+                },
+                "session_name": {
+                    "type": ["string", "null"],
+                    "description": "Optional tmux session to constrain shell-target reuse. Defaults to the pane's active tmux workspace session when con already knows it."
+                },
+                "cwd": {
+                    "type": ["string", "null"],
+                    "description": "Optional path hint. Existing tmux shell panes whose pane_current_path contains this value are preferred, and new shell targets inherit it when created."
+                },
+                "window_name": {
+                    "type": ["string", "null"],
+                    "description": "Optional name for a newly created tmux window."
+                },
+                "shell_command": {
+                    "type": ["string", "null"],
+                    "description": "Optional command for a newly created shell target. Defaults to an interactive login shell based on $SHELL."
+                },
+                "location": {
+                    "type": "string",
+                    "enum": ["new_window", "split_horizontal", "split_vertical"],
+                    "description": "Where to create a new shell target if none already exists."
+                },
+                "detached": {
+                    "type": "boolean",
+                    "description": "Whether a newly created target should start detached. Defaults to true."
+                }
+            },
+            "required": []
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -3501,42 +3500,42 @@ impl Tool for EnsureLocalAgentTargetTool {
     type Args = EnsureLocalAgentTargetArgs;
     type Output = EnsureLocalAgentTargetResult;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Reuse an existing LOCAL Codex, Claude Code, or OpenCode pane when one already matches, or create a fresh local agent-cli pane when needed. Pair this with ensure_local_shell_target so local coding workflows keep interactive agent UI and shell/file/test work in separate panes.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "agent_name": {
-                        "type": "string",
-                        "description": "Agent CLI family to reuse or launch, such as codex, claude, or opencode."
-                    },
-                    "cwd": {
-                        "type": ["string", "null"],
-                        "description": "Optional working directory for the local agent target. Existing targets whose cwd contains this value are preferred, and new panes start there."
-                    },
-                    "pane_index": {
-                        "type": ["integer", "null"],
-                        "description": "Optional con pane index to constrain reuse checks. Positional only."
-                    },
-                    "pane_id": {
-                        "type": ["integer", "null"],
-                        "description": "Optional stable pane id to constrain reuse checks."
-                    },
-                    "launch_command": {
-                        "type": ["string", "null"],
-                        "description": "Optional explicit launch command. Defaults to the canonical CLI name for the requested agent."
-                    },
-                    "location": {
-                        "type": "string",
-                        "enum": ["right", "down"],
-                        "description": "Where to place a newly created agent pane if one is needed. Defaults to right."
-                    }
+    fn description(&self) -> String {
+        "Reuse an existing LOCAL Codex, Claude Code, or OpenCode pane when one already matches, or create a fresh local agent-cli pane when needed. Pair this with ensure_local_shell_target so local coding workflows keep interactive agent UI and shell/file/test work in separate panes.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "agent_name": {
+                    "type": "string",
+                    "description": "Agent CLI family to reuse or launch, such as codex, claude, or opencode."
                 },
-                "required": ["agent_name"]
-            }),
-        }
+                "cwd": {
+                    "type": ["string", "null"],
+                    "description": "Optional working directory for the local agent target. Existing targets whose cwd contains this value are preferred, and new panes start there."
+                },
+                "pane_index": {
+                    "type": ["integer", "null"],
+                    "description": "Optional con pane index to constrain reuse checks. Positional only."
+                },
+                "pane_id": {
+                    "type": ["integer", "null"],
+                    "description": "Optional stable pane id to constrain reuse checks."
+                },
+                "launch_command": {
+                    "type": ["string", "null"],
+                    "description": "Optional explicit launch command. Defaults to the canonical CLI name for the requested agent."
+                },
+                "location": {
+                    "type": "string",
+                    "enum": ["right", "down"],
+                    "description": "Where to place a newly created agent pane if one is needed. Defaults to right."
+                }
+            },
+            "required": ["agent_name"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -3722,42 +3721,42 @@ impl Tool for EnsureLocalCodingWorkspaceTool {
     type Args = EnsureLocalCodingWorkspaceArgs;
     type Output = EnsureLocalCodingWorkspaceResult;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Prepare a LOCAL coding workspace as a deliberate pair: one pane for the interactive Codex / Claude Code / OpenCode UI, and a separate local shell pane for file edits, tests, git commands, and other shell work. Reuses existing matching panes when possible and creates only the missing side of the pair.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "agent_name": {
-                        "type": "string",
-                        "description": "Agent CLI family to reuse or launch, such as codex, claude, or opencode."
-                    },
-                    "cwd": {
-                        "type": ["string", "null"],
-                        "description": "Optional project directory the local coding workspace should be prepared in."
-                    },
-                    "pane_index": {
-                        "type": ["integer", "null"],
-                        "description": "Optional con pane index to bias or constrain agent-target reuse. Positional only."
-                    },
-                    "pane_id": {
-                        "type": ["integer", "null"],
-                        "description": "Optional stable pane id to bias or constrain agent-target reuse."
-                    },
-                    "launch_command": {
-                        "type": ["string", "null"],
-                        "description": "Optional explicit launch command for the agent CLI. Defaults to the canonical CLI command."
-                    },
-                    "location": {
-                        "type": "string",
-                        "enum": ["right", "down"],
-                        "description": "Where to place newly created panes. Defaults to right."
-                    }
+    fn description(&self) -> String {
+        "Prepare a LOCAL coding workspace as a deliberate pair: one pane for the interactive Codex / Claude Code / OpenCode UI, and a separate local shell pane for file edits, tests, git commands, and other shell work. Reuses existing matching panes when possible and creates only the missing side of the pair.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "agent_name": {
+                    "type": "string",
+                    "description": "Agent CLI family to reuse or launch, such as codex, claude, or opencode."
                 },
-                "required": ["agent_name"]
-            }),
-        }
+                "cwd": {
+                    "type": ["string", "null"],
+                    "description": "Optional project directory the local coding workspace should be prepared in."
+                },
+                "pane_index": {
+                    "type": ["integer", "null"],
+                    "description": "Optional con pane index to bias or constrain agent-target reuse. Positional only."
+                },
+                "pane_id": {
+                    "type": ["integer", "null"],
+                    "description": "Optional stable pane id to bias or constrain agent-target reuse."
+                },
+                "launch_command": {
+                    "type": ["string", "null"],
+                    "description": "Optional explicit launch command for the agent CLI. Defaults to the canonical CLI command."
+                },
+                "location": {
+                    "type": "string",
+                    "enum": ["right", "down"],
+                    "description": "Where to place newly created panes. Defaults to right."
+                }
+            },
+            "required": ["agent_name"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -3829,45 +3828,45 @@ impl Tool for AgentCliTurnTool {
     type Args = AgentCliTurnArgs;
     type Output = AgentCliTurnResult;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Send one natural-language turn to an already prepared interactive agent CLI target such as Codex, Claude Code, or OpenCode, then wait for the target to settle and return a fresh screen snapshot. This is the preferred tool for continuing work inside a known local agent pane or tmux agent target. It does not prepare missing targets; use ensure_local_agent_target, ensure_local_coding_workspace, or tmux_ensure_agent_target first when preparation is still required.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "agent_name": {
-                        "type": "string",
-                        "description": "Agent CLI family to target, such as codex, claude, or opencode."
-                    },
-                    "prompt": {
-                        "type": "string",
-                        "description": "Natural-language turn to send into the existing agent CLI target."
-                    },
-                    "pane_index": {
-                        "type": ["integer", "null"],
-                        "description": "Optional con pane index to constrain target selection. Positional only."
-                    },
-                    "pane_id": {
-                        "type": ["integer", "null"],
-                        "description": "Optional stable con pane id to constrain target selection."
-                    },
-                    "cwd_contains": {
-                        "type": ["string", "null"],
-                        "description": "Optional project-path hint used to prefer a matching existing target."
-                    },
-                    "timeout_secs": {
-                        "type": "integer",
-                        "description": "How long to wait for the agent target to settle after sending the prompt. Defaults to 90 seconds."
-                    },
-                    "lines": {
-                        "type": "integer",
-                        "description": "How many recent lines to read or capture after the turn settles. Defaults to 50."
-                    }
+    fn description(&self) -> String {
+        "Send one natural-language turn to an already prepared interactive agent CLI target such as Codex, Claude Code, or OpenCode, then wait for the target to settle and return a fresh screen snapshot. This is the preferred tool for continuing work inside a known local agent pane or tmux agent target. It does not prepare missing targets; use ensure_local_agent_target, ensure_local_coding_workspace, or tmux_ensure_agent_target first when preparation is still required.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "agent_name": {
+                    "type": "string",
+                    "description": "Agent CLI family to target, such as codex, claude, or opencode."
                 },
-                "required": ["agent_name", "prompt"]
-            }),
-        }
+                "prompt": {
+                    "type": "string",
+                    "description": "Natural-language turn to send into the existing agent CLI target."
+                },
+                "pane_index": {
+                    "type": ["integer", "null"],
+                    "description": "Optional con pane index to constrain target selection. Positional only."
+                },
+                "pane_id": {
+                    "type": ["integer", "null"],
+                    "description": "Optional stable con pane id to constrain target selection."
+                },
+                "cwd_contains": {
+                    "type": ["string", "null"],
+                    "description": "Optional project-path hint used to prefer a matching existing target."
+                },
+                "timeout_secs": {
+                    "type": "integer",
+                    "description": "How long to wait for the agent target to settle after sending the prompt. Defaults to 90 seconds."
+                },
+                "lines": {
+                    "type": "integer",
+                    "description": "How many recent lines to read or capture after the turn settles. Defaults to 50."
+                }
+            },
+            "required": ["agent_name", "prompt"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -4026,41 +4025,41 @@ impl Tool for TmuxShellTurnTool {
     type Args = TmuxShellTurnArgs;
     type Output = TmuxShellTurnResult;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Run one deterministic shell command inside an existing tmux shell target, wait for that target to settle, and return a fresh capture. Use this for file work, test runs, install checks, and other shell-lane work inside tmux instead of manually composing tmux_send_keys plus tmux_capture_pane.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "pane_index": {
-                        "type": ["integer", "null"],
-                        "description": "Optional con pane index that owns the tmux control anchor. Positional only."
-                    },
-                    "pane_id": {
-                        "type": ["integer", "null"],
-                        "description": "Optional stable con pane id that owns the tmux control anchor."
-                    },
-                    "target": {
-                        "type": "string",
-                        "description": "tmux shell target such as %17 or session:window.pane."
-                    },
-                    "command": {
-                        "type": "string",
-                        "description": "Shell command to run inside the existing tmux shell target."
-                    },
-                    "timeout_secs": {
-                        "type": "integer",
-                        "description": "How long to wait for the tmux shell target to settle after the command. Defaults to 90 seconds."
-                    },
-                    "lines": {
-                        "type": "integer",
-                        "description": "How many recent lines to capture after the command settles. Defaults to 50."
-                    }
+    fn description(&self) -> String {
+        "Run one deterministic shell command inside an existing tmux shell target, wait for that target to settle, and return a fresh capture. Use this for file work, test runs, install checks, and other shell-lane work inside tmux instead of manually composing tmux_send_keys plus tmux_capture_pane.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pane_index": {
+                    "type": ["integer", "null"],
+                    "description": "Optional con pane index that owns the tmux control anchor. Positional only."
                 },
-                "required": ["target", "command"]
-            }),
-        }
+                "pane_id": {
+                    "type": ["integer", "null"],
+                    "description": "Optional stable con pane id that owns the tmux control anchor."
+                },
+                "target": {
+                    "type": "string",
+                    "description": "tmux shell target such as %17 or session:window.pane."
+                },
+                "command": {
+                    "type": "string",
+                    "description": "Shell command to run inside the existing tmux shell target."
+                },
+                "timeout_secs": {
+                    "type": "integer",
+                    "description": "How long to wait for the tmux shell target to settle after the command. Defaults to 90 seconds."
+                },
+                "lines": {
+                    "type": "integer",
+                    "description": "How many recent lines to capture after the command settles. Defaults to 50."
+                }
+            },
+            "required": ["target", "command"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -4163,50 +4162,50 @@ impl Tool for TmuxEnsureAgentTargetTool {
     type Args = TmuxEnsureAgentTargetArgs;
     type Output = serde_json::Value;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Return a tmux pane that is suitable for interacting with a specific agent CLI. Reuses an existing tmux pane already running Codex, Claude Code, or OpenCode when one matches, otherwise creates a fresh tmux target with the requested agent launch command. This stays in the tmux control plane; it does not claim app-native Codex or OpenCode control unless a separate explicit attachment exists.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "pane_index": {
-                        "type": "integer",
-                        "description": "Target con pane index from list_panes. Positional only; it can change."
-                    },
-                    "pane_id": {
-                        "type": "integer",
-                        "description": "Stable target pane id from list_panes. Prefer this for follow-up tmux work."
-                    },
-                    "agent_name": {
-                        "type": "string",
-                        "description": "Agent CLI family to reuse or launch, such as codex, claude, or opencode."
-                    },
-                    "cwd": {
-                        "type": ["string", "null"],
-                        "description": "Optional path hint. Existing tmux agent panes whose pane_current_path contains this value are preferred, and new targets inherit it when created."
-                    },
-                    "window_name": {
-                        "type": ["string", "null"],
-                        "description": "Optional name for a newly created tmux window."
-                    },
-                    "launch_command": {
-                        "type": ["string", "null"],
-                        "description": "Optional explicit command to launch when no matching agent pane exists. Defaults to the canonical CLI name for the requested agent."
-                    },
-                    "location": {
-                        "type": "string",
-                        "enum": ["new_window", "split_horizontal", "split_vertical"],
-                        "description": "Where to create a new agent target if none already exists."
-                    },
-                    "detached": {
-                        "type": "boolean",
-                        "description": "Whether a newly created target should start detached. Defaults to true."
-                    }
+    fn description(&self) -> String {
+        "Return a tmux pane that is suitable for interacting with a specific agent CLI. Reuses an existing tmux pane already running Codex, Claude Code, or OpenCode when one matches, otherwise creates a fresh tmux target with the requested agent launch command. This stays in the tmux control plane; it does not claim app-native Codex or OpenCode control unless a separate explicit attachment exists.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pane_index": {
+                    "type": "integer",
+                    "description": "Target con pane index from list_panes. Positional only; it can change."
                 },
-                "required": ["agent_name"]
-            }),
-        }
+                "pane_id": {
+                    "type": "integer",
+                    "description": "Stable target pane id from list_panes. Prefer this for follow-up tmux work."
+                },
+                "agent_name": {
+                    "type": "string",
+                    "description": "Agent CLI family to reuse or launch, such as codex, claude, or opencode."
+                },
+                "cwd": {
+                    "type": ["string", "null"],
+                    "description": "Optional path hint. Existing tmux agent panes whose pane_current_path contains this value are preferred, and new targets inherit it when created."
+                },
+                "window_name": {
+                    "type": ["string", "null"],
+                    "description": "Optional name for a newly created tmux window."
+                },
+                "launch_command": {
+                    "type": ["string", "null"],
+                    "description": "Optional explicit command to launch when no matching agent pane exists. Defaults to the canonical CLI name for the requested agent."
+                },
+                "location": {
+                    "type": "string",
+                    "enum": ["new_window", "split_horizontal", "split_vertical"],
+                    "description": "Where to create a new agent target if none already exists."
+                },
+                "detached": {
+                    "type": "boolean",
+                    "description": "Whether a newly created target should start detached. Defaults to true."
+                }
+            },
+            "required": ["agent_name"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -4339,46 +4338,46 @@ impl Tool for ResolveWorkTargetTool {
     type Args = ResolveWorkTargetArgs;
     type Output = serde_json::Value;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Resolve the best pane or tmux target for a specific kind of work using con's typed control plane. Use this when multiple panes are open and you need to choose the right shell, the right tmux workspace, the best tmux shell pane, or a matching agent CLI target without re-deriving that logic from list_panes manually. When it returns a con pane target, prefer its stable pane_id for follow-up work.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "intent": {
-                        "type": "string",
-                        "enum": ["visible_shell", "remote_shell", "tmux_workspace", "tmux_shell", "agent_cli"],
-                        "description": "What kind of work target you need."
-                    },
-                    "pane_index": {
-                        "type": ["integer", "null"],
-                        "description": "Optional con pane index to constrain resolution to a single pane. Positional only."
-                    },
-                    "pane_id": {
-                        "type": ["integer", "null"],
-                        "description": "Optional stable pane id to constrain resolution to a single pane."
-                    },
-                    "host_contains": {
-                        "type": ["string", "null"],
-                        "description": "Optional case-insensitive filter for the effective host name."
-                    },
-                    "cwd_contains": {
-                        "type": ["string", "null"],
-                        "description": "Optional case-insensitive filter for working directory or tmux pane path."
-                    },
-                    "agent_name": {
-                        "type": ["string", "null"],
-                        "description": "Optional case-insensitive filter for an agent CLI name such as codex, claude, or opencode."
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "description": "Maximum number of candidates to return. Defaults to 8."
-                    }
+    fn description(&self) -> String {
+        "Resolve the best pane or tmux target for a specific kind of work using con's typed control plane. Use this when multiple panes are open and you need to choose the right shell, the right tmux workspace, the best tmux shell pane, or a matching agent CLI target without re-deriving that logic from list_panes manually. When it returns a con pane target, prefer its stable pane_id for follow-up work.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "intent": {
+                    "type": "string",
+                    "enum": ["visible_shell", "remote_shell", "tmux_workspace", "tmux_shell", "agent_cli"],
+                    "description": "What kind of work target you need."
                 },
-                "required": ["intent"]
-            }),
-        }
+                "pane_index": {
+                    "type": ["integer", "null"],
+                    "description": "Optional con pane index to constrain resolution to a single pane. Positional only."
+                },
+                "pane_id": {
+                    "type": ["integer", "null"],
+                    "description": "Optional stable pane id to constrain resolution to a single pane."
+                },
+                "host_contains": {
+                    "type": ["string", "null"],
+                    "description": "Optional case-insensitive filter for the effective host name."
+                },
+                "cwd_contains": {
+                    "type": ["string", "null"],
+                    "description": "Optional case-insensitive filter for working directory or tmux pane path."
+                },
+                "agent_name": {
+                    "type": ["string", "null"],
+                    "description": "Optional case-insensitive filter for an agent CLI name such as codex, claude, or opencode."
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of candidates to return. Defaults to 8."
+                }
+            },
+            "required": ["intent"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -4422,25 +4421,25 @@ impl Tool for ProbeShellContextTool {
     type Args = ProbeShellContextArgs;
     type Output = serde_json::Value;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Run a read-only shell-scoped probe in a pane that has the probe_shell_context capability. Use this only when list_panes reports a proven fresh shell prompt. Returns authoritative shell facts from that shell frame such as hostname, pwd, SSH env, TMUX env, tmux session/window/pane ids, pane_current_command, pane_current_path, and NVIM_LISTEN_ADDRESS when available. This is shell-scope truth, not proof of the foreground app after control passes to tmux or another TUI.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "pane_index": {
-                        "type": "integer",
-                        "description": "Target con pane index from list_panes. Positional only."
-                    },
-                    "pane_id": {
-                        "type": "integer",
-                        "description": "Stable target pane id from list_panes. Prefer this for follow-up work."
-                    }
+    fn description(&self) -> String {
+        "Run a read-only shell-scoped probe in a pane that has the probe_shell_context capability. Use this only when list_panes reports a proven fresh shell prompt. Returns authoritative shell facts from that shell frame such as hostname, pwd, SSH env, TMUX env, tmux session/window/pane ids, pane_current_command, pane_current_path, and NVIM_LISTEN_ADDRESS when available. This is shell-scope truth, not proof of the foreground app after control passes to tmux or another TUI.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pane_index": {
+                    "type": "integer",
+                    "description": "Target con pane index from list_panes. Positional only."
                 },
-                "required": []
-            }),
-        }
+                "pane_id": {
+                    "type": "integer",
+                    "description": "Stable target pane id from list_panes. Prefer this for follow-up work."
+                }
+            },
+            "required": []
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -4684,29 +4683,29 @@ impl Tool for ReadPaneTool {
     type Args = ReadPaneArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Read the recent visible output from a specific terminal pane. Use list_panes first to discover available panes. Prefer stable pane_id for follow-up work; pane_index is only positional.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "pane_index": {
-                        "type": "integer",
-                        "description": "The pane index from list_panes. Positional only."
-                    },
-                    "pane_id": {
-                        "type": "integer",
-                        "description": "Stable pane id from list_panes. Prefer this for follow-up work."
-                    },
-                    "lines": {
-                        "type": "integer",
-                        "description": "Number of recent lines to read (default: 50)"
-                    }
+    fn description(&self) -> String {
+        "Read the recent visible output from a specific terminal pane. Use list_panes first to discover available panes. Prefer stable pane_id for follow-up work; pane_index is only positional.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pane_index": {
+                    "type": "integer",
+                    "description": "The pane index from list_panes. Positional only."
                 },
-                "required": []
-            }),
-        }
+                "pane_id": {
+                    "type": "integer",
+                    "description": "Stable pane id from list_panes. Prefer this for follow-up work."
+                },
+                "lines": {
+                    "type": "integer",
+                    "description": "Number of recent lines to read (default: 50)"
+                }
+            },
+            "required": []
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -4764,29 +4763,29 @@ impl Tool for SendKeysTool {
     type Args = SendKeysArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Send raw keystrokes to a specific con terminal pane. Use this for direct TUI interaction, prompt-level shell input when exec_visible_shell is unavailable, and tmux prefix sequences only when tmux native control is unavailable. IMPORTANT: Always follow send_keys with read_pane to verify the action took effect. Common sequences: \\n (Enter), \\x1b (Escape), \\x03 (Ctrl-C), \\x02 (Ctrl-B, tmux prefix), \\x1b[A/B/C/D (arrow keys). For shell commands, prefer terminal_exec when exec_visible_shell is available. For tmux panes with query_tmux/send_tmux_keys, prefer tmux-native tools.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "pane_index": {
-                        "type": "integer",
-                        "description": "The pane index from list_panes. Positional only."
-                    },
-                    "pane_id": {
-                        "type": "integer",
-                        "description": "Stable pane id from list_panes. Prefer this for follow-up work."
-                    },
-                    "keys": {
-                        "type": "string",
-                        "description": "Keystrokes to send. Supports escape sequences: \\n (Enter), \\t (Tab), \\x03 (Ctrl-C), \\x1b (Escape), \\x1b[A (Up arrow), etc."
-                    }
+    fn description(&self) -> String {
+        "Send raw keystrokes to a specific con terminal pane. Use this for direct TUI interaction, prompt-level shell input when exec_visible_shell is unavailable, and tmux prefix sequences only when tmux native control is unavailable. IMPORTANT: Always follow send_keys with read_pane to verify the action took effect. Common sequences: \\n (Enter), \\x1b (Escape), \\x03 (Ctrl-C), \\x02 (Ctrl-B, tmux prefix), \\x1b[A/B/C/D (arrow keys). For shell commands, prefer terminal_exec when exec_visible_shell is available. For tmux panes with query_tmux/send_tmux_keys, prefer tmux-native tools.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pane_index": {
+                    "type": "integer",
+                    "description": "The pane index from list_panes. Positional only."
                 },
-                "required": ["keys"]
-            }),
-        }
+                "pane_id": {
+                    "type": "integer",
+                    "description": "Stable pane id from list_panes. Prefer this for follow-up work."
+                },
+                "keys": {
+                    "type": "string",
+                    "description": "Keystrokes to send. Supports escape sequences: \\n (Enter), \\t (Tab), \\x03 (Ctrl-C), \\x1b (Escape), \\x1b[A (Up arrow), etc."
+                }
+            },
+            "required": ["keys"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -4888,39 +4887,39 @@ impl Tool for BatchExecTool {
     type Args = BatchExecArgs;
     type Output = serde_json::Value;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Execute commands across multiple con panes in PARALLEL, but only when each pane's control_capabilities include exec_visible_shell. Prefer stable pane_id values from list_panes for follow-up work; pane_index is only positional.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "commands": {
-                        "type": "array",
-                        "description": "List of commands to execute, each targeting a specific pane",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "command": {
-                                    "type": "string",
-                                    "description": "The shell command to execute"
-                                },
-                                "pane_index": {
-                                    "type": "integer",
-                                    "description": "Target pane index from list_panes. Positional only."
-                                },
-                                "pane_id": {
-                                    "type": "integer",
-                                    "description": "Stable target pane id from list_panes. Prefer this for follow-up work."
-                                }
+    fn description(&self) -> String {
+        "Execute commands across multiple con panes in PARALLEL, but only when each pane's control_capabilities include exec_visible_shell. Prefer stable pane_id values from list_panes for follow-up work; pane_index is only positional.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "commands": {
+                    "type": "array",
+                    "description": "List of commands to execute, each targeting a specific pane",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "command": {
+                                "type": "string",
+                                "description": "The shell command to execute"
                             },
-                            "required": ["command"]
-                        }
+                            "pane_index": {
+                                "type": "integer",
+                                "description": "Target pane index from list_panes. Positional only."
+                            },
+                            "pane_id": {
+                                "type": "integer",
+                                "description": "Stable target pane id from list_panes. Prefer this for follow-up work."
+                            }
+                        },
+                        "required": ["command"]
                     }
-                },
-                "required": ["commands"]
-            }),
-        }
+                }
+            },
+            "required": ["commands"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -5015,33 +5014,33 @@ impl Tool for SearchPanesTool {
     type Args = SearchPanesArgs;
     type Output = String;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Search terminal scrollback and visible screen for text. Searches across all panes or a specific pane. Use this to find previous command output, error messages, or any text that appeared in any terminal pane.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "pattern": {
-                        "type": "string",
-                        "description": "Text to search for (case-insensitive substring match)"
-                    },
-                    "pane_index": {
-                        "type": "integer",
-                        "description": "Optional pane index from list_panes. Positional only."
-                    },
-                    "pane_id": {
-                        "type": "integer",
-                        "description": "Optional stable pane id from list_panes. Prefer this for follow-up work."
-                    },
-                    "max_matches": {
-                        "type": "integer",
-                        "description": "Maximum number of matching lines to return (default: 50)"
-                    }
+    fn description(&self) -> String {
+        "Search terminal scrollback and visible screen for text. Searches across all panes or a specific pane. Use this to find previous command output, error messages, or any text that appeared in any terminal pane.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Text to search for (case-insensitive substring match)"
                 },
-                "required": ["pattern"]
-            }),
-        }
+                "pane_index": {
+                    "type": "integer",
+                    "description": "Optional pane index from list_panes. Positional only."
+                },
+                "pane_id": {
+                    "type": "integer",
+                    "description": "Optional stable pane id from list_panes. Prefer this for follow-up work."
+                },
+                "max_matches": {
+                    "type": "integer",
+                    "description": "Maximum number of matching lines to return (default: 50)"
+                }
+            },
+            "required": ["pattern"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -5126,29 +5125,29 @@ impl Tool for WaitForTool {
     type Args = WaitForArgs;
     type Output = WaitForOutput;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Wait for a terminal pane to become idle or for a specific pattern to appear. Use after launching a command to wait for it to finish. Without a pattern, waits for idle — works universally (shell integration or output quiescence). With a pattern, polls until the text appears. Prefer idle mode (no pattern). Returns status: idle, matched, or timeout. On timeout, read_pane to check progress and call wait_for again if needed.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "pane_index": {
-                        "type": "integer",
-                        "description": "Target pane index from list_panes. Positional only."
-                    },
-                    "pane_id": {
-                        "type": "integer",
-                        "description": "Stable pane id from list_panes. Prefer this for follow-up work."
-                    },
-                    "pattern": {
-                        "type": "string",
-                        "description": "Text to wait for in pane output. If omitted, waits for the pane to become idle — preferred."
-                    }
+    fn description(&self) -> String {
+        "Wait for a terminal pane to become idle or for a specific pattern to appear. Use after launching a command to wait for it to finish. Without a pattern, waits for idle — works universally (shell integration or output quiescence). With a pattern, polls until the text appears. Prefer idle mode (no pattern). Returns status: idle, matched, or timeout. On timeout, read_pane to check progress and call wait_for again if needed.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "pane_index": {
+                    "type": "integer",
+                    "description": "Target pane index from list_panes. Positional only."
                 },
-                "required": []
-            }),
-        }
+                "pane_id": {
+                    "type": "integer",
+                    "description": "Stable pane id from list_panes. Prefer this for follow-up work."
+                },
+                "pattern": {
+                    "type": "string",
+                    "description": "Text to wait for in pane output. If omitted, waits for the pane to become idle — preferred."
+                }
+            },
+            "required": []
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -5702,34 +5701,34 @@ impl Tool for EnsureLocalShellTargetTool {
     type Args = EnsureLocalShellTargetArgs;
     type Output = EnsureLocalShellTargetResult;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Reuse an existing LOCAL visible shell pane when one is already suitable, or create a new one when needed. This is the preferred companion tool for local Codex, Claude Code, or OpenCode workflows: keep the agent CLI in one target, and prepare a separate shell target for file edits, test runs, and other shell commands.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "cwd": {
-                        "type": ["string", "null"],
-                        "description": "Optional working directory the local shell should be prepared in. If no reusable shell matches it, con creates a new pane and starts it there."
-                    },
-                    "pane_index": {
-                        "type": ["integer", "null"],
-                        "description": "Optional con pane index to constrain reuse checks. Positional only."
-                    },
-                    "pane_id": {
-                        "type": ["integer", "null"],
-                        "description": "Optional stable pane id to constrain reuse checks."
-                    },
-                    "location": {
-                        "type": "string",
-                        "enum": ["right", "down"],
-                        "description": "Where to place a newly created shell pane if one is needed. Defaults to right."
-                    }
+    fn description(&self) -> String {
+        "Reuse an existing LOCAL visible shell pane when one is already suitable, or create a new one when needed. This is the preferred companion tool for local Codex, Claude Code, or OpenCode workflows: keep the agent CLI in one target, and prepare a separate shell target for file edits, test runs, and other shell commands.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "cwd": {
+                    "type": ["string", "null"],
+                    "description": "Optional working directory the local shell should be prepared in. If no reusable shell matches it, con creates a new pane and starts it there."
                 },
-                "required": []
-            }),
-        }
+                "pane_index": {
+                    "type": ["integer", "null"],
+                    "description": "Optional con pane index to constrain reuse checks. Positional only."
+                },
+                "pane_id": {
+                    "type": ["integer", "null"],
+                    "description": "Optional stable pane id to constrain reuse checks."
+                },
+                "location": {
+                    "type": "string",
+                    "enum": ["right", "down"],
+                    "description": "Where to place a newly created shell pane if one is needed. Defaults to right."
+                }
+            },
+            "required": []
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -6012,38 +6011,38 @@ impl Tool for EnsureRemoteShellTargetTool {
     type Args = EnsureRemoteShellTargetArgs;
     type Output = EnsureRemoteShellTargetResult;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Reuse an existing SSH pane for a specific remote host when one is already available, or create a new pane and connect to that host when none exists. This is the preferred tool for multi-host remote orchestration so the agent does not keep creating duplicate SSH panes across turns. The result includes stable pane_id for follow-up work.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "host": {
-                        "type": "string",
-                        "description": "SSH host or alias to target, such as haswell or user@host."
-                    },
-                    "pane_index": {
-                        "type": ["integer", "null"],
-                        "description": "Optional con pane index to constrain reuse checks to a specific pane. Positional only."
-                    },
-                    "pane_id": {
-                        "type": ["integer", "null"],
-                        "description": "Optional stable pane id to constrain reuse checks to a specific pane."
-                    },
-                    "location": {
-                        "type": "string",
-                        "enum": ["right", "down"],
-                        "description": "Where to place a newly created pane if one is needed. Defaults to right."
-                    },
-                    "startup_command": {
-                        "type": ["string", "null"],
-                        "description": "Optional command to launch when a new pane is created. Defaults to `ssh <host>`."
-                    }
+    fn description(&self) -> String {
+        "Reuse an existing SSH pane for a specific remote host when one is already available, or create a new pane and connect to that host when none exists. This is the preferred tool for multi-host remote orchestration so the agent does not keep creating duplicate SSH panes across turns. The result includes stable pane_id for follow-up work.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "SSH host or alias to target, such as haswell or user@host."
                 },
-                "required": ["host"]
-            }),
-        }
+                "pane_index": {
+                    "type": ["integer", "null"],
+                    "description": "Optional con pane index to constrain reuse checks to a specific pane. Positional only."
+                },
+                "pane_id": {
+                    "type": ["integer", "null"],
+                    "description": "Optional stable pane id to constrain reuse checks to a specific pane."
+                },
+                "location": {
+                    "type": "string",
+                    "enum": ["right", "down"],
+                    "description": "Where to place a newly created pane if one is needed. Defaults to right."
+                },
+                "startup_command": {
+                    "type": ["string", "null"],
+                    "description": "Optional command to launch when a new pane is created. Defaults to `ssh <host>`."
+                }
+            },
+            "required": ["host"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -6067,42 +6066,42 @@ impl Tool for EnsureRemoteTmuxWorkspaceTool {
     type Args = EnsureRemoteTmuxWorkspaceArgs;
     type Output = EnsureRemoteTmuxWorkspaceResult;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Prepare a reusable REMOTE tmux session from a host shell anchor. con reuses or creates an SSH shell pane for the host, ensures the requested tmux session exists, and returns whether tmux-native control is immediately available from that same pane. Use this when you only need the tmux session/bootstrap fact. If you also need a clean tmux shell target for file work, prefer ensure_remote_tmux_shell_target instead of attaching tmux in the visible pane.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "host": {
-                        "type": "string",
-                        "description": "SSH host or alias to target, such as haswell or user@host."
-                    },
-                    "session_name": {
-                        "type": "string",
-                        "description": "tmux session name to ensure on that host."
-                    },
-                    "pane_index": {
-                        "type": ["integer", "null"],
-                        "description": "Optional con pane index to constrain SSH reuse checks. Positional only."
-                    },
-                    "pane_id": {
-                        "type": ["integer", "null"],
-                        "description": "Optional stable con pane id to constrain SSH reuse checks."
-                    },
-                    "location": {
-                        "type": "string",
-                        "enum": ["right", "down"],
-                        "description": "Where to place a newly created SSH pane if one is needed. Defaults to right."
-                    },
-                    "startup_command": {
-                        "type": ["string", "null"],
-                        "description": "Optional startup command for a newly created remote pane. Defaults to `ssh <host>`."
-                    }
+    fn description(&self) -> String {
+        "Prepare a reusable REMOTE tmux session from a host shell anchor. con reuses or creates an SSH shell pane for the host, ensures the requested tmux session exists, and returns whether tmux-native control is immediately available from that same pane. Use this when you only need the tmux session/bootstrap fact. If you also need a clean tmux shell target for file work, prefer ensure_remote_tmux_shell_target instead of attaching tmux in the visible pane.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "SSH host or alias to target, such as haswell or user@host."
                 },
-                "required": ["host", "session_name"]
-            }),
-        }
+                "session_name": {
+                    "type": "string",
+                    "description": "tmux session name to ensure on that host."
+                },
+                "pane_index": {
+                    "type": ["integer", "null"],
+                    "description": "Optional con pane index to constrain SSH reuse checks. Positional only."
+                },
+                "pane_id": {
+                    "type": ["integer", "null"],
+                    "description": "Optional stable con pane id to constrain SSH reuse checks."
+                },
+                "location": {
+                    "type": "string",
+                    "enum": ["right", "down"],
+                    "description": "Where to place a newly created SSH pane if one is needed. Defaults to right."
+                },
+                "startup_command": {
+                    "type": ["string", "null"],
+                    "description": "Optional startup command for a newly created remote pane. Defaults to `ssh <host>`."
+                }
+            },
+            "required": ["host", "session_name"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -6116,63 +6115,63 @@ impl Tool for EnsureRemoteTmuxShellTargetTool {
     type Args = EnsureRemoteTmuxShellTargetArgs;
     type Output = EnsureRemoteTmuxShellTargetResult;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Prepare the full REMOTE ssh->tmux shell-work path in one step. con reuses or creates an SSH pane for the host, ensures the requested tmux session exists there, verifies tmux-native control on that same pane, and then reuses or creates a clean tmux shell target for file work. The result includes both a tmux snapshot and the selected shell target, so you can describe the tmux workspace and continue file work without attaching tmux in the visible outer pane unless the user explicitly asks to enter it.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "host": {
-                        "type": "string",
-                        "description": "SSH host or alias to target, such as haswell or user@host."
-                    },
-                    "session_name": {
-                        "type": "string",
-                        "description": "tmux session name to ensure on that host."
-                    },
-                    "pane_index": {
-                        "type": ["integer", "null"],
-                        "description": "Optional con pane index to constrain SSH reuse checks. Positional only."
-                    },
-                    "pane_id": {
-                        "type": ["integer", "null"],
-                        "description": "Optional stable con pane id to constrain SSH reuse checks."
-                    },
-                    "location": {
-                        "type": "string",
-                        "enum": ["right", "down"],
-                        "description": "Where to place a newly created SSH pane if one is needed. Defaults to right."
-                    },
-                    "startup_command": {
-                        "type": ["string", "null"],
-                        "description": "Optional startup command for a newly created remote pane. Defaults to `ssh <host>`."
-                    },
-                    "cwd": {
-                        "type": ["string", "null"],
-                        "description": "Optional path hint for the tmux shell target. Existing shell panes whose tmux cwd contains this value are preferred, and new targets inherit it when created."
-                    },
-                    "window_name": {
-                        "type": ["string", "null"],
-                        "description": "Optional tmux window name for a newly created shell target."
-                    },
-                    "shell_command": {
-                        "type": ["string", "null"],
-                        "description": "Optional command for a newly created tmux shell target. Defaults to an interactive login shell."
-                    },
-                    "tmux_location": {
-                        "type": "string",
-                        "enum": ["new_window", "split_horizontal", "split_vertical"],
-                        "description": "Where to create a new tmux shell target if none already exists."
-                    },
-                    "detached": {
-                        "type": "boolean",
-                        "description": "Whether a newly created tmux shell target should start detached. Defaults to true."
-                    }
+    fn description(&self) -> String {
+        "Prepare the full REMOTE ssh->tmux shell-work path in one step. con reuses or creates an SSH pane for the host, ensures the requested tmux session exists there, verifies tmux-native control on that same pane, and then reuses or creates a clean tmux shell target for file work. The result includes both a tmux snapshot and the selected shell target, so you can describe the tmux workspace and continue file work without attaching tmux in the visible outer pane unless the user explicitly asks to enter it.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "SSH host or alias to target, such as haswell or user@host."
                 },
-                "required": ["host", "session_name"]
-            }),
-        }
+                "session_name": {
+                    "type": "string",
+                    "description": "tmux session name to ensure on that host."
+                },
+                "pane_index": {
+                    "type": ["integer", "null"],
+                    "description": "Optional con pane index to constrain SSH reuse checks. Positional only."
+                },
+                "pane_id": {
+                    "type": ["integer", "null"],
+                    "description": "Optional stable con pane id to constrain SSH reuse checks."
+                },
+                "location": {
+                    "type": "string",
+                    "enum": ["right", "down"],
+                    "description": "Where to place a newly created SSH pane if one is needed. Defaults to right."
+                },
+                "startup_command": {
+                    "type": ["string", "null"],
+                    "description": "Optional startup command for a newly created remote pane. Defaults to `ssh <host>`."
+                },
+                "cwd": {
+                    "type": ["string", "null"],
+                    "description": "Optional path hint for the tmux shell target. Existing shell panes whose tmux cwd contains this value are preferred, and new targets inherit it when created."
+                },
+                "window_name": {
+                    "type": ["string", "null"],
+                    "description": "Optional tmux window name for a newly created shell target."
+                },
+                "shell_command": {
+                    "type": ["string", "null"],
+                    "description": "Optional command for a newly created tmux shell target. Defaults to an interactive login shell."
+                },
+                "tmux_location": {
+                    "type": "string",
+                    "enum": ["new_window", "split_horizontal", "split_vertical"],
+                    "description": "Where to create a new tmux shell target if none already exists."
+                },
+                "detached": {
+                    "type": "boolean",
+                    "description": "Whether a newly created tmux shell target should start detached. Defaults to true."
+                }
+            },
+            "required": ["host", "session_name"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -6345,31 +6344,31 @@ impl Tool for RemoteExecTool {
     type Args = RemoteExecArgs;
     type Output = serde_json::Value;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Reuse or create SSH workspaces for one or more hosts, then execute the same shell command on all of them in parallel. This is the preferred high-level tool for routine multi-host checks so the model does not need to stitch ensure_remote_shell_target and batch_exec together manually. Each host result includes stable pane_id for follow-up work.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "hosts": {
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "description": "SSH hosts or aliases to target."
-                    },
-                    "command": {
-                        "type": "string",
-                        "description": "Shell command to run on each host."
-                    },
-                    "location": {
-                        "type": "string",
-                        "enum": ["right", "down"],
-                        "description": "Where to place a newly created pane if a host workspace does not exist yet. Defaults to right."
-                    }
+    fn description(&self) -> String {
+        "Reuse or create SSH workspaces for one or more hosts, then execute the same shell command on all of them in parallel. This is the preferred high-level tool for routine multi-host checks so the model does not need to stitch ensure_remote_shell_target and batch_exec together manually. Each host result includes stable pane_id for follow-up work.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "hosts": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "SSH hosts or aliases to target."
                 },
-                "required": ["hosts", "command"]
-            }),
-        }
+                "command": {
+                    "type": "string",
+                    "description": "Shell command to run on each host."
+                },
+                "location": {
+                    "type": "string",
+                    "enum": ["right", "down"],
+                    "description": "Where to place a newly created pane if a host workspace does not exist yet. Defaults to right."
+                }
+            },
+            "required": ["hosts", "command"]
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -6686,25 +6685,25 @@ impl Tool for CreatePaneTool {
     type Args = CreatePaneArgs;
     type Output = CreatePaneOutput;
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Create a new terminal pane (split in current tab). Optionally run a startup command (e.g. \"ssh host\"). The command executes automatically — do NOT re-send it via send_keys. You can choose split placement for better workspace layout. Returns both pane_index and stable pane_id plus the initial terminal output (waits for output to settle). Prefer pane_id for follow-up targeting.".to_string(),
-            parameters: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "command": {
-                        "type": "string",
-                        "description": "Optional startup command executed automatically in the new pane. Do NOT re-send this command — it already ran."
-                    },
-                    "location": {
-                        "type": "string",
-                        "enum": ["right", "down"],
-                        "description": "Where to place the new pane relative to the focused pane. Defaults to right for peer workspaces."
-                    }
+    fn description(&self) -> String {
+        "Create a new terminal pane (split in current tab). Optionally run a startup command (e.g. \"ssh host\"). The command executes automatically — do NOT re-send it via send_keys. You can choose split placement for better workspace layout. Returns both pane_index and stable pane_id plus the initial terminal output (waits for output to settle). Prefer pane_id for follow-up targeting.".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "Optional startup command executed automatically in the new pane. Do NOT re-send this command — it already ran."
+                },
+                "location": {
+                    "type": "string",
+                    "enum": ["right", "down"],
+                    "description": "Where to place the new pane relative to the focused pane. Defaults to right for peer workspaces."
                 }
-            }),
-        }
+            }
+        })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {

--- a/docs/impl/agent-harness.md
+++ b/docs/impl/agent-harness.md
@@ -71,9 +71,9 @@ ConWorkspace::send_to_agent()
                             ▼
                         AgentProvider (con-agent)
                             │
-                            ├── Builds Rig Agent with tools
-                            ├── Creates ConHook with event_tx + approval_rx
-                            └── agent.prompt(msg).with_hook(hook).with_history(history)
+                            ├── Builds Rig Agent with tools + ConHook
+                            ├── Creates streaming request with conversation history
+                            └── agent.stream_prompt(msg).history(history)
                                     │
                                     ▼
                                 Rig Agent Loop
@@ -196,7 +196,7 @@ The mutex is held briefly for two operations:
 1. **Snapshot** — clone conversation before agent call
 2. **Add message** — insert assistant response after agent completes
 
-Rig manages its own history via `with_history(&mut Vec<rig::message::Message>)`. Our `to_rig_history()` provides User/Assistant text pairs. Rig appends tool call/result messages during its turn loop.
+Each streaming request receives history from `to_rig_history()` as User/Assistant text pairs. Rig appends tool call/result messages during its turn loop and returns the final response to Con for persistence.
 
 ## Focused Pane Fact Preflight
 
@@ -235,7 +235,7 @@ auto_approve_tools = false  # skip approval for dangerous tools
 max_turns = 10              # max tool-use turns per request
 ```
 
-`auto_approve_tools = true` makes `ConHook` return `ToolCallHookAction::cont()` for all tools, bypassing the approval channel entirely.
+`auto_approve_tools = true` makes `ConHook` continue all tool calls without consulting the approval channel. Rig 0.40 uses an exact total model-call budget; Con preserves the ceiling shipped by its earlier Rig integration when converting `max_turns`.
 
 ## Input Classification
 

--- a/docs/impl/build-system.md
+++ b/docs/impl/build-system.md
@@ -51,7 +51,7 @@ members = [
 |------------|---------|
 | `gpui` | native GPU UI framework (upstream Zed git source) |
 | `gpui-component` | reusable UI controls (upstream Longbridge git source) |
-| `rig-core` | multi-provider agent runtime (pinned fork revision) |
+| `rig-core` | multi-provider agent runtime (crates.io) |
 | `tokio` | async runtime for agent work |
 | `crossbeam-channel` | UI and harness event routing |
 | `reqwest` | live model list fetch from models.dev |

--- a/docs/study/rig.md
+++ b/docs/study/rig.md
@@ -3,7 +3,9 @@
 ## Overview
 
 [Rig](https://rig.rs/) is the most mature Rust-native AI agent framework. MIT licensed.
-The current workspace pins `rig-core` to a maintained git revision in `wey-gu/rig` rather than a crates.io release. The architecture notes here still apply, but the exact provider surface is tied to that pinned revision.
+The workspace uses the published `rig-core` 0.40 release from crates.io. Con keeps
+provider construction, conversation persistence, terminal context, and approval
+policy in its own crates; Rig supplies provider clients and the agent run loop.
 
 ## Core Architecture
 
@@ -34,7 +36,7 @@ let agent = client
     .tool(ShellExecTool)
     .tool(FileReadTool)
     .max_tokens(4096)
-    .default_max_turns(10) // max tool call loops
+    .default_max_turns(12) // preserve Con's former max_turns = 10 ceiling
     .build();
 ```
 
@@ -62,8 +64,6 @@ let response: String = agent
 
 ```rust
 use rig::tool::Tool;
-use rig::completion::ToolDefinition;
-
 pub struct ShellExecTool;
 
 impl Tool for ShellExecTool {
@@ -72,12 +72,12 @@ impl Tool for ShellExecTool {
     type Args = ShellExecArgs;     // must impl Deserialize
     type Output = ShellExecOutput; // must impl Serialize
 
-    async fn definition(&self, _prompt: String) -> ToolDefinition {
-        ToolDefinition {
-            name: Self::NAME.to_string(),
-            description: "Execute a shell command".to_string(),
-            parameters: serde_json::json!({ /* JSON schema */ }),
-        }
+    fn description(&self) -> String {
+        "Execute a shell command".to_string()
+    }
+
+    fn parameters(&self) -> serde_json::Value {
+        serde_json::json!({ /* JSON schema */ })
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
@@ -86,25 +86,20 @@ impl Tool for ShellExecTool {
 }
 ```
 
-## PromptHook Trait (lifecycle callbacks)
+## AgentHook Trait (lifecycle callbacks)
 
 ```rust
-use rig::agent::PromptHook;
+use rig::agent::{AgentHook, Flow, HookContext, StepEvent};
 
-impl PromptHook<M> for MyHook {
-    async fn on_text_delta(&self, delta: &str, aggregated: &str) -> HookAction {
-        // Stream token to UI
-        HookAction::cont()
-    }
-
-    async fn on_tool_call(&self, name: &str, ...) -> ToolCallHookAction {
-        // Log or approve/deny tool calls
-        ToolCallHookAction::cont()
-    }
-
-    async fn on_tool_result(&self, name: &str, ...) -> HookAction {
-        // Observe tool results
-        HookAction::cont()
+impl<M: CompletionModel> AgentHook<M> for MyHook {
+    async fn on_event(&self, _ctx: &HookContext, event: StepEvent<'_, M>) -> Flow {
+        match event {
+            StepEvent::TextDelta { delta, .. } => stream_to_ui(delta),
+            StepEvent::ToolCall { tool_name, .. } => request_approval(tool_name),
+            StepEvent::ToolResult { result, .. } => record_result(result),
+            _ => {}
+        }
+        Flow::cont()
     }
 }
 ```
@@ -117,48 +112,47 @@ use rig::OneOrMany;
 
 // User message
 Message::User {
-    content: OneOrMany::one(UserContent::Text(Text { text: "hello".into() }))
+    content: OneOrMany::one(UserContent::Text(Text::new("hello")))
 }
 
 // Assistant message
 Message::Assistant {
     id: None,
-    content: OneOrMany::one(AssistantContent::Text(Text { text: "hi".into() }))
+    content: OneOrMany::one(AssistantContent::Text(Text::new("hi")))
 }
 ```
 
-## Streaming (RawStreamingChoice)
+## Streaming
 
 ```rust
-use rig::streaming::{StreamingCompletionResponse, RawStreamingChoice};
+use rig::agent::MultiTurnStreamItem;
+use rig::streaming::StreamedAssistantContent;
 
 // Streaming responses yield these variants:
-RawStreamingChoice::Message(String)       // text chunk
-RawStreamingChoice::ToolCall(...)         // complete tool call
-RawStreamingChoice::ToolCallDelta { .. }  // partial tool call
-RawStreamingChoice::Reasoning { .. }      // reasoning content
-RawStreamingChoice::FinalResponse(R)      // provider response object
+MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::Text(...))
+MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::Reasoning(...))
+MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::ToolCall { ... })
+MultiTurnStreamItem::StreamUserItem(...)  // completed tool result
+MultiTurnStreamItem::FinalResponse(...)   // unified PromptResponse
 ```
 
 ## Integration with con
 
 1. `con-agent/provider.rs` creates `anthropic::Client` from config
-2. Builds an `Agent` with our 4 tool implementations
-3. Uses `Chat::chat()` for multi-turn conversation
+2. Builds an `Agent` with Con's terminal, tmux, file, and workspace tools
+3. Uses `stream_prompt()` for live multi-turn conversation
 4. `con-agent/conversation.rs` converts our Message types to Rig's `Vec<Message>`
 5. `con-core/harness.rs` runs agent work on a shared tokio runtime
 
-## Key Differences from Rig 0.10
+## Key Differences from Rig 0.36
 
-- `Tool` trait now uses `const NAME`, associated types for Args/Output/Error
-- `definition()` and `call()` are now async methods (not derive macros)
-- Client uses generic `Client<Ext, H>` architecture with `Capabilities` trait
-- `Chat::chat()` takes `impl Into<Message>` + `Vec<Message>` history
-- `PromptHook` replaces ad-hoc streaming callbacks
-- Agent builder has typestate for tool configuration (NoToolConfig → WithBuilderTools)
+- `Tool` exposes synchronous `description()` and `parameters()` metadata methods.
+- `AgentHook::on_event()` replaces the model-generic `PromptHook` method set.
+- `PromptResponse` unifies streaming and non-streaming final output.
+- `max_turns` is a total model-call budget, including the initial request.
+- Per-delta hook interest is explicit, avoiding dispatch work for unused stream events.
 
 ## Workspace Integration Notes
 
-Rig-core uses `workspace = true` for its deps. Since it lives inside our repo (at `3pp/rig/`),
-Cargo resolves those against OUR workspace root. We added rig-core's transitive workspace deps
-(as-any, async-stream, bytes, etc.) to our workspace Cargo.toml to satisfy these references.
+Rig is an ordinary crates.io dependency. `3pp/` remains read-only reference material and is
+never part of dependency resolution.


### PR DESCRIPTION
## Summary

- replace the old upstream Git revision with the published `rig-core 0.40.0` crate
- migrate all 34 Con tools to Rig’s flattened metadata API and ConHook to hooks v2
- preserve streaming output, approval/cancellation, conversation history, and the previously shipped `max_turns` ceiling
- update the agent architecture and dependency documentation

## Why a separate PR

Rig 0.40 is a breaking runtime migration, not a lockfile-only update. Keeping it separate from beta.78 makes the provider, tool, and streaming changes reviewable and leaves the shipped release unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test --workspace` (493 tests plus doc tests)
- `git diff --check`

## Risk controls

- Con registers the hook on each request-scoped agent, as before.
- Delta interest is limited to text events; tool steering events remain mandatory.
- Rig 0.36 allowed `max_turns + 2` calls; a tested compatibility conversion retains that exact ceiling under Rig 0.40’s literal model-call budget.
- Tool names, descriptions, schemas, argument/output types, and execution bodies are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core multi-provider agent loop (streaming, tool approval, and turn budgeting), but tool contracts and execution bodies are unchanged and new tests cover hook and stream edge cases.
> 
> **Overview**
> **Upgrades Con’s AI harness to Rig 0.40** by depending on the published `rig-core` crate instead of an interim git revision, with lockfile updates for Rig’s transitive stack (e.g. websocket/tokio bumps).
> 
> **Runtime API migration:** `ConHook` now implements Rig’s **`AgentHook`** and handles **`StepEvent`** (text deltas, tool calls/results) with **`Flow::cont` / `Flow::skip`**, still driving the same approval channel, cancellation polling, and UI events. All agent **`Tool`** implementations expose synchronous **`description()` / `parameters()`** instead of async `ToolDefinition`. Agent construction registers the hook via **`add_hook`**, streams with **`stream_prompt(...).history(...)`**, and reads final text from **`FinalResponse.output`**.
> 
> **Behavior preserved:** **`rig_model_call_budget`** maps user **`max_turns`** so the effective model-call ceiling matches the older Rig semantics; stream consumption still backfills text when deltas are missing and avoids duplicating live tokens. Conversation history uses Rig’s **`Text::new`** helpers.
> 
> Docs, changelog, and **unit tests** for the budget helper, unified final responses, and hook approval paths accompany the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0ba03c6e607a255cad638b910c5385b091d171a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->