### PR TITLE
fix(editor): wrap blockquote content and center preview column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ con is still pre-release, so entries may group related beta work while the produ
   [#254](https://github.com/nowledge-co/con-terminal/pull/254) by
   [@sunny0826](https://github.com/sunny0826))_
 
+### Fixed
+
+**Editor**
+
+- Fixed Markdown preview layout in wide editor panes: blockquotes now wrap
+  inside the preview column, and prose is centered instead of hugging the left
+  edge. _(PR [#255](https://github.com/nowledge-co/con-terminal/pull/255) by
+  [@sunny0826](https://github.com/sunny0826))_
+
 ---
 
 ## `v0.1.0-beta.79` - 2026-07-25

--- a/crates/con-app/src/chat_markdown.rs
+++ b/crates/con-app/src/chat_markdown.rs
@@ -526,12 +526,15 @@ pub fn render_parsed_chat_markdown_file_preview(
     // caches that early measurement — wrapped text then paints taller than
     // its slot and overlaps the next block. Block containers measure with
     // the definite width directly, so spacing is done with padding instead
-    // of flex gap.
+    // of flex gap. Each block sits in a single-child flex row so the
+    // content-width-capped blocks center horizontally in wide panes.
     div()
         .w_full()
         .children(document.blocks.iter().enumerate().map(|(idx, block)| {
             div()
                 .w_full()
+                .flex()
+                .justify_center()
                 .pb(if idx + 1 == block_count {
                     px(0.0)
                 } else {
@@ -1995,13 +1998,19 @@ fn render_blockquote_children(
                 .gap(px(9.0))
                 .child(
                     div()
+                        .flex_none()
                         .w(px(3.0))
                         .h_full()
                         .min_h(px(18.0))
                         .bg(style.quote_tint),
                 )
                 .child(
+                    // flex_1 + min_w_0: without them the column sizes to the
+                    // text's intrinsic (unwrapped) width and long quote lines
+                    // overflow instead of wrapping.
                     div()
+                        .flex_1()
+                        .min_w_0()
                         .flex()
                         .flex_col()
                         .gap(style.inner_gap)
@@ -4141,6 +4150,48 @@ mod tests {
         assert!(
             last_row.bottom() <= paragraph.top(),
             "last list row overlaps paragraph: row={last_row:?} paragraph={paragraph:?}"
+        );
+    }
+
+    #[gpui::test]
+    fn blockquote_content_wraps_within_container(cx: &mut gpui::TestAppContext) {
+        // Long quote text must wrap to multiple lines (taller than one line
+        // plus padding) instead of overflowing the container horizontally.
+        let (_view, cx) = cx.add_window_view(|_window, _cx| PreviewLayoutTestView {
+            source: "> 微服务架构风格这种开发方法，是以开发一组小型服务的方式来开发一个独立的应用系统。其中每个小型服务都运行在自己的进程中，并通过轻量级的机制互相通信，通常是 HTTP 资源接口。\n",
+            scroll: None,
+        });
+        let quote = cx
+            .debug_bounds("chat-md-block-0")
+            .expect("quote block bounds");
+        assert!(
+            quote.size.height > px(50.0),
+            "blockquote did not wrap (single-line height): {quote:?}"
+        );
+        assert!(
+            quote.size.width <= px(720.0),
+            "blockquote exceeded the content width cap: {quote:?}"
+        );
+    }
+
+    #[gpui::test]
+    fn preview_content_centers_within_wide_panes(cx: &mut gpui::TestAppContext) {
+        let (_view, cx) = cx.add_window_view(|_window, _cx| PreviewLayoutTestView {
+            source: "plain paragraph text that stays on one line\n",
+            scroll: None,
+        });
+        let viewport = cx.update(|window, _cx| window.viewport_size());
+        let block = cx.debug_bounds("chat-md-block-0").expect("block bounds");
+
+        assert!(
+            block.size.width <= px(720.0),
+            "content column not capped: {block:?}"
+        );
+        let expected_left = (viewport.width - block.size.width) / 2.0;
+        let diff: f32 = (block.left() - expected_left).into();
+        assert!(
+            diff.abs() < 2.0,
+            "content column not centered: block={block:?} viewport={viewport:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Two preview rendering fixes on top of the merged markdown preview (#254): blockquote content now wraps instead of overflowing horizontally, and the content column centers in wide editor panes instead of hugging the left edge.

## Key Changes

- **Blockquote wrapping (`render_blockquote_children`)**: the quote content column gets `flex_1().min_w_0()`. Without them the flex item sized to the text's intrinsic (unwrapped) width, so long `> ...` quotes painted past the pane edge instead of wrapping.
- **Tint bar hardening**: the 3px quote bar gets `flex_none()` so very narrow panes can't compress it.
- **Centered preview column (`render_parsed_chat_markdown_file_preview`)**: each block now sits in a single-child `flex().justify_center()` row. The 720px-capped blocks (paragraphs, headings, quotes, lists) center horizontally; full-width blocks (code, tables, mermaid) are unchanged. A single-child flex row is used deliberately rather than `flex_col`, which was the root cause of the text mis-measurement fixed in #254 (see postmortem `2026-07-29-markdown-preview-flex-col-text-measure.md`).
- **Tests**: two new `debug_bounds` layout regression tests — quote wrapping (`blockquote_content_wraps_within_container`) and centering (`preview_content_centers_within_wide_panes`, asserts symmetric margins at a 1920px viewport).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor / Code cleanup
- [ ] Documentation update

## Testing Performed

- `cargo test --workspace`: 513 tests green.
- New layout tests verify: quote block reaches two-line height within the 720px cap; content column centers with symmetric margins.
- Manual: open a long-form markdown file, toggle preview — quotes wrap inside the pane and the document column is centered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown previews in wide editor panes.
  * Fixed blockquote content so long lines wrap without overflowing.
  * Centered file preview content while preserving width constraints.

* **Tests**
  * Added coverage for blockquote wrapping and centered preview layouts.

* **Documentation**
  * Added changelog entries describing the Markdown preview layout fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->