### PR TITLE
fix(flatpak): publish verified native bundles

### DIFF
--- a/.github/workflows/ci-portable.yml
+++ b/.github/workflows/ci-portable.yml
@@ -18,6 +18,7 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/ci-portable.yml"
+      - ".github/workflows/publish-flatpak.yml"
       - ".github/workflows/release-*.yml"
       - ".cargo/**"
       - "Cargo.toml"
@@ -29,6 +30,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/ci-portable.yml"
+      - ".github/workflows/publish-flatpak.yml"
       - ".github/workflows/release-*.yml"
       - ".cargo/**"
       - "Cargo.toml"

--- a/.github/workflows/publish-flatpak.yml
+++ b/.github/workflows/publish-flatpak.yml
@@ -33,8 +33,35 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  release-channel:
+    name: Resolve release channel
+    runs-on: ubuntu-latest
+    outputs:
+      channel: ${{ steps.channel.outputs.channel }}
+    steps:
+      - name: Resolve channel
+        id: channel
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            channel="nightly"
+          elif [[ "${{ github.ref_type }}" == "tag" ]]; then
+            case "$GITHUB_REF_NAME" in
+              v*-beta.*) channel="beta" ;;
+              v*-dev.*) channel="dev" ;;
+              *)         channel="stable" ;;
+            esac
+          elif [[ "${{ github.ref_name }}" == "main" ]]; then
+            channel="unstable"
+          else
+            channel="unstable"
+          fi
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+
   build-flatpak:
     name: Build Flatpak (${{ matrix.arch }})
+    needs: release-channel
     runs-on: ${{ matrix.runner }}
     container:
       image: ghcr.io/aetherpak/cli:v0.33.2-builder
@@ -225,10 +252,11 @@ jobs:
 
   publish-repo:
     name: Publish Repository
-    needs: build-flatpak
+    needs: [release-channel, build-flatpak]
     uses: aetherpak/actions/.github/workflows/publish.yml@v3
     with:
-      config: packaging/flatpak/aetherpak.yaml
+      config: packaging/flatpak/aetherpak-publish.yaml
+      branch: ${{ needs.release-channel.outputs.channel }}
       # The binaries are built by this workflow and passed in as prebuilt
       # bundles. Do not let AetherPak's source-change detector skip importing
       # them when only release metadata or channel configuration changed.

--- a/packaging/flatpak/aetherpak-publish.yaml
+++ b/packaging/flatpak/aetherpak-publish.yaml
@@ -1,0 +1,39 @@
+# Repository-side view of the Flatpak publication.
+#
+# The release workflow builds and smoke-tests the bundles in a separate native
+# job, then passes them to AetherPak through `prebuilt-bundle-artifact`. The
+# reusable publisher still requires URL/checksum fields to plan a bundle
+# matrix, so these values are deliberately inert placeholders: that workflow
+# input always supplies the local, verified bundle and the URLs are never
+# fetched. Keep this file separate from aetherpak.yaml, which is the build
+# configuration used to assemble the bundles.
+registry: ghcr.io
+pages_url: https://con-releases.nowledge.co
+oci_repository: nowledge-co/con-terminal
+remote_name: con-terminal
+repo_title: "con Flatpak Repository"
+repo_homepage: https://con.nowledge.co/
+
+channel_mappings:
+  "v*-beta*": "beta"
+  "v*-dev*": "dev"
+  "v*": "stable"
+  "main": "unstable"
+  "nightly": "nightly"
+
+branding:
+  logo_url: "https://con.nowledge.co/assets/icon_con_192.png"
+  favicon_url: "https://con.nowledge.co/assets/icon_con_192.png"
+  accent_color: "#ffc798"
+  footer_text: "&copy; 2026 Nowledge Labs"
+  index_template: "packaging/flatpak/index-template.html"
+
+apps:
+  - id: co.nowledge.con
+    bundles:
+      x86_64:
+        url: "https://github.com/nowledge-co/con-terminal/actions"
+        sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+      aarch64:
+        url: "https://github.com/nowledge-co/con-terminal/actions"
+        sha256: "0000000000000000000000000000000000000000000000000000000000000000"


### PR DESCRIPTION
## Summary
- publish the native, smoke-tested Flatpak bundles instead of rebuilding from a clean AetherPak container
- keep build and publication configurations explicit and separate
- resolve the release channel once and pass it to AetherPak so unstable, beta, dev, nightly, and stable do not collapse into one branch

## Why
The release workflow successfully built both native bundles, but the reusable publisher classified the repository's zero-manifest config as a manifest build and then failed because `target/release/con` is not present in its isolated job. This uses AetherPak's supported bundle-import matrix with the already verified workflow artifacts.

## Verification
- `actionlint .github/workflows/publish-flatpak.yml`
- Ruby YAML parsing for workflow and both AetherPak configs
- AetherPak v0.33.2 plan validation against the bundle-source shape
- no cross compilation

Follow-up for run `32699161846`: the two native build jobs passed; publication failed at the isolated manifest rebuild, which this PR removes.
