### PR TITLE
fix(linux): make Zig AArch64 linker compatible

### DIFF
--- a/.github/workflows/publish-flatpak.yml
+++ b/.github/workflows/publish-flatpak.yml
@@ -90,6 +90,33 @@ jobs:
         with:
           version: 0.15.2
 
+      - name: Configure Zig C toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          tool_dir="$RUNNER_TEMP/con-zig-tools"
+          mkdir -p "$tool_dir"
+
+          # The AetherPak builder intentionally stays minimal and does not
+          # provide a host C compiler. Keep native C build scripts (for
+          # example aws-lc-sys) deterministic without adding an apt-based
+          # toolchain to the image.
+          cat > "$tool_dir/cc" <<'EOF'
+          #!/usr/bin/env bash
+          exec zig cc "$@"
+          EOF
+          cat > "$tool_dir/c++" <<'EOF'
+          #!/usr/bin/env bash
+          exec zig c++ "$@"
+          EOF
+          chmod +x "$tool_dir/cc" "$tool_dir/c++"
+          ln -sf cc "$tool_dir/clang"
+          ln -sf c++ "$tool_dir/clang++"
+
+          echo "$tool_dir" >> "$GITHUB_PATH"
+          echo "CC=$tool_dir/cc" >> "$GITHUB_ENV"
+          echo "CXX=$tool_dir/c++" >> "$GITHUB_ENV"
+
       - name: Compile Release Binaries
         env:
           CON_RELEASE_VERSION: ${{ steps.meta.outputs.version }}

--- a/scripts/linux/release.sh
+++ b/scripts/linux/release.sh
@@ -119,7 +119,17 @@ if [[ -n "$zig_bin" ]]; then
     esac
     cat > "$linker_wrapper" <<EOF
 #!/bin/bash
-exec "$zig_bin" cc -target "$zig_target" -L"$repo_root/target/syslibs" "\$@"
+args=()
+for arg in "\$@"; do
+  # Rust's aarch64 target adds this GNU ld workaround by default. Zig's
+  # lld does not implement it; dropping only this optional flag keeps the
+  # rest of the linker invocation and ABI unchanged.
+  if [[ "\$arg" == "-Wl,--fix-cortex-a53-843419" ]]; then
+    continue
+  fi
+  args+=("\$arg")
+done
+exec "$zig_bin" cc -target "$zig_target" -L"$repo_root/target/syslibs" "\${args[@]}"
 EOF
     chmod +x "$linker_wrapper"
   fi


### PR DESCRIPTION
## Summary

Fix the AArch64 Flatpak release build after the previous workflow fixes exposed the actual linker invocation.

Rust adds `-Wl,--fix-cortex-a53-843419` to the standard AArch64 target link command. Zig 0.15.2's lld backend rejects this GNU ld-only optional flag. The release wrapper now removes only that exact flag before invoking Zig; all other linker arguments, target selection, sysroot compatibility, and ABI flags are preserved.

## Evidence

Run `32693927191`:
- x86_64 reached the build successfully.
- aarch64 failed during the first Rust build-script link with `unsupported linker arg: --fix-cortex-a53-843419`.

## Validation

- `bash -n scripts/linux/release.sh`
- `git diff --check`
