### PR TITLE
fix(macos): preserve shifted terminal input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ con is still pre-release, so entries may group related beta work while the produ
   shell right-clicks. _(PR
   [#266](https://github.com/nowledge-co/con-terminal/pull/266) by
   [@sunny0826](https://github.com/sunny0826))_
+- Fixed shifted text input in macOS terminal applications such as LazyGit, so
+  `Shift+P` reaches apps as uppercase `P` instead of triggering lowercase `p`
+  actions. _(PR [#264](https://github.com/nowledge-co/con-terminal/pull/264) by
+  [@Eric-Song-Nop](https://github.com/Eric-Song-Nop))_
 
 ---
 

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -2208,6 +2208,7 @@ mod tests {
         );
         assert_eq!(gpui_consumed_mods_to_ghostty(&modifiers, Some("\n")), 0);
         assert_eq!(gpui_consumed_mods_to_ghostty(&modifiers, Some("\t")), 0);
+        assert_eq!(gpui_consumed_mods_to_ghostty(&modifiers, Some("")), 0);
         assert_eq!(gpui_consumed_mods_to_ghostty(&modifiers, None), 0);
     }
 }

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -1447,21 +1447,11 @@ impl GhosttyView {
             return false;
         }
 
-        let mods = gpui_mods_to_ghostty(&keystroke.modifiers);
-        let key_name = keystroke.key.as_str();
-
         // Try to map GPUI key name to macOS virtual keycode.
-        if let Some((keycode, unshifted_codepoint)) = gpui_key_to_keycode(key_name) {
-            // Build the text field: the character this key produces (if printable).
-            // For non-printable keys (arrows, F-keys), text is null.
-            let text_string = keystroke.key_char.as_deref().or_else(|| {
-                if key_name.len() == 1 {
-                    Some(key_name)
-                } else {
-                    None
-                }
-            });
-            let cstr = text_string.and_then(|s| std::ffi::CString::new(s).ok());
+        if let Some(payload) = gpui_key_payload(keystroke) {
+            let cstr = payload
+                .text
+                .and_then(|text| std::ffi::CString::new(text).ok());
             let text_ptr = cstr
                 .as_ref()
                 .map(|c| c.as_ptr())
@@ -1469,11 +1459,11 @@ impl GhosttyView {
 
             let key_event = ffi::ghostty_input_key_s {
                 action: ffi::ghostty_input_action_e::GHOSTTY_ACTION_PRESS,
-                mods,
-                consumed_mods: 0,
-                keycode,
+                mods: payload.mods,
+                consumed_mods: payload.consumed_mods,
+                keycode: payload.keycode,
                 text: text_ptr,
-                unshifted_codepoint,
+                unshifted_codepoint: payload.unshifted_codepoint,
                 composing: false,
             };
 
@@ -1489,8 +1479,8 @@ impl GhosttyView {
                 return true;
             }
         }
-        if key_name.len() == 1 {
-            terminal.send_text(key_name);
+        if keystroke.key.len() == 1 {
+            terminal.send_text(&keystroke.key);
             return true;
         }
         false
@@ -1664,6 +1654,59 @@ fn gpui_mods_to_ghostty(mods: &Modifiers) -> i32 {
         m |= ffi::GHOSTTY_MODS_SUPER;
     }
     m
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct GhosttyKeyPayload<'a> {
+    mods: i32,
+    consumed_mods: i32,
+    keycode: u32,
+    text: Option<&'a str>,
+    unshifted_codepoint: u32,
+}
+
+/// Convert a GPUI keystroke into stable value fields and borrowed text for a
+/// Ghostty key event. The caller turns `text` into a temporary C string before
+/// the FFI call so the pointer cannot outlive its backing storage.
+fn gpui_key_payload<'a>(keystroke: &'a Keystroke) -> Option<GhosttyKeyPayload<'a>> {
+    let key_name = keystroke.key.as_str();
+    let (keycode, unshifted_codepoint) = gpui_key_to_keycode(key_name)?;
+    let translated_text = keystroke.key_char.as_deref();
+    let text = translated_text.or_else(|| (key_name.len() == 1).then_some(key_name));
+
+    Some(GhosttyKeyPayload {
+        mods: gpui_mods_to_ghostty(&keystroke.modifiers),
+        consumed_mods: gpui_consumed_mods_to_ghostty(&keystroke.modifiers, translated_text),
+        keycode,
+        text,
+        unshifted_codepoint,
+    })
+}
+
+/// Return the Shift modifier safely inferred as consumed by text translation.
+///
+/// GPUI keeps the produced text in `Keystroke::key_char`, but does not expose
+/// AppKit's translation modifiers separately. A printable `key_char` plus an
+/// active Shift is enough to recover the casing modifier used by text
+/// translation. Option is intentionally left effective because Ghostty's
+/// `macos-option-as-alt` setting controls whether it participates in text
+/// translation, and GPUI does not expose that surface-adjusted modifier state.
+/// Control characters stay on the key-event path, where modifiers such as
+/// Shift must remain effective (for example, Shift+Enter in the Kitty keyboard
+/// protocol).
+fn gpui_consumed_mods_to_ghostty(mods: &Modifiers, text: Option<&str>) -> i32 {
+    let Some(text) = text else {
+        return 0;
+    };
+    if text.is_empty() || text.chars().any(char::is_control) {
+        return 0;
+    }
+
+    if mods.shift {
+        ffi::GHOSTTY_MODS_SHIFT
+    } else {
+        0
+    }
 }
 
 fn gpui_scroll_mods_to_ghostty(delta: &ScrollDelta) -> i32 {
@@ -2144,7 +2187,11 @@ impl Render for GhosttyView {
 
 #[cfg(test)]
 mod tests {
-    use super::should_send_ime_insert_as_key_event;
+    use super::{
+        gpui_consumed_mods_to_ghostty, gpui_key_payload, should_send_ime_insert_as_key_event,
+    };
+    use con_ghostty::ffi;
+    use gpui::{Keystroke, Modifiers};
 
     #[test]
     fn direct_ascii_ime_commits_use_key_event_path() {
@@ -2153,5 +2200,56 @@ mod tests {
         assert!(!should_send_ime_insert_as_key_event(""));
         assert!(!should_send_ime_insert_as_key_event("hello\n"));
         assert!(!should_send_ime_insert_as_key_event("你好"));
+    }
+
+    #[test]
+    fn shifted_printable_key_payload_marks_shift_consumed() {
+        let keystroke = Keystroke {
+            modifiers: Modifiers::shift(),
+            key: "p".into(),
+            key_char: Some("P".into()),
+        };
+
+        let payload = gpui_key_payload(&keystroke).expect("p has a macOS keycode mapping");
+        assert_eq!(payload.text, Some("P"));
+        assert_eq!(payload.mods, ffi::GHOSTTY_MODS_SHIFT);
+        assert_eq!(payload.consumed_mods, ffi::GHOSTTY_MODS_SHIFT);
+        assert_eq!(payload.keycode, 0x23);
+        assert_eq!(payload.unshifted_codepoint, 'p' as u32);
+
+        let fallback_keystroke = Keystroke {
+            key_char: None,
+            ..keystroke
+        };
+        let fallback = gpui_key_payload(&fallback_keystroke).expect("p stays mapped");
+        assert_eq!(fallback.text, Some("p"));
+        assert_eq!(fallback.consumed_mods, 0);
+    }
+
+    #[test]
+    fn printable_text_translation_consumes_shift_only() {
+        let modifiers = Modifiers {
+            control: true,
+            alt: true,
+            shift: true,
+            platform: true,
+            function: true,
+        };
+
+        assert_eq!(
+            gpui_consumed_mods_to_ghostty(&Modifiers::shift(), Some("P")),
+            ffi::GHOSTTY_MODS_SHIFT
+        );
+        assert_eq!(
+            gpui_consumed_mods_to_ghostty(&modifiers, Some("P")),
+            ffi::GHOSTTY_MODS_SHIFT
+        );
+        assert_eq!(
+            gpui_consumed_mods_to_ghostty(&Modifiers::alt(), Some("å")),
+            0
+        );
+        assert_eq!(gpui_consumed_mods_to_ghostty(&modifiers, Some("\n")), 0);
+        assert_eq!(gpui_consumed_mods_to_ghostty(&modifiers, Some("\t")), 0);
+        assert_eq!(gpui_consumed_mods_to_ghostty(&modifiers, None), 0);
     }
 }

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -1447,11 +1447,22 @@ impl GhosttyView {
             return false;
         }
 
+        let mods = gpui_mods_to_ghostty(&keystroke.modifiers);
+        let key_name = keystroke.key.as_str();
+
         // Try to map GPUI key name to macOS virtual keycode.
-        if let Some(payload) = gpui_key_payload(keystroke) {
-            let cstr = payload
-                .text
-                .and_then(|text| std::ffi::CString::new(text).ok());
+        if let Some((keycode, unshifted_codepoint)) = gpui_key_to_keycode(key_name) {
+            // Only key_char represents actual text translation. The key-name
+            // fallback must not consume Shift.
+            let translated_text = keystroke.key_char.as_deref();
+            let text_string = translated_text.or_else(|| {
+                if key_name.len() == 1 {
+                    Some(key_name)
+                } else {
+                    None
+                }
+            });
+            let cstr = text_string.and_then(|text| std::ffi::CString::new(text).ok());
             let text_ptr = cstr
                 .as_ref()
                 .map(|c| c.as_ptr())
@@ -1459,11 +1470,11 @@ impl GhosttyView {
 
             let key_event = ffi::ghostty_input_key_s {
                 action: ffi::ghostty_input_action_e::GHOSTTY_ACTION_PRESS,
-                mods: payload.mods,
-                consumed_mods: payload.consumed_mods,
-                keycode: payload.keycode,
+                mods,
+                consumed_mods: gpui_consumed_mods_to_ghostty(&keystroke.modifiers, translated_text),
+                keycode,
                 text: text_ptr,
-                unshifted_codepoint: payload.unshifted_codepoint,
+                unshifted_codepoint,
                 composing: false,
             };
 
@@ -1479,8 +1490,8 @@ impl GhosttyView {
                 return true;
             }
         }
-        if keystroke.key.len() == 1 {
-            terminal.send_text(&keystroke.key);
+        if key_name.len() == 1 {
+            terminal.send_text(key_name);
             return true;
         }
         false
@@ -1654,33 +1665,6 @@ fn gpui_mods_to_ghostty(mods: &Modifiers) -> i32 {
         m |= ffi::GHOSTTY_MODS_SUPER;
     }
     m
-}
-
-#[derive(Debug, PartialEq, Eq)]
-struct GhosttyKeyPayload<'a> {
-    mods: i32,
-    consumed_mods: i32,
-    keycode: u32,
-    text: Option<&'a str>,
-    unshifted_codepoint: u32,
-}
-
-/// Convert a GPUI keystroke into stable value fields and borrowed text for a
-/// Ghostty key event. The caller turns `text` into a temporary C string before
-/// the FFI call so the pointer cannot outlive its backing storage.
-fn gpui_key_payload<'a>(keystroke: &'a Keystroke) -> Option<GhosttyKeyPayload<'a>> {
-    let key_name = keystroke.key.as_str();
-    let (keycode, unshifted_codepoint) = gpui_key_to_keycode(key_name)?;
-    let translated_text = keystroke.key_char.as_deref();
-    let text = translated_text.or_else(|| (key_name.len() == 1).then_some(key_name));
-
-    Some(GhosttyKeyPayload {
-        mods: gpui_mods_to_ghostty(&keystroke.modifiers),
-        consumed_mods: gpui_consumed_mods_to_ghostty(&keystroke.modifiers, translated_text),
-        keycode,
-        text,
-        unshifted_codepoint,
-    })
 }
 
 /// Return the Shift modifier safely inferred as consumed by text translation.
@@ -2187,11 +2171,9 @@ impl Render for GhosttyView {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        gpui_consumed_mods_to_ghostty, gpui_key_payload, should_send_ime_insert_as_key_event,
-    };
+    use super::{gpui_consumed_mods_to_ghostty, should_send_ime_insert_as_key_event};
     use con_ghostty::ffi;
-    use gpui::{Keystroke, Modifiers};
+    use gpui::Modifiers;
 
     #[test]
     fn direct_ascii_ime_commits_use_key_event_path() {
@@ -2200,30 +2182,6 @@ mod tests {
         assert!(!should_send_ime_insert_as_key_event(""));
         assert!(!should_send_ime_insert_as_key_event("hello\n"));
         assert!(!should_send_ime_insert_as_key_event("你好"));
-    }
-
-    #[test]
-    fn shifted_printable_key_payload_marks_shift_consumed() {
-        let keystroke = Keystroke {
-            modifiers: Modifiers::shift(),
-            key: "p".into(),
-            key_char: Some("P".into()),
-        };
-
-        let payload = gpui_key_payload(&keystroke).expect("p has a macOS keycode mapping");
-        assert_eq!(payload.text, Some("P"));
-        assert_eq!(payload.mods, ffi::GHOSTTY_MODS_SHIFT);
-        assert_eq!(payload.consumed_mods, ffi::GHOSTTY_MODS_SHIFT);
-        assert_eq!(payload.keycode, 0x23);
-        assert_eq!(payload.unshifted_codepoint, 'p' as u32);
-
-        let fallback_keystroke = Keystroke {
-            key_char: None,
-            ..keystroke
-        };
-        let fallback = gpui_key_payload(&fallback_keystroke).expect("p stays mapped");
-        assert_eq!(fallback.text, Some("p"));
-        assert_eq!(fallback.consumed_mods, 0);
     }
 
     #[test]

--- a/postmortem/2026-08-10-lazygit-shift-key-input.md
+++ b/postmortem/2026-08-10-lazygit-shift-key-input.md
@@ -1,0 +1,39 @@
+# LazyGit Shift key input was encoded as a modified key
+
+## What happened
+
+On macOS, pressing `Shift+P` in terminal applications such as LazyGit invoked
+the lowercase `p` action instead of the uppercase `P` action. Con forwarded the
+physical key, generated text, and active Shift modifier to libghostty, but said
+that no modifier had been consumed while generating the text.
+
+## Root cause
+
+GPUI represents the AppKit event as a physical key (`p`), active modifiers
+(`Shift`), and generated text (`P`). Its `Keystroke` type does not carry a
+separate consumed-modifier field, so Con has to reconstruct that value for
+libghostty. The macOS bridge hard-coded `consumed_mods` to zero.
+
+Libghostty therefore treated Shift as an effective modifier instead of the
+modifier already used to translate `p` into `P`. Applications using enhanced
+keyboard input, including LazyGit through tcell, received a modified-key event
+rather than ordinary uppercase text.
+
+## Fix applied
+
+The GPUI-to-Ghostty bridge now marks Shift as consumed when GPUI provides
+printable translated text. Control-character, textless, and fallback-text
+events keep every modifier effective so combinations such as `Shift+Enter`
+retain their terminal protocol meaning. Option also remains effective because
+whether it participates in text translation depends on Ghostty's
+`macos-option-as-alt` setting, which this GPUI event does not expose. A unit
+test locks down these boundaries, including the `Shift+P` case represented by
+consumed Shift.
+
+## What we learned
+
+Forwarding generated text and active modifiers is not sufficient for terminal
+key events. The consumed-modifier mask is part of the event's semantics and
+must follow the source platform's text-translation rules. When adapting a
+platform event through a higher-level UI toolkit, compare every field against
+the native terminal integration rather than defaulting metadata to zero.


### PR DESCRIPTION
## Summary

- reconstruct consumed Shift from GPUI printable translated text before forwarding key events to libghostty
- keep fallback, control-character, and Option modifiers effective to preserve terminal protocol and `macos-option-as-alt` behavior
- add focused modifier regression coverage, a beta.83 changelog entry, and a postmortem

## Root cause

GPUI preserves the physical key, active modifiers, and translated text, but does not expose consumed modifiers. Con hard-coded `consumed_mods` to zero, so libghostty treated Shift as an effective modifier and emitted an enhanced key event instead of uppercase text.

## Validation

- `cargo test -p con --bin con ghostty_view::tests -- --nocapture` — 2 passed with mise-managed Zig 0.15.2/CMake and a local SDK compatibility shim
- `rustfmt --edition 2024 --check crates/con-app/src/ghostty_view.rs`
- `git diff --check`

The filtered binary test target currently needs a temporary import for a pre-existing `sidebar.rs` test compile error; that file is unchanged by this PR.

Fixes #249

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS terminal input for shifted printable characters, including `Shift+P`.
  * Shifted keys now produce expected uppercase text in applications such as LazyGit.
  * Preserved correct behavior for control characters, textless keys, fallback input, and other modifier combinations.

* **Documentation**
  * Added release notes and a postmortem documenting the macOS shifted-input issue and resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->