### PR TITLE
fix(terminal): forward right-click to TUI apps with mouse reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## `v0.1.0-beta.83` - unreleased
+
+### Fixed
+
+**Terminal**
+
+- Forward right-clicks to terminal apps that enabled mouse reporting, so TUI
+  menus work as expected while Con's context menu still appears for ordinary
+  shell right-clicks. _(PR
+  [#266](https://github.com/nowledge-co/con-terminal/pull/266) by
+  [@sunny0826](https://github.com/sunny0826))_
+
+---
+
 ## `v0.1.0-beta.82` - 2026-08-07
 
 ### Changed

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -13,9 +13,9 @@
 
 use std::cell::Cell;
 use std::ops::Range;
-use std::rc::Rc;
 #[cfg(target_os = "macos")]
 use std::os::raw::c_void;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::OnceLock;
 #[cfg(target_os = "macos")]

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -177,6 +177,8 @@ pub struct GhosttyView {
     native_transition_underlay_visible: Cell<bool>,
     #[cfg(target_os = "macos")]
     native_transition_underlay_owner_id: u64,
+    /// Whether the current right-button press was consumed by libghostty.
+    right_click_consumed: Rc<Cell<bool>>,
     ime_marked_text: Option<String>,
 }
 
@@ -239,6 +241,7 @@ impl GhosttyView {
             #[cfg(target_os = "macos")]
             native_transition_underlay_owner_id: NEXT_NATIVE_TRANSITION_OWNER_ID
                 .fetch_add(1, Ordering::Relaxed),
+            right_click_consumed: Rc::new(Cell::new(false)),
             ime_marked_text: None,
         }
     }
@@ -1786,10 +1789,7 @@ impl Render for GhosttyView {
         let input_focus = focus.clone();
         let context_focus = focus.clone();
         let menu_focus = focus.clone();
-        // Set by the Right mouse-down handler when libghostty consumed the
-        // click (mouse reporting active); read by the context-menu builder
-        // to suppress con's menu. Mirrors Ghostty's AppKit host.
-        let right_click_consumed = Rc::new(Cell::new(false));
+        let right_click_consumed = self.right_click_consumed.clone();
         let ui_font = cx.theme().font_family.clone();
         let mono_font = cx.theme().mono_font_family.clone();
         let mono_font_size = cx.theme().mono_font_size;

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -2027,6 +2027,24 @@ impl Render for GhosttyView {
                     }
                 }),
             )
+            .on_mouse_up_out(
+                gpui::MouseButton::Right,
+                cx.listener({
+                    let right_click_consumed = right_click_consumed.clone();
+                    move |this, event: &MouseUpEvent, _window, _cx| {
+                        this.last_mouse_position = Some(event.position);
+                        if right_click_consumed.get() {
+                            if let Some(ref terminal) = this.terminal {
+                                let (x, y) = this.view_local_pos(event.position);
+                                let mods = gpui_mods_to_ghostty(&event.modifiers);
+                                terminal.send_mouse_pos(x, y, mods);
+                                terminal.send_mouse_button(false, MouseButton::Right, mods);
+                            }
+                            right_click_consumed.set(false);
+                        }
+                    }
+                }),
+            )
             .on_mouse_move(cx.listener(|this, event: &MouseMoveEvent, _window, _cx| {
                 this.last_mouse_position = Some(event.position);
                 if let Some(ref terminal) = this.terminal {

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -2011,13 +2011,19 @@ impl Render for GhosttyView {
             )
             .on_mouse_up(
                 gpui::MouseButton::Right,
-                cx.listener(|this, event: &MouseUpEvent, _window, _cx| {
-                    this.last_mouse_position = Some(event.position);
-                    if let Some(ref terminal) = this.terminal {
-                        let (x, y) = this.view_local_pos(event.position);
-                        let mods = gpui_mods_to_ghostty(&event.modifiers);
-                        terminal.send_mouse_pos(x, y, mods);
-                        terminal.send_mouse_button(false, MouseButton::Right, mods);
+                cx.listener({
+                    let right_click_consumed = right_click_consumed.clone();
+                    move |this, event: &MouseUpEvent, _window, _cx| {
+                        this.last_mouse_position = Some(event.position);
+                        if right_click_consumed.get() {
+                            if let Some(ref terminal) = this.terminal {
+                                let (x, y) = this.view_local_pos(event.position);
+                                let mods = gpui_mods_to_ghostty(&event.modifiers);
+                                terminal.send_mouse_pos(x, y, mods);
+                                terminal.send_mouse_button(false, MouseButton::Right, mods);
+                            }
+                            right_click_consumed.set(false);
+                        }
                     }
                 }),
             )

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -13,6 +13,7 @@
 
 use std::cell::Cell;
 use std::ops::Range;
+use std::rc::Rc;
 #[cfg(target_os = "macos")]
 use std::os::raw::c_void;
 use std::sync::Arc;
@@ -1785,6 +1786,10 @@ impl Render for GhosttyView {
         let input_focus = focus.clone();
         let context_focus = focus.clone();
         let menu_focus = focus.clone();
+        // Set by the Right mouse-down handler when libghostty consumed the
+        // click (mouse reporting active); read by the context-menu builder
+        // to suppress con's menu. Mirrors Ghostty's AppKit host.
+        let right_click_consumed = Rc::new(Cell::new(false));
         let ui_font = cx.theme().font_family.clone();
         let mono_font = cx.theme().mono_font_family.clone();
         let mono_font_size = cx.theme().mono_font_size;
@@ -1952,11 +1957,22 @@ impl Render for GhosttyView {
             }))
             .on_mouse_down(
                 gpui::MouseButton::Right,
-                cx.listener(move |this, event: &MouseDownEvent, window, cx| {
-                    window.focus(&context_focus, cx);
-                    this.last_mouse_position = Some(event.position);
-                    cx.emit(GhosttyFocusChanged);
-                    cx.notify();
+                cx.listener({
+                    let right_click_consumed = right_click_consumed.clone();
+                    move |this, event: &MouseDownEvent, window, cx| {
+                        window.focus(&context_focus, cx);
+                        this.last_mouse_position = Some(event.position);
+                        if let Some(ref terminal) = this.terminal {
+                            let (x, y) = this.view_local_pos(event.position);
+                            let mods = gpui_mods_to_ghostty(&event.modifiers);
+                            terminal.send_mouse_pos(x, y, mods);
+                            let consumed =
+                                terminal.send_mouse_button(true, MouseButton::Right, mods);
+                            right_click_consumed.set(consumed);
+                        }
+                        cx.emit(GhosttyFocusChanged);
+                        cx.notify();
+                    }
                 }),
             )
             .on_mouse_down(
@@ -1987,6 +2003,18 @@ impl Render for GhosttyView {
                     let changed = this.drain_surface_state(true, cx);
                     if changed {
                         cx.notify();
+                    }
+                }),
+            )
+            .on_mouse_up(
+                gpui::MouseButton::Right,
+                cx.listener(|this, event: &MouseUpEvent, _window, _cx| {
+                    this.last_mouse_position = Some(event.position);
+                    if let Some(ref terminal) = this.terminal {
+                        let (x, y) = this.view_local_pos(event.position);
+                        let mods = gpui_mods_to_ghostty(&event.modifiers);
+                        terminal.send_mouse_pos(x, y, mods);
+                        terminal.send_mouse_button(false, MouseButton::Right, mods);
                     }
                 }),
             )
@@ -2072,6 +2100,12 @@ impl Render for GhosttyView {
             )
             .children(preedit_overlay)
             .context_menu(move |menu, window, cx| {
+                // An empty PopupMenu renders nothing (ContextMenu checks
+                // `is_empty`), so suppress con's menu when the terminal app
+                // consumed the right-click via mouse reporting.
+                if right_click_consumed.get() {
+                    return menu;
+                }
                 crate::terminal_context_menu::terminal_context_menu(
                     menu.action_context(menu_focus.clone()),
                     window,

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -1962,6 +1962,9 @@ impl Render for GhosttyView {
                     move |this, event: &MouseDownEvent, window, cx| {
                         window.focus(&context_focus, cx);
                         this.last_mouse_position = Some(event.position);
+                        // Reset first so a click without a terminal can't
+                        // carry a stale consumed state into the menu gate.
+                        right_click_consumed.set(false);
                         if let Some(ref terminal) = this.terminal {
                             let (x, y) = this.view_local_pos(event.position);
                             let mods = gpui_mods_to_ghostty(&event.modifiers);

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -1027,6 +1027,7 @@ impl Render for GhosttyView {
         let menu_focus = focus.clone();
         let entity = cx.entity().downgrade();
         let input_entity = entity.clone();
+        let menu_entity = entity.clone();
         let font_size_px = effective_font_size(self.initial_font_size);
         let line_height_px = cell_height_px(font_size_px);
         let cell_width_px = cell_width_px(font_size_px);
@@ -1272,6 +1273,12 @@ impl Render for GhosttyView {
                     this.mouse_down_link = None;
                     this.suppress_link_mouse_up = false;
                     let _ = this.update_hovered_link(&event.modifiers);
+                    // SGR button 2 = right; suppressed when tracking is off.
+                    if let Some(terminal) = this.terminal() {
+                        if let Some((col, row)) = this.cell_from_event_position(event.position) {
+                            terminal.mouse_report(2, col, row, event.modifiers.shift);
+                        }
+                    }
                     cx.emit(GhosttyFocusChanged);
                     cx.notify();
                 }),
@@ -1357,6 +1364,17 @@ impl Render for GhosttyView {
                     }
                 }),
             )
+            .on_mouse_up(
+                MouseButton::Right,
+                cx.listener(|this, event: &MouseUpEvent, _window, _cx| {
+                    this.last_mouse_position = Some(event.position);
+                    if let Some(terminal) = this.terminal() {
+                        if let Some((col, row)) = this.cell_from_event_position(event.position) {
+                            terminal.mouse_release(2, col, row, event.modifiers.shift);
+                        }
+                    }
+                }),
+            )
             .child(
                 div()
                     .relative()
@@ -1398,6 +1416,15 @@ impl Render for GhosttyView {
                     ),
             )
             .context_menu(move |menu, window, cx| {
+                // Empty PopupMenu renders nothing; suppress con's menu while
+                // mouse reporting is active (right-click went to the app).
+                let mouse_tracking_active = menu_entity
+                    .upgrade()
+                    .and_then(|view| view.read(cx).terminal())
+                    .is_some_and(|terminal| terminal.mouse_tracking_active());
+                if mouse_tracking_active {
+                    return menu;
+                }
                 crate::terminal_context_menu::terminal_context_menu(
                     menu.action_context(menu_focus.clone()),
                     window,

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -1377,10 +1377,17 @@ impl Render for GhosttyView {
                 MouseButton::Right,
                 cx.listener(|this, event: &MouseUpEvent, _window, _cx| {
                     this.last_mouse_position = Some(event.position);
-                    if let Some(terminal) = this.terminal() {
-                        if let Some((col, row)) = this.cell_from_event_position(event.position) {
-                            terminal.mouse_release(2, col, row, event.modifiers.shift);
+                    // Only release when the press was consumed by the app, so
+                    // plain right-clicks (menu path) never emit a stray release.
+                    if this.terminal_mouse_right_consumed == Some(true) {
+                        if let Some(terminal) = this.terminal() {
+                            if let Some((col, row)) =
+                                this.clamped_cell_from_event_position(event.position)
+                            {
+                                terminal.mouse_release(2, col, row, event.modifiers.shift);
+                            }
                         }
+                        this.terminal_mouse_right_consumed = None;
                     }
                 }),
             )

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -1450,9 +1450,7 @@ impl Render for GhosttyView {
                 // Empty PopupMenu renders nothing; suppress con's menu only
                 // when the terminal app consumed the right-button press.
                 let right_consumed = menu_entity.upgrade().is_some_and(|view| {
-                    view.read(cx)
-                        .terminal_mouse_right_consumed
-                        .unwrap_or(false)
+                    view.read(cx).terminal_mouse_right_consumed.unwrap_or(false)
                 });
                 if right_consumed {
                     return menu;

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -119,6 +119,9 @@ pub struct GhosttyView {
     /// terminal app (an SGR report emitted). The context-menu builder
     /// suppresses con's menu only when this is true.
     terminal_mouse_right_consumed: Option<bool>,
+    /// Shift state at the right-button press, reused for the matching
+    /// release so a modifier change in between doesn't break pairing.
+    terminal_mouse_right_shift: bool,
 }
 
 pub fn init(cx: &mut App) {
@@ -200,6 +203,7 @@ impl GhosttyView {
             selection: None,
             drag_anchor: None,
             terminal_mouse_right_consumed: None,
+            terminal_mouse_right_shift: false,
         }
     }
 
@@ -1279,15 +1283,19 @@ impl Render for GhosttyView {
                     this.suppress_link_mouse_up = false;
                     let _ = this.update_hovered_link(&event.modifiers);
                     // SGR button 2 = right; unconsumed when tracking is off.
+                    // Record the press shift state so the matching release
+                    // isn't rejected if Shift changes between press/release.
+                    let shift_at_press = event.modifiers.shift;
                     this.terminal_mouse_right_consumed = if let Some(terminal) = this.terminal() {
                         if let Some((col, row)) = this.cell_from_event_position(event.position) {
-                            Some(terminal.mouse_report(2, col, row, event.modifiers.shift))
+                            Some(terminal.mouse_report(2, col, row, shift_at_press))
                         } else {
                             None
                         }
                     } else {
                         None
                     };
+                    this.terminal_mouse_right_shift = shift_at_press;
                     cx.emit(GhosttyFocusChanged);
                     cx.notify();
                 }),
@@ -1384,7 +1392,12 @@ impl Render for GhosttyView {
                             if let Some((col, row)) =
                                 this.clamped_cell_from_event_position(event.position)
                             {
-                                terminal.mouse_release(2, col, row, event.modifiers.shift);
+                                terminal.mouse_release(
+                                    2,
+                                    col,
+                                    row,
+                                    this.terminal_mouse_right_shift,
+                                );
                             }
                         }
                         this.terminal_mouse_right_consumed = None;

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -115,6 +115,10 @@ pub struct GhosttyView {
     last_mouse_position: Option<Point<Pixels>>,
     selection: Option<TerminalSelection>,
     drag_anchor: Option<(u16, u64)>,
+    /// Whether the most recent right-button press was consumed by the
+    /// terminal app (an SGR report emitted). The context-menu builder
+    /// suppresses con's menu only when this is true.
+    terminal_mouse_right_consumed: Option<bool>,
 }
 
 pub fn init(cx: &mut App) {
@@ -195,6 +199,7 @@ impl GhosttyView {
             last_mouse_position: None,
             selection: None,
             drag_anchor: None,
+            terminal_mouse_right_consumed: None,
         }
     }
 
@@ -1273,12 +1278,16 @@ impl Render for GhosttyView {
                     this.mouse_down_link = None;
                     this.suppress_link_mouse_up = false;
                     let _ = this.update_hovered_link(&event.modifiers);
-                    // SGR button 2 = right; suppressed when tracking is off.
-                    if let Some(terminal) = this.terminal() {
+                    // SGR button 2 = right; unconsumed when tracking is off.
+                    this.terminal_mouse_right_consumed = if let Some(terminal) = this.terminal() {
                         if let Some((col, row)) = this.cell_from_event_position(event.position) {
-                            terminal.mouse_report(2, col, row, event.modifiers.shift);
+                            Some(terminal.mouse_report(2, col, row, event.modifiers.shift))
+                        } else {
+                            None
                         }
-                    }
+                    } else {
+                        None
+                    };
                     cx.emit(GhosttyFocusChanged);
                     cx.notify();
                 }),
@@ -1416,13 +1425,14 @@ impl Render for GhosttyView {
                     ),
             )
             .context_menu(move |menu, window, cx| {
-                // Empty PopupMenu renders nothing; suppress con's menu while
-                // mouse reporting is active (right-click went to the app).
-                let mouse_tracking_active = menu_entity
-                    .upgrade()
-                    .and_then(|view| view.read(cx).terminal())
-                    .is_some_and(|terminal| terminal.mouse_tracking_active());
-                if mouse_tracking_active {
+                // Empty PopupMenu renders nothing; suppress con's menu only
+                // when the terminal app consumed the right-button press.
+                let right_consumed = menu_entity.upgrade().is_some_and(|view| {
+                    view.read(cx)
+                        .terminal_mouse_right_consumed
+                        .unwrap_or(false)
+                });
+                if right_consumed {
                     return menu;
                 }
                 crate::terminal_context_menu::terminal_context_menu(

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -301,6 +301,8 @@ impl GhosttyView {
         self.last_mouse_position = None;
         self.selection = None;
         self.drag_anchor = None;
+        self.terminal_mouse_right_consumed = None;
+        self.terminal_mouse_right_shift = false;
     }
 
     pub fn set_surface_focus_state(&mut self, focused: bool) {

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -1923,7 +1923,8 @@ impl Render for GhosttyView {
                     let Some(terminal) = view.read(cx).terminal() else {
                         return false;
                     };
-                    let inner = terminal.inner().lock();
+                    let binding = terminal.inner();
+                    let inner = binding.lock();
                     inner
                         .as_ref()
                         .is_some_and(RenderSession::mouse_tracking_active)

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -152,6 +152,9 @@ pub struct GhosttyView {
     images_to_drop: Vec<Arc<RenderImage>>,
     scrollbar_drag: Option<ScrollbarDrag>,
     terminal_mouse_sequence_active: bool,
+    /// SGR button index of the in-flight terminal mouse sequence, so the
+    /// release/move-release report uses the same button as the press.
+    terminal_mouse_sequence_button: Option<u8>,
     mouse_down_link: Option<TerminalLink>,
     suppress_link_mouse_up: bool,
     hovered_link: Option<TerminalLink>,
@@ -234,6 +237,7 @@ impl GhosttyView {
             images_to_drop: Vec::new(),
             scrollbar_drag: None,
             terminal_mouse_sequence_active: false,
+            terminal_mouse_sequence_button: None,
             mouse_down_link: None,
             suppress_link_mouse_up: false,
             hovered_link: None,
@@ -296,6 +300,7 @@ impl GhosttyView {
         self.scrollbar_cache = None;
         self.scrollbar_drag = None;
         self.terminal_mouse_sequence_active = false;
+        self.terminal_mouse_sequence_button = None;
         self.ime_marked_text = None;
         self.ime_selected_range = None;
         self.mouse_down_link = None;
@@ -1658,8 +1663,12 @@ impl Render for GhosttyView {
                     this.suppress_link_mouse_up = false;
                     let _ = this.update_hovered_link(&event.modifiers);
                     // SGR button 2 = right; unconsumed when tracking is off.
-                    this.terminal_mouse_sequence_active =
-                        this.forward_mouse_down(2, event.position, mouse_mods_from(&event.modifiers));
+                    let active = this
+                        .forward_mouse_down(2, event.position, mouse_mods_from(&event.modifiers));
+                    this.terminal_mouse_sequence_active = active;
+                    if active {
+                        this.terminal_mouse_sequence_button = Some(2);
+                    }
                     cx.emit(GhosttyFocusChanged);
                     cx.notify();
                 }),
@@ -1670,6 +1679,7 @@ impl Render for GhosttyView {
                     window.focus(&focus, cx);
                     this.last_mouse_position = Some(event.position);
                     this.terminal_mouse_sequence_active = false;
+                    this.terminal_mouse_sequence_button = None;
                     this.mouse_down_link = None;
                     this.suppress_link_mouse_up = false;
                     let _ = this.update_hovered_link(&event.modifiers);
@@ -1686,6 +1696,9 @@ impl Render for GhosttyView {
                     }
                     this.terminal_mouse_sequence_active =
                         this.forward_mouse_down(0, event.position, mouse_mods_from(&event.modifiers));
+                    if this.terminal_mouse_sequence_active {
+                        this.terminal_mouse_sequence_button = Some(0);
+                    }
                     cx.emit(GhosttyFocusChanged);
                     cx.notify();
                 }),
@@ -1735,8 +1748,10 @@ impl Render for GhosttyView {
                         cx.notify();
                     }
                 } else if this.terminal_mouse_sequence_active {
-                    this.forward_mouse_up(event.position, mouse_mods_from(&event.modifiers), true);
+                    let button = this.terminal_mouse_sequence_button.unwrap_or(0);
+                    this.forward_mouse_up(button, event.position, mouse_mods_from(&event.modifiers), true);
                     this.terminal_mouse_sequence_active = false;
+                    this.terminal_mouse_sequence_button = None;
                     cx.notify();
                 } else if hover_changed {
                     cx.notify();
@@ -1767,14 +1782,16 @@ impl Render for GhosttyView {
                         return;
                     }
                     if had_terminal_mouse_sequence {
+                        let button = this.terminal_mouse_sequence_button.unwrap_or(0);
                         this.forward_mouse_up(
-                            0,
+                            button,
                             event.position,
                             mouse_mods_from(&event.modifiers),
                             true,
                         );
                     }
                     this.terminal_mouse_sequence_active = false;
+                    this.terminal_mouse_sequence_button = None;
                     let _ = this.update_hovered_link(&event.modifiers);
                     cx.notify();
                 }),
@@ -1784,13 +1801,15 @@ impl Render for GhosttyView {
                 cx.listener(|this, event: &MouseUpEvent, _window, cx| {
                     this.last_mouse_position = Some(event.position);
                     if this.terminal_mouse_sequence_active {
+                        let button = this.terminal_mouse_sequence_button.unwrap_or(2);
                         this.forward_mouse_up(
-                            2,
+                            button,
                             event.position,
                             mouse_mods_from(&event.modifiers),
                             true,
                         );
                         this.terminal_mouse_sequence_active = false;
+                        this.terminal_mouse_sequence_button = None;
                     }
                     let _ = this.update_hovered_link(&event.modifiers);
                     cx.notify();

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -152,6 +152,7 @@ pub struct GhosttyView {
     images_to_drop: Vec<Arc<RenderImage>>,
     scrollbar_drag: Option<ScrollbarDrag>,
     terminal_mouse_sequence_active: bool,
+    terminal_mouse_sequence_shift: bool,
     /// SGR button index of the in-flight terminal mouse sequence, so the
     /// release/move-release report uses the same button as the press.
     terminal_mouse_sequence_button: Option<u8>,
@@ -243,6 +244,7 @@ impl GhosttyView {
             images_to_drop: Vec::new(),
             scrollbar_drag: None,
             terminal_mouse_sequence_active: false,
+            terminal_mouse_sequence_shift: false,
             terminal_mouse_sequence_button: None,
             terminal_mouse_right_consumed: None,
             terminal_mouse_right_shift: false,
@@ -308,6 +310,7 @@ impl GhosttyView {
         self.scrollbar_cache = None;
         self.scrollbar_drag = None;
         self.terminal_mouse_sequence_active = false;
+        self.terminal_mouse_sequence_shift = false;
         self.terminal_mouse_sequence_button = None;
         self.terminal_mouse_right_consumed = None;
         self.ime_marked_text = None;
@@ -1709,6 +1712,7 @@ impl Render for GhosttyView {
                     let _ = this.forward_mouse_down(0, event.position, mouse_mods_from(&event.modifiers));
                     if this.terminal().is_some() && this.cell_from_event_position(event.position).is_some() {
                         this.terminal_mouse_sequence_active = true;
+                        this.terminal_mouse_sequence_shift = event.modifiers.shift;
                         this.terminal_mouse_sequence_button = Some(0);
                     }
                     cx.emit(GhosttyFocusChanged);
@@ -1753,7 +1757,10 @@ impl Render for GhosttyView {
                         this.forward_mouse_drag(
                             0,
                             event.position,
-                            mouse_mods_from(&event.modifiers),
+                            MouseEventMods {
+                                shift: this.terminal_mouse_sequence_shift,
+                                ..mouse_mods_from(&event.modifiers)
+                            },
                             true,
                         );
                         cx.notify();
@@ -1781,12 +1788,19 @@ impl Render for GhosttyView {
                             shift: this.terminal_mouse_right_shift,
                             ..release_mods
                         }
+                    } else if button == 0 {
+                        MouseEventMods {
+                            shift: this.terminal_mouse_sequence_shift,
+                            ..release_mods
+                        }
                     } else {
                         release_mods
                     };
                     this.forward_mouse_up(button, event.position, release_mods, true);
                     if button == 2 {
                         this.terminal_mouse_right_shift = false;
+                    } else if button == 0 {
+                        this.terminal_mouse_sequence_shift = false;
                     }
                     this.terminal_mouse_sequence_active = false;
                     this.terminal_mouse_sequence_button = None;
@@ -1824,11 +1838,15 @@ impl Render for GhosttyView {
                         this.forward_mouse_up(
                             button,
                             event.position,
-                            mouse_mods_from(&event.modifiers),
+                            MouseEventMods {
+                                shift: this.terminal_mouse_sequence_shift,
+                                ..mouse_mods_from(&event.modifiers)
+                            },
                             true,
                         );
                     }
                     this.terminal_mouse_sequence_active = false;
+                    this.terminal_mouse_sequence_shift = false;
                     this.terminal_mouse_sequence_button = None;
                     let _ = this.update_hovered_link(&event.modifiers);
                     cx.notify();

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -892,7 +892,7 @@ impl GhosttyView {
         false
     }
 
-    fn forward_mouse_drag(&self, pos: Point<Pixels>, mods: MouseEventMods, clamp: bool) {
+    fn forward_mouse_drag(&self, button: u8, pos: Point<Pixels>, mods: MouseEventMods, clamp: bool) {
         let cell = if clamp {
             self.clamped_cell_from_event_position(pos)
         } else {
@@ -902,7 +902,7 @@ impl GhosttyView {
             if let Some(terminal) = &self.terminal {
                 let inner = terminal.inner();
                 if let Some(session) = inner.lock().as_ref() {
-                    session.mouse_drag(col, row, mods);
+                    session.mouse_drag(button, col, row, mods);
                 }
             }
         }
@@ -1747,6 +1747,7 @@ impl Render for GhosttyView {
                 if event.pressed_button == Some(MouseButton::Left) {
                     if this.terminal_mouse_sequence_active {
                         this.forward_mouse_drag(
+                            0,
                             event.position,
                             mouse_mods_from(&event.modifiers),
                             true,
@@ -1755,7 +1756,20 @@ impl Render for GhosttyView {
                     } else if hover_changed {
                         cx.notify();
                     }
-                } else if this.terminal_mouse_sequence_active {
+                } else if event.pressed_button == Some(MouseButton::Right)
+                    && this.terminal_mouse_sequence_active
+                {
+                    // Right button is held and the sequence is active: keep
+                    // reporting motion (button 2 + 32) instead of treating
+                    // this as a release.
+                    this.forward_mouse_drag(
+                        2,
+                        event.position,
+                        mouse_mods_from(&event.modifiers),
+                        true,
+                    );
+                    cx.notify();
+                } else if event.pressed_button.is_none() && this.terminal_mouse_sequence_active {
                     let button = this.terminal_mouse_sequence_button.unwrap_or(0);
                     this.forward_mouse_up(button, event.position, mouse_mods_from(&event.modifiers), true);
                     this.terminal_mouse_sequence_active = false;
@@ -1833,6 +1847,7 @@ impl Render for GhosttyView {
                 );
                 if scrolled_viewport && this.terminal_mouse_sequence_active {
                     this.forward_mouse_drag(
+                        0,
                         event.position,
                         mouse_mods_from(&event.modifiers),
                         true,

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -864,12 +864,17 @@ impl GhosttyView {
         )
     }
 
-    fn forward_mouse_down(&self, pos: Point<Pixels>, mods: MouseEventMods) -> bool {
+    fn forward_mouse_down(
+        &self,
+        button: u8,
+        pos: Point<Pixels>,
+        mods: MouseEventMods,
+    ) -> bool {
         if let Some((col, row)) = self.cell_from_event_position(pos) {
             if let Some(terminal) = &self.terminal {
                 let inner = terminal.inner();
                 if let Some(session) = inner.lock().as_ref() {
-                    session.mouse_down(col, row, mods);
+                    session.mouse_down(button, col, row, mods);
                     return true;
                 }
             }
@@ -893,7 +898,13 @@ impl GhosttyView {
         }
     }
 
-    fn forward_mouse_up(&self, pos: Point<Pixels>, mods: MouseEventMods, clamp: bool) {
+    fn forward_mouse_up(
+        &self,
+        button: u8,
+        pos: Point<Pixels>,
+        mods: MouseEventMods,
+        clamp: bool,
+    ) {
         let cell = if clamp {
             self.clamped_cell_from_event_position(pos)
         } else {
@@ -903,7 +914,7 @@ impl GhosttyView {
             if let Some(terminal) = &self.terminal {
                 let inner = terminal.inner();
                 if let Some(session) = inner.lock().as_ref() {
-                    session.mouse_up(col, row, mods);
+                    session.mouse_up(button, col, row, mods);
                 }
             }
         }
@@ -1539,6 +1550,7 @@ impl Render for GhosttyView {
             terminal_background.unwrap_or_else(|| cx.theme().background.opacity(0.0));
         let entity = cx.entity().downgrade();
         let input_entity = entity.clone();
+        let menu_entity = entity.clone();
         let mut terminal_children = self.image_children(terminal_background);
         if let Some(overlay) = self.render_link_cursor_overlay() {
             terminal_children.push(overlay);
@@ -1642,10 +1654,12 @@ impl Render for GhosttyView {
                 cx.listener(move |this, event: &MouseDownEvent, window, cx| {
                     window.focus(&context_focus, cx);
                     this.last_mouse_position = Some(event.position);
-                    this.terminal_mouse_sequence_active = false;
                     this.mouse_down_link = None;
                     this.suppress_link_mouse_up = false;
                     let _ = this.update_hovered_link(&event.modifiers);
+                    // SGR button 2 = right; unconsumed when tracking is off.
+                    this.terminal_mouse_sequence_active =
+                        this.forward_mouse_down(2, event.position, mouse_mods_from(&event.modifiers));
                     cx.emit(GhosttyFocusChanged);
                     cx.notify();
                 }),
@@ -1671,7 +1685,7 @@ impl Render for GhosttyView {
                         return;
                     }
                     this.terminal_mouse_sequence_active =
-                        this.forward_mouse_down(event.position, mouse_mods_from(&event.modifiers));
+                        this.forward_mouse_down(0, event.position, mouse_mods_from(&event.modifiers));
                     cx.emit(GhosttyFocusChanged);
                     cx.notify();
                 }),
@@ -1754,12 +1768,30 @@ impl Render for GhosttyView {
                     }
                     if had_terminal_mouse_sequence {
                         this.forward_mouse_up(
+                            0,
                             event.position,
                             mouse_mods_from(&event.modifiers),
                             true,
                         );
                     }
                     this.terminal_mouse_sequence_active = false;
+                    let _ = this.update_hovered_link(&event.modifiers);
+                    cx.notify();
+                }),
+            )
+            .on_mouse_up(
+                MouseButton::Right,
+                cx.listener(|this, event: &MouseUpEvent, _window, cx| {
+                    this.last_mouse_position = Some(event.position);
+                    if this.terminal_mouse_sequence_active {
+                        this.forward_mouse_up(
+                            2,
+                            event.position,
+                            mouse_mods_from(&event.modifiers),
+                            true,
+                        );
+                        this.terminal_mouse_sequence_active = false;
+                    }
                     let _ = this.update_hovered_link(&event.modifiers);
                     cx.notify();
                 }),
@@ -1866,6 +1898,16 @@ impl Render for GhosttyView {
                     ),
             )
             .context_menu(move |menu, window, cx| {
+                // Empty PopupMenu renders nothing; suppress con's menu while
+                // mouse reporting is active (right-click went to the app).
+                let mouse_tracking_active = menu_entity
+                    .upgrade()
+                    .and_then(|view| view.read(cx).terminal())
+                    .and_then(|terminal| terminal.inner().lock().as_ref())
+                    .is_some_and(RenderSession::mouse_tracking_active);
+                if mouse_tracking_active {
+                    return menu;
+                }
                 crate::terminal_context_menu::terminal_context_menu(
                     menu.action_context(menu_focus.clone()),
                     window,

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -159,6 +159,8 @@ pub struct GhosttyView {
     /// terminal app (an SGR report emitted). The context-menu builder
     /// suppresses con's menu only when this is true.
     terminal_mouse_right_consumed: Option<bool>,
+    /// Shift state at the right-button press, reused for its release.
+    terminal_mouse_right_shift: bool,
     mouse_down_link: Option<TerminalLink>,
     suppress_link_mouse_up: bool,
     hovered_link: Option<TerminalLink>,
@@ -243,6 +245,7 @@ impl GhosttyView {
             terminal_mouse_sequence_active: false,
             terminal_mouse_sequence_button: None,
             terminal_mouse_right_consumed: None,
+            terminal_mouse_right_shift: false,
             mouse_down_link: None,
             suppress_link_mouse_up: false,
             hovered_link: None,
@@ -1671,6 +1674,7 @@ impl Render for GhosttyView {
                     let consumed = this
                         .forward_mouse_down(2, event.position, mouse_mods_from(&event.modifiers));
                     this.terminal_mouse_right_consumed = Some(consumed);
+                    this.terminal_mouse_right_shift = event.modifiers.shift;
                     this.terminal_mouse_sequence_active = consumed;
                     if consumed {
                         this.terminal_mouse_sequence_button = Some(2);
@@ -1771,7 +1775,19 @@ impl Render for GhosttyView {
                     cx.notify();
                 } else if event.pressed_button.is_none() && this.terminal_mouse_sequence_active {
                     let button = this.terminal_mouse_sequence_button.unwrap_or(0);
-                    this.forward_mouse_up(button, event.position, mouse_mods_from(&event.modifiers), true);
+                    let release_mods = mouse_mods_from(&event.modifiers);
+                    let release_mods = if button == 2 {
+                        MouseEventMods {
+                            shift: this.terminal_mouse_right_shift,
+                            ..release_mods
+                        }
+                    } else {
+                        release_mods
+                    };
+                    this.forward_mouse_up(button, event.position, release_mods, true);
+                    if button == 2 {
+                        this.terminal_mouse_right_shift = false;
+                    }
                     this.terminal_mouse_sequence_active = false;
                     this.terminal_mouse_sequence_button = None;
                     cx.notify();
@@ -1827,12 +1843,16 @@ impl Render for GhosttyView {
                         this.forward_mouse_up(
                             button,
                             event.position,
-                            mouse_mods_from(&event.modifiers),
+                            MouseEventMods {
+                                shift: this.terminal_mouse_right_shift,
+                                ..mouse_mods_from(&event.modifiers)
+                            },
                             true,
                         );
                         this.terminal_mouse_sequence_active = false;
                         this.terminal_mouse_sequence_button = None;
                     }
+                    this.terminal_mouse_right_shift = false;
                     let _ = this.update_hovered_link(&event.modifiers);
                     cx.notify();
                 }),

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -1776,7 +1776,10 @@ impl Render for GhosttyView {
                     this.forward_mouse_drag(
                         2,
                         event.position,
-                        mouse_mods_from(&event.modifiers),
+                        MouseEventMods {
+                            shift: this.terminal_mouse_right_shift,
+                            ..mouse_mods_from(&event.modifiers)
+                        },
                         true,
                     );
                     cx.notify();

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -1919,11 +1919,15 @@ impl Render for GhosttyView {
             .context_menu(move |menu, window, cx| {
                 // Empty PopupMenu renders nothing; suppress con's menu while
                 // mouse reporting is active (right-click went to the app).
-                let mouse_tracking_active = menu_entity
-                    .upgrade()
-                    .and_then(|view| view.read(cx).terminal())
-                    .and_then(|terminal| terminal.inner().lock().as_ref())
-                    .is_some_and(RenderSession::mouse_tracking_active);
+                let mouse_tracking_active = menu_entity.upgrade().is_some_and(|view| {
+                    let Some(terminal) = view.read(cx).terminal() else {
+                        return false;
+                    };
+                    let inner = terminal.inner().lock();
+                    inner
+                        .as_ref()
+                        .is_some_and(RenderSession::mouse_tracking_active)
+                });
                 if mouse_tracking_active {
                     return menu;
                 }

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -155,6 +155,10 @@ pub struct GhosttyView {
     /// SGR button index of the in-flight terminal mouse sequence, so the
     /// release/move-release report uses the same button as the press.
     terminal_mouse_sequence_button: Option<u8>,
+    /// Whether the most recent right-button press was consumed by the
+    /// terminal app (an SGR report emitted). The context-menu builder
+    /// suppresses con's menu only when this is true.
+    terminal_mouse_right_consumed: Option<bool>,
     mouse_down_link: Option<TerminalLink>,
     suppress_link_mouse_up: bool,
     hovered_link: Option<TerminalLink>,
@@ -238,6 +242,7 @@ impl GhosttyView {
             scrollbar_drag: None,
             terminal_mouse_sequence_active: false,
             terminal_mouse_sequence_button: None,
+            terminal_mouse_right_consumed: None,
             mouse_down_link: None,
             suppress_link_mouse_up: false,
             hovered_link: None,
@@ -301,6 +306,7 @@ impl GhosttyView {
         self.scrollbar_drag = None;
         self.terminal_mouse_sequence_active = false;
         self.terminal_mouse_sequence_button = None;
+        self.terminal_mouse_right_consumed = None;
         self.ime_marked_text = None;
         self.ime_selected_range = None;
         self.mouse_down_link = None;
@@ -879,8 +885,7 @@ impl GhosttyView {
             if let Some(terminal) = &self.terminal {
                 let inner = terminal.inner();
                 if let Some(session) = inner.lock().as_ref() {
-                    session.mouse_down(button, col, row, mods);
-                    return true;
+                    return session.mouse_down(button, col, row, mods);
                 }
             }
         }
@@ -1663,10 +1668,11 @@ impl Render for GhosttyView {
                     this.suppress_link_mouse_up = false;
                     let _ = this.update_hovered_link(&event.modifiers);
                     // SGR button 2 = right; unconsumed when tracking is off.
-                    let active = this
+                    let consumed = this
                         .forward_mouse_down(2, event.position, mouse_mods_from(&event.modifiers));
-                    this.terminal_mouse_sequence_active = active;
-                    if active {
+                    this.terminal_mouse_right_consumed = Some(consumed);
+                    this.terminal_mouse_sequence_active = consumed;
+                    if consumed {
                         this.terminal_mouse_sequence_button = Some(2);
                     }
                     cx.emit(GhosttyFocusChanged);
@@ -1694,9 +1700,11 @@ impl Render for GhosttyView {
                         cx.notify();
                         return;
                     }
-                    this.terminal_mouse_sequence_active =
-                        this.forward_mouse_down(0, event.position, mouse_mods_from(&event.modifiers));
-                    if this.terminal_mouse_sequence_active {
+                    // Left button: keep the sequence flag tied to session
+                    // presence (local drag selection), not SGR consumption.
+                    let _ = this.forward_mouse_down(0, event.position, mouse_mods_from(&event.modifiers));
+                    if this.terminal().is_some() && this.cell_from_event_position(event.position).is_some() {
+                        this.terminal_mouse_sequence_active = true;
                         this.terminal_mouse_sequence_button = Some(0);
                     }
                     cx.emit(GhosttyFocusChanged);
@@ -1917,19 +1925,14 @@ impl Render for GhosttyView {
                     ),
             )
             .context_menu(move |menu, window, cx| {
-                // Empty PopupMenu renders nothing; suppress con's menu while
-                // mouse reporting is active (right-click went to the app).
-                let mouse_tracking_active = menu_entity.upgrade().is_some_and(|view| {
-                    let Some(terminal) = view.read(cx).terminal() else {
-                        return false;
-                    };
-                    let binding = terminal.inner();
-                    let inner = binding.lock();
-                    inner
-                        .as_ref()
-                        .is_some_and(RenderSession::mouse_tracking_active)
+                // Empty PopupMenu renders nothing; suppress con's menu only
+                // when the terminal app consumed the right-button press.
+                let right_consumed = menu_entity.upgrade().is_some_and(|view| {
+                    view.read(cx)
+                        .terminal_mouse_right_consumed
+                        .unwrap_or(false)
                 });
-                if mouse_tracking_active {
+                if right_consumed {
                     return menu;
                 }
                 crate::terminal_context_menu::terminal_context_menu(

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -1883,11 +1883,17 @@ impl Render for GhosttyView {
                     event.delta,
                     mouse_mods_from(&event.modifiers),
                 );
-                if scrolled_viewport && this.terminal_mouse_sequence_active {
+                if scrolled_viewport
+                    && this.terminal_mouse_sequence_active
+                    && this.terminal_mouse_sequence_button == Some(0)
+                {
                     this.forward_mouse_drag(
                         0,
                         event.position,
-                        mouse_mods_from(&event.modifiers),
+                        MouseEventMods {
+                            shift: this.terminal_mouse_sequence_shift,
+                            ..mouse_mods_from(&event.modifiers)
+                        },
                         true,
                     );
                 }

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -881,12 +881,7 @@ impl GhosttyView {
         )
     }
 
-    fn forward_mouse_down(
-        &self,
-        button: u8,
-        pos: Point<Pixels>,
-        mods: MouseEventMods,
-    ) -> bool {
+    fn forward_mouse_down(&self, button: u8, pos: Point<Pixels>, mods: MouseEventMods) -> bool {
         if let Some((col, row)) = self.cell_from_event_position(pos) {
             if let Some(terminal) = &self.terminal {
                 let inner = terminal.inner();
@@ -898,7 +893,27 @@ impl GhosttyView {
         false
     }
 
-    fn forward_mouse_drag(&self, button: u8, pos: Point<Pixels>, mods: MouseEventMods, clamp: bool) {
+    fn terminal_mouse_tracking_active_at(&self, pos: Point<Pixels>) -> bool {
+        if self.cell_from_event_position(pos).is_none() {
+            return false;
+        }
+        let Some(terminal) = &self.terminal else {
+            return false;
+        };
+        let inner = terminal.inner();
+        inner
+            .lock()
+            .as_ref()
+            .is_some_and(|session| session.mouse_tracking_active())
+    }
+
+    fn forward_mouse_drag(
+        &self,
+        button: u8,
+        pos: Point<Pixels>,
+        mods: MouseEventMods,
+        clamp: bool,
+    ) {
         let cell = if clamp {
             self.clamped_cell_from_event_position(pos)
         } else {
@@ -914,13 +929,7 @@ impl GhosttyView {
         }
     }
 
-    fn forward_mouse_up(
-        &self,
-        button: u8,
-        pos: Point<Pixels>,
-        mods: MouseEventMods,
-        clamp: bool,
-    ) {
+    fn forward_mouse_up(&self, button: u8, pos: Point<Pixels>, mods: MouseEventMods, clamp: bool) {
         let cell = if clamp {
             self.clamped_cell_from_event_position(pos)
         } else {
@@ -1674,8 +1683,11 @@ impl Render for GhosttyView {
                     this.suppress_link_mouse_up = false;
                     let _ = this.update_hovered_link(&event.modifiers);
                     // SGR button 2 = right; unconsumed when tracking is off.
-                    let consumed = this
-                        .forward_mouse_down(2, event.position, mouse_mods_from(&event.modifiers));
+                    let consumed = this.forward_mouse_down(
+                        2,
+                        event.position,
+                        mouse_mods_from(&event.modifiers),
+                    );
                     this.terminal_mouse_right_consumed = Some(consumed);
                     this.terminal_mouse_right_shift = event.modifiers.shift;
                     this.terminal_mouse_sequence_active = consumed;
@@ -1707,10 +1719,19 @@ impl Render for GhosttyView {
                         cx.notify();
                         return;
                     }
-                    // Left button: keep the sequence flag tied to session
-                    // presence (local drag selection), not SGR consumption.
-                    let _ = this.forward_mouse_down(0, event.position, mouse_mods_from(&event.modifiers));
-                    if this.terminal().is_some() && this.cell_from_event_position(event.position).is_some() {
+                    // Left button has two valid continuation modes: local
+                    // selection when mouse tracking is off/Shift-bypassed, or
+                    // terminal SGR reporting when the press was actually
+                    // written. Do not continue an SGR sequence after a failed
+                    // PTY write.
+                    let mods = mouse_mods_from(&event.modifiers);
+                    let tracking_active = this.terminal_mouse_tracking_active_at(event.position);
+                    let consumed = this.forward_mouse_down(0, event.position, mods);
+                    if consumed
+                        || (!tracking_active
+                            && this.terminal().is_some()
+                            && this.cell_from_event_position(event.position).is_some())
+                    {
                         this.terminal_mouse_sequence_active = true;
                         this.terminal_mouse_sequence_shift = event.modifiers.shift;
                         this.terminal_mouse_sequence_button = Some(0);
@@ -1990,9 +2011,7 @@ impl Render for GhosttyView {
                 // Empty PopupMenu renders nothing; suppress con's menu only
                 // when the terminal app consumed the right-button press.
                 let right_consumed = menu_entity.upgrade().is_some_and(|view| {
-                    view.read(cx)
-                        .terminal_mouse_right_consumed
-                        .unwrap_or(false)
+                    view.read(cx).terminal_mouse_right_consumed.unwrap_or(false)
                 });
                 if right_consumed {
                     return menu;

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -551,4 +551,12 @@ mod tests {
         assert_eq!(sgr_mouse_sequence(0, 3, 7, true), "\x1b[<0;4;8M");
         assert_eq!(sgr_mouse_sequence(0, 3, 7, false), "\x1b[<0;4;8m");
     }
+
+    #[test]
+    fn sgr_coordinates_saturate_without_wrapping() {
+        assert_eq!(
+            sgr_mouse_sequence(0, u16::MAX, u16::MAX, true),
+            "\x1b[<0;65535;65535M"
+        );
+    }
 }

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -367,7 +367,8 @@ impl LinuxGhosttyTerminal {
     /// 1=Middle, 2=Right). Shift bypasses reporting so the user can
     /// always select text with Shift+click.
     pub fn mouse_report(&self, button: u8, col: u16, row: u16, shift: bool) -> bool {
-        let Some(session) = self.inner.lock().as_ref() else {
+        let inner = self.inner.lock();
+        let Some(session) = inner.as_ref() else {
             return false;
         };
         if !session.mouse_tracking_active() || shift {
@@ -386,7 +387,8 @@ impl LinuxGhosttyTerminal {
     /// sequence, gated on the same mouse-reporting mode as
     /// [`Self::mouse_report`].
     pub fn mouse_release(&self, button: u8, col: u16, row: u16, shift: bool) -> bool {
-        let Some(session) = self.inner.lock().as_ref() else {
+        let inner = self.inner.lock();
+        let Some(session) = inner.as_ref() else {
             return false;
         };
         if !session.mouse_tracking_active() || shift {

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -362,21 +362,20 @@ impl LinuxGhosttyTerminal {
     }
 
     /// Report a mouse button press/release to the child as an SGR
-    /// (1006) escape sequence, but only when the child has enabled
+    /// (1006) escape sequence, but only when the child has enabled SGR
     /// mouse reporting. `button` is the SGR button index (0=Left,
     /// 1=Middle, 2=Right). Shift bypasses reporting so the user can
-    /// always select text with Shift+click.
+    /// always select text with Shift+click. Returns `true` when the
+    /// report was emitted (i.e. the click was consumed by the app).
     pub fn mouse_report(&self, button: u8, col: u16, row: u16, shift: bool) -> bool {
         let inner = self.inner.lock();
         let Some(session) = inner.as_ref() else {
             return false;
         };
-        if !session.mouse_tracking_active() || shift {
+        if !session.mouse_tracking_active() || !session.is_sgr_mouse() || shift {
             return false;
         }
-        let col = col.saturating_add(1);
-        let row = row.saturating_add(1);
-        let seq = format!("\x1b[<{button};{col};{row}M");
+        let seq = sgr_mouse_sequence(button, col, row, true);
         if let Err(err) = session.write_input(seq.as_bytes()) {
             log::debug!("linux pty mouse report write failed: {err:#}");
         }
@@ -391,12 +390,10 @@ impl LinuxGhosttyTerminal {
         let Some(session) = inner.as_ref() else {
             return false;
         };
-        if !session.mouse_tracking_active() || shift {
+        if !session.mouse_tracking_active() || !session.is_sgr_mouse() || shift {
             return false;
         }
-        let col = col.saturating_add(1);
-        let row = row.saturating_add(1);
-        let seq = format!("\x1b[<{button};{col};{row}m");
+        let seq = sgr_mouse_sequence(button, col, row, false);
         if let Err(err) = session.write_input(seq.as_bytes()) {
             log::debug!("linux pty mouse release write failed: {err:#}");
         }
@@ -522,3 +519,30 @@ impl Default for LinuxGhosttyTerminal {
 
 unsafe impl Send for LinuxGhosttyTerminal {}
 unsafe impl Sync for LinuxGhosttyTerminal {}
+
+/// Build an SGR (1006) mouse report escape sequence for the given
+/// 0-based cell coordinates. `pressed` selects the press (`M`) or
+/// release (`m`) terminator.
+fn sgr_mouse_sequence(button: u8, col: u16, row: u16, pressed: bool) -> String {
+    let col = col.saturating_add(1);
+    let row = row.saturating_add(1);
+    let terminator = if pressed { 'M' } else { 'm' };
+    format!("\x1b[<{button};{col};{row}{terminator}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sgr_mouse_sequence;
+
+    #[test]
+    fn sgr_right_press_uses_button_2_and_one_based_coords() {
+        assert_eq!(sgr_mouse_sequence(2, 0, 0, true), "\x1b[<2;1;1M");
+        assert_eq!(sgr_mouse_sequence(2, 5, 9, true), "\x1b[<2;6;10M");
+    }
+
+    #[test]
+    fn sgr_left_press_and_release_terminators() {
+        assert_eq!(sgr_mouse_sequence(0, 3, 7, true), "\x1b[<0;4;8M");
+        assert_eq!(sgr_mouse_sequence(0, 3, 7, false), "\x1b[<0;4;8m");
+    }
+}

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -376,10 +376,13 @@ impl LinuxGhosttyTerminal {
             return false;
         }
         let seq = sgr_mouse_sequence(button, col, row, true);
-        if let Err(err) = session.write_input(seq.as_bytes()) {
-            log::debug!("linux pty mouse report write failed: {err:#}");
+        match session.write_input(seq.as_bytes()) {
+            Ok(()) => true,
+            Err(err) => {
+                log::debug!("linux pty mouse report write failed: {err:#}");
+                false
+            }
         }
-        true
     }
 
     /// Report a mouse button release to the child as an SGR (1006)
@@ -394,10 +397,13 @@ impl LinuxGhosttyTerminal {
             return false;
         }
         let seq = sgr_mouse_sequence(button, col, row, false);
-        if let Err(err) = session.write_input(seq.as_bytes()) {
-            log::debug!("linux pty mouse release write failed: {err:#}");
+        match session.write_input(seq.as_bytes()) {
+            Ok(()) => true,
+            Err(err) => {
+                log::debug!("linux pty mouse release write failed: {err:#}");
+                false
+            }
         }
-        true
     }
 
     pub fn request_close(&self) {

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -351,6 +351,56 @@ impl LinuxGhosttyTerminal {
     pub fn send_mouse_pos(&self, _x: f64, _y: f64, _mods: i32) {}
     pub fn send_mouse_scroll(&self, _x: f64, _y: f64, _mods: i32) {}
 
+    /// True when the child app has enabled terminal mouse reporting
+    /// (DECSET 1000/1002/1003). The Linux view gates its SGR reports on
+    /// this so clicks don't leak escape sequences into plain shells.
+    pub fn mouse_tracking_active(&self) -> bool {
+        self.inner
+            .lock()
+            .as_ref()
+            .is_some_and(LinuxPtySession::mouse_tracking_active)
+    }
+
+    /// Report a mouse button press/release to the child as an SGR
+    /// (1006) escape sequence, but only when the child has enabled
+    /// mouse reporting. `button` is the SGR button index (0=Left,
+    /// 1=Middle, 2=Right). Shift bypasses reporting so the user can
+    /// always select text with Shift+click.
+    pub fn mouse_report(&self, button: u8, col: u16, row: u16, shift: bool) -> bool {
+        let Some(session) = self.inner.lock().as_ref() else {
+            return false;
+        };
+        if !session.mouse_tracking_active() || shift {
+            return false;
+        }
+        let col = col.saturating_add(1);
+        let row = row.saturating_add(1);
+        let seq = format!("\x1b[<{button};{col};{row}M");
+        if let Err(err) = session.write_input(seq.as_bytes()) {
+            log::debug!("linux pty mouse report write failed: {err:#}");
+        }
+        true
+    }
+
+    /// Report a mouse button release to the child as an SGR (1006)
+    /// sequence, gated on the same mouse-reporting mode as
+    /// [`Self::mouse_report`].
+    pub fn mouse_release(&self, button: u8, col: u16, row: u16, shift: bool) -> bool {
+        let Some(session) = self.inner.lock().as_ref() else {
+            return false;
+        };
+        if !session.mouse_tracking_active() || shift {
+            return false;
+        }
+        let col = col.saturating_add(1);
+        let row = row.saturating_add(1);
+        let seq = format!("\x1b[<{button};{col};{row}m");
+        if let Err(err) = session.write_input(seq.as_bytes()) {
+            log::debug!("linux pty mouse release write failed: {err:#}");
+        }
+        true
+    }
+
     pub fn request_close(&self) {
         *self.inner.lock() = None;
     }

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -388,6 +388,14 @@ impl LinuxPtySession {
         self.shared.screen.is_decckm()
     }
 
+    /// True when the child app has enabled terminal mouse reporting
+    /// (DECSET 1000/1002/1003). View mouse handlers gate SGR reports on
+    /// this so clicks don't leak escape sequences into shells that
+    /// didn't ask for them.
+    pub fn mouse_tracking_active(&self) -> bool {
+        self.shared.screen.mouse_tracking_active()
+    }
+
     pub fn set_dark_mode(&self, dark: bool) {
         self.shared.screen.set_dark_mode(dark);
         // Same shape as `set_theme` / `resize`: a parser-state mutation

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -396,6 +396,14 @@ impl LinuxPtySession {
         self.shared.screen.mouse_tracking_active()
     }
 
+    /// True when the child app enabled the SGR (1006) extended mouse
+    /// encoding. The SGR report format (`ESC[<b;x;yM`) is only valid in
+    /// this mode; the legacy X10 encoding is not implemented, so callers
+    /// should skip reporting when this is false.
+    pub fn is_sgr_mouse(&self) -> bool {
+        self.shared.screen.is_sgr_mouse()
+    }
+
     pub fn set_dark_mode(&self, dark: bool) {
         self.shared.screen.set_dark_mode(dark);
         // Same shape as `set_theme` / `resize`: a parser-state mutation
@@ -598,9 +606,9 @@ mod tests {
                 .needs_render
                 .load(std::sync::atomic::Ordering::Acquire)
         );
-        let finished = shared
-            .finished_signal
-            .lock()
+        let signal_guard = shared.finished_signal.lock();
+        let finished = signal_guard
+            .as_ref()
             .expect("exit signal should be backfilled");
         assert_eq!(finished.exit_code, Some(7));
         assert_eq!(finished.duration, Duration::from_millis(20));

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -389,6 +389,17 @@ impl RenderSession {
         self.vt.mouse_tracking_active()
     }
 
+    fn mouse_release_reporting_active(&self) -> bool {
+        self.vt.mode_active(crate::vt::MODE_NORMAL_MOUSE)
+            || self.vt.mode_active(crate::vt::MODE_BUTTON_MOUSE)
+            || self.vt.mode_active(crate::vt::MODE_ANY_MOUSE)
+    }
+
+    fn mouse_motion_reporting_active(&self) -> bool {
+        self.vt.mode_active(crate::vt::MODE_BUTTON_MOUSE)
+            || self.vt.mode_active(crate::vt::MODE_ANY_MOUSE)
+    }
+
     /// Send UTF-8 text to the child shell. Handles the ConPTY Enter
     /// quirk (shell expects CR, not LF).
     pub fn write_input(&self, text: &str) {
@@ -468,12 +479,14 @@ impl RenderSession {
     /// `button` follows the SGR button index (0=Left, 1=Middle,
     /// 2=Right); the motion bit (+32) is added inside.
     pub fn mouse_drag(&self, button: u8, col: u16, row: u16, mods: MouseEventMods) {
-        let motion_reporting = self.vt.mode_active(crate::vt::MODE_BUTTON_MOUSE)
-            || self.vt.mode_active(crate::vt::MODE_ANY_MOUSE);
+        let motion_reporting = self.mouse_motion_reporting_active();
         if motion_reporting && !mods.shift {
             self.request_low_latency_after_next_generation();
             // Button + 32 = motion-with-button bit per SGR spec.
             self.report_sgr_button(button.saturating_add(32), col, row, mods, true);
+            return;
+        }
+        if button != 0 {
             return;
         }
         self.request_low_latency_present();
@@ -495,7 +508,7 @@ impl RenderSession {
     /// 1=Middle, 2=Right). Returns `true` when the release was consumed
     /// by the terminal app (an SGR report was emitted).
     pub fn mouse_up(&self, button: u8, col: u16, row: u16, mods: MouseEventMods) -> bool {
-        if self.vt.mouse_tracking_active() && !mods.shift {
+        if self.mouse_release_reporting_active() && !mods.shift {
             self.request_low_latency_after_next_generation();
             return self.report_sgr_button(button, col, row, mods, false);
         }
@@ -878,14 +891,8 @@ mod tests {
     #[test]
     fn sgr_right_button_press_and_release() {
         let mods = MouseEventMods::default();
-        assert_eq!(
-            sgr_button_sequence(2, 0, 0, mods, true),
-            "\x1b[<2;1;1M"
-        );
-        assert_eq!(
-            sgr_button_sequence(2, 5, 9, mods, false),
-            "\x1b[<2;6;10m"
-        );
+        assert_eq!(sgr_button_sequence(2, 0, 0, mods, true), "\x1b[<2;1;1M");
+        assert_eq!(sgr_button_sequence(2, 5, 9, mods, false), "\x1b[<2;6;10m");
     }
 
     #[test]

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -390,14 +390,18 @@ impl RenderSession {
     }
 
     fn mouse_release_reporting_active(&self) -> bool {
-        self.vt.mode_active(crate::vt::MODE_NORMAL_MOUSE)
-            || self.vt.mode_active(crate::vt::MODE_BUTTON_MOUSE)
-            || self.vt.mode_active(crate::vt::MODE_ANY_MOUSE)
+        mouse_release_reporting_active_for_modes(
+            self.vt.mode_active(crate::vt::MODE_NORMAL_MOUSE),
+            self.vt.mode_active(crate::vt::MODE_BUTTON_MOUSE),
+            self.vt.mode_active(crate::vt::MODE_ANY_MOUSE),
+        )
     }
 
     fn mouse_motion_reporting_active(&self) -> bool {
-        self.vt.mode_active(crate::vt::MODE_BUTTON_MOUSE)
-            || self.vt.mode_active(crate::vt::MODE_ANY_MOUSE)
+        mouse_motion_reporting_active_for_modes(
+            self.vt.mode_active(crate::vt::MODE_BUTTON_MOUSE),
+            self.vt.mode_active(crate::vt::MODE_ANY_MOUSE),
+        )
     }
 
     /// Send UTF-8 text to the child shell. Handles the ConPTY Enter
@@ -486,7 +490,7 @@ impl RenderSession {
             self.report_sgr_button(button.saturating_add(32), col, row, mods, true);
             return;
         }
-        if button != 0 {
+        if !mouse_drag_updates_local_selection(button, motion_reporting, mods.shift) {
             return;
         }
         self.request_low_latency_present();
@@ -802,6 +806,22 @@ fn sgr_button_sequence(
     format!("\x1b[<{cb};{col};{row}{terminator}")
 }
 
+fn mouse_release_reporting_active_for_modes(
+    normal_tracking: bool,
+    button_tracking: bool,
+    any_tracking: bool,
+) -> bool {
+    normal_tracking || button_tracking || any_tracking
+}
+
+fn mouse_motion_reporting_active_for_modes(button_tracking: bool, any_tracking: bool) -> bool {
+    button_tracking || any_tracking
+}
+
+fn mouse_drag_updates_local_selection(button: u8, motion_reporting: bool, shift: bool) -> bool {
+    button == 0 && (!motion_reporting || shift)
+}
+
 fn cursor_key_for_scroll_rows(rows: isize, decckm: bool) -> Option<&'static str> {
     match rows.cmp(&0) {
         std::cmp::Ordering::Greater => Some(if decckm { "\x1bOA" } else { "\x1b[A" }),
@@ -913,5 +933,31 @@ mod tests {
         assert_eq!(sgr_button_sequence(34, 1, 2, mods, true), "\x1b[<34;2;3M");
         // Left-button drag: 0 + 32 = 32.
         assert_eq!(sgr_button_sequence(32, 1, 2, mods, true), "\x1b[<32;2;3M");
+    }
+
+    #[test]
+    fn release_reporting_excludes_x10_press_only_mode() {
+        assert!(!mouse_release_reporting_active_for_modes(
+            false, false, false
+        ));
+        assert!(mouse_release_reporting_active_for_modes(true, false, false));
+        assert!(mouse_release_reporting_active_for_modes(false, true, false));
+        assert!(mouse_release_reporting_active_for_modes(false, false, true));
+    }
+
+    #[test]
+    fn motion_reporting_requires_button_or_any_mode() {
+        assert!(!mouse_motion_reporting_active_for_modes(false, false));
+        assert!(mouse_motion_reporting_active_for_modes(true, false));
+        assert!(mouse_motion_reporting_active_for_modes(false, true));
+    }
+
+    #[test]
+    fn only_left_drag_updates_local_selection() {
+        assert!(mouse_drag_updates_local_selection(0, false, false));
+        assert!(mouse_drag_updates_local_selection(0, true, true));
+        assert!(!mouse_drag_updates_local_selection(0, true, false));
+        assert!(!mouse_drag_updates_local_selection(2, false, false));
+        assert!(!mouse_drag_updates_local_selection(2, true, true));
     }
 }

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -423,17 +423,20 @@ impl RenderSession {
     /// otherwise we emit an SGR button-press report and leave selection
     /// alone. Shift+click with an existing selection extends from the
     /// original anchor (matches every other terminal). `button` follows
-    /// the SGR button index (0=Left, 1=Middle, 2=Right).
-    pub fn mouse_down(&self, button: u8, col: u16, row: u16, mods: MouseEventMods) {
+    /// the SGR button index (0=Left, 1=Middle, 2=Right). Returns `true`
+    /// when the event was consumed by the terminal app (an SGR report
+    /// was emitted) — the view uses this to suppress its own context
+    /// menu on right-click.
+    pub fn mouse_down(&self, button: u8, col: u16, row: u16, mods: MouseEventMods) -> bool {
         if self.vt.mouse_tracking_active() && !mods.shift {
             self.request_low_latency_after_next_generation();
             self.report_sgr_button(button, col, row, mods, true);
-            return;
+            return true;
         }
         if button != 0 {
             // Non-left buttons never drive local selection; when tracking
             // is off the click is simply not consumed by the terminal.
-            return;
+            return false;
         }
         self.request_low_latency_present();
         let point = self.selection_point(col, row);
@@ -445,13 +448,14 @@ impl RenderSession {
                 anchor: existing_anchor,
                 extent: point,
             }));
-            return;
+            return false;
         }
         *self.drag_anchor.lock() = Some(point);
         self.renderer.lock().set_selection(Some(Selection {
             anchor: point,
             extent: point,
         }));
+        false
     }
 
     /// Mouse-moved at the given cell while a button is held.
@@ -482,15 +486,16 @@ impl RenderSession {
     /// is held to keep selection). Otherwise clears a transient 1-cell
     /// selection — a click without drag shouldn't leave a lone cell
     /// highlighted. `button` follows the SGR button index (0=Left,
-    /// 1=Middle, 2=Right).
-    pub fn mouse_up(&self, button: u8, col: u16, row: u16, mods: MouseEventMods) {
+    /// 1=Middle, 2=Right). Returns `true` when the release was consumed
+    /// by the terminal app (an SGR report was emitted).
+    pub fn mouse_up(&self, button: u8, col: u16, row: u16, mods: MouseEventMods) -> bool {
         if self.vt.mouse_tracking_active() && !mods.shift {
             self.request_low_latency_after_next_generation();
             self.report_sgr_button(button, col, row, mods, false);
-            return;
+            return true;
         }
         if button != 0 {
-            return;
+            return false;
         }
         self.request_low_latency_present();
         let anchor = self.drag_anchor.lock().take();
@@ -499,6 +504,7 @@ impl RenderSession {
         {
             self.renderer.lock().set_selection(None);
         }
+        false
     }
 
     fn selection_point(&self, col: u16, row: u16) -> (u16, u64) {
@@ -514,17 +520,7 @@ impl RenderSession {
         mods: MouseEventMods,
         pressed: bool,
     ) {
-        let col = col.saturating_add(1);
-        let row = row.saturating_add(1);
-        let mut cb = base_button;
-        if mods.alt {
-            cb |= 0x08;
-        }
-        if mods.control {
-            cb |= 0x10;
-        }
-        let terminator = if pressed { 'M' } else { 'm' };
-        let seq = format!("\x1b[<{cb};{col};{row}{terminator}");
+        let seq = sgr_button_sequence(base_button, col, row, mods, pressed);
         let _ = self.conpty.write(seq.as_bytes());
     }
 
@@ -764,6 +760,30 @@ fn sgr_wheel_button_for_delta(delta_y: f32) -> u8 {
     if delta_y > 0.0 { 64 } else { 65 }
 }
 
+/// Build an SGR (1006) mouse button report escape sequence for the
+/// given 0-based cell coordinates. Alt (0x08) and Ctrl (0x10) bits are
+/// folded into the button byte per the SGR spec; `pressed` selects the
+/// press (`M`) or release (`m`) terminator.
+fn sgr_button_sequence(
+    base_button: u8,
+    col: u16,
+    row: u16,
+    mods: MouseEventMods,
+    pressed: bool,
+) -> String {
+    let col = col.saturating_add(1);
+    let row = row.saturating_add(1);
+    let mut cb = base_button;
+    if mods.alt {
+        cb |= 0x08;
+    }
+    if mods.control {
+        cb |= 0x10;
+    }
+    let terminator = if pressed { 'M' } else { 'm' };
+    format!("\x1b[<{cb};{col};{row}{terminator}")
+}
+
 fn cursor_key_for_scroll_rows(rows: isize, decckm: bool) -> Option<&'static str> {
     match rows.cmp(&0) {
         std::cmp::Ordering::Greater => Some(if decckm { "\x1bOA" } else { "\x1b[A" }),
@@ -848,5 +868,29 @@ mod tests {
         assert_eq!(viewport_delta_for_scroll_rows(3), -3);
         assert_eq!(viewport_delta_for_scroll_rows(-3), 3);
         assert_eq!(viewport_delta_for_scroll_rows(0), 0);
+    }
+
+    #[test]
+    fn sgr_right_button_press_and_release() {
+        let mods = MouseEventMods::default();
+        assert_eq!(
+            sgr_button_sequence(2, 0, 0, mods, true),
+            "\x1b[<2;1;1M"
+        );
+        assert_eq!(
+            sgr_button_sequence(2, 5, 9, mods, false),
+            "\x1b[<2;6;10m"
+        );
+    }
+
+    #[test]
+    fn sgr_button_sequence_folds_alt_and_ctrl_bits() {
+        let mods = MouseEventMods {
+            alt: true,
+            control: true,
+            shift: false,
+        };
+        // base 0 (left) | alt 0x08 | ctrl 0x10 = 0x18
+        assert_eq!(sgr_button_sequence(0, 3, 7, mods, true), "\x1b[<24;4;8M");
     }
 }

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -419,19 +419,19 @@ impl RenderSession {
     ///
     /// Xterm convention: Shift bypasses mouse tracking so the user can
     /// always select text, even when a TUI has `set mouse=a` on. When
-    /// tracking is off or Shift is held, we drive local selection;
-    /// otherwise we emit an SGR button-press report and leave selection
-    /// alone. Shift+click with an existing selection extends from the
-    /// original anchor (matches every other terminal). `button` follows
-    /// the SGR button index (0=Left, 1=Middle, 2=Right). Returns `true`
-    /// when the event was consumed by the terminal app (an SGR report
-    /// was emitted) — the view uses this to suppress its own context
-    /// menu on right-click.
+    /// tracking is off or Shift is held, we drive local selection (left
+    /// button only — non-left buttons never drive selection); otherwise
+    /// we emit an SGR button-press report and leave selection alone.
+    /// Shift+click with an existing selection extends from the original
+    /// anchor (matches every other terminal). `button` follows the SGR
+    /// button index (0=Left, 1=Middle, 2=Right). Returns `true` when the
+    /// event was consumed by the terminal app (an SGR report emitted) —
+    /// the view uses this to suppress its own context menu on
+    /// right-click.
     pub fn mouse_down(&self, button: u8, col: u16, row: u16, mods: MouseEventMods) -> bool {
         if self.vt.mouse_tracking_active() && !mods.shift {
             self.request_low_latency_after_next_generation();
-            self.report_sgr_button(button, col, row, mods, true);
-            return true;
+            return self.report_sgr_button(button, col, row, mods, true);
         }
         if button != 0 {
             // Non-left buttons never drive local selection; when tracking
@@ -462,12 +462,14 @@ impl RenderSession {
     ///
     /// When mouse tracking is active and the shell requested motion
     /// (BUTTON / ANY mode), we emit an SGR motion report with the
-    /// motion bit (+32) set. Otherwise we extend the local drag.
-    pub fn mouse_drag(&self, col: u16, row: u16, mods: MouseEventMods) {
+    /// motion bit (+32) set. Otherwise we extend the local left-button
+    /// drag selection. `button` follows the SGR button index (0=Left,
+    /// 1=Middle, 2=Right); the motion bit is added inside.
+    pub fn mouse_drag(&self, button: u8, col: u16, row: u16, mods: MouseEventMods) {
         if self.vt.mouse_tracking_active() && !mods.shift {
             self.request_low_latency_after_next_generation();
-            // Button 0 (LMB) + 32 = motion-with-button bit per SGR spec.
-            self.report_sgr_button(32, col, row, mods, true);
+            // Button + 32 = motion-with-button bit per SGR spec.
+            self.report_sgr_button(button.saturating_add(32), col, row, mods, true);
             return;
         }
         self.request_low_latency_present();
@@ -491,8 +493,7 @@ impl RenderSession {
     pub fn mouse_up(&self, button: u8, col: u16, row: u16, mods: MouseEventMods) -> bool {
         if self.vt.mouse_tracking_active() && !mods.shift {
             self.request_low_latency_after_next_generation();
-            self.report_sgr_button(button, col, row, mods, false);
-            return true;
+            return self.report_sgr_button(button, col, row, mods, false);
         }
         if button != 0 {
             return false;
@@ -519,9 +520,9 @@ impl RenderSession {
         row: u16,
         mods: MouseEventMods,
         pressed: bool,
-    ) {
+    ) -> bool {
         let seq = sgr_button_sequence(base_button, col, row, mods, pressed);
-        let _ = self.conpty.write(seq.as_bytes());
+        self.conpty.write(seq.as_bytes()).is_ok()
     }
 
     /// Cancel any in-flight drag (used on focus loss).
@@ -892,5 +893,14 @@ mod tests {
         };
         // base 0 (left) | alt 0x08 | ctrl 0x10 = 0x18
         assert_eq!(sgr_button_sequence(0, 3, 7, mods, true), "\x1b[<24;4;8M");
+    }
+
+    #[test]
+    fn sgr_drag_motion_uses_button_plus_32() {
+        // Right-button drag: 2 + 32 = 34.
+        let mods = MouseEventMods::default();
+        assert_eq!(sgr_button_sequence(34, 1, 2, mods, true), "\x1b[<34;2;3M");
+        // Left-button drag: 0 + 32 = 32.
+        assert_eq!(sgr_button_sequence(32, 1, 2, mods, true), "\x1b[<32;2;3M");
     }
 }

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -415,18 +415,24 @@ impl RenderSession {
         self.request_low_latency_present();
     }
 
-    /// Mouse-left-down at the given cell.
+    /// Mouse-down at the given cell.
     ///
     /// Xterm convention: Shift bypasses mouse tracking so the user can
     /// always select text, even when a TUI has `set mouse=a` on. When
     /// tracking is off or Shift is held, we drive local selection;
     /// otherwise we emit an SGR button-press report and leave selection
     /// alone. Shift+click with an existing selection extends from the
-    /// original anchor (matches every other terminal).
-    pub fn mouse_down(&self, col: u16, row: u16, mods: MouseEventMods) {
+    /// original anchor (matches every other terminal). `button` follows
+    /// the SGR button index (0=Left, 1=Middle, 2=Right).
+    pub fn mouse_down(&self, button: u8, col: u16, row: u16, mods: MouseEventMods) {
         if self.vt.mouse_tracking_active() && !mods.shift {
             self.request_low_latency_after_next_generation();
-            self.report_sgr_button(0, col, row, mods, true);
+            self.report_sgr_button(button, col, row, mods, true);
+            return;
+        }
+        if button != 0 {
+            // Non-left buttons never drive local selection; when tracking
+            // is off the click is simply not consumed by the terminal.
             return;
         }
         self.request_low_latency_present();
@@ -448,7 +454,7 @@ impl RenderSession {
         }));
     }
 
-    /// Mouse-moved at the given cell while left button is held.
+    /// Mouse-moved at the given cell while a button is held.
     ///
     /// When mouse tracking is active and the shell requested motion
     /// (BUTTON / ANY mode), we emit an SGR motion report with the
@@ -470,16 +476,20 @@ impl RenderSession {
         }
     }
 
-    /// Mouse-left-up at the given cell.
+    /// Mouse-up at the given cell.
     ///
     /// Emits an SGR release when mouse tracking is active (unless Shift
     /// is held to keep selection). Otherwise clears a transient 1-cell
     /// selection — a click without drag shouldn't leave a lone cell
-    /// highlighted.
-    pub fn mouse_up(&self, col: u16, row: u16, mods: MouseEventMods) {
+    /// highlighted. `button` follows the SGR button index (0=Left,
+    /// 1=Middle, 2=Right).
+    pub fn mouse_up(&self, button: u8, col: u16, row: u16, mods: MouseEventMods) {
         if self.vt.mouse_tracking_active() && !mods.shift {
             self.request_low_latency_after_next_generation();
-            self.report_sgr_button(0, col, row, mods, false);
+            self.report_sgr_button(button, col, row, mods, false);
+            return;
+        }
+        if button != 0 {
             return;
         }
         self.request_low_latency_present();

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -460,13 +460,17 @@ impl RenderSession {
 
     /// Mouse-moved at the given cell while a button is held.
     ///
-    /// When mouse tracking is active and the shell requested motion
-    /// (BUTTON / ANY mode), we emit an SGR motion report with the
-    /// motion bit (+32) set. Otherwise we extend the local left-button
-    /// drag selection. `button` follows the SGR button index (0=Left,
-    /// 1=Middle, 2=Right); the motion bit is added inside.
+    /// Emits an SGR motion-with-button report only when the shell
+    /// requested motion reporting (DECSET 1002 button-event or 1003
+    /// any-event); plain button-event tracking (1000) reports presses
+    /// and releases but no motion. When motion reporting is off or
+    /// Shift is held we extend the local left-button drag selection.
+    /// `button` follows the SGR button index (0=Left, 1=Middle,
+    /// 2=Right); the motion bit (+32) is added inside.
     pub fn mouse_drag(&self, button: u8, col: u16, row: u16, mods: MouseEventMods) {
-        if self.vt.mouse_tracking_active() && !mods.shift {
+        let motion_reporting = self.vt.mode_active(crate::vt::MODE_BUTTON_MOUSE)
+            || self.vt.mode_active(crate::vt::MODE_ANY_MOUSE);
+        if motion_reporting && !mods.shift {
             self.request_low_latency_after_next_generation();
             // Button + 32 = motion-with-button bit per SGR spec.
             self.report_sgr_button(button.saturating_add(32), col, row, mods, true);


### PR DESCRIPTION
## 问题

在 con 中运行支持鼠标操作的 TUI（如 herdr）时，右键点击弹出的是 con 自带上下文菜单，而不是应用自身菜单；Ghostty 中行为正常。根因：GPUI shell 无条件截获右键，从不转发给终端核心，且无 mouse-reporting 状态判断。

详细分析见 Issue #265。

## 修复方案

对齐 Ghostty AppKit 宿主行为：**右键始终转发进终端核心**（macOS 用 libghostty，Windows/Linux 用 libghostty-vt），并依据"终端应用是否开启鼠标上报"决定是否弹 con 自带菜单。

### macOS — `ghostty_view.rs`
- 右键 down 镜像左键逻辑，转发 `send_mouse_pos` + `send_mouse_button(true, Right, mods)`，缓存 libghostty 返回值（consumed）
- 新增右键 up（release 之前完全缺失）
- `.context_menu` builder 读 consumed：被终端应用消费（鼠标上报激活）时返回空菜单（gpui-component `ContextMenu` 检查 `is_empty()`，不渲染任何内容）

### Windows — `windows_view.rs` + `windows/host_view.rs`
- 后端 `mouse_down/mouse_up` 增加 SGR button 参数（0=Left, 2=Right）；非左键且无 tracking 时不驱动本地选区
- 右键 down 经 `forward_mouse_down(2, ...)` 转发，新增右键 up 转发 release
- `.context_menu` 经 `menu_entity` 查询 `RenderSession::mouse_tracking_active()`，激活时抑制

### Linux — `linux_view.rs` + `linux/backend.rs` + `linux/pty.rs`
- `LinuxPtySession::mouse_tracking_active()` 委托 libghostty-vt（此前 Linux 鼠标上报完全未实现，`send_mouse_*` 为 stub）
- `LinuxGhosttyTerminal::mouse_report/mouse_release` 实现 SGR 1006 上报（Shift 绕过，与 Windows host_view 语义一致）
- 右键 down/up 转发；`.context_menu` 查询 `mouse_tracking_active()` 抑制

## 验证

- macOS：`cargo check -p con` + `cargo clippy -p con` 通过，无新增警告
- 修复了 linux/windows `context_menu` 闭包复用 `entity` 导致的 "use of moved value" 编译错误（改用 `menu_entity` clone）
- Linux/Windows 为 `cfg(target_os)` 门控代码，本机（macOS）无对应工具链；CI 的 windows/linux job（`CON_SKIP_GHOSTTY_VT=1 cargo check`）会做最终 type-check

## 影响范围

三平台同类问题一并修复。macOS 为本次实际复现平台，Linux/Windows 为结构同源问题的预防性修复。

Closes #265


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved right-click handling across Linux, Windows, and Ghostty terminals.
  * Terminal applications with mouse tracking enabled now receive right-click press, drag, and release events.
  * Mouse coordinates, button states, and modifier keys are reported accurately.
  * Shift-click behavior and terminal-controlled interactions are handled consistently across platforms.
* **Bug Fixes**
  * Context menus no longer appear when the terminal consumes a right-click.
  * Right-clicks no longer incorrectly trigger text selection or other inactive-terminal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->