### PR TITLE
fix(flatpak): force publishing prebuilt bundles

### DIFF
--- a/.github/workflows/publish-flatpak.yml
+++ b/.github/workflows/publish-flatpak.yml
@@ -229,6 +229,10 @@ jobs:
     uses: aetherpak/actions/.github/workflows/publish.yml@v3
     with:
       config: packaging/flatpak/aetherpak.yaml
+      # The binaries are built by this workflow and passed in as prebuilt
+      # bundles. Do not let AetherPak's source-change detector skip importing
+      # them when only release metadata or channel configuration changed.
+      force-all: true
       prebuilt-bundle-artifact: flatpak-bundle-{app-id}-{arch}
       pages-url: https://con-releases.nowledge.co
       site-subpath: flatpak


### PR DESCRIPTION
The release workflow compiles and uploads prebuilt bundles before calling AetherPak publish. AetherPak plan uses source-change detection and returned `count: 0` for release-only/channel-config changes, so it skipped the publish matrix and never produced the site artifact.

Set `force-all: true` for this prebuilt-bundle path so every successful architecture build is imported and published. Keep `deploy: false` because this repository owns the final gh-pages merge in the following job.