### PR TITLE
fix(release): prevent platform workflows cancelling each other

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -20,10 +20,6 @@ on:
 permissions:
   contents: write
 
-concurrency:
-  group: con-gh-pages-publish
-  cancel-in-progress: false
-
 jobs:
   build:
     name: Build linux-x86_64
@@ -226,6 +222,9 @@ jobs:
 
   update-appcast:
     name: Update Sparkle appcast (linux-x86_64)
+    concurrency:
+      group: con-gh-pages-publish
+      cancel-in-progress: false
     # Run on macOS because Sparkle's `sign_update` tool ships only in
     # the macOS Sparkle distribution. Identical pattern to
     # release-windows.yml's appcast job — same Ed25519 keypair, same

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -9,10 +9,6 @@ permissions:
   contents: write
   pages: write
 
-concurrency:
-  group: con-gh-pages-publish
-  cancel-in-progress: false
-
 jobs:
   build:
     name: Build ${{ matrix.arch }}
@@ -221,6 +217,9 @@ jobs:
 
   update-appcast:
     name: Update Sparkle appcast
+    concurrency:
+      group: con-gh-pages-publish
+      cancel-in-progress: false
     runs-on: macos-15
     needs: publish
 

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -17,10 +17,6 @@ on:
 permissions:
   contents: write
 
-concurrency:
-  group: con-gh-pages-publish
-  cancel-in-progress: false
-
 jobs:
   build:
     name: Build windows-x86_64
@@ -400,6 +396,9 @@ jobs:
 
   update-appcast:
     name: Update Sparkle appcast (windows-x86_64)
+    concurrency:
+      group: con-gh-pages-publish
+      cancel-in-progress: false
     # Run on macOS because Sparkle's `sign_update` tool ships only in
     # the macOS Sparkle distribution. The signing key is the same
     # Ed25519 keypair used for macOS artifacts — the Windows client

--- a/postmortem/2026-08-25-release-concurrency-cancellation.md
+++ b/postmortem/2026-08-25-release-concurrency-cancellation.md
@@ -1,0 +1,28 @@
+# Release workflows cancelled before building
+
+## What happened
+
+The first beta.85 tag triggered Linux, macOS, Windows, and Flatpak workflows,
+but only the first workflow acquired the repository's `con-gh-pages-publish`
+concurrency group. The remaining workflows were cancelled before GitHub created
+their jobs because a concurrency group allows only one running and one pending
+run; later pending runs replace earlier ones.
+
+## Root cause
+
+The concurrency group was declared at workflow scope in all three platform
+release workflows. That serialized platform builds, even though only the
+appcast update jobs write the shared `gh-pages` branch.
+
+## Fix applied
+
+The platform workflow-level locks were removed. The lock now applies only to
+each platform's `update-appcast` job. Platform builds and GitHub Release asset
+publishes can run concurrently; appcast writers remain serialized to protect
+the shared branch.
+
+## What we learned
+
+Concurrency should protect the smallest shared mutation, not the whole build
+pipeline. Release preflight must verify that every tag-triggered platform
+workflow has created jobs before treating a tag as publishable.


### PR DESCRIPTION
## Summary

- Scope the shared gh-pages concurrency lock to appcast update jobs.
- Allow Linux, macOS, Windows, and Flatpak builds to run concurrently.
- Document the beta.85 cancellation root cause in a postmortem.

The beta.85 tag exposed this: the workflow-level `con-gh-pages-publish` group
allowed one running and one pending run, so later platform workflows were
cancelled before creating jobs. Only appcast writers mutate the shared
gh-pages branch and need serialization.
