### PR TITLE
fix(editor): align full-bleed blocks with markdown preview column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ con is still pre-release, so entries may group related beta work while the produ
   [#257](https://github.com/nowledge-co/con-terminal/pull/257) by
   [@sunny0826](https://github.com/sunny0826))_
 
+### Fixed
+
+**Editor**
+
+- Fixed Markdown preview alignment in wide editor panes: code blocks, tables,
+  and Mermaid diagrams now share the centered content column instead of
+  spanning the pane edge, and long code lines scroll horizontally. _(PR
+  [#258](https://github.com/nowledge-co/con-terminal/pull/258) by
+  [@sunny0826](https://github.com/sunny0826))_
+
 ---
 
 ## `v0.1.0-beta.80` - 2026-08-05

--- a/crates/con-app/src/chat_markdown.rs
+++ b/crates/con-app/src/chat_markdown.rs
@@ -2248,6 +2248,7 @@ fn render_code_block(
     let (code_text, code_runs) =
         cached_highlighted_code_runs(code, language, highlight_cache, style);
     let code_column = div()
+        .debug_selector(|| "chat-md-code-text".into())
         .whitespace_nowrap()
         .font_family(style.theme.mono_font_family.clone())
         .text_size(style.code_font_size)
@@ -2263,6 +2264,7 @@ fn render_code_block(
                 // sizes to its intrinsic width and becomes the scroll extent.
                 div()
                     .id((SharedString::from(copy_id), 0))
+                    .debug_selector(|| "chat-md-code-scroll".into())
                     .w_full()
                     .flex()
                     .overflow_x_scroll()
@@ -4116,6 +4118,84 @@ mod tests {
         }
     }
 
+    struct BlockLayoutTestView {
+        source: &'static str,
+        block_index: usize,
+    }
+
+    impl Render for BlockLayoutTestView {
+        fn render(
+            &mut self,
+            _window: &mut Window,
+            cx: &mut gpui::Context<Self>,
+        ) -> impl IntoElement {
+            let document = Arc::new(ParsedChatMarkdown::parse(self.source));
+            let block_index = self.block_index;
+            let view = cx.new(|_| {
+                ChatMarkdownBlockView::new(
+                    document,
+                    block_index,
+                    ChatMarkdownTone::Message,
+                    "layout-test",
+                )
+            });
+            div().size_full().child(view)
+        }
+    }
+
+    const LONG_CODE_LINE: &str = "const deeply_nested_value = client.workspace().panes().active().terminal().selection().unwrap_or_default().replace(\"alpha\", \"omega\");";
+
+    fn assert_code_block_layout(cx: &mut gpui::VisualTestContext, prose_selector: &'static str) {
+        let prose = cx.debug_bounds(prose_selector).expect("prose bounds");
+        let code = cx.debug_bounds("chat-md-block-1").expect("code bounds");
+        let scroll = cx
+            .debug_bounds("chat-md-code-scroll")
+            .expect("code scroll bounds");
+        let code_text = cx
+            .debug_bounds("chat-md-code-text")
+            .expect("code text bounds");
+
+        assert!(
+            code.size.width <= px(720.0),
+            "code block not capped to content width: {code:?}"
+        );
+        let diff: f32 = (prose.left() - code.left()).into();
+        assert!(
+            diff.abs() < 2.0,
+            "code block left edge differs from prose column: prose={prose:?} code={code:?}"
+        );
+        assert!(
+            code_text.size.width > scroll.size.width,
+            "long code line did not create horizontal overflow: text={code_text:?} scroll={scroll:?}"
+        );
+        assert!(
+            code_text.size.height < px(32.0),
+            "long code line wrapped instead of staying on one line: {code_text:?}"
+        );
+    }
+
+    fn assert_code_block_overflows_horizontally(cx: &mut gpui::VisualTestContext) {
+        let scroll = cx
+            .debug_bounds("chat-md-code-scroll")
+            .expect("code scroll bounds");
+        let code_text = cx
+            .debug_bounds("chat-md-code-text")
+            .expect("code text bounds");
+
+        assert!(
+            scroll.size.width <= px(720.0),
+            "code scroll not capped to content width: {scroll:?}"
+        );
+        assert!(
+            code_text.size.width > scroll.size.width,
+            "long code line did not create horizontal overflow: text={code_text:?} scroll={scroll:?}"
+        );
+        assert!(
+            code_text.size.height < px(32.0),
+            "long code line wrapped instead of staying on one line: {code_text:?}"
+        );
+    }
+
     #[gpui::test]
     fn list_tail_and_paragraph_do_not_overlap(cx: &mut gpui::TestAppContext) {
         let (_view, cx) = cx.add_window_view(|_window, _cx| PreviewLayoutTestView {
@@ -4190,24 +4270,32 @@ mod tests {
     #[gpui::test]
     fn code_block_aligns_with_prose_column(cx: &mut gpui::TestAppContext) {
         cx.update(gpui_component::init);
+        let source = Box::leak(
+            format!(
+                "plain paragraph text that stays on one line\n\n```rust\n{LONG_CODE_LINE}\n```\n"
+            )
+            .into_boxed_str(),
+        );
         let (_view, cx) = cx.add_window_view(|_window, _cx| PreviewLayoutTestView {
-            source: "plain paragraph text that stays on one line\n\n```rust\nfn main() {}\n```\n",
+            source,
             scroll: None,
         });
-        let paragraph = cx
-            .debug_bounds("chat-md-block-0")
-            .expect("paragraph bounds");
-        let code = cx.debug_bounds("chat-md-block-1").expect("code bounds");
-
-        assert!(
-            code.size.width <= px(720.0),
-            "code block not capped to content width: {code:?}"
-        );
-        let diff: f32 = (paragraph.left() - code.left()).into();
-        assert!(
-            diff.abs() < 2.0,
-            "code block left edge differs from prose column: paragraph={paragraph:?} code={code:?}"
-        );
+        assert_code_block_layout(cx, "chat-md-block-0");
     }
 
+    #[gpui::test]
+    fn block_view_code_block_aligns_and_scrolls_long_lines(cx: &mut gpui::TestAppContext) {
+        cx.update(gpui_component::init);
+        let source = Box::leak(
+            format!(
+                "plain paragraph text that stays on one line\n\n```rust\n{LONG_CODE_LINE}\n```\n"
+            )
+            .into_boxed_str(),
+        );
+        let (_view, cx) = cx.add_window_view(|_window, _cx| BlockLayoutTestView {
+            source,
+            block_index: 1,
+        });
+        assert_code_block_overflows_horizontally(cx);
+    }
 }

--- a/crates/con-app/src/chat_markdown.rs
+++ b/crates/con-app/src/chat_markdown.rs
@@ -876,15 +876,7 @@ impl ChatMarkdownBlockView {
         table_scroll_handle: Option<&ScrollHandle>,
         cx: &mut gpui::Context<Self>,
     ) -> AnyElement {
-        let mut wrapper = div().w_full();
-        if !matches!(
-            block,
-            MarkdownBlock::CodeBlock { .. }
-                | MarkdownBlock::Mermaid { .. }
-                | MarkdownBlock::Table { .. }
-        ) {
-            wrapper = wrapper.max_w(style.content_width);
-        }
+        let wrapper = div().w_full().max_w(style.content_width);
 
         wrapper
             .child(self.render_block(block, index, style, table_scroll_handle, cx))
@@ -1953,17 +1945,10 @@ fn render_block_with_width(
     table_scroll_handle: Option<&ScrollHandle>,
     copy_namespace: &str,
 ) -> AnyElement {
-    let mut wrapper = div()
+    let wrapper = div()
         .w_full()
+        .max_w(style.content_width)
         .debug_selector(move || format!("chat-md-block-{index}"));
-    if !matches!(
-        block,
-        MarkdownBlock::CodeBlock { .. }
-            | MarkdownBlock::Mermaid { .. }
-            | MarkdownBlock::Table { .. }
-    ) {
-        wrapper = wrapper.max_w(style.content_width);
-    }
 
     wrapper
         .child(render_block(
@@ -2234,7 +2219,7 @@ fn render_code_block(
                 .child(header_label),
         )
         .child(div().h(px(1.0)).flex_1().bg(style.rule_color.opacity(0.36)))
-        .child(Clipboard::new(copy_id).value(SharedString::from(code.to_string())));
+        .child(Clipboard::new(copy_id.clone()).value(SharedString::from(code.to_string())));
 
     let block = div()
         .w_full()
@@ -2263,7 +2248,7 @@ fn render_code_block(
     let (code_text, code_runs) =
         cached_highlighted_code_runs(code, language, highlight_cache, style);
     let code_column = div()
-        .w_full()
+        .whitespace_nowrap()
         .font_family(style.theme.mono_font_family.clone())
         .text_size(style.code_font_size)
         .line_height(style.code_line_height)
@@ -2273,7 +2258,14 @@ fn render_code_block(
     block
         .child(
             div().px(px(10.0)).pb(px(10.0)).child(
+                // Stateful scroll container (id + overflow_x_scroll like the
+                // table) so long lines scroll horizontally; the nowrap column
+                // sizes to its intrinsic width and becomes the scroll extent.
                 div()
+                    .id((SharedString::from(copy_id), 0))
+                    .w_full()
+                    .flex()
+                    .overflow_x_scroll()
                     .rounded(px(10.0))
                     .bg(style.code_block_body_background.opacity(0.985))
                     .px(px(12.0))
@@ -4194,4 +4186,28 @@ mod tests {
             "content column not centered: block={block:?} viewport={viewport:?}"
         );
     }
+
+    #[gpui::test]
+    fn code_block_aligns_with_prose_column(cx: &mut gpui::TestAppContext) {
+        cx.update(gpui_component::init);
+        let (_view, cx) = cx.add_window_view(|_window, _cx| PreviewLayoutTestView {
+            source: "plain paragraph text that stays on one line\n\n```rust\nfn main() {}\n```\n",
+            scroll: None,
+        });
+        let paragraph = cx
+            .debug_bounds("chat-md-block-0")
+            .expect("paragraph bounds");
+        let code = cx.debug_bounds("chat-md-block-1").expect("code bounds");
+
+        assert!(
+            code.size.width <= px(720.0),
+            "code block not capped to content width: {code:?}"
+        );
+        let diff: f32 = (paragraph.left() - code.left()).into();
+        assert!(
+            diff.abs() < 2.0,
+            "code block left edge differs from prose column: paragraph={paragraph:?} code={code:?}"
+        );
+    }
+
 }


### PR DESCRIPTION
## Summary

In wide editor panes the Markdown preview centers prose in a 720px column, but code blocks, tables, and Mermaid diagrams skipped the width cap and rendered full-bleed, hugging the left sidebar instead of aligning with the text. This PR caps every block at the preview column width and makes long code lines scroll horizontally instead of soft-wrapping.

<img width="2400" height="1600" alt="image" src="https://github.com/user-attachments/assets/21faa853-7a4c-4fca-b565-4d4a420b6b6b" />

## Key Changes

- **chat_markdown.rs (`render_block_with_width`, both preview + agent panel paths)**: removed the `matches!` exclusion that let CodeBlock/Mermaid/Table bypass `max_w(content_width)` — all blocks now share the centered content column
- **chat_markdown.rs (`render_code_block`)**: code body is now a stateful flex scroll container (`.id(...)` + `.overflow_x_scroll()`, matching the table pattern — plain overflow style on a non-stateful div is a no-op in GPUI) with a `whitespace_nowrap()` code column sized to its intrinsic width, so long lines scroll horizontally rather than wrapping at 720px
- **Regression test**: `code_block_aligns_with_prose_column` asserts the code block is capped at 720px and its left edge matches the prose column in a wide window

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing Performed

- `cargo test -p con --bin con chat_markdown` → 36 passed, 0 failed (incl. the new regression test)
- Verified with the gpui test harness in a 1920px window: code block left edge now equals the paragraph's (600px), width capped at 720px; a 300-char line measures 2426px intrinsic width inside the scroll container (no wrap, real scroll extent)

## Notes for Reviewers

- Table/Mermaid internal horizontal scroll is preserved (their scroll divs are nested inside the capped wrapper)
- This is a deliberate revisit of the pre-existing full-width block decision (originally `99cf230`), not a regression from the recent centering work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved Markdown preview alignment in wide editor panes.
- Constrained code blocks, tables, and Mermaid diagrams to the configured content width.
- Added horizontal scrolling for long code lines without wrapping or expanding the layout.
- Centered rendered content for a more consistent reading experience.
- Improved layout consistency across Markdown elements, including code blocks, tables, and diagrams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->