### PR TITLE
feat(config): 定义 Terminal Profile 配置契约

### DIFF
--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -96,6 +96,99 @@ impl Default for TerminalConfig {
     }
 }
 
+/// User-defined terminal launch profiles.
+///
+/// This is the configuration contract only. Terminal creation does not consume
+/// these values yet, so an empty configuration deliberately preserves the
+/// existing platform shell discovery behavior.
+///
+/// # Example
+/// ```toml
+/// [profiles]
+/// default = "ubuntu"
+///
+/// [[profiles.list]]
+/// id = "pwsh"
+/// name = "PowerShell"
+/// program = "pwsh.exe"
+/// args = ["-NoLogo"]
+/// starting_directory = "%USERPROFILE%"
+/// startup_command = "Invoke-ConBootstrap"
+/// theme = "flexoki-light"
+///
+/// [[profiles.list]]
+/// id = "ubuntu"
+/// name = "Ubuntu 24.04"
+/// kind = "wsl"
+/// distribution = "Ubuntu-24.04"
+/// program = "/bin/zsh"
+/// args = ["-l"]
+/// theme = "flexoki-dark"
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ProfilesConfig {
+    /// Stable profile id used when a new terminal does not explicitly choose one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<String>,
+    /// Explicit user profiles in menu order.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub list: Vec<TerminalProfileConfig>,
+}
+
+impl ProfilesConfig {
+    fn is_empty(&self) -> bool {
+        self.default.is_none() && self.list.is_empty()
+    }
+}
+
+/// One terminal launch profile.
+///
+/// `id` and `name` are intentionally required. Optional values inherit Con's
+/// global terminal settings or the platform's normal shell discovery behavior.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TerminalProfileConfig {
+    /// Stable, user-controlled identifier referenced by [`ProfilesConfig::default`].
+    pub id: String,
+    /// Human-readable name shown by future profile pickers.
+    pub name: String,
+    /// Native shell or WSL launch behavior.
+    #[serde(default, skip_serializing_if = "TerminalProfileKind::is_shell")]
+    pub kind: TerminalProfileKind,
+    /// Local executable, or the shell executable inside WSL for a WSL profile.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub program: Option<String>,
+    /// Arguments passed to `program` without platform-specific quoting.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    /// Initial working directory. Platform environment variables may be used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub starting_directory: Option<String>,
+    /// Command to run once the interactive shell is ready.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub startup_command: Option<String>,
+    /// WSL distribution name, used only when `kind = "wsl"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub distribution: Option<String>,
+    /// Per-profile terminal theme. `None` inherits [`TerminalConfig::theme`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub theme: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminalProfileKind {
+    #[default]
+    Shell,
+    Wsl,
+}
+
+impl TerminalProfileKind {
+    fn is_shell(&self) -> bool {
+        matches!(self, Self::Shell)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct AppearanceConfig {
@@ -752,6 +845,8 @@ impl NetworkConfig {
 #[serde(default)]
 pub struct Config {
     pub terminal: TerminalConfig,
+    #[serde(default, skip_serializing_if = "ProfilesConfig::is_empty")]
+    pub profiles: ProfilesConfig,
     pub appearance: AppearanceConfig,
     pub agent: AgentConfig,
     pub keybindings: KeybindingConfig,
@@ -987,8 +1082,8 @@ fn replace_file(tmp_path: &Path, path: &Path) -> Result<()> {
 mod tests {
     use super::{
         Config, DEFAULT_TERMINAL_FONT_FAMILY, NetworkConfig, SkillsConfig, TabsOrientation,
-        config_declares_agent_provider_provenance, migrate_agent_provider_provenance,
-        sanitize_terminal_font_family,
+        TerminalProfileKind, config_declares_agent_provider_provenance,
+        migrate_agent_provider_provenance, sanitize_terminal_font_family,
     };
     use con_agent::ProviderKind;
 
@@ -1065,6 +1160,128 @@ mod tests {
             sanitize_terminal_font_family("JetBrains Mono"),
             "JetBrains Mono"
         );
+    }
+
+    #[test]
+    fn legacy_configs_receive_empty_profiles() {
+        let content = r#"
+[terminal]
+font_size = 14.0
+"#;
+        let config: Config = toml::from_str(content).unwrap();
+
+        assert!(config.profiles.default.is_none());
+        assert!(config.profiles.list.is_empty());
+    }
+
+    #[test]
+    fn default_config_omits_empty_profiles_table() {
+        let encoded = toml::to_string(&Config::default()).unwrap();
+        let document: toml::Value = toml::from_str(&encoded).unwrap();
+
+        assert!(document.get("profiles").is_none());
+    }
+
+    #[test]
+    fn terminal_profile_defaults_inherit_platform_behavior() {
+        let content = r#"
+[[profiles.list]]
+id = "fish"
+name = "Fish"
+"#;
+        let config: Config = toml::from_str(content).unwrap();
+        let profile = &config.profiles.list[0];
+
+        assert_eq!(profile.kind, TerminalProfileKind::Shell);
+        assert!(profile.program.is_none());
+        assert!(profile.args.is_empty());
+        assert!(profile.starting_directory.is_none());
+        assert!(profile.startup_command.is_none());
+        assert!(profile.distribution.is_none());
+        assert!(profile.theme.is_none());
+    }
+
+    #[test]
+    fn terminal_profiles_parse_shell_and_wsl_fields() {
+        let content = r#"
+[profiles]
+default = "ubuntu"
+
+[[profiles.list]]
+id = "pwsh"
+name = "PowerShell"
+program = "pwsh.exe"
+args = ["-NoLogo"]
+starting_directory = "%USERPROFILE%"
+startup_command = "Invoke-ConBootstrap"
+theme = "flexoki-light"
+
+[[profiles.list]]
+id = "ubuntu"
+name = "Ubuntu 24.04"
+kind = "wsl"
+distribution = "Ubuntu-24.04"
+program = "/bin/zsh"
+args = ["-l"]
+starting_directory = "/home/eric"
+startup_command = "source ~/.config/con/bootstrap.sh"
+theme = "flexoki-dark"
+"#;
+        let config: Config = toml::from_str(content).unwrap();
+        let pwsh = &config.profiles.list[0];
+        let ubuntu = &config.profiles.list[1];
+
+        assert_eq!(config.profiles.default.as_deref(), Some("ubuntu"));
+        assert_eq!(pwsh.kind, TerminalProfileKind::Shell);
+        assert_eq!(pwsh.program.as_deref(), Some("pwsh.exe"));
+        assert_eq!(pwsh.args, ["-NoLogo"]);
+        assert_eq!(pwsh.starting_directory.as_deref(), Some("%USERPROFILE%"));
+        assert_eq!(pwsh.startup_command.as_deref(), Some("Invoke-ConBootstrap"));
+        assert_eq!(pwsh.theme.as_deref(), Some("flexoki-light"));
+        assert_eq!(ubuntu.kind, TerminalProfileKind::Wsl);
+        assert_eq!(ubuntu.distribution.as_deref(), Some("Ubuntu-24.04"));
+        assert_eq!(ubuntu.program.as_deref(), Some("/bin/zsh"));
+        assert_eq!(ubuntu.args, ["-l"]);
+        assert_eq!(ubuntu.starting_directory.as_deref(), Some("/home/eric"));
+        assert_eq!(
+            ubuntu.startup_command.as_deref(),
+            Some("source ~/.config/con/bootstrap.sh")
+        );
+        assert_eq!(ubuntu.theme.as_deref(), Some("flexoki-dark"));
+    }
+
+    #[test]
+    fn terminal_profiles_round_trip_through_toml() {
+        let content = r#"
+[profiles]
+default = "ubuntu"
+
+[[profiles.list]]
+id = "pwsh"
+name = "PowerShell"
+program = "pwsh.exe"
+args = ["-NoLogo"]
+starting_directory = "%USERPROFILE%"
+startup_command = "Invoke-ConBootstrap"
+theme = "flexoki-light"
+
+[[profiles.list]]
+id = "ubuntu"
+name = "Ubuntu 24.04"
+kind = "wsl"
+distribution = "Ubuntu-24.04"
+program = "/bin/zsh"
+args = ["-l"]
+theme = "flexoki-dark"
+"#;
+        let original: Config = toml::from_str(content).unwrap();
+        let encoded = toml::to_string_pretty(&original).unwrap();
+        let decoded: Config = toml::from_str(&encoded).unwrap();
+
+        assert_eq!(decoded.profiles, original.profiles);
+        assert!(encoded.contains("[[profiles.list]]"));
+        assert!(encoded.contains("kind = \"wsl\""));
+        assert!(!encoded.contains("kind = \"shell\""));
     }
 
     #[test]


### PR DESCRIPTION
## 背景

这是 #274 的第一阶段：先定义 Terminal Profile 的配置契约，后续再接入设置界面、终端创建流程和各平台运行时。

## 本 PR 做了什么

- 新增顶层 `profiles` 配置：
  - `default`：新建终端时使用的 Profile ID
  - `list`：按菜单顺序保存 Profile
- 新增 `TerminalProfileConfig`：
  - `id`、`name`
  - `kind = "shell" | "wsl"`
  - `program`、`args`
  - `starting_directory`
  - `startup_command`
  - `distribution`（WSL）
  - `theme`
- 使用结构化的 `program + args`，避免把平台相关的命令行转义提前固化进配置格式。
- 空配置不会序列化出 `[profiles]`，旧配置仍保持当前的平台 Shell 自动发现行为。
- 增加旧配置兼容、默认值、Shell/WSL 解析及 TOML round-trip 单元测试。

## 配置示例

```toml
[profiles]
default = "ubuntu"

[[profiles.list]]
id = "pwsh"
name = "PowerShell"
program = "pwsh.exe"
args = ["-NoLogo"]
starting_directory = "%USERPROFILE%"
startup_command = "Invoke-ConBootstrap"
theme = "flexoki-light"

[[profiles.list]]
id = "ubuntu"
name = "Ubuntu 24.04"
kind = "wsl"
distribution = "Ubuntu-24.04"
program = "/bin/zsh"
args = ["-l"]
theme = "flexoki-dark"
```

## 明确不在本 PR 范围内

- 不读取或应用 Profile 启动终端
- 不实现 WSL Distribution 发现与启动参数转换
- 不增加 Settings UI 的 Profile CRUD
- 不应用每个 Profile 的终端主题
- 不改动 Workspace Layout Profile；两者仍是不同概念

## 验证

- ✅ `cargo fmt -p con-core -- --check`
- ✅ `cargo test -p con-core`（93 passed）
- ⚠️ `cargo check -p con` 在构建 `con-ghostty` 前置步骤被本机 Zig 版本拦截：当前为 0.16.0，仓库要求 0.15.2
- ⚠️ `cargo fmt --all -- --check` 仍会命中本分支未修改的既有格式差异：`crates/con-app/src/workspace/render.rs`

Part of #274