### PR TITLE
fix(flatpak): keep channel mapping keys Viper-safe

### DIFF
--- a/packaging/flatpak/aetherpak.yaml
+++ b/packaging/flatpak/aetherpak.yaml
@@ -7,8 +7,11 @@ repo_title: "con Flatpak Repository"
 repo_homepage: https://con.nowledge.co/
 
 channel_mappings:
-  "v*-beta.*": "beta"
-  "v*-dev.*": "dev"
+  # Keep dots out of mapping keys: Viper treats dots in map keys as
+  # hierarchical separators, while these glob patterns only need to
+  # distinguish the channel prefix.
+  "v*-beta*": "beta"
+  "v*-dev*": "dev"
   "v*": "stable"
   "main": "unstable"
   "nightly": "nightly"


### PR DESCRIPTION
AetherPak correctly expects `channel_mappings` as `map[string]string`, but Viper interprets dots in YAML map keys as hierarchy separators. The existing `v*-beta.*` and `v*-dev.*` keys therefore decode as nested maps.

Use equivalent prefix globs without dots (`v*-beta*` and `v*-dev*`) so beta/dev tags still route to the same branches and the configuration decodes successfully.