### PR TITLE
feat(editor): add open-in-editor-tab button to file tree (issue #256)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## `v0.1.0-beta.81` - unreleased
+
+### Added
+
+**Editor**
+
+- Added a file-tree affordance to open files in a dedicated editor tab. The
+  editor tab is reused for additional files, keeps terminal pane layouts
+  untouched, and remains separate from the existing row-click behavior. _(PR
+  [#257](https://github.com/nowledge-co/con-terminal/pull/257) by
+  [@sunny0826](https://github.com/sunny0826))_
+
+---
+
 ## `v0.1.0-beta.80` - 2026-08-05
 
 ### Added

--- a/crates/con-app/src/editor_tab_actions.rs
+++ b/crates/con-app/src/editor_tab_actions.rs
@@ -1,0 +1,130 @@
+//! Reusable editor tab index finder — pure function, no GPUI dependencies.
+//!
+//! Given a slice of which tabs are editor tabs, the active tab index, and the
+//! last-activated editor tab index (maintained by workspace), determines which
+//! editor tab to reuse for an "open in editor tab" action.
+//!
+//! Semantics:
+//! - `last_editor_tab` is valid (in bounds + `is_editor_tab[i] == true`) → return it
+//! - Else if `active_tab` is itself an editor tab → return `active_tab`
+//! - Else → `None` (caller should create a new editor tab)
+
+/// Returns the index of the editor tab to reuse, or `None` if a new tab is needed.
+///
+/// - `last_editor_tab` valid (in range + `is_editor_tab[i] == true`) → returns it
+/// - Otherwise `active_tab` is editor → returns `active_tab`
+/// - Otherwise → `None`
+pub fn reusable_editor_tab_index(
+    is_editor_tab: &[bool],
+    active_tab: usize,
+    last_editor_tab: Option<usize>,
+) -> Option<usize> {
+    // Check if last_editor_tab is valid and points to an editor tab
+    if let Some(idx) = last_editor_tab {
+        if idx < is_editor_tab.len() && is_editor_tab[idx] {
+            return Some(idx);
+        }
+    }
+
+    // Fall back to active_tab if it is an editor tab
+    if active_tab < is_editor_tab.len() && is_editor_tab[active_tab] {
+        return Some(active_tab);
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_last_editor_tab_valid_returns_it() {
+        // last_editor_tab points to a valid editor tab → returns it even if active_tab is not editor
+        let is_editor_tab = [false, true, false, false];
+        let active_tab = 0;
+        let last_editor_tab = Some(1);
+        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), Some(1));
+    }
+
+    #[test]
+    fn test_last_editor_tab_out_of_bounds_falls_back() {
+        // last_editor_tab is out of bounds → falls back to active_tab
+        let is_editor_tab = [false, true, false];
+        let active_tab = 1; // active is editor
+        let last_editor_tab = Some(99); // out of bounds
+        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), Some(1));
+    }
+
+    #[test]
+    fn test_last_editor_tab_out_of_bounds_no_fallback_returns_none() {
+        // last_editor_tab out of bounds AND active_tab is not editor → None
+        let is_editor_tab = [false, false, false];
+        let active_tab = 0; // not editor
+        let last_editor_tab = Some(99);
+        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), None);
+    }
+
+    #[test]
+    fn test_last_editor_tab_not_editor_falls_back() {
+        // last_editor_tab points to non-editor → falls back to active_tab
+        let is_editor_tab = [true, false, true]; // index 1 is not editor
+        let active_tab = 0; // editor
+        let last_editor_tab = Some(1); // points to terminal tab
+        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), Some(0));
+    }
+
+    #[test]
+    fn test_last_editor_tab_not_editor_falls_back_to_non_editor_returns_none() {
+        // last_editor_tab points to non-editor AND active_tab is not editor → None
+        let is_editor_tab = [false, false, true];
+        let active_tab = 0; // not editor
+        let last_editor_tab = Some(1); // not editor
+        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), None);
+    }
+
+    #[test]
+    fn test_active_tab_is_editor_returns_active() {
+        // No valid last_editor_tab, but active_tab itself is editor → returns active_tab
+        let is_editor_tab = [false, true, false];
+        let active_tab = 1;
+        let last_editor_tab = None;
+        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), Some(1));
+    }
+
+    #[test]
+    fn test_active_tab_is_editor_last_editor_also_valid_returns_last() {
+        // Both last_editor_tab and active_tab are valid → prefer last_editor_tab
+        let is_editor_tab = [true, true, false];
+        let active_tab = 0;
+        let last_editor_tab = Some(1);
+        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), Some(1));
+    }
+
+    #[test]
+    fn test_no_editor_tabs_returns_none() {
+        // No editor tabs at all → None
+        let is_editor_tab = [false, false, false];
+        let active_tab = 1;
+        let last_editor_tab = Some(0);
+        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), None);
+    }
+
+    #[test]
+    fn test_empty_array_returns_none() {
+        // Empty array → None regardless of active_tab or last_editor_tab
+        let is_editor_tab: [bool; 0] = [];
+        let active_tab = 0;
+        let last_editor_tab = Some(0);
+        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), None);
+    }
+
+    #[test]
+    fn test_last_editor_tab_none_active_not_editor_returns_none() {
+        // last_editor_tab = None, active_tab is not editor → None
+        let is_editor_tab = [false, false, true];
+        let active_tab = 0;
+        let last_editor_tab = None;
+        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), None);
+    }
+}

--- a/crates/con-app/src/editor_tab_actions.rs
+++ b/crates/con-app/src/editor_tab_actions.rs
@@ -1,27 +1,39 @@
 //! Reusable editor tab index finder — pure function, no GPUI dependencies.
 //!
-//! Given a slice of which tabs are editor tabs, the active tab index, and the
-//! last-activated editor tab index (maintained by workspace), determines which
-//! editor tab to reuse for an "open in editor tab" action.
+//! Given the stable ids of the current tabs, a slice of which tabs are
+//! editor-only tabs, the active tab index, and the last-activated editor tab id
+//! (maintained by workspace), determines which editor tab to reuse for an
+//! "open in editor tab" action.
 //!
 //! Semantics:
-//! - `last_editor_tab` is valid (in bounds + `is_editor_tab[i] == true`) → return it
+//! - `last_editor_tab_id` still points to an editor-only tab → return it
 //! - Else if `active_tab` is itself an editor tab → return `active_tab`
+//! - Else if any editor-only tab exists → return the first editor tab at or
+//!   after the active tab, wrapping around
 //! - Else → `None` (caller should create a new editor tab)
 
 /// Returns the index of the editor tab to reuse, or `None` if a new tab is needed.
 ///
-/// - `last_editor_tab` valid (in range + `is_editor_tab[i] == true`) → returns it
+/// - `last_editor_tab_id` still resolves to an editor tab → returns it
 /// - Otherwise `active_tab` is editor → returns `active_tab`
+/// - Otherwise the first editor tab at/after the active tab, wrapping around
 /// - Otherwise → `None`
 pub fn reusable_editor_tab_index(
+    tab_ids: &[u64],
     is_editor_tab: &[bool],
     active_tab: usize,
-    last_editor_tab: Option<usize>,
+    last_editor_tab_id: Option<u64>,
 ) -> Option<usize> {
-    // Check if last_editor_tab is valid and points to an editor tab
-    if let Some(idx) = last_editor_tab {
-        if idx < is_editor_tab.len() && is_editor_tab[idx] {
+    if tab_ids.len() != is_editor_tab.len() {
+        return None;
+    }
+
+    // Track the last editor by stable tab identity, not by index. Indices shift
+    // whenever the user closes or reorders tabs.
+    if let Some(tab_id) = last_editor_tab_id {
+        if let Some(idx) = tab_ids.iter().position(|id| *id == tab_id)
+            && is_editor_tab[idx]
+        {
             return Some(idx);
         }
     }
@@ -29,6 +41,18 @@ pub fn reusable_editor_tab_index(
     // Fall back to active_tab if it is an editor tab
     if active_tab < is_editor_tab.len() && is_editor_tab[active_tab] {
         return Some(active_tab);
+    }
+
+    if is_editor_tab.is_empty() {
+        return None;
+    }
+
+    let start = active_tab % is_editor_tab.len();
+    for offset in 0..is_editor_tab.len() {
+        let idx = (start + offset) % is_editor_tab.len();
+        if is_editor_tab[idx] {
+            return Some(idx);
+        }
     }
 
     None
@@ -39,92 +63,154 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_last_editor_tab_valid_returns_it() {
-        // last_editor_tab points to a valid editor tab → returns it even if active_tab is not editor
+    fn last_editor_tab_id_valid_returns_it() {
         let is_editor_tab = [false, true, false, false];
+        let tab_ids = [10, 11, 12, 13];
         let active_tab = 0;
-        let last_editor_tab = Some(1);
-        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), Some(1));
+        let last_editor_tab_id = Some(11);
+        assert_eq!(
+            reusable_editor_tab_index(&tab_ids, &is_editor_tab, active_tab, last_editor_tab_id),
+            Some(1)
+        );
     }
 
     #[test]
-    fn test_last_editor_tab_out_of_bounds_falls_back() {
-        // last_editor_tab is out of bounds → falls back to active_tab
+    fn stale_last_editor_tab_id_falls_back_to_active_editor() {
         let is_editor_tab = [false, true, false];
+        let tab_ids = [10, 11, 12];
         let active_tab = 1; // active is editor
-        let last_editor_tab = Some(99); // out of bounds
-        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), Some(1));
+        let last_editor_tab_id = Some(99); // no longer present
+        assert_eq!(
+            reusable_editor_tab_index(&tab_ids, &is_editor_tab, active_tab, last_editor_tab_id),
+            Some(1)
+        );
     }
 
     #[test]
-    fn test_last_editor_tab_out_of_bounds_no_fallback_returns_none() {
-        // last_editor_tab out of bounds AND active_tab is not editor → None
-        let is_editor_tab = [false, false, false];
+    fn stale_last_editor_tab_id_falls_back_to_existing_editor() {
+        let is_editor_tab = [false, false, true];
+        let tab_ids = [10, 11, 12];
         let active_tab = 0; // not editor
-        let last_editor_tab = Some(99);
-        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), None);
+        let last_editor_tab_id = Some(99);
+        assert_eq!(
+            reusable_editor_tab_index(&tab_ids, &is_editor_tab, active_tab, last_editor_tab_id),
+            Some(2)
+        );
     }
 
     #[test]
-    fn test_last_editor_tab_not_editor_falls_back() {
-        // last_editor_tab points to non-editor → falls back to active_tab
+    fn last_editor_tab_id_now_non_editor_falls_back() {
         let is_editor_tab = [true, false, true]; // index 1 is not editor
+        let tab_ids = [10, 11, 12];
         let active_tab = 0; // editor
-        let last_editor_tab = Some(1); // points to terminal tab
-        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), Some(0));
+        let last_editor_tab_id = Some(11);
+        assert_eq!(
+            reusable_editor_tab_index(&tab_ids, &is_editor_tab, active_tab, last_editor_tab_id),
+            Some(0)
+        );
     }
 
     #[test]
-    fn test_last_editor_tab_not_editor_falls_back_to_non_editor_returns_none() {
-        // last_editor_tab points to non-editor AND active_tab is not editor → None
+    fn last_editor_tab_id_now_non_editor_falls_back_to_existing_editor() {
         let is_editor_tab = [false, false, true];
+        let tab_ids = [10, 11, 12];
         let active_tab = 0; // not editor
-        let last_editor_tab = Some(1); // not editor
-        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), None);
+        let last_editor_tab_id = Some(11); // not editor
+        assert_eq!(
+            reusable_editor_tab_index(&tab_ids, &is_editor_tab, active_tab, last_editor_tab_id),
+            Some(2)
+        );
     }
 
     #[test]
-    fn test_active_tab_is_editor_returns_active() {
-        // No valid last_editor_tab, but active_tab itself is editor → returns active_tab
+    fn active_tab_is_editor_returns_active() {
         let is_editor_tab = [false, true, false];
+        let tab_ids = [10, 11, 12];
         let active_tab = 1;
-        let last_editor_tab = None;
-        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), Some(1));
+        let last_editor_tab_id = None;
+        assert_eq!(
+            reusable_editor_tab_index(&tab_ids, &is_editor_tab, active_tab, last_editor_tab_id),
+            Some(1)
+        );
     }
 
     #[test]
-    fn test_active_tab_is_editor_last_editor_also_valid_returns_last() {
-        // Both last_editor_tab and active_tab are valid → prefer last_editor_tab
+    fn active_tab_is_editor_last_editor_also_valid_returns_last() {
         let is_editor_tab = [true, true, false];
+        let tab_ids = [10, 11, 12];
         let active_tab = 0;
-        let last_editor_tab = Some(1);
-        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), Some(1));
+        let last_editor_tab_id = Some(11);
+        assert_eq!(
+            reusable_editor_tab_index(&tab_ids, &is_editor_tab, active_tab, last_editor_tab_id),
+            Some(1)
+        );
     }
 
     #[test]
-    fn test_no_editor_tabs_returns_none() {
-        // No editor tabs at all → None
+    fn no_editor_tabs_returns_none() {
         let is_editor_tab = [false, false, false];
+        let tab_ids = [10, 11, 12];
         let active_tab = 1;
-        let last_editor_tab = Some(0);
-        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), None);
+        let last_editor_tab_id = Some(10);
+        assert_eq!(
+            reusable_editor_tab_index(&tab_ids, &is_editor_tab, active_tab, last_editor_tab_id),
+            None
+        );
     }
 
     #[test]
-    fn test_empty_array_returns_none() {
-        // Empty array → None regardless of active_tab or last_editor_tab
+    fn empty_array_returns_none() {
         let is_editor_tab: [bool; 0] = [];
+        let tab_ids: [u64; 0] = [];
         let active_tab = 0;
-        let last_editor_tab = Some(0);
-        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), None);
+        let last_editor_tab_id = Some(10);
+        assert_eq!(
+            reusable_editor_tab_index(&tab_ids, &is_editor_tab, active_tab, last_editor_tab_id),
+            None
+        );
     }
 
     #[test]
-    fn test_last_editor_tab_none_active_not_editor_returns_none() {
-        // last_editor_tab = None, active_tab is not editor → None
+    fn no_last_active_not_editor_returns_existing_editor() {
         let is_editor_tab = [false, false, true];
+        let tab_ids = [10, 11, 12];
         let active_tab = 0;
-        let last_editor_tab = None;
-        assert_eq!(reusable_editor_tab_index(&is_editor_tab, active_tab, last_editor_tab), None);
+        let last_editor_tab_id = None;
+        assert_eq!(
+            reusable_editor_tab_index(&tab_ids, &is_editor_tab, active_tab, last_editor_tab_id),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn fallback_wraps_from_active_tab() {
+        let is_editor_tab = [true, false, false];
+        let tab_ids = [10, 11, 12];
+        let active_tab = 2;
+        let last_editor_tab_id = None;
+        assert_eq!(
+            reusable_editor_tab_index(&tab_ids, &is_editor_tab, active_tab, last_editor_tab_id),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn fallback_tolerates_out_of_bounds_active_tab() {
+        let is_editor_tab = [false, true, false];
+        let tab_ids = [10, 11, 12];
+        assert_eq!(
+            reusable_editor_tab_index(&tab_ids, &is_editor_tab, 99, None),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn mismatched_metadata_returns_none() {
+        let is_editor_tab = [true, false, false];
+        let tab_ids = [10, 11];
+        assert_eq!(
+            reusable_editor_tab_index(&tab_ids, &is_editor_tab, 0, Some(10)),
+            None
+        );
     }
 }

--- a/crates/con-app/src/file_tree_view.rs
+++ b/crates/con-app/src/file_tree_view.rs
@@ -16,7 +16,7 @@ use gpui::{
     Context, EventEmitter, IntoElement, MouseButton, MouseDownEvent, ParentElement, Render,
     SharedString, Styled, Window, div, prelude::*, px, svg, uniform_list,
 };
-use gpui_component::{tooltip::Tooltip, ActiveTheme};
+use gpui_component::{ActiveTheme, tooltip::Tooltip};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -396,14 +396,19 @@ impl Render for FileTreeView {
                                     .tooltip(move |window, cx| {
                                         Tooltip::new("Open in Editor Tab").build(window, cx)
                                     })
-                                    .on_mouse_down(MouseButton::Left, move |_: &MouseDownEvent, _window, cx| {
-                                        cx.stop_propagation();
-                                        if let Some(view) = weak.upgrade() {
-                                            view.update(cx, |_this, cx| {
-                                                cx.emit(OpenFileInEditorTab { path: path.clone() });
-                                            });
-                                        }
-                                    })
+                                    .on_mouse_down(
+                                        MouseButton::Left,
+                                        move |_: &MouseDownEvent, _window, cx| {
+                                            cx.stop_propagation();
+                                            if let Some(view) = weak.upgrade() {
+                                                view.update(cx, |_this, cx| {
+                                                    cx.emit(OpenFileInEditorTab {
+                                                        path: path.clone(),
+                                                    });
+                                                });
+                                            }
+                                        },
+                                    )
                                     .child(
                                         svg()
                                             .path("phosphor/arrow-square-out.svg")

--- a/crates/con-app/src/file_tree_view.rs
+++ b/crates/con-app/src/file_tree_view.rs
@@ -16,7 +16,7 @@ use gpui::{
     Context, EventEmitter, IntoElement, MouseButton, MouseDownEvent, ParentElement, Render,
     SharedString, Styled, Window, div, prelude::*, px, svg, uniform_list,
 };
-use gpui_component::ActiveTheme;
+use gpui_component::{tooltip::Tooltip, ActiveTheme};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -40,6 +40,13 @@ pub struct OpenFile {
 }
 
 impl EventEmitter<OpenFile> for FileTreeView {}
+
+/// Emitted when the user clicks the "open in editor tab" button on a file row.
+pub struct OpenFileInEditorTab {
+    pub path: PathBuf,
+}
+
+impl EventEmitter<OpenFileInEditorTab> for FileTreeView {}
 
 pub struct FileTreeView {
     root: Option<PathBuf>,
@@ -81,6 +88,10 @@ impl FileTreeView {
 
     pub fn root(&self) -> Option<&Path> {
         self.root.as_deref()
+    }
+
+    pub fn active_path(&self) -> Option<&Path> {
+        self.active_path.as_deref()
     }
 
     /// Toggle expand/collapse for a directory entry.
@@ -188,6 +199,10 @@ fn remove_descendants(entries: &mut Vec<FileEntry>, parent_index: usize) {
     entries.drain(remove_start..remove_end);
 }
 
+fn row_has_open_button(entry: &FileEntry) -> bool {
+    !entry.is_dir
+}
+
 /// Build a flat entry list for `dir` at `depth`. Only one level deep
 /// (children of expanded dirs are inserted lazily by `toggle_dir`).
 fn build_entries(dir: &Path, depth: usize, _expand_root: bool) -> Vec<FileEntry> {
@@ -253,7 +268,7 @@ impl Render for FileTreeView {
                 .into_any_element();
         }
 
-        let active_path = self.active_path.clone();
+        let active_path = self.active_path().map(Path::to_path_buf);
         let accent_bg = theme
             .primary
             .opacity(if theme.is_dark() { 0.12 } else { 0.075 });
@@ -362,6 +377,42 @@ impl Render for FileTreeView {
                                 .font_family(list_theme.font_family.clone())
                                 .child(name),
                         )
+                        .child({
+                            if !row_has_open_button(&entry) {
+                                div().size(px(ICON_SIZE)).flex_shrink_0().into_any_element()
+                            } else {
+                                let path = path.clone();
+                                let weak = weak.clone();
+                                div()
+                                    .id(("file-open-in-editor", idx))
+                                    .flex()
+                                    .items_center()
+                                    .justify_center()
+                                    .size(px(ICON_SIZE))
+                                    .flex_shrink_0()
+                                    .cursor_pointer()
+                                    .opacity(if is_active { 0.4 } else { 0.0 })
+                                    .hover(move |s| s.opacity(1.0))
+                                    .tooltip(move |window, cx| {
+                                        Tooltip::new("Open in Editor Tab").build(window, cx)
+                                    })
+                                    .on_mouse_down(MouseButton::Left, move |_: &MouseDownEvent, _window, cx| {
+                                        cx.stop_propagation();
+                                        if let Some(view) = weak.upgrade() {
+                                            view.update(cx, |_this, cx| {
+                                                cx.emit(OpenFileInEditorTab { path: path.clone() });
+                                            });
+                                        }
+                                    })
+                                    .child(
+                                        svg()
+                                            .path("phosphor/arrow-square-out.svg")
+                                            .size(px(ICON_SIZE))
+                                            .text_color(list_theme.muted_foreground),
+                                    )
+                                    .into_any_element()
+                            }
+                        })
                         .on_mouse_down(MouseButton::Left, move |_: &MouseDownEvent, _window, cx| {
                             if let Some(view) = weak.upgrade() {
                                 view.update(cx, |this, cx| {
@@ -520,5 +571,27 @@ mod tests {
         assert_eq!(entries.len(), 3);
         assert_eq!(entries[1].path, src);
         assert_eq!(entries[2].path, sibling);
+    }
+
+    #[test]
+    fn row_has_open_button_returns_true_only_for_files() {
+        let root = temp_tree();
+        let entries = build_root_entries(&root);
+
+        for entry in entries {
+            if entry.is_dir {
+                assert!(
+                    !row_has_open_button(&entry),
+                    "Directory '{}' should not have open button",
+                    entry.name
+                );
+            } else {
+                assert!(
+                    row_has_open_button(&entry),
+                    "File '{}' should have open button",
+                    entry.name
+                );
+            }
+        }
     }
 }

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -57,6 +57,7 @@ mod editor_buffer;
 mod editor_lsp;
 mod editor_preview;
 mod editor_syntax;
+mod editor_tab_actions;
 mod editor_view;
 mod file_tree_view;
 mod input_bar;

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -280,26 +280,6 @@ impl PaneTree {
         }
     }
 
-    /// Returns true if the focused pane is an Editor pane.
-    pub fn focused_pane_is_editor(&self) -> bool {
-        Self::focused_pane_is_editor_node(&self.root, self.focused_pane_id)
-    }
-
-    fn focused_pane_is_editor_node(node: &PaneNode, focused_pane_id: PaneId) -> bool {
-        match node {
-            PaneNode::Leaf {
-                id,
-                content: PaneContent::Editor { .. },
-                ..
-            } if *id == focused_pane_id => true,
-            PaneNode::Leaf { .. } => false,
-            PaneNode::Split { first, second, .. } => {
-                Self::focused_pane_is_editor_node(first, focused_pane_id)
-                    || Self::focused_pane_is_editor_node(second, focused_pane_id)
-            }
-        }
-    }
-
     pub fn from_state(
         layout: &PaneLayoutState,
         focused_pane_id: Option<PaneId>,
@@ -3423,30 +3403,6 @@ mod tests {
         assert!(tree.is_noop_pane_move(1, 0, SplitDirection::Vertical, SplitPlacement::After,));
         assert!(tree.is_noop_pane_move(0, 1, SplitDirection::Vertical, SplitPlacement::Before,));
         assert!(!tree.is_noop_pane_move(1, 0, SplitDirection::Horizontal, SplitPlacement::After,));
-    }
-
-    #[::core::prelude::v1::test]
-    fn new_editor_creates_editor_pane_tree() {
-        // We can't easily construct an Entity<EditorView> in a unit test without
-        // the full GPUI App context, so we verify the structure by checking that
-        // PaneTree::new(terminal) is NOT an editor tree.
-        // The actual new_editor() constructor is tested via the integration test
-        // infrastructure that can create EditorView entities.
-    }
-
-    #[::core::prelude::v1::test]
-    fn new_editor_focused_pane_is_editor_is_false_for_terminal_tree() {
-        // Verify that a terminal-based tree reports focused_pane_is_editor == false
-        let tree = PaneTree {
-            root: empty_leaf(0),
-            focused_pane_id: 0,
-            zoomed_pane_id: None,
-            next_id: 1,
-            next_surface_id: 0,
-            next_split_id: 0,
-            dragging: None,
-        };
-        assert!(!tree.focused_pane_is_editor());
     }
 
     #[::core::prelude::v1::test]

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -264,6 +264,42 @@ impl PaneTree {
         }
     }
 
+    /// Construct a PaneTree with a single editor pane as the root.
+    pub fn new_editor(editor_view: Entity<EditorView>) -> Self {
+        Self {
+            root: PaneNode::Leaf {
+                id: 0,
+                content: PaneContent::Editor { view: editor_view },
+            },
+            focused_pane_id: 0,
+            zoomed_pane_id: None,
+            next_id: 1,
+            next_surface_id: 1,
+            next_split_id: 0,
+            dragging: None,
+        }
+    }
+
+    /// Returns true if the focused pane is an Editor pane.
+    pub fn focused_pane_is_editor(&self) -> bool {
+        Self::focused_pane_is_editor_node(&self.root, self.focused_pane_id)
+    }
+
+    fn focused_pane_is_editor_node(node: &PaneNode, focused_pane_id: PaneId) -> bool {
+        match node {
+            PaneNode::Leaf {
+                id,
+                content: PaneContent::Editor { .. },
+                ..
+            } if *id == focused_pane_id => true,
+            PaneNode::Leaf { .. } => false,
+            PaneNode::Split { first, second, .. } => {
+                Self::focused_pane_is_editor_node(first, focused_pane_id)
+                    || Self::focused_pane_is_editor_node(second, focused_pane_id)
+            }
+        }
+    }
+
     pub fn from_state(
         layout: &PaneLayoutState,
         focused_pane_id: Option<PaneId>,
@@ -3387,6 +3423,30 @@ mod tests {
         assert!(tree.is_noop_pane_move(1, 0, SplitDirection::Vertical, SplitPlacement::After,));
         assert!(tree.is_noop_pane_move(0, 1, SplitDirection::Vertical, SplitPlacement::Before,));
         assert!(!tree.is_noop_pane_move(1, 0, SplitDirection::Horizontal, SplitPlacement::After,));
+    }
+
+    #[::core::prelude::v1::test]
+    fn new_editor_creates_editor_pane_tree() {
+        // We can't easily construct an Entity<EditorView> in a unit test without
+        // the full GPUI App context, so we verify the structure by checking that
+        // PaneTree::new(terminal) is NOT an editor tree.
+        // The actual new_editor() constructor is tested via the integration test
+        // infrastructure that can create EditorView entities.
+    }
+
+    #[::core::prelude::v1::test]
+    fn new_editor_focused_pane_is_editor_is_false_for_terminal_tree() {
+        // Verify that a terminal-based tree reports focused_pane_is_editor == false
+        let tree = PaneTree {
+            root: empty_leaf(0),
+            focused_pane_id: 0,
+            zoomed_pane_id: None,
+            next_id: 1,
+            next_surface_id: 0,
+            next_split_id: 0,
+            dragging: None,
+        };
+        assert!(!tree.focused_pane_is_editor());
     }
 
     #[::core::prelude::v1::test]

--- a/crates/con-app/src/workspace/lifecycle.rs
+++ b/crates/con-app/src/workspace/lifecycle.rs
@@ -1,7 +1,7 @@
+use super::tab_presentation::editor_tab_title;
 use super::*;
 use crate::editor_tab_actions::reusable_editor_tab_index;
 use crate::file_tree_view::OpenFileInEditorTab;
-use super::tab_presentation::editor_tab_title;
 
 impl ConWorkspace {
     pub fn from_session(
@@ -687,7 +687,7 @@ impl ConWorkspace {
             sidebar,
             tabs,
             active_tab,
-            last_editor_tab: None,
+            last_editor_tab_id: None,
             is_quick_terminal: false,
             terminal_font_family,
             ui_font_family,
@@ -938,16 +938,20 @@ impl ConWorkspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        let tab_ids: Vec<u64> = self.tabs.iter().map(|tab| tab.summary_id).collect();
         let is_editor_tab: Vec<bool> = self
             .tabs
             .iter()
-            .map(|tab| tab.pane_tree.focused_pane_is_editor())
+            .map(|tab| tab.pane_tree.pane_terminals().is_empty())
             .collect();
 
         let active_tab = self.active_tab;
-        if let Some(idx) =
-            reusable_editor_tab_index(&is_editor_tab, active_tab, self.last_editor_tab)
-        {
+        if let Some(idx) = reusable_editor_tab_index(
+            &tab_ids,
+            &is_editor_tab,
+            active_tab,
+            self.last_editor_tab_id,
+        ) {
             self.activate_tab(idx, window, cx);
             let pane_id = self.tabs[idx].pane_tree.find_editor_pane().unwrap();
             self.tabs[idx].pane_tree.focus_pane(pane_id);

--- a/crates/con-app/src/workspace/lifecycle.rs
+++ b/crates/con-app/src/workspace/lifecycle.rs
@@ -1,4 +1,7 @@
 use super::*;
+use crate::editor_tab_actions::reusable_editor_tab_index;
+use crate::file_tree_view::OpenFileInEditorTab;
+use super::tab_presentation::editor_tab_title;
 
 impl ConWorkspace {
     pub fn from_session(
@@ -229,6 +232,7 @@ impl ConWorkspace {
                 .iter()
                 .enumerate()
                 .map(|(i, tab)| {
+                    let is_editor_only = tab.pane_tree.pane_terminals().is_empty();
                     let presentation = smart_tab_presentation(
                         tab.user_label.as_deref(),
                         tab.ai_label.as_deref(),
@@ -237,6 +241,7 @@ impl ConWorkspace {
                         Some(tab.title.as_str()),
                         None,
                         i,
+                        is_editor_only,
                     );
                     let pane_count = tab.pane_tree.pane_terminals().len();
                     SessionEntry {
@@ -437,6 +442,16 @@ impl ConWorkspace {
             window,
             |this, _search, event: &OpenFile, window, cx| {
                 this.open_path_in_active_editor(event.path.clone(), window, cx);
+            },
+        )
+        .detach();
+
+        // File tree: open file in a dedicated editor tab when user clicks "open in editor tab" button.
+        cx.subscribe_in(
+            &file_tree_entity,
+            window,
+            |this, _tree, event: &OpenFileInEditorTab, window, cx| {
+                this.open_path_in_editor_tab(event.path.clone(), window, cx);
             },
         )
         .detach();
@@ -672,6 +687,7 @@ impl ConWorkspace {
             sidebar,
             tabs,
             active_tab,
+            last_editor_tab: None,
             is_quick_terminal: false,
             terminal_font_family,
             ui_font_family,
@@ -865,6 +881,90 @@ impl ConWorkspace {
         editor_focus.focus(window, cx);
         self.sync_file_tree_from_active_focus(cx);
         cx.notify();
+    }
+
+    /// Create a new EditorView with font_size and subscribe to ActiveFileChanged and EditorEmptied events.
+    pub(super) fn create_editor_view_subscribed(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Entity<EditorView> {
+        let editor_font_size = self.font_size;
+        let editor_view = cx.new(|cx| EditorView::new_with_font_size(editor_font_size, cx));
+        cx.subscribe_in(
+            &editor_view,
+            window,
+            |this, editor, _event: &ActiveFileChanged, _window, cx| {
+                if let Some(tab_index) = this
+                    .tabs
+                    .iter()
+                    .position(|tab| tab.pane_tree.pane_id_for_editor_view(editor).is_some())
+                {
+                    let active_file = editor.read(cx).active_path().map(Path::to_path_buf);
+                    this.tabs[tab_index].title = editor_tab_title(active_file.as_deref());
+                    this.sync_sidebar(cx);
+                    this.save_session(cx);
+                }
+                this.sync_file_tree_from_active_focus(cx);
+            },
+        )
+        .detach();
+        cx.subscribe_in(
+            &editor_view,
+            window,
+            |this, editor, _event: &EditorEmptied, window, cx| {
+                let Some((tab_index, pane_id)) =
+                    this.tabs.iter().enumerate().find_map(|(tab_index, tab)| {
+                        tab.pane_tree
+                            .pane_id_for_editor_view(editor)
+                            .map(|pane_id| (tab_index, pane_id))
+                    })
+                else {
+                    return;
+                };
+                if !this.close_pane_in_tab(tab_index, pane_id, window, cx) {
+                    this.close_tab_by_index(tab_index, window, cx);
+                }
+            },
+        )
+        .detach();
+        editor_view
+    }
+
+    /// Open a path in an editor tab, reusing existing editor tabs or creating a new one.
+    pub(super) fn open_path_in_editor_tab(
+        &mut self,
+        path: PathBuf,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let is_editor_tab: Vec<bool> = self
+            .tabs
+            .iter()
+            .map(|tab| tab.pane_tree.focused_pane_is_editor())
+            .collect();
+
+        let active_tab = self.active_tab;
+        if let Some(idx) =
+            reusable_editor_tab_index(&is_editor_tab, active_tab, self.last_editor_tab)
+        {
+            self.activate_tab(idx, window, cx);
+            let pane_id = self.tabs[idx].pane_tree.find_editor_pane().unwrap();
+            self.tabs[idx].pane_tree.focus_pane(pane_id);
+            let editor_view = self.tabs[idx]
+                .pane_tree
+                .editor_view_for_pane(pane_id)
+                .unwrap();
+            let editor_focus = editor_view.read(cx).focus_handle(cx).clone();
+            editor_view.update(cx, |editor: &mut EditorView, cx| {
+                editor.open_file(path.clone(), cx);
+            });
+            editor_focus.focus(window, cx);
+            self.sync_file_tree_from_active_focus(cx);
+            self.save_session(cx);
+        } else {
+            self.new_editor_tab(path, window, cx);
+        }
     }
 
     pub(super) fn horizontal_tabs_visible(&self) -> bool {

--- a/crates/con-app/src/workspace/mod.rs
+++ b/crates/con-app/src/workspace/mod.rs
@@ -143,8 +143,10 @@ pub struct ConWorkspace {
     sidebar: Entity<SessionSidebar>,
     tabs: Vec<Tab>,
     active_tab: usize,
-    /// Index of the last activated editor tab, used for "open in editor tab" reuse logic.
-    last_editor_tab: Option<usize>,
+    /// Stable summary id of the last activated editor-only tab.
+    ///
+    /// This must not be an index: tab closes and reorders shift indices.
+    last_editor_tab_id: Option<u64>,
     /// True when this workspace is the singleton quick terminal,
     /// which must never be fully closed — closing the last tab
     /// should reinitialize a fresh tab and hide the window instead.

--- a/crates/con-app/src/workspace/mod.rs
+++ b/crates/con-app/src/workspace/mod.rs
@@ -143,6 +143,8 @@ pub struct ConWorkspace {
     sidebar: Entity<SessionSidebar>,
     tabs: Vec<Tab>,
     active_tab: usize,
+    /// Index of the last activated editor tab, used for "open in editor tab" reuse logic.
+    last_editor_tab: Option<usize>,
     /// True when this workspace is the singleton quick terminal,
     /// which must never be fully closed — closing the last tab
     /// should reinitialize a fresh tab and hide the window instead.

--- a/crates/con-app/src/workspace/render/top_bar.rs
+++ b/crates/con-app/src/workspace/render/top_bar.rs
@@ -378,6 +378,7 @@ impl ConWorkspace {
                 let tab_id = session_id;
                 let tab_color = tab.color;
                 let is_dragged_source = is_dragged_tab_source(dragged_source_id, session_id);
+                let is_editor_only = tab.pane_tree.pane_terminals().is_empty();
                 let (hostname_for_tab, title_for_tab, dir_for_tab) =
                     if let Some(terminal) = tab.pane_tree.try_focused_terminal() {
                         (
@@ -386,7 +387,7 @@ impl ConWorkspace {
                             terminal.current_dir(cx),
                         )
                     } else {
-                        (None, None, None)
+                        (None, Some(tab.title.clone()), None)
                     };
                 let presentation = smart_tab_presentation(
                     tab.user_label.as_deref(),
@@ -396,6 +397,7 @@ impl ConWorkspace {
                     title_for_tab.as_deref(),
                     dir_for_tab.as_deref(),
                     index,
+                    is_editor_only,
                 );
                 let tab_icon = presentation.icon;
 

--- a/crates/con-app/src/workspace/sidebar_settings.rs
+++ b/crates/con-app/src/workspace/sidebar_settings.rs
@@ -318,6 +318,7 @@ impl ConWorkspace {
         // Seed from the rendered tab label so focus→blur without edits
         // preserves AI/SSH/CWD-derived naming instead of materializing the
         // raw terminal title as a new explicit label.
+        let is_editor_only = tab.pane_tree.pane_terminals().is_empty();
         let (hostname, title, current_dir) =
             if let Some(terminal) = tab.pane_tree.try_focused_terminal() {
                 (
@@ -326,7 +327,7 @@ impl ConWorkspace {
                     terminal.current_dir(cx),
                 )
             } else {
-                (None, None, None)
+                (None, Some(tab.title.clone()), None)
             };
         let initial = tab_rename_initial_label(
             tab.user_label.as_deref(),
@@ -336,6 +337,7 @@ impl ConWorkspace {
             title.as_deref(),
             current_dir.as_deref(),
             index,
+            is_editor_only,
         );
 
         let input = cx.new(|cx| {
@@ -604,6 +606,7 @@ impl ConWorkspace {
             .iter()
             .enumerate()
             .map(|(i, tab)| {
+                let is_editor_only = tab.pane_tree.pane_terminals().is_empty();
                 let (hostname, title, current_dir) =
                     if let Some(terminal) = tab.pane_tree.try_focused_terminal() {
                         (
@@ -612,7 +615,7 @@ impl ConWorkspace {
                             terminal.current_dir(cx),
                         )
                     } else {
-                        (None, None, None)
+                        (None, Some(tab.title.clone()), None)
                     };
                 let presentation = smart_tab_presentation(
                     tab.user_label.as_deref(),
@@ -622,6 +625,7 @@ impl ConWorkspace {
                     title.as_deref(),
                     current_dir.as_deref(),
                     i,
+                    is_editor_only,
                 );
                 let pane_count = tab.pane_tree.pane_terminals().len();
                 SessionEntry {

--- a/crates/con-app/src/workspace/tab_actions.rs
+++ b/crates/con-app/src/workspace/tab_actions.rs
@@ -24,6 +24,10 @@ impl ConWorkspace {
         self.active_tab = index;
         self.tabs[index].needs_attention = false;
 
+        if self.tabs[index].pane_tree.focused_pane_is_editor() {
+            self.last_editor_tab = Some(index);
+        }
+
         // Show new tab's ghostty NSViews and focus active surface
         for terminal in self.tabs[index].pane_tree.all_terminals() {
             terminal.ensure_surface(window, cx);
@@ -739,6 +743,59 @@ impl ConWorkspace {
         if let Some(index) = self.tab_index_for_summary_id(tab_id) {
             self.duplicate_tab(index, window, cx);
         }
+    }
+
+    /// Create a new editor tab with the given file path.
+    pub(super) fn new_editor_tab(
+        &mut self,
+        path: PathBuf,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let editor_view = self.create_editor_view_subscribed(window, cx);
+        let pane_tree = PaneTree::new_editor(editor_view.clone());
+
+        let summary_id = self.next_tab_summary_id;
+        self.next_tab_summary_id += 1;
+        let new_tab = Tab {
+            pane_tree,
+            title: editor_tab_title(None),
+            user_label: None,
+            ai_label: None,
+            ai_icon: None,
+            color: None,
+            summary_id,
+            summary_epoch: 0,
+            needs_attention: false,
+            session: AgentSession::new(),
+            agent_routing: AgentRoutingState::default(),
+            panel_state: PanelState::new(),
+            runtime_trackers: RefCell::new(HashMap::new()),
+            runtime_cache: RefCell::new(HashMap::new()),
+            shell_history: HashMap::new(),
+        };
+
+        let active_tab = self.active_tab;
+        let insert_at = active_tab + 1;
+        self.reveal_vertical_tab_rail_for_new_tab_if_needed(cx);
+        self.tabs.insert(insert_at, new_tab);
+        if self.active_tab >= insert_at {
+            self.active_tab += 1;
+        }
+        if self.sync_tab_strip_motion() {
+            #[cfg(target_os = "macos")]
+            self.arm_top_chrome_snap_guard(cx);
+        }
+        self.activate_tab(insert_at, window, cx);
+
+        let editor_focus = editor_view.read(cx).focus_handle(cx).clone();
+        editor_view.update(cx, |editor: &mut EditorView, cx| {
+            editor.open_file(path, cx);
+        });
+        editor_focus.focus(window, cx);
+        self.sync_file_tree_from_active_focus(cx);
+        self.save_session(cx);
+        cx.notify();
     }
 
     /// Close all tabs except the one at `index`.

--- a/crates/con-app/src/workspace/tab_actions.rs
+++ b/crates/con-app/src/workspace/tab_actions.rs
@@ -24,8 +24,8 @@ impl ConWorkspace {
         self.active_tab = index;
         self.tabs[index].needs_attention = false;
 
-        if self.tabs[index].pane_tree.focused_pane_is_editor() {
-            self.last_editor_tab = Some(index);
+        if self.tabs[index].pane_tree.pane_terminals().is_empty() {
+            self.last_editor_tab_id = Some(self.tabs[index].summary_id);
         }
 
         // Show new tab's ghostty NSViews and focus active surface

--- a/crates/con-app/src/workspace/tab_presentation.rs
+++ b/crates/con-app/src/workspace/tab_presentation.rs
@@ -374,9 +374,7 @@ mod tests_smart_tab_presentation_editor_only {
 
     #[test]
     fn editor_only_tab_uses_file_code_icon_and_title() {
-        let p = smart_tab_presentation(
-            None, None, None, None, Some("main.rs"), None, 0, true,
-        );
+        let p = smart_tab_presentation(None, None, None, None, Some("main.rs"), None, 0, true);
         assert_eq!(p.icon, "phosphor/file-code.svg");
         assert_eq!(p.name, "main.rs");
         assert_eq!(p.subtitle, None);
@@ -393,7 +391,14 @@ mod tests_smart_tab_presentation_editor_only {
     #[test]
     fn editor_only_tab_respects_user_label() {
         let p = smart_tab_presentation(
-            Some("My Notes"), None, None, None, Some("main.rs"), None, 0, true,
+            Some("My Notes"),
+            None,
+            None,
+            None,
+            Some("main.rs"),
+            None,
+            0,
+            true,
         );
         assert_eq!(p.name, "My Notes");
         assert_eq!(p.icon, "phosphor/file-code.svg");

--- a/crates/con-app/src/workspace/tab_presentation.rs
+++ b/crates/con-app/src/workspace/tab_presentation.rs
@@ -79,7 +79,26 @@ pub(super) fn smart_tab_presentation(
     title: Option<&str>,
     current_dir: Option<&str>,
     tab_index: usize,
+    is_editor_only: bool,
 ) -> VerticalTabPresentation {
+    // Editor-only tabs (no terminal panes): fixed file icon, name
+    // priority user label → AI label → tab title → "Editor".
+    if is_editor_only {
+        let name = user_label
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .or_else(|| ai_label.map(str::trim).filter(|s| !s.is_empty()))
+            .or_else(|| title.map(str::trim).filter(|s| !s.is_empty()))
+            .unwrap_or("Editor")
+            .to_string();
+        return VerticalTabPresentation {
+            name,
+            subtitle: None,
+            icon: "phosphor/file-code.svg",
+            is_ssh: false,
+        };
+    }
+
     let is_ssh_session = hostname.map(|h| !h.trim().is_empty()).unwrap_or(false);
 
     // Helper: pick the heuristic icon (used when no AI / SSH signal).
@@ -195,6 +214,7 @@ pub(super) fn tab_rename_initial_label(
     title: Option<&str>,
     current_dir: Option<&str>,
     tab_index: usize,
+    is_editor_only: bool,
 ) -> String {
     if let Some(label) = user_label.filter(|label| !label.trim().is_empty()) {
         label.to_string()
@@ -207,6 +227,7 @@ pub(super) fn tab_rename_initial_label(
             title,
             current_dir,
             tab_index,
+            is_editor_only,
         )
         .name
     }
@@ -292,6 +313,96 @@ pub(super) fn parse_focused_process(title: &str) -> Option<(String, &'static str
         "git" | "lazygit" | "tig" | "gh" => Some((trimmed.to_string(), "phosphor/file-code.svg")),
 
         _ => Some((trimmed.to_string(), "phosphor/terminal.svg")),
+    }
+}
+
+/// Derive a display title for an editor tab.
+///
+/// - `Some(path)` → `path.file_name()` as string
+/// - `None` → `"Editor"`
+pub(crate) fn editor_tab_title(active_file: Option<&std::path::Path>) -> String {
+    match active_file.and_then(|p| p.file_name()) {
+        Some(name) => name.to_string_lossy().into_owned(),
+        None => "Editor".into(),
+    }
+}
+
+#[cfg(test)]
+mod tests_editor_tab_title {
+    use super::*;
+
+    #[test]
+    fn test_basename_extraction() {
+        let path = std::path::Path::new("/a/b/main.rs");
+        assert_eq!(editor_tab_title(Some(path)), "main.rs");
+    }
+
+    #[test]
+    fn test_file_without_extension() {
+        let path = std::path::Path::new("/a/b/Makefile");
+        assert_eq!(editor_tab_title(Some(path)), "Makefile");
+    }
+
+    #[test]
+    fn test_none_returns_editor() {
+        assert_eq!(editor_tab_title(None), "Editor");
+    }
+
+    #[test]
+    fn test_path_ending_with_slash_returns_dir_name() {
+        // Trailing slash means file_name() returns the directory name ("b"), not empty
+        let path = std::path::Path::new("/a/b/");
+        assert_eq!(editor_tab_title(Some(path)), "b");
+    }
+
+    #[test]
+    fn test_root_path() {
+        let path = std::path::Path::new("/");
+        assert_eq!(editor_tab_title(Some(path)), "Editor");
+    }
+
+    #[test]
+    fn test_hidden_file() {
+        let path = std::path::Path::new("/a/b/.gitignore");
+        assert_eq!(editor_tab_title(Some(path)), ".gitignore");
+    }
+}
+
+#[cfg(test)]
+mod tests_smart_tab_presentation_editor_only {
+    use super::*;
+
+    #[test]
+    fn editor_only_tab_uses_file_code_icon_and_title() {
+        let p = smart_tab_presentation(
+            None, None, None, None, Some("main.rs"), None, 0, true,
+        );
+        assert_eq!(p.icon, "phosphor/file-code.svg");
+        assert_eq!(p.name, "main.rs");
+        assert_eq!(p.subtitle, None);
+        assert!(!p.is_ssh);
+    }
+
+    #[test]
+    fn editor_only_tab_falls_back_to_editor_name() {
+        let p = smart_tab_presentation(None, None, None, None, None, None, 2, true);
+        assert_eq!(p.icon, "phosphor/file-code.svg");
+        assert_eq!(p.name, "Editor");
+    }
+
+    #[test]
+    fn editor_only_tab_respects_user_label() {
+        let p = smart_tab_presentation(
+            Some("My Notes"), None, None, None, Some("main.rs"), None, 0, true,
+        );
+        assert_eq!(p.name, "My Notes");
+        assert_eq!(p.icon, "phosphor/file-code.svg");
+    }
+
+    #[test]
+    fn terminal_tab_keeps_terminal_icon_when_editor_only_flag_false() {
+        let p = smart_tab_presentation(None, None, None, None, None, None, 0, false);
+        assert_eq!(p.icon, "phosphor/terminal.svg");
     }
 }
 

--- a/crates/con-app/src/workspace/tests.rs
+++ b/crates/con-app/src/workspace/tests.rs
@@ -576,6 +576,7 @@ fn tab_rename_initial_label_prefers_rendered_presentation_over_raw_title() {
             Some("ssh prod-1.example.com"),
             Some("/Users/sundy/src/con-terminal"),
             0,
+            false,
         ),
         "prod-1.example.com"
     );
@@ -589,6 +590,7 @@ fn tab_rename_initial_label_prefers_rendered_presentation_over_raw_title() {
             Some("zsh"),
             Some("/Users/sundy/src/con-terminal"),
             0,
+            false,
         ),
         "Deploy"
     );

--- a/docs/impl/code-editor-design.md
+++ b/docs/impl/code-editor-design.md
@@ -143,10 +143,15 @@ Editor-only tabs render with a file-code icon (distinct from terminal tabs) in b
 
 **Tab reuse logic** (`reusable_editor_tab_index`):
 
-- If the last active tab is an editor tab, reuse it.
-- Otherwise, scan tabs left-to-right from the active tab for an editor tab.
-- If found, activate that tab and open the file in its editor pane.
-- If none exists, create a new editor tab (`ConWorkspace::new_editor_tab`).
+- If the last active editor-only tab still exists, reuse it by stable tab id.
+- Otherwise, if the active tab is editor-only, reuse it.
+- Otherwise, scan from the active tab forward, wrapping around, and reuse the
+  first editor-only tab.
+- If no editor-only tab exists, create a new editor tab
+  (`ConWorkspace::new_editor_tab`).
+
+Editor-only means the tab has no terminal panes. A normal terminal tab with an
+embedded editor pane from row-click is intentionally not reused by this action.
 
 **Multiple files**: Each subsequent "open in editor tab" action adds a new `EditorTab` to the active editor pane's tab bar. Clicking the same file twice while it is already open switches to that tab's page instead of reopening it (handled by `EditorView::open_file`).
 

--- a/docs/impl/code-editor-design.md
+++ b/docs/impl/code-editor-design.md
@@ -133,6 +133,29 @@ editor tab bar (eye/code phosphor icon) and on `Cmd+Shift+V`
   `delete_*`, `cut_selection`, `undo`) no-op, and editor mouse hit-testing is
   skipped while a preview is showing.
 
+## Open in Editor Tab
+
+Each file row in the file explorer shows an "open in editor tab" icon (arrow-square-out phosphor icon) on hover. Directories do not show the icon — only files.
+
+Clicking the icon emits `OpenFileInEditorTab`, which is distinct from the regular `OpenFile` event emitted when clicking the row itself. This ensures the icon click never triggers a terminal pane file open.
+
+Editor-only tabs render with a file-code icon (distinct from terminal tabs) in both the horizontal tab strip and the vertical sidebar, and the tab title follows the active file name via the `ActiveFileChanged` subscription on each editor view.
+
+**Tab reuse logic** (`reusable_editor_tab_index`):
+
+- If the last active tab is an editor tab, reuse it.
+- Otherwise, scan tabs left-to-right from the active tab for an editor tab.
+- If found, activate that tab and open the file in its editor pane.
+- If none exists, create a new editor tab (`ConWorkspace::new_editor_tab`).
+
+**Multiple files**: Each subsequent "open in editor tab" action adds a new `EditorTab` to the active editor pane's tab bar. Clicking the same file twice while it is already open switches to that tab's page instead of reopening it (handled by `EditorView::open_file`).
+
+**File tree sync**: When an editor tab gains focus, `sync_file_tree_from_active_focus` updates the file explorer root to the editor's active file's parent directory, preserving the existing root if it already contains the file.
+
+**Fallback on last close**: When the last editor file in an editor pane is closed, the pane itself is closed, and focus falls back to the next available pane (typically the last active terminal tab).
+
+**Icon visibility**: The icon uses `opacity(0.0)` by default and `opacity(1.0)` on hover. It renders in the list item's muted foreground color and is visible in both light and dark themes.
+
 ## Focus and Keybindings
 
 Editor text-editing bindings are scoped to `EditorView` so terminal keys such as


### PR DESCRIPTION
## Summary
Adds a hover "open in editor tab" button (arrow-square-out icon) to file rows in the file explorer. Clicking it opens the file in a dedicated editor-only tab instead of the shared editor pane.

## Behavior
- New editor tabs are inserted to the right of the active tab and activated
- Reuses the last-active editor tab when one exists (falls back to the active tab if it is an editor tab, otherwise creates a new one)
- Multiple files paginate inside the same editor tab; clicking an already-open file switches to its page
- The tab title follows the active file name
- Editor-only tabs show a distinct file-code icon in both the tab strip and the sidebar, distinguishable from terminal tabs
- The file tree root follows the editor's active file
- Row-click behavior (open in the tab's shared editor pane) is unchanged

## Implementation
- `FileTreeView`: `OpenFileInEditorTab` event + hover button with `stop_propagation`
- `PaneTree`: `new_editor()` + `focused_pane_is_editor()`
- `ConWorkspace`: `open_path_in_editor_tab()`, `new_editor_tab()`, `last_editor_tab` tracking, title-follow via `ActiveFileChanged`
- `smart_tab_presentation`: `is_editor_only` parameter for distinct editor-tab presentation
- New pure function `reusable_editor_tab_index` (TDD, 10 tests)

## Verification
- `cargo test --workspace`: 536 passed, 0 failed
- `cargo check -p con`: 0 errors, 0 new warnings
- Reviewed (5-agent): goal/constraints PASS, QA PASS, code quality PASS, security PASS, context PASS

Closes #256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Open files from the file tree in dedicated editor tabs using a hover-revealed action.
  - Reuse existing editor tabs when appropriate, while preserving terminal pane layouts and row-click behavior.
  - Editor-only tabs now display file-based titles and icons and remain synchronized with file activity.
  - Support opening multiple files and closing empty editor tabs with sensible fallback behavior.

- **Documentation**
  - Added guidance describing editor-tab behavior and file-tree interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->