### PR TITLE
chore(markdown): refresh Markdown renderer stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## `v0.1.0-beta.82` - unreleased
+
+### Changed
+
+**Markdown**
+
+- Updated the Mermaid renderer and HTML parser stack used by rich Markdown so
+  diagram and inline HTML previews stay aligned with current upstream fixes.
+  _(PR [#263](https://github.com/nowledge-co/con-terminal/pull/263) by
+  [@wey-gu](https://github.com/wey-gu))_
+
+### Fixed
+
+**Sidebar**
+
+- Fixed pinned sidebar tab clicks so selecting the active tab no longer
+  collapses the panel, preserving drag reorder and double-click rename flows.
+  _(PR [#261](https://github.com/nowledge-co/con-terminal/pull/261) by
+  [@sunny0826](https://github.com/sunny0826))_
+- Fixed vertical-tab hover cards so they render as workspace overlays, stay
+  inside the window, and clear stale hover state when the rail is hidden. _(PR
+  [#262](https://github.com/nowledge-co/con-terminal/pull/262) by
+  [@sunny0826](https://github.com/sunny0826))_
+
+---
+
 ## `v0.1.0-beta.81` - 2026-08-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,7 +621,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1288,11 +1288,11 @@ dependencies = [
  "gpui-component",
  "gpui-component-assets",
  "gpui_platform",
- "html5ever",
+ "html5ever 0.39.0",
  "image",
  "log",
  "markdown",
- "markup5ever_rcdom",
+ "markup5ever_rcdom 0.39.0+unofficial",
  "mathjax-svg-rs",
  "mermaid-rs-renderer",
  "objc",
@@ -2103,7 +2103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2886,13 +2886,13 @@ dependencies = [
  "gpui",
  "gpui-component-macros",
  "gpui_macros",
- "html5ever",
+ "html5ever 0.27.0",
  "instant",
  "itertools 0.13.0",
  "log",
  "lsp-types",
  "markdown",
- "markup5ever_rcdom",
+ "markup5ever_rcdom 0.3.0",
  "notify",
  "num-traits",
  "once_cell",
@@ -3349,10 +3349,20 @@ checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
+ "markup5ever 0.12.1",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
 ]
 
 [[package]]
@@ -4293,10 +4303,21 @@ checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
 dependencies = [
  "log",
  "phf 0.11.3",
- "phf_codegen",
- "string_cache",
- "string_cache_codegen",
- "tendril",
+ "phf_codegen 0.11.3",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+ "tendril 0.4.3",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril 0.5.1",
+ "web_atoms",
 ]
 
 [[package]]
@@ -4305,10 +4326,22 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edaa21ab3701bfee5099ade5f7e1f84553fd19228cf332f13cd6e964bf59be18"
 dependencies = [
- "html5ever",
- "markup5ever",
- "tendril",
- "xml5ever",
+ "html5ever 0.27.0",
+ "markup5ever 0.12.1",
+ "tendril 0.4.3",
+ "xml5ever 0.18.1",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.39.0+unofficial"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ac010f19d6c4af81eeb4018a39d7a115de9d285af45c126a4ac02e6fc5716b7"
+dependencies = [
+ "html5ever 0.39.0",
+ "markup5ever 0.39.0",
+ "tendril 0.5.1",
+ "xml5ever 0.39.0",
 ]
 
 [[package]]
@@ -4384,9 +4417,9 @@ dependencies = [
 
 [[package]]
 name = "mermaid-rs-renderer"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b808a8c109e16ba5de1c829bd9326aea0a72c176174ddb681284f56579d892ac"
+checksum = "6cb5b469222ce6b9896edf0a969cf68464f5a028ef394fd6643f00bd943df117"
 dependencies = [
  "anyhow",
  "fontdb",
@@ -5126,6 +5159,7 @@ checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
  "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -5136,6 +5170,16 @@ checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -5598,7 +5642,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6230,7 +6274,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6243,7 +6287,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6311,7 +6355,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6332,7 +6376,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6937,7 +6981,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -7003,6 +7046,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
 name = "string_cache_codegen"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7010,6 +7066,18 @@ checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
 ]
@@ -7291,7 +7359,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7303,6 +7371,15 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
+dependencies = [
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -8412,7 +8489,7 @@ dependencies = [
  "smol",
  "take-until",
  "tempfile",
- "tendril",
+ "tendril 0.4.3",
  "unicase",
  "url",
  "walkdir",
@@ -8825,6 +8902,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "web_atoms"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
+]
+
+[[package]]
 name = "webpki-root-certs"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9060,7 +9149,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9870,7 +9959,17 @@ checksum = "9bbb26405d8e919bc1547a5aa9abc95cbfa438f04844f5fdd9dc7596b748bf69"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
+ "markup5ever 0.12.1",
+]
+
+[[package]]
+name = "xml5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab627f34ff61b80d756180d556f9c68801d836d271b3b8c094504ceca69d221"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,8 +63,8 @@ sum-tree = { version = "0.2.0", package = "zed-sum-tree" }
 rust-i18n = "3"
 lsp-types = { version = "0.97.0", features = ["proposed"] }
 unicode-width = "0.2"
-html5ever = "0.27.0"
-markup5ever_rcdom = "0.3.0"
+html5ever = "0.39.0"
+markup5ever_rcdom = "=0.39.0"
 
 # Utilities
 anyhow = "1"
@@ -84,7 +84,7 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 http = "1"
 url = "2"
 rust-embed = { version = "8.7.2", features = ["interpolate-folder-path", "include-exclude"] }
-mermaid-rs-renderer = { version = "0.2.2", default-features = false }
+mermaid-rs-renderer = { version = "0.3.1", default-features = false }
 mathjax-svg-rs = "0.4.0"
 
 [workspace.lints.clippy]


### PR DESCRIPTION
## Summary
- bump `mermaid-rs-renderer` from `0.2.2` to `0.3.1`
- bump Con's direct rich-Markdown HTML parser stack from `html5ever`/`markup5ever_rcdom` `0.27`/`0.3` to `0.39`
- document the release-visible Markdown renderer/parser refresh under `v0.1.0-beta.82`

## Why these, and not a broad dependency sweep
The Zed v1.5 note points at faster and more accurate Mermaid rendering. In Con, the directly relevant bounded dependency is `mermaid-rs-renderer`, used by the agent panel and Markdown editor preview.

While auditing adjacent markdown dependencies, `html5ever` and `markup5ever_rcdom` were also materially behind. Those are directly used by Con's rich Markdown HTML handling, so they are included in this PR after local parser/render tests passed.

I intentionally did not include unrelated/runtime-foundation bumps here:
- GPUI/Zed is a UI/runtime foundation bump and should be validated separately across macOS, Windows, and Linux.
- `gpui-component` is newer upstream, but it shares GPUI types and should move with GPUI validation, not as a drive-by lockfile update.
- Rig `0.41.0` is available, but it touches the agent harness/provider/tool path and needs dedicated harness/provider tests.
- `mathjax-svg-rs` is already on the latest published crate version (`0.4.0`).
- `notify` latest is `9.0.0-rc.4`; we should not take a release candidate for file watching in a beta release unless it fixes a concrete bug.

## Notes
`gpui-component` still depends on the older html5ever stack, so the lockfile temporarily contains both parser stacks. Con's own Markdown code uses the new stack.

## Validation
- `cargo check -p con --no-default-features --features bin-con-app --locked`
- `cargo test -p con chat_markdown --no-default-features --features bin-con-app --locked`
- `cargo check --workspace --locked`
- `cargo update --workspace --dry-run` reported 0 semver-compatible lock updates
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated Mermaid diagram rendering for more accurate, reliable diagrams in rich Markdown previews.
  * Improved HTML parsing for more consistent preview rendering.

* **Bug Fixes**
  * Fixed clicks on pinned sidebar tabs.
  * Fixed hover cards for vertical sidebar tabs.

* **Documentation**
  * Added release notes for version 0.1.0-beta.82.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user-visible Markdown/Mermaid/HTML preview behavior without app logic changes; risk is bounded by targeted `chat_markdown` tests but major parser/renderer upgrades can still surface rendering regressions.
> 
> **Overview**
> Bumps **rich Markdown** dependencies only: `mermaid-rs-renderer` **0.2.2 → 0.3.1** and Con’s direct **`html5ever` / `markup5ever_rcdom` stack to 0.39** (from 0.27 / 0.3). Agent panel and editor Markdown preview keep the same code paths in `chat_markdown`; they just pick up upstream Mermaid and inline-HTML parsing fixes.
> 
> The lockfile temporarily carries **two** html5ever stacks because `gpui-component` still pins the older one; Con’s Markdown code uses the new versions explicitly.
> 
> Documents the change under **`v0.1.0-beta.82`** in the changelog. No GPUI, Rig, or other runtime foundation bumps in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad45aa04413641688c82ac26f9efb91b9bb4c06b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->