### PR TITLE
fix(flatpak): point pruning at published index

### DIFF
--- a/.github/workflows/prune-flatpak.yml
+++ b/.github/workflows/prune-flatpak.yml
@@ -22,7 +22,7 @@ jobs:
     with:
       registry: ghcr.io
       oci-repository: nowledge-co/con-terminal
-      pages-url: https://con-releases.nowledge.co
+      pages-url: https://con-releases.nowledge.co/flatpak
       dry-run: ${{ inputs.dry-run || false }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed
- Point the GHCR pruning workflow at the published Flatpak index under `/flatpak`.
- Keep the existing fail-closed guard so pruning aborts when the index cannot be fetched.

## Verification
- Confirmed `https://con-releases.nowledge.co/flatpak/index/static` returns HTTP 200 and the expected `Results` array.
- `git diff --check` and workflow validation pass.
- The latest scheduled failure was caused by the old root URL returning 404; no versions were deleted.