### PR TITLE
fix(sidebar): render the vertical-tab hover card as a workspace overlay

### DIFF
--- a/crates/con-app/src/sidebar.rs
+++ b/crates/con-app/src/sidebar.rs
@@ -443,6 +443,14 @@ impl SessionSidebar {
         self.active_tool_slot = active_slot;
     }
 
+    /// Clear lingering rail hover state. Called by the workspace when the
+    /// rail leaves the layout (panel hidden / vertical tabs off) — an
+    /// unmounted rail cannot deliver the hover-leave event, so without this
+    /// the hover card could persist or reappear once the rail is restored.
+    pub fn clear_hovered_rail(&mut self) {
+        self.hovered_rail = None;
+    }
+
     pub fn show_rail_only_preserving_pinned(&mut self, cx: &mut Context<Self>) {
         if matches!(self.mode, PanelMode::Collapsed) {
             self.hovered_rail = None;
@@ -1121,10 +1129,13 @@ impl SessionSidebar {
         // Anchor the card vertically on the cursor — its row IS the
         // icon under the cursor by construction.
         let cursor = window.mouse_position();
+        // Rendered card heights (px) — keep in sync with the layout below:
+        //   no subtitle: py 8*2 + name 16 + meta (mt 2 + 13) = 47
+        //   subtitle:    py 8*2 + name 16 + sub (mt 2 + 14) + meta (mt 4 + 13) = 65
         let card_height = if session.subtitle.is_some() {
-            64.0
+            65.0
         } else {
-            44.0
+            47.0
         };
         let min_top = self.leading_top_pad + RAIL_TOP_CONTROLS_HEIGHT + 8.0;
         let top = hover_card_top_for_cursor(

--- a/crates/con-app/src/sidebar.rs
+++ b/crates/con-app/src/sidebar.rs
@@ -1097,7 +1097,10 @@ impl SessionSidebar {
     /// computing the rail layout from this side, which is brittle —
     /// the cursor IS the icon, and "follow the cursor" is the
     /// established Apple tooltip pattern (Finder, Mail, Safari).
-    #[allow(dead_code)]
+    ///
+    /// Composed by the workspace as a root overlay (window coordinates)
+    /// so it paints above the terminal and is not clipped by the
+    /// sidebar's overflow-hidden container.
     pub fn render_hover_card_overlay(
         &mut self,
         window: &mut Window,
@@ -1124,7 +1127,12 @@ impl SessionSidebar {
             44.0
         };
         let min_top = self.leading_top_pad + RAIL_TOP_CONTROLS_HEIGHT + 8.0;
-        let top = (f32::from(cursor.y) - card_height / 2.0).max(min_top);
+        let top = hover_card_top_for_cursor(
+            f32::from(cursor.y),
+            card_height,
+            min_top,
+            window.viewport_size().height.as_f32(),
+        );
 
         let name_color = theme.foreground;
         let sub_color = theme.muted_foreground.opacity(0.65);
@@ -1801,16 +1809,13 @@ impl Render for SessionSidebar {
         let _progress = self.width_motion.value(window);
 
         if self.tools_panel_open || self.rail_only_override {
-            let mut rail = div()
+            return div()
                 .relative()
                 .h_full()
                 .w(px(RAIL_WIDTH))
                 .flex_shrink_0()
-                .child(self.render_rail(window, cx));
-            if let Some(hover_card) = self.render_hover_card_overlay(window, cx) {
-                rail = rail.child(hover_card);
-            }
-            return rail.into_any_element();
+                .child(self.render_rail(window, cx))
+                .into_any_element();
         }
 
         match self.mode {
@@ -1836,18 +1841,13 @@ impl Render for SessionSidebar {
                     )
                     .into_any_element()
             }
-            PanelMode::Collapsed => {
-                let mut rail = div()
-                    .relative()
-                    .h_full()
-                    .w(px(RAIL_WIDTH))
-                    .flex_shrink_0()
-                    .child(self.render_rail(window, cx));
-                if let Some(hover_card) = self.render_hover_card_overlay(window, cx) {
-                    rail = rail.child(hover_card);
-                }
-                rail.into_any_element()
-            }
+            PanelMode::Collapsed => div()
+                .relative()
+                .h_full()
+                .w(px(RAIL_WIDTH))
+                .flex_shrink_0()
+                .child(self.render_rail(window, cx))
+                .into_any_element(),
         }
     }
 }
@@ -1906,6 +1906,21 @@ fn point_in_bounds(p: &gpui::Point<gpui::Pixels>, b: &gpui::Bounds<gpui::Pixels>
         && p.x < b.origin.x + b.size.width
         && p.y >= b.origin.y
         && p.y < b.origin.y + b.size.height
+}
+
+/// Clamp the hover card's top edge so the card stays inside the
+/// window: at least `min_top` from the top, and never closer to
+/// the bottom than an 8px margin. Degenerate small windows fall
+/// back to `min_top` (`max_top < min_top` can never reach clamp,
+/// which requires min <= max).
+fn hover_card_top_for_cursor(
+    cursor_y: f32,
+    card_height: f32,
+    min_top: f32,
+    viewport_height: f32,
+) -> f32 {
+    let max_top = (viewport_height - card_height - 8.0).max(min_top);
+    (cursor_y - card_height / 2.0).clamp(min_top, max_top)
 }
 
 /// Map the cursor's y-position during a rail drag to a drop slot
@@ -2407,5 +2422,26 @@ mod tests {
             reopened,
             active_generation
         ));
+    }
+
+    #[test]
+    fn hover_card_top_mid_window_unclamped() {
+        assert_eq!(hover_card_top_for_cursor(400.0, 64.0, 100.0, 800.0), 368.0);
+    }
+
+    #[test]
+    fn hover_card_top_clamps_to_min_top() {
+        assert_eq!(hover_card_top_for_cursor(20.0, 64.0, 100.0, 800.0), 100.0);
+    }
+
+    #[test]
+    fn hover_card_top_clamps_to_bottom_margin() {
+        // cursor near the bottom: 800 - 64 - 8 = 728
+        assert_eq!(hover_card_top_for_cursor(790.0, 64.0, 100.0, 800.0), 728.0);
+    }
+
+    #[test]
+    fn hover_card_top_degenerate_small_window_uses_min_top() {
+        assert_eq!(hover_card_top_for_cursor(100.0, 64.0, 100.0, 120.0), 100.0);
     }
 }

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -1294,10 +1294,16 @@ impl Render for ConWorkspace {
 
         // Vertical-tab rail hover card — composed here as a root overlay
         // (window coordinates) so it paints above the terminal and is not
-        // clipped by the sidebar's overflow-hidden container.
-        if let Some(hover_card) = self
-            .sidebar
-            .update(cx, |sidebar, cx| sidebar.render_hover_card_overlay(window, cx))
+        // clipped by the sidebar's overflow-hidden container. Only composed
+        // while the rail is actually in the layout; when it is not, clear
+        // stale hover state (an unmounted rail cannot deliver hover-leave).
+        if !show_vertical_tabs {
+            self.sidebar.update(cx, |sidebar, _cx| sidebar.clear_hovered_rail());
+        }
+        if show_vertical_tabs
+            && let Some(hover_card) = self
+                .sidebar
+                .update(cx, |sidebar, cx| sidebar.render_hover_card_overlay(window, cx))
         {
             root = root.child(hover_card);
         }

--- a/crates/con-app/src/workspace/render.rs
+++ b/crates/con-app/src/workspace/render.rs
@@ -972,7 +972,9 @@ impl Render for ConWorkspace {
         let show_compact_top_bar_separator =
             cfg!(not(target_os = "macos")) && top_bar_height > 0.5 && tab_strip_progress <= 0.01;
 
-        let theme = cx.theme();
+        // Owned clone: `theme` outlives the sidebar overlay update below,
+        // which mutably borrows `cx` (the `&Theme` borrow would conflict).
+        let theme = cx.theme().clone();
         let mut root = div()
             .relative()
             .flex()
@@ -1289,6 +1291,16 @@ impl Render for ConWorkspace {
             );
         }
         root = root.child(main_area);
+
+        // Vertical-tab rail hover card — composed here as a root overlay
+        // (window coordinates) so it paints above the terminal and is not
+        // clipped by the sidebar's overflow-hidden container.
+        if let Some(hover_card) = self
+            .sidebar
+            .update(cx, |sidebar, cx| sidebar.render_hover_card_overlay(window, cx))
+        {
+            root = root.child(hover_card);
+        }
 
         if let Some(preview) = self
             .tab_drag_preview


### PR DESCRIPTION
## Summary

The vertical-tab rail hover card was **never rendered** — completely invisible in every state, since 2026-05-12.

<img width="2400" height="1600" alt="image" src="https://github.com/user-attachments/assets/7a7e5837-dc87-4dcb-af3b-b7d80020d24d" />

### Root cause

The card (240px wide, positioned at `left = RAIL_WIDTH + 6 = 50px`) was composed inside the sidebar entity as a child of the 44px rail container (`sidebar.rs` `render()`). That container is a descendant of the workspace's `left_sidebar` div, which has **`.overflow_hidden()`** and is only **44px wide** in the collapsed state. GPUI clips a subtree to its container's bounds when `overflow: hidden`, so the card at x=50..290 lay entirely outside the clip bounds and was painted nowhere.

Regression timeline:
- **2026-04-24** `beffd7c` — hover card shipped, composed in workspace overlay coords (visible).
- **2026-05-12** `d22db09` "Normalize vertical sidebar layout (#201)" — card moved *into* the sidebar entity.
- **2026-05-12** `299ae92` — `left_sidebar` carries `overflow_hidden`.
- Result: invisible for ~3 months, through beta 81.

## Change

1. **`sidebar.rs`** — removed the card composition from the sidebar's own `render()` (tools branch + collapsed branch); `render_hover_card_overlay()` stays as a public API (dropped the stale `#[allow(dead_code)]`).
2. **`workspace/render.rs`** — the card is now composed on the workspace **root overlay stack** (window coordinates, painted last — same pattern as the drag-preview overlays), after `main_area`:
   ```rust
   if let Some(hover_card) = self
       .sidebar
       .update(cx, |sidebar, cx| sidebar.render_hover_card_overlay(window, cx))
   {
       root = root.child(hover_card);
   }
   ```
3. Kept the bottom clamp (`hover_card_top_for_cursor` + 4 unit tests) — it now operates in window coordinates, which is correct at root.

## Bonus fixes (masked by the clipping)

- **28px anchor offset**: the card's `top` was computed from `window.mouse_position()` (window coords) but positioned relative to the rail container, whose origin is below the 28px top bar → the card rendered ~28px below the cursor. Composed at root, the card now tracks the cursor exactly.
- **Bottom overflow** (the original issue report): near the window bottom, the meta row ("N panes" / SSH / unread) was cut off. Now clamped to stay fully visible with an 8px margin.

## Verification

- `cargo run -p con` compiles and runs (borrow fix: `theme` is now an owned clone since it outlives the `sidebar.update(cx, ..)` mutable borrow).
- Manual: collapsed rail — hovering a session icon shows the card beside the cursor; hovering the bottom-most icons keeps the card fully on-screen; Files/Search open — card floats above the tools panel; pinned mode unchanged (card still suppressed by design).
- 4 new unit tests for `hover_card_top_for_cursor` (mid-window / top clamp / bottom clamp / degenerate window).

Fixes #260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar hover cards so they display above terminal content without being clipped.
  * Adjusted hover-card positioning to remain visible within the viewport, including in small windows.
  * Added spacing from the bottom edge for improved visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->