### PR TITLE
fix(flatpak): avoid container Git ownership failure

### DIFF
--- a/.github/workflows/publish-flatpak.yml
+++ b/.github/workflows/publish-flatpak.yml
@@ -73,7 +73,7 @@ jobs:
             echo "version=$version" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.ref_name }}" == "main" ]]; then
             # Main branch build -> unstable
-            short_sha="$(git rev-parse --short HEAD)"
+            short_sha="${GITHUB_SHA:0:7}"
             echo "channel=unstable" >> "$GITHUB_OUTPUT"
             echo "version=0.1.0-unstable-${short_sha}" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary

Fix the second post-merge failure in the Flatpak publisher.

The AetherPak builder runs inside a container whose checkout ownership differs from the runner user. The metadata step called `git rev-parse`, which Git rejected as a dubious repository. Use the trusted `GITHUB_SHA` provided by Actions instead; this avoids changing global `safe.directory` and removes the container-specific Git dependency.

## Validation

- `actionlint .github/workflows/publish-flatpak.yml`
- `git diff --check`

Observed in run `32693812787`, after #278 fixed the invalid Zig action.
