### PR TITLE
feat(appearance): add setting to keep window open when closing last tab

### DIFF
--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -216,6 +216,7 @@ pub struct SettingsPanel {
     background_image_fit_select: Entity<SelectState<Vec<String>>>,
     background_image_repeat: bool,
     hide_pane_title_bar: bool,
+    close_to_quit: bool,
     save_error: Option<String>,
     save_error_kind: Option<SettingsSaveErrorKind>,
     last_saved_at: Option<std::time::SystemTime>,
@@ -1654,6 +1655,7 @@ impl SettingsPanel {
             background_image_fit_select,
             background_image_repeat: config.appearance.background_image_repeat,
             hide_pane_title_bar: config.appearance.hide_pane_title_bar,
+            close_to_quit: config.appearance.close_to_quit,
             save_error: None,
             save_error_kind: None,
             last_saved_at: std::fs::metadata(Config::config_path())
@@ -1868,6 +1870,7 @@ impl SettingsPanel {
         });
         self.background_image_repeat = self.config.appearance.background_image_repeat;
         self.hide_pane_title_bar = self.config.appearance.hide_pane_title_bar;
+        self.close_to_quit = self.config.appearance.close_to_quit;
         self.provider_model_fetching = false;
         self.provider_model_status = None;
         self.provider_model_status_error = false;
@@ -3818,6 +3821,38 @@ impl SettingsPanel {
                                     }
                                     if let Some(snapshot) = &mut this.preview_snapshot {
                                         snapshot.appearance.hide_pane_title_bar = *checked;
+                                    }
+                                    this.save_error = None;
+                                    this.save_error_kind = None;
+                                    cx.emit(AppearancePreview);
+                                    cx.notify();
+                                })),
+                            theme,
+                        ))
+                        .child(row_separator(theme))
+                        .child(toggle_row(
+                            "Quit on Last Tab Close",
+                            "Close the window when the last tab is closed. When off, a fresh tab opens instead.",
+                            Switch::new("close-to-quit-toggle")
+                                .checked(self.close_to_quit)
+                                .small()
+                                .on_click(cx.listener(|this, checked: &bool, _, cx| {
+                                    let previous = this.config.appearance.close_to_quit;
+                                    this.close_to_quit = *checked;
+                                    this.config.appearance.close_to_quit = *checked;
+                                    if let Err(err) = this.config.save() {
+                                        this.close_to_quit = previous;
+                                        this.config.appearance.close_to_quit = previous;
+                                        log::warn!(
+                                            "settings: persist close_to_quit failed: {err}"
+                                        );
+                                        this.save_error = Some(err.to_string());
+                                        this.save_error_kind = Some(SettingsSaveErrorKind::Other);
+                                        cx.notify();
+                                        return;
+                                    }
+                                    if let Some(snapshot) = &mut this.preview_snapshot {
+                                        snapshot.appearance.close_to_quit = *checked;
                                     }
                                     this.save_error = None;
                                     this.save_error_kind = None;

--- a/crates/con-app/src/workspace/window_actions.rs
+++ b/crates/con-app/src/workspace/window_actions.rs
@@ -565,6 +565,17 @@ impl ConWorkspace {
                 return;
             }
 
+            if !self.config.appearance.close_to_quit {
+                // Keep the window open: create a fresh tab, then close the
+                // old one. Creating the new tab first lets it inherit the
+                // current working directory before the old terminal is torn
+                // down. After new_tab we have two tabs (old at 0, new at 1),
+                // so the recursive close takes the normal multi-tab path.
+                self.new_tab(&NewTab, window, cx);
+                self.close_tab_by_index(0, window, cx);
+                return;
+            }
+
             self.close_window_from_last_tab(window, cx);
             return;
         }

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -123,6 +123,10 @@ pub struct AppearanceConfig {
     /// Workspace tab presentation. Vertical is the default; horizontal remains
     /// available for users who prefer a top tab strip.
     pub tabs_orientation: TabsOrientation,
+    /// When `true` (default), closing the last tab closes the window (and
+    /// quits the app on Windows/Linux). When `false`, closing the last tab
+    /// opens a fresh tab instead so the window stays open.
+    pub close_to_quit: bool,
 }
 
 impl Default for AppearanceConfig {
@@ -143,6 +147,7 @@ impl Default for AppearanceConfig {
             restore_terminal_text: default_restore_terminal_text(),
             hide_pane_title_bar: false,
             tabs_orientation: TabsOrientation::Vertical,
+            close_to_quit: true,
         }
     }
 }
@@ -1255,6 +1260,38 @@ tabs_orientation = "horizontal"
             config.appearance.tabs_orientation,
             TabsOrientation::Horizontal
         );
+    }
+
+    #[test]
+    fn close_to_quit_defaults_to_true() {
+        let config = Config::default();
+        assert!(config.appearance.close_to_quit);
+    }
+
+    #[test]
+    fn omitted_close_to_quit_defaults_to_true() {
+        let content = r#"
+[appearance]
+terminal_opacity = 0.8
+"#;
+        let config: Config = toml::from_str(content).unwrap();
+        assert!(config.appearance.close_to_quit);
+    }
+
+    #[test]
+    fn close_to_quit_is_preserved_when_set_false() {
+        let content = r#"
+[appearance]
+close_to_quit = false
+"#;
+        let config: Config = toml::from_str(content).unwrap();
+        assert!(!config.appearance.close_to_quit);
+
+        // Round-trip through serialization.
+        let serialized = toml::to_string(&config).unwrap();
+        assert!(serialized.contains("close_to_quit = false"));
+        let reparsed: Config = toml::from_str(&serialized).unwrap();
+        assert!(!reparsed.appearance.close_to_quit);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

<img width="2064" height="1584" alt="1d675543-b9bf-481e-a253-01da188c6e4b" src="https://github.com/user-attachments/assets/088c41a5-5fec-4d26-b24a-c45f962a9d79" />


Adds a new `appearance.close_to_quit` setting (default `true`) that controls what happens when the **last tab** in a window is closed.

- **`true` (default, unchanged behavior):** closing the last tab closes the window (and quits the app on Windows/Linux).
- **`false`:** closing the last tab opens a fresh tab instead, so the window stays open and the app keeps running.

## Motivation

Closes #236 — "Add setting to not close the app when the last tab is closed".

## Changes

- `con-core`: add `AppearanceConfig::close_to_quit` field with default + TOML round-trip unit tests.
- `con-app`: in `close_tab_by_index`, when the last tab is closed and `close_to_quit` is `false`, create a new tab (inheriting the current working directory) before tearing down the old one, instead of closing the window.
- `con-app`: add a "Quit on Last Tab Close" toggle to the Settings → Appearance panel, wired to save + preview the config value immediately.

## Behavior detail

When `close_to_quit = false`, the fresh tab inherits the closing tab's working directory (the new tab is created first, before the old terminal is shut down), matching the "reopen a terminal where I was" expectation.

## Testing

- `cargo test -p con-core` — 35 tests pass, including 3 new ones:
  - `close_to_quit_defaults_to_true`
  - `omitted_close_to_quit_defaults_to_true`
  - `close_to_quit_is_preserved_when_set_false`
- Verified the app builds on macOS (x86_64) via CI on `macos-15-intel`.

## Config example

```toml
[appearance]
close_to_quit = false
```

Closes #236
