### PR TITLE
fix(flatpak): support builder package managers

### DIFF
--- a/.github/workflows/publish-flatpak.yml
+++ b/.github/workflows/publish-flatpak.yml
@@ -138,12 +138,24 @@ jobs:
           echo "CXX=$tool_dir/c++" >> "$GITHUB_ENV"
 
       - name: Install Linux build dependencies
+        shell: bash
         run: |
           set -euo pipefail
-          apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-            pkg-config \
-            libfontconfig1-dev
+          if command -v apk >/dev/null 2>&1; then
+            apk add --no-cache pkgconf fontconfig-dev
+          elif command -v apt-get >/dev/null 2>&1; then
+            apt-get update
+            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+              pkg-config \
+              libfontconfig1-dev
+          elif command -v dnf >/dev/null 2>&1; then
+            dnf install -y pkgconf-pkg-config fontconfig-devel
+          elif command -v microdnf >/dev/null 2>&1; then
+            microdnf install -y pkgconf-pkg-config fontconfig-devel
+          else
+            echo "no supported Linux package manager found for fontconfig dependencies" >&2
+            exit 1
+          fi
 
       - name: Compile Release Binaries
         env:


### PR DESCRIPTION
The AetherPak builder image is Alpine-based and has no `apt-get`, so #282 still failed before compilation. Select the package manager available in the container and install the matching `pkg-config`/fontconfig development packages: apk, apt-get, dnf, or microdnf.

This keeps the Flatpak release workflow portable across builder image changes without touching runtime packaging or application code.