### PR TITLE
fix(flatpak): install Linux UI linker dependencies

### DIFF
--- a/.github/workflows/publish-flatpak.yml
+++ b/.github/workflows/publish-flatpak.yml
@@ -142,16 +142,34 @@ jobs:
         run: |
           set -euo pipefail
           if command -v apk >/dev/null 2>&1; then
-            apk add --no-cache pkgconf fontconfig-dev
+            apk add --no-cache \
+              pkgconf \
+              fontconfig-dev \
+              libxkbcommon-dev \
+              libxkbcommon-x11 \
+              libxcb-dev
           elif command -v apt-get >/dev/null 2>&1; then
             apt-get update
             DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
               pkg-config \
-              libfontconfig1-dev
+              libfontconfig1-dev \
+              libxkbcommon-dev \
+              libxkbcommon-x11-dev \
+              libxcb1-dev
           elif command -v dnf >/dev/null 2>&1; then
-            dnf install -y pkgconf-pkg-config fontconfig-devel
+            dnf install -y \
+              pkgconf-pkg-config \
+              fontconfig-devel \
+              libxkbcommon-devel \
+              libxkbcommon-x11-devel \
+              libxcb-devel
           elif command -v microdnf >/dev/null 2>&1; then
-            microdnf install -y pkgconf-pkg-config fontconfig-devel
+            microdnf install -y \
+              pkgconf-pkg-config \
+              fontconfig-devel \
+              libxkbcommon-devel \
+              libxkbcommon-x11-devel \
+              libxcb-devel
           else
             echo "no supported Linux package manager found for fontconfig dependencies" >&2
             exit 1


### PR DESCRIPTION
The Alpine builder now gets fontconfig, but the final GPUI link still cannot resolve `xkbcommon` and `xkbcommon-x11`. Install the matching xkbcommon/x11/xcb development packages for Alpine, Debian, and Fedora-family builders.

This completes the system linker prerequisites for the Flatpak binary and does not change application code or runtime dependencies.