### PR TITLE
fix(macos): deliver OSC 9 and 777 desktop notifications

### DIFF
--- a/crates/con-ghostty/build.rs
+++ b/crates/con-ghostty/build.rs
@@ -68,6 +68,14 @@ fn build_macos() {
     let zig_bin = env::var_os("CON_ZIG_BIN").unwrap_or_else(|| std::ffi::OsString::from("zig"));
     let zig_global_cache_dir = zig_global_cache_dir("macos");
 
+    cc::Build::new()
+        .file("src/objc/desktop_notification.m")
+        .flag("-fobjc-arc")
+        .flag("-fblocks")
+        .flag("-fmodules")
+        .compile("con_ghostty_objc_trampolines");
+    println!("cargo:rerun-if-changed=src/objc/desktop_notification.m");
+
     let build_args = vec![
         "build".to_string(),
         "-Dapp-runtime=none".to_string(),
@@ -124,6 +132,7 @@ fn build_macos() {
         "IOSurface",
         "QuartzCore",
         "Carbon",
+        "UserNotifications",
     ] {
         println!("cargo:rustc-link-lib=framework={}", framework);
     }

--- a/crates/con-ghostty/src/ffi.rs
+++ b/crates/con-ghostty/src/ffi.rs
@@ -336,6 +336,14 @@ pub enum ghostty_action_tag_e {
     GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD,
 }
 
+/// Action payload for DESKTOP_NOTIFICATION (OSC 9 and OSC 777).
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct ghostty_action_desktop_notification_s {
+    pub title: *const c_char,
+    pub body: *const c_char,
+}
+
 /// Action payload for SET_TITLE.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
@@ -394,13 +402,11 @@ pub union ghostty_action_u {
     pub goto_split: ghostty_action_goto_split_e,
     pub resize_split: ghostty_action_resize_split_s,
     pub scrollbar: ghostty_action_scrollbar_s,
+    pub desktop_notification: ghostty_action_desktop_notification_s,
     pub set_title: ghostty_action_set_title_s,
     pub pwd: ghostty_action_pwd_s,
     pub command_finished: ghostty_action_command_finished_s,
     pub open_url: ghostty_action_open_url_s,
-    // The union size is determined by the largest variant in ghostty.h;
-    // we pad to ensure correct size.
-    pub _pad: [u8; 128],
 }
 
 #[repr(C)]
@@ -408,6 +414,12 @@ pub struct ghostty_action_s {
     pub tag: ghostty_action_tag_e,
     pub action: ghostty_action_u,
 }
+
+// The action is passed by value to ghostty_runtime_action_cb, so these sizes
+// must exactly match ghostty.h at the pinned Ghostty revision.
+const _: [(); 16] = [(); std::mem::size_of::<ghostty_action_desktop_notification_s>()];
+const _: [(); 24] = [(); std::mem::size_of::<ghostty_action_u>()];
+const _: [(); 32] = [(); std::mem::size_of::<ghostty_action_s>()];
 
 // ── Clipboard types ─────────────────────────────────────────
 

--- a/crates/con-ghostty/src/objc/desktop_notification.m
+++ b/crates/con-ghostty/src/objc/desktop_notification.m
@@ -1,0 +1,46 @@
+#import <Foundation/Foundation.h>
+#import <UserNotifications/UserNotifications.h>
+#include <stdbool.h>
+
+bool con_ghostty_show_desktop_notification(const char *title, const char *body) {
+    if (title == NULL || body == NULL) {
+        return false;
+    }
+
+    NSString *notificationTitle = [NSString stringWithUTF8String:title];
+    NSString *notificationBody = [NSString stringWithUTF8String:body];
+    if (notificationTitle == nil || notificationBody == nil) {
+        return false;
+    }
+
+    UNUserNotificationCenter *center = UNUserNotificationCenter.currentNotificationCenter;
+    UNAuthorizationOptions options = UNAuthorizationOptionAlert | UNAuthorizationOptionSound;
+    [center requestAuthorizationWithOptions:options
+                          completionHandler:^(BOOL granted, NSError *error) {
+        if (error != nil) {
+            NSLog(@"[con-notification] authorization failed: %@", error);
+            return;
+        }
+        if (!granted) {
+            return;
+        }
+
+        UNMutableNotificationContent *content = [[UNMutableNotificationContent alloc] init];
+        content.title = notificationTitle;
+        content.body = notificationBody;
+        content.sound = UNNotificationSound.defaultSound;
+
+        UNNotificationRequest *request = [UNNotificationRequest
+            requestWithIdentifier:NSUUID.UUID.UUIDString
+                           content:content
+                           trigger:nil];
+        [center addNotificationRequest:request
+                 withCompletionHandler:^(NSError *scheduleError) {
+            if (scheduleError != nil) {
+                NSLog(@"[con-notification] scheduling failed: %@", scheduleError);
+            }
+        }];
+    }];
+
+    return true;
+}

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -1440,6 +1440,10 @@ unsafe extern "C" fn action_callback(
                 });
                 true
             }
+            ffi::ghostty_action_tag_e::GHOSTTY_ACTION_DESKTOP_NOTIFICATION => {
+                let notification = action.action.desktop_notification;
+                con_ghostty_show_desktop_notification(notification.title, notification.body)
+            }
             ffi::ghostty_action_tag_e::GHOSTTY_ACTION_NEW_SPLIT => {
                 let direction = match action.action.new_split {
                     ffi::ghostty_action_split_direction_e::GHOSTTY_SPLIT_DIRECTION_RIGHT => {
@@ -1524,6 +1528,13 @@ unsafe extern "C" fn action_callback(
             _ => false,
         }
     }
+}
+
+unsafe extern "C" {
+    fn con_ghostty_show_desktop_notification(
+        title: *const std::os::raw::c_char,
+        body: *const std::os::raw::c_char,
+    ) -> bool;
 }
 
 /// Clipboard read — ghostty wants to paste. Read from macOS pasteboard and complete the request.

--- a/postmortem/2026-08-25-macos-osc-desktop-notifications.md
+++ b/postmortem/2026-08-25-macos-osc-desktop-notifications.md
@@ -1,0 +1,43 @@
+# macOS OSC desktop notifications were dropped
+
+## What happened
+
+Terminal applications could emit OSC 9 or OSC 777 desktop notifications, and
+the embedded Ghostty runtime parsed them, but Con never displayed a macOS
+notification or requested notification permission. The runtime action callback
+reported the action as unhandled.
+
+## Root cause
+
+Con's hand-written Rust mirror of `ghostty.h` declared the
+`GHOSTTY_ACTION_DESKTOP_NOTIFICATION` tag but omitted its `title` and `body`
+payload from the action union. `action_callback` consequently had no matching
+handler and returned `false`.
+
+The FFI union also contained a synthetic 128-byte padding member. At the pinned
+Ghostty revision the C union is 24 bytes, so Con's by-value callback argument
+was 136 bytes instead of the header's 32 bytes. Reading only the leading fields
+had hidden the mismatch, but it was not an ABI-safe representation.
+
+## Fix applied
+
+The Rust bindings now mirror the desktop-notification payload and enforce the
+pinned header's payload, union, and action sizes at compile time. The action
+callback forwards the borrowed, NUL-terminated UTF-8 strings synchronously to a
+small Objective-C bridge, which copies them into `NSString` values before the
+callback returns.
+
+The bridge uses `UNUserNotificationCenter` to request alert and sound
+authorization asynchronously. When authorization succeeds, it schedules the
+same notification immediately with a unique identifier. No permission or
+notification work blocks Ghostty's main-thread tick.
+
+## What we learned
+
+- A C union passed by value must match the upstream size exactly; oversized
+  "safety" padding changes the ABI rather than making it safer.
+- Borrowed callback strings must be copied before any asynchronous native API
+  captures them.
+- Native permission requests should preserve the triggering notification so a
+  first-time user does not approve notifications only to lose the event that
+  caused the prompt.


### PR DESCRIPTION
## Summary

- Deliver macOS desktop notifications emitted by Ghostty for OSC 9 and OSC 777.
- Request alert and sound permission through `UNUserNotificationCenter`, then preserve and schedule the notification that triggered the first permission request.
- Correct Con's Rust mirror of the by-value Ghostty action ABI and add compile-time size checks for the pinned header.

Fixes #289.

## Root cause

Ghostty already parsed OSC 9 and OSC 777 and emitted `GHOSTTY_ACTION_DESKTOP_NOTIFICATION`, but Con did not mirror the notification payload or handle that action in its runtime callback. The callback therefore reported the action as unhandled.

The Rust action union also had a synthetic 128-byte padding member. Because Ghostty passes this action by value, that padding made Con's representation 136 bytes while the pinned C header defines a 32-byte action.

## Implementation

- Mirror `ghostty_action_desktop_notification_s` and its action union member.
- Remove the synthetic union padding and assert the notification payload, union, and action sizes at compile time.
- Forward notification actions to a small Objective-C bridge backed by `UNUserNotificationCenter`.
- Copy Ghostty's borrowed title and body strings before starting asynchronous permission and scheduling work.
- Link the macOS build against `UserNotifications.framework`.

## Testing

- `cargo fmt --all -- --check`
- `CON_ZIG_BIN=/opt/homebrew/opt/zig@0.15/bin/zig cargo test -p con-ghostty`
- `CON_ZIG_BIN=/opt/homebrew/opt/zig@0.15/bin/zig CON_CHANNEL=dev ./scripts/macos/build-app.sh`
- Confirmed OSC 777 and OSC 9 notification banners in a locally signed development app on macOS 27.

<img width="392" height="92" alt="Zed 2026-08-25 14 26 38" src="https://github.com/user-attachments/assets/fb75f7b1-4a2a-4eaa-97c9-b719def584f4" />
<img width="381" height="95" alt="Zed 2026-08-25 14 26 39" src="https://github.com/user-attachments/assets/17bff159-5375-4a45-91cd-9018b8b24743" />
