### PR TITLE
fix(sidebar): keep icons from distorting under window compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ con is still pre-release, so entries may group related beta work while the produ
   [#270](https://github.com/nowledge-co/con-terminal/pull/270) by
   [@sunny0826](https://github.com/sunny0826))_
 
+### Fixed
+
+**Sidebar**
+
+- Fixed sidebar rail icons and file-search result icons stretching when the
+  window is compressed. The session rail now keeps controls fixed and scrolls
+  the session list instead of shrinking icon boxes. _(PR
+  [#272](https://github.com/nowledge-co/con-terminal/pull/272) by
+  [@sunny0826](https://github.com/sunny0826))_
+
 ---
 
 ## `v0.1.0-beta.83` - 2026-08-11

--- a/crates/con-app/src/sidebar.rs
+++ b/crates/con-app/src/sidebar.rs
@@ -205,6 +205,7 @@ impl Render for DraggedTab {
                 svg()
                     .path(self.icon)
                     .size(px(12.0))
+                    .flex_shrink_0()
                     .text_color(theme.foreground),
             )
             .child(div().truncate().child(self.label.clone()))
@@ -759,7 +760,7 @@ impl SessionSidebar {
             theme.muted_foreground
         };
         self.tab_bounds.borrow_mut().clear();
-        let mut rail = div()
+        let rail = div()
             .id("tab-sidebar-rail")
             .relative()
             .w(px(RAIL_WIDTH))
@@ -969,6 +970,22 @@ impl SessionSidebar {
                 cx.listener(|_, _, _, cx| cx.emit(NewSession)),
             ));
 
+        // Session pill list — the only vertically scrollable region of
+        // the rail. The control buttons and dividers above stay fixed:
+        // when the window is short or there are many sessions, this area
+        // absorbs the vertical deficit (flex_1 + min_h_0) and scrolls
+        // instead of compressing the 32px pills.
+        let mut pill_list = div()
+            .id("tab-sidebar-rail-scroll")
+            .flex_1()
+            .min_h_0()
+            .w_full()
+            .flex()
+            .flex_col()
+            .items_center()
+            .gap(px(RAIL_ICON_GAP))
+            .overflow_y_scroll();
+
         for (i, session) in self.sessions.iter().enumerate() {
             let is_active = i == self.active_session;
             let active_bg = elevated_surface(theme, self.ui_opacity);
@@ -1007,6 +1024,7 @@ impl SessionSidebar {
                 .items_center()
                 .justify_center()
                 .size(px(RAIL_ICON_SIZE))
+                .flex_shrink_0()
                 .rounded(px(8.0))
                 .cursor_pointer()
                 .bg(pill_bg)
@@ -1048,6 +1066,7 @@ impl SessionSidebar {
                     svg()
                         .path(session.icon)
                         .size(px(16.0))
+                        .flex_shrink_0()
                         .text_color(if is_active {
                             theme.foreground
                         } else {
@@ -1089,10 +1108,10 @@ impl SessionSidebar {
                 pill = pill.child(rail_drop_indicator(theme, false));
             }
 
-            rail = rail.child(pill);
+            pill_list = pill_list.child(pill);
         }
 
-        rail.child(div().flex_1())
+        rail.child(pill_list)
     }
 
     /// Floating hover card shown next to the hovered rail icon.
@@ -1784,6 +1803,7 @@ impl SessionSidebar {
                     .flex()
                     .items_center()
                     .gap(px(2.0))
+                    .flex_shrink_0()
                     .child(rename_btn)
                     .child(close_btn),
             );
@@ -2015,13 +2035,20 @@ where
     div()
         .id(id)
         .size(px(28.0))
+        .flex_shrink_0()
         .flex()
         .items_center()
         .justify_center()
         .rounded(px(6.0))
         .cursor_pointer()
         .hover(move |s| s.bg(hover_bg))
-        .child(svg().path(icon).size(px(14.0)).text_color(icon_color))
+        .child(
+            svg()
+                .path(icon)
+                .size(px(14.0))
+                .flex_shrink_0()
+                .text_color(icon_color),
+        )
         .on_mouse_down(MouseButton::Left, handler)
 }
 
@@ -2149,6 +2176,7 @@ where
     div()
         .id(id)
         .size(px(20.0))
+        .flex_shrink_0()
         .flex()
         .items_center()
         .justify_center()
@@ -2159,6 +2187,7 @@ where
             svg()
                 .path(icon)
                 .size(px(11.0))
+                .flex_shrink_0()
                 .text_color(theme.muted_foreground.opacity(0.72)),
         )
         .on_mouse_down(MouseButton::Left, handler)

--- a/crates/con-app/src/sidebar.rs
+++ b/crates/con-app/src/sidebar.rs
@@ -49,8 +49,14 @@ const RAIL_ICON_SIZE: f32 = 32.0;
 /// Vertical gap between rail icons. Used to compute the icon's
 /// y-center for hover-card anchoring.
 const RAIL_ICON_GAP: f32 = 2.0;
-const RAIL_TOP_CONTROLS_HEIGHT: f32 =
-    28.0 + RAIL_ICON_GAP + 28.0 + RAIL_ICON_GAP + 5.0 + RAIL_ICON_GAP;
+const RAIL_BUTTON_SIZE: f32 = 28.0;
+const RAIL_DIVIDER_HEIGHT: f32 = 5.0;
+const RAIL_TOP_CONTROL_COUNT: f32 = 4.0;
+const RAIL_TOP_DIVIDER_COUNT: f32 = 2.0;
+const RAIL_TOP_GAP_COUNT_BEFORE_SESSIONS: f32 = 6.0;
+const RAIL_TOP_CONTROLS_HEIGHT: f32 = RAIL_BUTTON_SIZE * RAIL_TOP_CONTROL_COUNT
+    + RAIL_DIVIDER_HEIGHT * RAIL_TOP_DIVIDER_COUNT
+    + RAIL_ICON_GAP * RAIL_TOP_GAP_COUNT_BEFORE_SESSIONS;
 
 /// Cubic ease-out feel for the panel width animation.
 #[cfg(not(target_os = "macos"))]
@@ -1998,10 +2004,8 @@ fn rail_slot_from_local_y(
     }
     // Mirror the rail layout in render_rail:
     //   pt(leading_top_pad)
-    //   + expand button (28 px) + RAIL_ICON_GAP
-    //   + new-tab button (28 px) + RAIL_ICON_GAP
-    //   + separator h(1) + my(2)*2 = 5 px + RAIL_ICON_GAP
-    //   + i * (RAIL_ICON_SIZE + RAIL_ICON_GAP)
+    //   + top controls (expand, files, search, new, two dividers, gaps)
+    //   + scrollable session list rows
     let header = leading_top_pad + RAIL_TOP_CONTROLS_HEIGHT;
     let stride = RAIL_ICON_SIZE + RAIL_ICON_GAP;
     if local_y < header {
@@ -2327,11 +2331,11 @@ fn normalize_sidebar_rename_label(value: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        PanelMode, RailModeButtonAction, SessionSidebar, SidebarDragPreviewState,
-        begin_rename_after_cancel_lifecycle, begin_rename_lifecycle,
+        PanelMode, RAIL_ICON_SIZE, RAIL_TOP_CONTROLS_HEIGHT, RailModeButtonAction, SessionSidebar,
+        SidebarDragPreviewState, begin_rename_after_cancel_lifecycle, begin_rename_lifecycle,
         blur_should_commit_for_lifecycle, cancel_rename_lifecycle, hover_card_top_for_cursor,
-        normalize_sidebar_rename_label, vertical_drag_overlay_probe_position,
-        vertical_slot_from_bounds,
+        normalize_sidebar_rename_label, rail_slot_from_local_y,
+        vertical_drag_overlay_probe_position, vertical_slot_from_bounds,
     };
     use gpui::{Bounds, Point, Size, px};
 
@@ -2363,6 +2367,22 @@ mod tests {
         assert_eq!(vertical_slot_from_bounds(px(90.0), &bounds, 2), Some(0));
         assert_eq!(vertical_slot_from_bounds(px(121.0), &bounds, 2), Some(1));
         assert_eq!(vertical_slot_from_bounds(px(180.0), &bounds, 2), Some(2));
+    }
+
+    #[test]
+    fn rail_slot_from_local_y_starts_after_fixed_controls() {
+        assert_eq!(
+            rail_slot_from_local_y(RAIL_TOP_CONTROLS_HEIGHT - 1.0, 3, 0.0),
+            Some(0)
+        );
+        assert_eq!(
+            rail_slot_from_local_y(RAIL_TOP_CONTROLS_HEIGHT, 3, 0.0),
+            Some(0)
+        );
+        assert_eq!(
+            rail_slot_from_local_y(RAIL_TOP_CONTROLS_HEIGHT + RAIL_ICON_SIZE * 0.75, 3, 0.0),
+            Some(1)
+        );
     }
 
     #[test]

--- a/crates/con-app/src/sidebar_search_view.rs
+++ b/crates/con-app/src/sidebar_search_view.rs
@@ -343,6 +343,7 @@ impl Render for SidebarSearchView {
                                 svg()
                                     .path("phosphor/file-text.svg")
                                     .size(px(13.0))
+                                    .flex_shrink_0()
                                     .text_color(theme.muted_foreground.opacity(0.72)),
                             )
                             .child(


### PR DESCRIPTION
## Problem

Closes #271 — sidebar icons distort when the window is compressed.

## Root cause

GPUI defaults to `flex_shrink: 1`, and `svg()` scales non-uniformly into its final layout box. Several sidebar icons and their fixed-size containers were missing `flex_shrink_0()`, so window compression turned their layout boxes non-square and stretched/squashed the icons.

## Fix

- `crates/con-app/src/sidebar.rs` (8 sites) + `crates/con-app/src/sidebar_search_view.rs` (1 site): add `.flex_shrink_0()` to the rail control buttons, session pills, panel row small buttons and row-tail button group, search file row icon, and drag preview icon (plus their containers), matching the existing codebase convention
- Rail overflow hardening: wrap the session pill list in a `flex_1 + min_h_0 + overflow_y_scroll` scroll container with the top control cluster staying fixed; with short windows / many sessions the pill area scrolls instead of being clipped, so all sessions remain reachable

## Verification

- `cargo check -p con` passes
- `cargo test -p con sidebar`: 22 passed, 0 failed
- `rustfmt --check` / `git diff --check` pass
- Two rounds of independent code review: all 9 protections land on the correct flex children, no out-of-scope changes, drag/indicator/centering layout intact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar behavior in narrow windows by keeping controls, icons, and session items at consistent sizes.
  * Added scrolling for session items while keeping sidebar controls fixed in place.
  * Prevented search-result file icons from being compressed.
* **Documentation**
  * Added unreleased changelog notes for the sidebar sizing and session-rail improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->