### PR TITLE
fix(flatpak): restore publish workflow execution

### DIFF
--- a/.github/workflows/publish-flatpak.yml
+++ b/.github/workflows/publish-flatpak.yml
@@ -86,7 +86,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install Zig Compiler
-        uses: mitchellh/setup-zig@v1
+        uses: mlugg/setup-zig@v2.2.1
         with:
           version: 0.15.2
 
@@ -102,7 +102,7 @@ jobs:
       - name: Audit Dynamic Library Dependencies
         run: |
           set -euo pipefail
-          stage_dir="$(ls -td dist/con-*-linux-* 2>/dev/null | head -1 || true)"
+          stage_dir="$(find dist -maxdepth 1 -type d -name 'con-*-linux-*' -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -1 | cut -d' ' -f2- || true)"
           if [[ -n "${stage_dir}" && -d "${stage_dir}" ]]; then
             echo "==> Auditing dynamic library linkage in ${stage_dir}..."
             for bin in "${stage_dir}/con" "${stage_dir}/con-cli"; do


### PR DESCRIPTION
## Summary

Fix the post-merge Flatpak publisher discovered on `main` after #276.

- Replace the nonexistent `mitchellh/setup-zig@v1` action with the pinned, valid `mlugg/setup-zig@v2.2.1` action.
- Keep Zig pinned to `0.15.2`.
- Replace the `ls -td` staging-directory lookup with an explicit `find`/mtime lookup so the workflow passes shellcheck and handles paths predictably.

## Validation

- `actionlint .github/workflows/publish-flatpak.yml`
- `git diff --check`

The failure was observed in run `32693668997`: both architecture jobs failed during job setup because GitHub could not resolve `mitchellh/setup-zig`.
