### PR TITLE
fix(agent): restore GPT-5.6 discovery and harden Rig 0.40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ con is still pre-release, so entries may group related beta work while the produ
 - Fixed ChatGPT Subscription model discovery after the Codex model catalog
   started requiring an explicit client compatibility version. **Fetch Models**
   now loads the account's available catalog, including GPT-5.6 models where
-  available, and the offline fallback includes the GPT-5.6 family. _(Issue
-  [#251](https://github.com/nowledge-co/con-terminal/issues/251), reported by
+  available, and the offline fallback includes the GPT-5.6 family. _(PR
+  [#252](https://github.com/nowledge-co/con-terminal/pull/252) by
+  [@wey-gu](https://github.com/wey-gu); reported in issue
+  [#251](https://github.com/nowledge-co/con-terminal/issues/251) by
   [@zjp1997720](https://github.com/zjp1997720))_
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ con is still pre-release, so entries may group related beta work while the produ
   [#250](https://github.com/nowledge-co/con-terminal/pull/250) by
   [@wey-gu](https://github.com/wey-gu))_
 
+### Fixed
+
+**Providers**
+
+- Fixed ChatGPT Subscription model discovery after the Codex model catalog
+  started requiring an explicit client compatibility version. **Fetch Models**
+  now loads the account's available catalog, including GPT-5.6 models where
+  available, and the offline fallback includes the GPT-5.6 family. _(Issue
+  [#251](https://github.com/nowledge-co/con-terminal/issues/251), reported by
+  [@zjp1997720](https://github.com/zjp1997720))_
+
 ---
 
 ## `v0.1.0-beta.78` - 2026-07-15

--- a/crates/con-agent/Cargo.toml
+++ b/crates/con-agent/Cargo.toml
@@ -23,3 +23,6 @@ uuid.workspace = true
 chrono.workspace = true
 dirs.workspace = true
 gethostname.workspace = true
+
+[dev-dependencies]
+rig = { workspace = true, features = ["test-utils"] }

--- a/crates/con-agent/src/hook.rs
+++ b/crates/con-agent/src/hook.rs
@@ -182,6 +182,49 @@ impl ConHook {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::StreamExt;
+    use rig::agent::{AgentBuilder, MultiTurnStreamItem};
+    use rig::streaming::StreamingPrompt;
+    use rig::test_utils::{MockCompletionModel, MockStreamEvent, MockToolError};
+    use rig::tool::Tool;
+    use serde::Deserialize;
+    use std::sync::atomic::AtomicUsize;
+
+    #[derive(Deserialize)]
+    struct ContractToolArgs {
+        value: String,
+    }
+
+    #[derive(Clone)]
+    struct ContractTool {
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl Tool for ContractTool {
+        const NAME: &'static str = "shell_exec";
+        type Error = MockToolError;
+        type Args = ContractToolArgs;
+        type Output = String;
+
+        fn description(&self) -> String {
+            "Rig migration contract tool".to_string()
+        }
+
+        fn parameters(&self) -> serde_json::Value {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "value": { "type": "string" }
+                },
+                "required": ["value"]
+            })
+        }
+
+        async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(args.value)
+        }
+    }
 
     fn hook(
         auto_approve: bool,
@@ -256,5 +299,122 @@ mod tests {
                 reason: "Tool approval timed out or cancelled".into()
             }
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rig_streaming_loop_preserves_con_tool_and_text_events() {
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call(
+                    "tool-1",
+                    ContractTool::NAME,
+                    serde_json::json!({"value": "tool output"}),
+                ),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("final answer"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let (hook, event_rx, _approval_tx) = hook(true, false);
+        let agent = AgentBuilder::new(model)
+            .tool(ContractTool {
+                calls: calls.clone(),
+            })
+            .add_hook(hook)
+            .default_max_turns(3)
+            .build();
+
+        let mut stream = agent.stream_prompt("run the contract tool").await;
+        let mut final_output = None;
+        while let Some(item) = stream.next().await {
+            match item.expect("Rig streaming loop should complete") {
+                MultiTurnStreamItem::FinalResponse(response) => {
+                    final_output = Some(response.output);
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(final_output.as_deref(), Some("final answer"));
+
+        let events = event_rx.try_iter().collect::<Vec<_>>();
+        let start_call_id = events.iter().find_map(|event| match event {
+            AgentEvent::ToolCallStart {
+                call_id, tool_name, ..
+            } if tool_name == ContractTool::NAME => Some(call_id.as_str()),
+            _ => None,
+        });
+        let start_call_id = start_call_id.expect("Con hook should emit the tool start");
+        assert!(!start_call_id.is_empty());
+        assert!(events.iter().any(|event| matches!(
+            event,
+            AgentEvent::ToolCallComplete {
+                call_id,
+                tool_name,
+                result,
+            } if call_id == start_call_id
+                && tool_name == ContractTool::NAME
+                && result.contains("tool output")
+        )));
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, AgentEvent::Token(text) if text == "final answer"))
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rig_streaming_loop_does_not_execute_denied_dangerous_tool() {
+        let model = MockCompletionModel::from_stream_turns([
+            vec![
+                MockStreamEvent::tool_call(
+                    "tool-2",
+                    ContractTool::NAME,
+                    serde_json::json!({"value": "must not execute"}),
+                ),
+                MockStreamEvent::final_response_with_total_tokens(4),
+            ],
+            vec![
+                MockStreamEvent::text("denied"),
+                MockStreamEvent::final_response_with_total_tokens(6),
+            ],
+        ]);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let (hook, event_rx, approval_tx) = hook(false, false);
+        approval_tx
+            .send(ToolApprovalDecision {
+                call_id: "tool-2".into(),
+                allowed: false,
+                reason: Some("Denied by test".into()),
+            })
+            .unwrap();
+        let agent = AgentBuilder::new(model)
+            .tool(ContractTool {
+                calls: calls.clone(),
+            })
+            .add_hook(hook)
+            .default_max_turns(3)
+            .build();
+
+        let mut stream = agent.stream_prompt("run the contract tool").await;
+        while let Some(item) = stream.next().await {
+            if matches!(
+                item.expect("Rig streaming loop should recover from denied tool"),
+                MultiTurnStreamItem::FinalResponse(_)
+            ) {
+                break;
+            }
+        }
+
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        assert!(event_rx.try_iter().any(|event| matches!(
+            event,
+            AgentEvent::ToolCallComplete { result, .. } if result.contains("Denied by test")
+        )));
     }
 }

--- a/crates/con-agent/src/hook.rs
+++ b/crates/con-agent/src/hook.rs
@@ -153,7 +153,14 @@ impl ConHook {
                     }
 
                     match approval_rx.recv_timeout(APPROVAL_POLL_INTERVAL) {
-                        Ok(decision) => return Some(decision),
+                        Ok(decision) if decision.call_id == call_id => return Some(decision),
+                        Ok(decision) => {
+                            log::warn!(
+                                "[agent] Ignoring approval for tool call {} while waiting for {}",
+                                decision.call_id,
+                                call_id,
+                            );
+                        }
                         Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
                             if std::time::Instant::now() >= deadline {
                                 return None;
@@ -265,6 +272,13 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn dangerous_tool_honors_denial_reason() {
         let (hook, event_rx, approval_tx) = hook(false, false);
+        approval_tx
+            .send(ToolApprovalDecision {
+                call_id: "other-call".into(),
+                allowed: true,
+                reason: None,
+            })
+            .unwrap();
         approval_tx
             .send(ToolApprovalDecision {
                 call_id: "call-2".into(),
@@ -386,13 +400,25 @@ mod tests {
         ]);
         let calls = Arc::new(AtomicUsize::new(0));
         let (hook, event_rx, approval_tx) = hook(false, false);
-        approval_tx
-            .send(ToolApprovalDecision {
-                call_id: "tool-2".into(),
-                allowed: false,
-                reason: Some("Denied by test".into()),
-            })
-            .unwrap();
+        let approval_event_rx = event_rx.clone();
+        let approval_thread = std::thread::spawn(move || {
+            loop {
+                match approval_event_rx.recv_timeout(std::time::Duration::from_secs(5)) {
+                    Ok(AgentEvent::ToolCallStart { call_id, .. }) => {
+                        approval_tx
+                            .send(ToolApprovalDecision {
+                                call_id,
+                                allowed: false,
+                                reason: Some("Denied by test".into()),
+                            })
+                            .unwrap();
+                        return;
+                    }
+                    Ok(_) => {}
+                    Err(error) => panic!("tool approval event should arrive: {error}"),
+                }
+            }
+        });
         let agent = AgentBuilder::new(model)
             .tool(ContractTool {
                 calls: calls.clone(),
@@ -410,6 +436,9 @@ mod tests {
                 break;
             }
         }
+        approval_thread
+            .join()
+            .expect("approval thread should finish");
 
         assert_eq!(calls.load(Ordering::SeqCst), 0);
         assert!(event_rx.try_iter().any(|event| matches!(

--- a/crates/con-agent/src/hook.rs
+++ b/crates/con-agent/src/hook.rs
@@ -86,6 +86,35 @@ const APPROVAL_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_mi
 /// Total approval timeout: 5 minutes.
 const APPROVAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
 
+fn wait_for_tool_approval(
+    approval_rx: &crossbeam_channel::Receiver<ToolApprovalDecision>,
+    cancel_flag: &AtomicBool,
+    call_id: &str,
+    timeout: std::time::Duration,
+    poll_interval: std::time::Duration,
+) -> Option<ToolApprovalDecision> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if cancel_flag.load(Ordering::Relaxed) {
+            return None;
+        }
+
+        let remaining = deadline.checked_duration_since(std::time::Instant::now())?;
+        match approval_rx.recv_timeout(remaining.min(poll_interval)) {
+            Ok(decision) if decision.call_id == call_id => return Some(decision),
+            Ok(decision) => {
+                log::warn!(
+                    "[agent] Ignoring approval for tool call {} while waiting for {}",
+                    decision.call_id,
+                    call_id,
+                );
+            }
+            Err(crossbeam_channel::RecvTimeoutError::Timeout) => {}
+            Err(crossbeam_channel::RecvTimeoutError::Disconnected) => return None,
+        }
+    }
+}
+
 impl<M: CompletionModel> AgentHook<M> for ConHook {
     async fn on_event(&self, _ctx: &HookContext, event: StepEvent<'_, M>) -> Flow {
         match event {
@@ -145,32 +174,13 @@ impl ConHook {
             // Poll for approval with short intervals so we can respond
             // to cancellation (e.g. app quit) without blocking shutdown.
             let decision = tokio::task::block_in_place(|| {
-                let deadline = std::time::Instant::now() + APPROVAL_TIMEOUT;
-                loop {
-                    // Check cancellation first — enables clean shutdown
-                    if cancel_flag.load(Ordering::Relaxed) {
-                        return None;
-                    }
-
-                    match approval_rx.recv_timeout(APPROVAL_POLL_INTERVAL) {
-                        Ok(decision) if decision.call_id == call_id => return Some(decision),
-                        Ok(decision) => {
-                            log::warn!(
-                                "[agent] Ignoring approval for tool call {} while waiting for {}",
-                                decision.call_id,
-                                call_id,
-                            );
-                        }
-                        Err(crossbeam_channel::RecvTimeoutError::Timeout) => {
-                            if std::time::Instant::now() >= deadline {
-                                return None;
-                            }
-                        }
-                        Err(crossbeam_channel::RecvTimeoutError::Disconnected) => {
-                            return None;
-                        }
-                    }
-                }
+                wait_for_tool_approval(
+                    &approval_rx,
+                    &cancel_flag,
+                    &call_id,
+                    APPROVAL_TIMEOUT,
+                    APPROVAL_POLL_INTERVAL,
+                )
             });
 
             match decision {
@@ -312,6 +322,53 @@ mod tests {
             Flow::Skip {
                 reason: "Tool approval timed out or cancelled".into()
             }
+        );
+    }
+
+    #[test]
+    fn approval_wait_keeps_its_deadline_under_mismatched_decisions() {
+        let (approval_tx, approval_rx) = crossbeam_channel::bounded(1);
+        let keep_sending = Arc::new(AtomicBool::new(true));
+        let sent = Arc::new(AtomicUsize::new(0));
+        let sender_keep_sending = keep_sending.clone();
+        let sender_sent = sent.clone();
+        let sender = std::thread::spawn(move || {
+            while sender_keep_sending.load(Ordering::Relaxed) {
+                if approval_tx
+                    .send_timeout(
+                        ToolApprovalDecision {
+                            call_id: "other-call".into(),
+                            allowed: true,
+                            reason: None,
+                        },
+                        std::time::Duration::from_millis(1),
+                    )
+                    .is_ok()
+                {
+                    sender_sent.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        });
+        let cancel_flag = AtomicBool::new(false);
+        let timeout = std::time::Duration::from_millis(40);
+        let started = std::time::Instant::now();
+
+        let decision = wait_for_tool_approval(
+            &approval_rx,
+            &cancel_flag,
+            "expected-call",
+            timeout,
+            std::time::Duration::from_millis(10),
+        );
+        let elapsed = started.elapsed();
+        keep_sending.store(false, Ordering::Relaxed);
+        sender.join().unwrap();
+
+        assert!(decision.is_none());
+        assert!(sent.load(Ordering::Relaxed) > 0);
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "mismatched approvals extended the deadline: {elapsed:?}"
         );
     }
 

--- a/crates/con-app/src/model_registry.rs
+++ b/crates/con-app/src/model_registry.rs
@@ -12,6 +12,10 @@ use std::time::{Duration, Instant};
 
 const API_URL: &str = "https://models.dev/api.json";
 const CHATGPT_CODEX_API_BASE_URL: &str = "https://chatgpt.com/backend-api/codex";
+// The Codex model catalog filters entries by client compatibility. Keep this
+// explicit: 0.144.0 is the first catalog version whose wire contract Con
+// supports that exposes the GPT-5.6 family.
+const CHATGPT_CODEX_MODELS_CLIENT_VERSION: &str = "0.144.0";
 const CACHE_TTL: Duration = Duration::from_secs(3600); // 1 hour
 
 // ── Fallback model lists (used when API is unreachable) ──────────────
@@ -38,6 +42,9 @@ fn fallback_models(provider: &ProviderKind) -> &'static [&'static str] {
             "gpt-4.1-mini",
         ],
         ProviderKind::ChatGPT => &[
+            "gpt-5.6-sol",
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
             "gpt-5.5",
             "gpt-5.4",
             "gpt-5.4-mini",
@@ -427,6 +434,24 @@ impl ModelRegistry {
 
         parsed.set_path(&path);
         parsed.set_fragment(None);
+        let query_pairs = parsed
+            .query_pairs()
+            .map(|(key, value)| (key.into_owned(), value.into_owned()))
+            .collect::<Vec<_>>();
+        if !query_pairs
+            .iter()
+            .any(|(key, value)| key == "client_version" && !value.trim().is_empty())
+        {
+            parsed.set_query(None);
+            parsed
+                .query_pairs_mut()
+                .extend_pairs(
+                    query_pairs
+                        .iter()
+                        .filter(|(key, _)| key != "client_version"),
+                )
+                .append_pair("client_version", CHATGPT_CODEX_MODELS_CLIENT_VERSION);
+        }
         Ok(parsed.to_string())
     }
 
@@ -611,6 +636,9 @@ mod tests {
         assert_eq!(
             registry.models_for(&ProviderKind::ChatGPT),
             vec![
+                "gpt-5.6-sol".to_string(),
+                "gpt-5.6-terra".to_string(),
+                "gpt-5.6-luna".to_string(),
                 "gpt-5.5".to_string(),
                 "gpt-5.4".to_string(),
                 "gpt-5.4-mini".to_string(),
@@ -702,21 +730,42 @@ mod tests {
     fn chatgpt_subscription_models_url_uses_codex_models_endpoint() {
         assert_eq!(
             ModelRegistry::chatgpt_subscription_models_url(None).unwrap(),
-            "https://chatgpt.com/backend-api/codex/models"
+            "https://chatgpt.com/backend-api/codex/models?client_version=0.144.0"
         );
         assert_eq!(
             ModelRegistry::chatgpt_subscription_models_url(Some(
                 "https://chatgpt.com/backend-api/codex"
             ))
             .unwrap(),
-            "https://chatgpt.com/backend-api/codex/models"
+            "https://chatgpt.com/backend-api/codex/models?client_version=0.144.0"
         );
         assert_eq!(
             ModelRegistry::chatgpt_subscription_models_url(Some(
                 "https://chatgpt.com/backend-api/codex/models"
             ))
             .unwrap(),
-            "https://chatgpt.com/backend-api/codex/models"
+            "https://chatgpt.com/backend-api/codex/models?client_version=0.144.0"
+        );
+        assert_eq!(
+            ModelRegistry::chatgpt_subscription_models_url(Some(
+                "https://chatgpt.com/backend-api/codex?region=us"
+            ))
+            .unwrap(),
+            "https://chatgpt.com/backend-api/codex/models?region=us&client_version=0.144.0"
+        );
+        assert_eq!(
+            ModelRegistry::chatgpt_subscription_models_url(Some(
+                "https://chatgpt.com/backend-api/codex/models?client_version=0.200.0"
+            ))
+            .unwrap(),
+            "https://chatgpt.com/backend-api/codex/models?client_version=0.200.0"
+        );
+        assert_eq!(
+            ModelRegistry::chatgpt_subscription_models_url(Some(
+                "https://chatgpt.com/backend-api/codex?region=us&client_version="
+            ))
+            .unwrap(),
+            "https://chatgpt.com/backend-api/codex/models?region=us&client_version=0.144.0"
         );
     }
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -73,9 +73,10 @@ cheaper model for suggestions if you want inline help without slowing down the
 terminal.
 
 ChatGPT and GitHub Copilot can use OAuth, so you can leave the API key empty for
-those sign-in flows. OpenAI-compatible hosts can fetch models from `/models`
-when the host supports it. If the host has no models endpoint, type the model ID
-manually and save it.
+those sign-in flows. After signing in to ChatGPT, use **Fetch Models** to load
+the models available to that subscription. OpenAI-compatible hosts can fetch
+models from `/models` when the host supports it. If the host has no models
+endpoint, type the model ID manually and save it.
 
 The provider picker in the agent panel shows configured providers. If a provider
 is missing there, configure it first in Settings.

--- a/postmortem/2026-07-25-chatgpt-model-list-client-version.md
+++ b/postmortem/2026-07-25-chatgpt-model-list-client-version.md
@@ -1,0 +1,38 @@
+# ChatGPT model discovery required a client version
+
+## What happened
+
+ChatGPT Subscription sign-in succeeded, but **Fetch Models** failed with HTTP
+400. The Codex model catalog reported that the `client_version` query parameter
+was missing, so the model picker could not discover GPT-5.6 or any other models
+available to the account.
+
+## Root cause
+
+Con owns model discovery because Rig's ChatGPT provider does not expose a model
+listing capability. Con called the correct Codex `/models` endpoint with the
+correct OAuth token, but the endpoint contract evolved to require a client
+compatibility version.
+
+The value is also a capability boundary. Codex filters catalog entries by each
+model's minimum client version; GPT-5.6 first appears at version `0.144.0`.
+Using Con's package version would therefore satisfy the parameter syntactically
+while still hiding compatible models.
+
+## Fix applied
+
+- Declare the Codex model-catalog compatibility level explicitly as `0.144.0`.
+- Add `client_version` to ChatGPT model-list URLs while preserving unrelated
+  query parameters and respecting a non-empty advanced override.
+- Add GPT-5.6 Sol, Terra, and Luna to the curated offline fallback.
+- Cover default URLs, custom query parameters, explicit overrides, empty
+  overrides, and fallback ordering with unit tests.
+
+## What we learned
+
+Provider discovery endpoints are versioned protocols, even when they look like
+simple REST lists. Their compatibility identifiers must describe the wire
+contract Con supports, not Con's marketing version or the newest upstream
+number. Advancing this value should be an explicit, tested decision so newer
+catalog entries are only exposed after their request and response behavior is
+known to work.


### PR DESCRIPTION
## Summary

- send the required Codex `client_version` when ChatGPT Subscription fetches its account model catalog
- expose GPT-5.6 Sol, Terra, and Luna from the curated offline fallback
- preserve custom query parameters and explicit non-empty compatibility overrides
- document the compatibility boundary and the user-facing Fetch Models flow

Fixes #251.

## Rig version audit

Rig `0.40.0` is already the latest stable `rig-core` release on crates.io and the latest upstream release/tag. `cargo update -p rig-core --dry-run` locks zero packages, so this PR deliberately keeps the published crates.io dependency instead of moving to unreleased Git source.

## Validation

- `cargo test --workspace` (496 tests)
- deterministic Rig 0.40 streaming contract tests: tool execution, correlated tool events, live text deltas, final response, and denied-tool non-execution
- `cargo check -p con --no-default-features --features con/bin-con-app`
- `cargo fmt --all -- --check`
- `python3 scripts/docs/validate-manifest.py`
- `git diff --check`
- live OAuth model-catalog request: HTTP 200 with eight models, including `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`

A live Rig 0.40 ChatGPT OAuth streaming smoke completed successfully against the production backend and returned the expected final response.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider model discovery URLs and agent approval gating; changes are well-tested but affect OAuth catalog fetch and dangerous-tool execution paths.
> 
> **Overview**
> Restores **ChatGPT Subscription Fetch Models** after Codex began requiring a **`client_version`** query on `/models`. Con now defaults to compatibility **`0.144.0`** (the boundary for GPT-5.6), keeps other query params, honors a non-empty override, and adds **GPT-5.6 Sol/Terra/Luna** to the offline fallback. Docs and a postmortem describe the versioned catalog contract.
> 
> **Agent tool approval** is refactored into `wait_for_tool_approval`, which only applies decisions whose **`call_id`** matches the pending tool—other approvals are logged and ignored so mismatched messages cannot stall or skew timeouts. **Rig 0.40** streaming contract tests cover tool/text events and denied dangerous tools without execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 139b790c0f6b015e7ac50a49087e0b34ebafacaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ChatGPT model discovery by enforcing required client compatibility information for the Codex model catalog.
  * Fetch Models now retrieves the full available provider model catalog (including GPT-5.6 where available) while preserving existing URL parameters and overrides.
  * Improved dangerous-tool approval handling to only apply the approval decision that matches the currently awaited tool call.
* **Documentation**
  * Reworked AI provider settings documentation formatting.
  * Added a postmortem covering the ChatGPT model discovery incident and fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


