### PR TITLE
 feat: upgrade libghostty and add portable Kitty protocol support

### DIFF
--- a/.github/workflows/ci-portable.yml
+++ b/.github/workflows/ci-portable.yml
@@ -7,11 +7,11 @@ name: ci-portable
 #   - con-cli   (control client, Unix socket + named pipe transport)
 #   - con-agent (tokio, rig)
 #   - con-terminal (theme helpers)
-#   - con-ghostty  (stub backend on non-macOS, libghostty wrapper on macOS)
-#   - con          (the UI binary — stub terminal view on non-macOS)
+#   - con-ghostty  (real libghostty-vt backend on Windows and Linux)
+#   - con          (the cross-platform UI binary)
 #
-# Jobs run `cargo check` (not `cargo build`) to keep CI fast; they also
-# run the test suite for crates that can run hermetic tests on the host.
+# Jobs run both checks and linked tests so libghostty-vt ABI or symbol drift
+# cannot hide behind Cargo's non-linking `check` path.
 
 on:
   push:
@@ -58,14 +58,9 @@ jobs:
     # the ancestor directory is still `con`. We sidestep the whole tree
     # by cloning into C:\src\repo outside $GITHUB_WORKSPACE and pointing
     # every subsequent step there.
-    #
-    # CON_SKIP_GHOSTTY_VT tells con-ghostty's build.rs to skip the
-    # zig-driven libghostty-vt build. `cargo check` doesn't link, so
-    # unresolved symbols don't matter; Zig 0.13+ isn't preinstalled on
-    # windows-latest images so trying to build would panic.
     env:
-      CON_SKIP_GHOSTTY_VT: "1"
       CON_CHECKOUT_DIR: C:\src\repo
+      ZIG_GLOBAL_CACHE_DIR: C:\zc
     defaults:
       run:
         working-directory: C:\src\repo
@@ -88,6 +83,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: C:\src\repo
+      - name: Prepare short-path Zig cache
+        working-directory: C:\
+        shell: pwsh
+        run: New-Item -ItemType Directory -Force -Path $env:ZIG_GLOBAL_CACHE_DIR | Out-Null
+      - name: Install Zig 0.16.0
+        uses: mlugg/setup-zig@v2.2.1
+        with:
+          version: 0.16.0
       - name: PowerShell installer parse check
         shell: pwsh
         run: |
@@ -104,14 +107,14 @@ jobs:
           }
       - name: cargo check — portable crates
         run: cargo check -p con-core -p con-cli -p con-agent -p con-terminal -p con-ghostty
-      - name: cargo check — UI binary (stub terminal backend)
+      - name: cargo check — UI binary
         # The default `bin-con` target compiles to `con.exe`, which Win32
         # file APIs reject because CON is a reserved device name. The
         # `bin-con-app` feature routes the same `main.rs` to `con-app.exe`
         # instead — mirrors what `cargo wbuild` / `cargo wrun` do locally.
         run: cargo check -p con --no-default-features --features con/bin-con-app
       - name: cargo test — portable crates
-        run: cargo test -p con-core -p con-cli -p con-agent -p con-terminal
+        run: cargo test -p con-core -p con-cli -p con-agent -p con-terminal -p con-ghostty
 
   linux:
     name: check (ubuntu-latest)
@@ -133,11 +136,11 @@ jobs:
           done
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Install Zig 0.15.2
+      - name: Install Zig 0.16.0
         shell: bash
         run: |
           set -euo pipefail
-          ZIG_VERSION="0.15.2"
+          ZIG_VERSION="0.16.0"
           ZIG_ARCH="x86_64"
           ZIG_DIR="zig-${ZIG_ARCH}-linux-${ZIG_VERSION}"
           ZIG_TARBALL="${ZIG_DIR}.tar.xz"
@@ -169,7 +172,7 @@ jobs:
             libfreetype-dev libfontconfig1-dev
       - name: cargo check — portable crates
         run: cargo check -p con-core -p con-cli -p con-agent -p con-terminal -p con-ghostty
-      - name: cargo check — UI binary (stub terminal backend)
+      - name: cargo check — UI binary
         run: cargo check -p con
       - name: cargo test — portable crates
-        run: cargo test -p con-core -p con-cli -p con-agent -p con-terminal
+        run: cargo test -p con-core -p con-cli -p con-agent -p con-terminal -p con-ghostty

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,9 +37,7 @@ env:
 jobs:
   e2e:
     name: e2e (macos-15)
-    # Keep e2e on the same stable macOS generation as release builds. The
-    # macOS 26 preview image behind macos-latest currently breaks the Zig 0.15.2
-    # libghostty build before Rust code is compiled.
+    # Keep e2e on the same stable macOS generation as release builds.
     runs-on: macos-15
     timeout-minutes: 30
 
@@ -50,11 +48,11 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install Zig 0.15.2
+      - name: Install Zig 0.16.0
         shell: bash
         run: |
           set -euo pipefail
-          ZIG_VERSION="0.15.2"
+          ZIG_VERSION="0.16.0"
           ZIG_ARCH="aarch64"
           # Use x86_64 on Intel runners
           if [[ "$(uname -m)" == "x86_64" ]]; then

--- a/.github/workflows/publish-flatpak.yml
+++ b/.github/workflows/publish-flatpak.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Install Zig Compiler
         uses: mlugg/setup-zig@v2.2.1
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Configure Zig C toolchain
         shell: bash

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -78,13 +78,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install Zig 0.15.2
+      - name: Install Zig 0.16.0
         # Same Zig the linux CI smoke test installs — needed for
         # con-ghostty's libghostty-vt build.
         shell: bash
         run: |
           set -euo pipefail
-          ZIG_VERSION="0.15.2"
+          ZIG_VERSION="0.16.0"
           ZIG_ARCH="x86_64"
           ZIG_DIR="zig-${ZIG_ARCH}-linux-${ZIG_VERSION}"
           ZIG_TARBALL="${ZIG_DIR}.tar.xz"

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -53,11 +53,11 @@ jobs:
           brew update
           brew install cmake
 
-      - name: Install Zig 0.15.2
+      - name: Install Zig 0.16.0
         shell: bash
         run: |
           set -euo pipefail
-          ZIG_VERSION="0.15.2"
+          ZIG_VERSION="0.16.0"
           case "${{ matrix.arch }}" in
             arm64)  ZIG_ARCH="aarch64" ;;
             x86_64) ZIG_ARCH="x86_64" ;;

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -104,10 +104,10 @@ jobs:
           Add-MpPreference -ExclusionPath "$env:USERPROFILE\.local" -ErrorAction SilentlyContinue
           Add-MpPreference -ExclusionPath $env:ZIG_GLOBAL_CACHE_DIR -ErrorAction SilentlyContinue
 
-      - name: Install Zig 0.15.2
+      - name: Install Zig 0.16.0
         shell: pwsh
         run: |
-          $ZigVersion = "0.15.2"
+          $ZigVersion = "0.16.0"
           $ZigDir    = "zig-x86_64-windows-$ZigVersion"
           $ZigZip    = "$ZigDir.zip"
           $Dest      = "$env:USERPROFILE\.local"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ The `3pp/` directory contains third-party source checkouts for **read-only refer
 ## Build
 
 ```bash
-# Prerequisites: rust (stable, edition 2024), cmake, Zig 0.15.2 exactly (for libghostty / libghostty-vt)
+# Prerequisites: rust (stable, edition 2024), cmake, Zig 0.16.0 exactly (for libghostty / libghostty-vt)
 cargo build            # debug (macOS)
 cargo build --release  # release (macOS)
 cargo run -p con       # run the terminal (macOS)
@@ -68,12 +68,12 @@ the path to the long-term GPU-accelerated grid renderer on each
 non-macOS target.
 
 ```bash
-# Windows (from a Developer Command Prompt for VS 2022; needs Zig 0.15.2 exactly on PATH
+# Windows (from a Developer Command Prompt for VS 2022; needs Zig 0.16.0 exactly on PATH
 # for libghostty-vt; the binary ships as `con-app.exe` because `CON` is a
 # reserved DOS device name):
 cargo wbuild -p con --release          # produces target\release\con-app.exe
 cargo wrun   -p con
-cargo wtest  -p con-core -p con-cli -p con-agent -p con-terminal
+cargo wtest  -p con-core -p con-cli -p con-agent -p con-terminal -p con-ghostty
 
 # Linux (needs the GPUI linux runtime deps — see .github/workflows/ci-portable.yml):
 cargo build -p con --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,6 +1387,7 @@ dependencies = [
  "core-foundation 0.10.0",
  "dispatch",
  "etagere",
+ "image",
  "log",
  "objc",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,6 +1388,7 @@ dependencies = [
  "dispatch",
  "etagere",
  "image",
+ "libc",
  "log",
  "objc",
  "parking_lot",

--- a/HACKING.md
+++ b/HACKING.md
@@ -40,10 +40,9 @@ For the full breakdown, see `docs/impl/agent-harness.md`.
 
 - Rust (stable, edition 2024)
 - `cmake`
-- **Zig**: use **Zig 0.15.2 exactly** for full terminal builds.
-  Do not read this as `0.15.2+`: Zig `0.16.0` changes build APIs
-  that the pinned Ghostty revision does not support yet, and
-  `con-ghostty` will fail while compiling libghostty.
+- **Zig**: use **Zig 0.16.0 exactly** for full terminal builds.
+  The pinned Ghostty revision requires this version; older Zig releases
+  cannot build it, and newer releases may change the build APIs again.
 
 ### Quick setup with mise (recommended)
 
@@ -51,7 +50,7 @@ If you use [mise](https://mise.jdx.dev/), the repo root `mise.toml`
 pins the exact Zig version. Run:
 
 ```bash
-mise install   # installs zig 0.15.2
+mise install   # installs zig 0.16.0
 ```
 
 Then use `just` for all build / run / test tasks (see below).
@@ -60,12 +59,12 @@ Then use `just` for all build / run / test tasks (see below).
 
 If you do not use mise, install the prerequisites yourself:
 
-- **Zig**: download the official 0.15.2 archive from
-  `https://ziglang.org/download/0.15.2/` and put the directory on
+- **Zig**: download the official 0.16.0 archive from
+  `https://ziglang.org/download/0.16.0/` and put the directory on
   `PATH`, or set `CON_ZIG_BIN=/path/to/zig`.
-- **macOS**: `cmake` plus Zig 0.15.2. The macOS release workflow installs Zig 0.15.2 explicitly before building embedded libghostty.
-- **Windows**: Zig 0.15.2, Visual Studio 2022 Build Tools with the Windows 10/11 SDK. Run full builds from a _Developer Command Prompt for VS 2022_ so `rc.exe` is on `PATH`. If Windows Defender is on, either add an exclusion for the repo dir or disable real-time scanning — Zig's sub-build exes get briefly locked by MpEngine and spawn with `FileNotFound`.
-- **Linux**: Zig 0.15.2, plus the GPUI runtime apt deps the CI job already installs:
+- **macOS**: `cmake` plus Zig 0.16.0. The macOS release workflow installs Zig 0.16.0 explicitly before building embedded libghostty.
+- **Windows**: Zig 0.16.0, Visual Studio 2022 Build Tools with the Windows 10/11 SDK. Run full builds from a _Developer Command Prompt for VS 2022_ so `rc.exe` is on `PATH`. If Windows Defender is on, either add an exclusion for the repo dir or disable real-time scanning — Zig's sub-build exes get briefly locked by MpEngine and spawn with `FileNotFound`.
+- **Linux**: Zig 0.16.0, plus the GPUI runtime apt deps the CI job already installs:
   ```sh
   sudo apt-get install -y --no-install-recommends \
     libxcb-composite0-dev libxcb-dri2-0-dev libxcb-glx0-dev \
@@ -76,9 +75,9 @@ If you do not use mise, install the prerequisites yourself:
   The `mesa-vulkan-drivers` line gives you a software ICD (llvmpipe) as a fallback for headless / VM environments; on a real desktop with a hardware GPU you can skip it.
 
 CI mirrors this deliberately:
-- `release-macos.yml`, `release-linux.yml`, and `release-windows.yml` install Zig 0.15.2 before release builds.
-- The Linux PR smoke check in `ci-portable.yml` also installs Zig 0.15.2 because it type-checks `con-ghostty` with `libghostty-vt`.
-- The Windows PR smoke check sets `CON_SKIP_GHOSTTY_VT=1` because `cargo check` does not link and GitHub's Windows image does not ship our required Zig. That keeps PR checks fast, but it is not a substitute for a full Windows release build.
+- `release-macos.yml`, `release-linux.yml`, and `release-windows.yml` install Zig 0.16.0 before release builds.
+- The Linux PR smoke check in `ci-portable.yml` also installs Zig 0.16.0 because it type-checks `con-ghostty` with `libghostty-vt`.
+- The Windows and Linux PR jobs build and link the real libghostty-vt backend, then run `con-ghostty` tests. Do not replace these with `CON_SKIP_GHOSTTY_VT` or check-only coverage: removed symbols and calling-convention drift otherwise remain invisible until release.
 
 ## Build
 

--- a/crates/con-app/Cargo.toml
+++ b/crates/con-app/Cargo.toml
@@ -92,6 +92,10 @@ smallvec = "1"
 raw-window-handle = "0.6"
 unicode-width.workspace = true
 x11rb = "0.13.2"
+# Linux wraps shared libghostty-vt Kitty RGBA snapshots in GPUI
+# `RenderImage`s, whose constructor exposes these concrete crate types.
+image = { version = "0.25", default-features = false }
+smallvec = "1"
 
 [target.'cfg(unix)'.dependencies]
 socket2 = "0.6"

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -539,7 +539,7 @@ impl GhosttyView {
         }
     }
 
-    pub fn shutdown_surface(&mut self) {
+    pub fn shutdown_surface(&mut self, _window: Option<&mut Window>, _cx: &mut App) {
         self.native_view_visible.set(false);
 
         if let Some(ref terminal) = self.terminal {

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -313,7 +313,7 @@ impl GhosttyView {
         changed
     }
 
-    fn send_terminal_paste_payload(&self, payload: TerminalPastePayload) -> bool {
+    fn handle_terminal_paste_payload(&self, payload: TerminalPastePayload) -> bool {
         let Some(terminal) = &self.terminal else {
             return false;
         };
@@ -347,7 +347,7 @@ impl GhosttyView {
             return false;
         };
 
-        self.send_terminal_paste_payload(payload)
+        self.handle_terminal_paste_payload(payload)
     }
 
     pub fn pump_deferred_work(&mut self, cx: &mut Context<Self>) -> bool {
@@ -1977,7 +1977,7 @@ impl Render for GhosttyView {
                 };
                 window.focus(&this.focus_handle, cx);
                 this.restored_screen_text = None;
-                if this.send_terminal_paste_payload(payload) {
+                if this.handle_terminal_paste_payload(payload) {
                     cx.emit(GhosttyFocusChanged);
                     cx.notify();
                 }

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -2103,6 +2103,7 @@ mod tests {
             cols: 5,
             rows: 3,
             cells: Vec::new(),
+            kitty_placements: Default::default(),
             dirty_rows: Vec::new(),
             cursor: VtCursor {
                 col: 0,
@@ -2134,6 +2135,7 @@ mod tests {
             cols: 4,
             rows: 3,
             cells,
+            kitty_placements: Default::default(),
             dirty_rows: Vec::new(),
             cursor: VtCursor {
                 col: 0,
@@ -2163,6 +2165,7 @@ mod tests {
             cols: 4,
             rows: 3,
             cells: vec![Default::default(); 12],
+            kitty_placements: Default::default(),
             dirty_rows: vec![1],
             cursor: VtCursor {
                 col: 2,

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -13,14 +13,15 @@
 //! and layout state. The Windows D3D11 path remains the model for the
 //! eventual native renderer.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::sync::Arc;
 
 use con_ghostty::vt::{VtKeyAction, VtKeyEvent, VtKeyModifiers, VtPasteResult, VtPasteSource};
 use con_ghostty::{
     ATTR_BOLD, ATTR_INVERSE, ATTR_ITALIC, ATTR_STRIKE, ATTR_UNDERLINE, GhosttyApp,
-    GhosttySplitDirection, GhosttyTerminal, ScreenSnapshot, SurfaceSize, VtCell, VtCursor,
+    GhosttySplitDirection, GhosttyTerminal, KittyImage, KittyPlacement, ScreenSnapshot,
+    SurfaceSize, VtCell, VtCursor,
 };
 use futures::StreamExt;
 use futures::channel::mpsc::unbounded;
@@ -28,6 +29,8 @@ use gpui::*;
 use gpui_component::button::{Button, ButtonVariants as _};
 use gpui_component::menu::ContextMenuExt;
 use gpui_component::{ActiveTheme, Sizable as _};
+use image::{Frame, RgbaImage};
+use smallvec::SmallVec;
 
 use crate::terminal_ime::{TerminalImeInputHandler, TerminalImeView};
 use crate::terminal_links::{self, TerminalLink};
@@ -42,6 +45,7 @@ const DEFAULT_CELL_WIDTH_RATIO: f32 = 0.62;
 const DEFAULT_CELL_HEIGHT_RATIO: f32 = 1.45;
 const TERMINAL_PADDING_X_PX: f32 = 12.0;
 const TERMINAL_PADDING_Y_PX: f32 = 10.0;
+const KITTY_BELOW_BACKGROUND_LIMIT: i32 = i32::MIN / 2;
 
 /// Resolved logical font size used for both the cell-grid estimate
 /// (`estimate_surface_size`) and the actual paint (`render`). Both
@@ -65,6 +69,18 @@ fn cell_width_px(font_size_px: f32) -> f32 {
 
 fn cell_height_px(font_size_px: f32) -> f32 {
     (font_size_px * DEFAULT_CELL_HEIGHT_RATIO).round().max(14.0)
+}
+
+fn physical_cell_size(font_size_px: f32, scale_factor: f32) -> (u32, u32) {
+    let scale_factor = scale_factor.max(f32::EPSILON);
+    (
+        (cell_width_px(font_size_px) * scale_factor)
+            .round()
+            .max(1.0) as u32,
+        (cell_height_px(font_size_px) * scale_factor)
+            .round()
+            .max(1.0) as u32,
+    )
 }
 
 actions!(ghostty, [ConsumeTab, ConsumeTabPrev]);
@@ -100,6 +116,8 @@ pub struct GhosttyView {
     row_cache_cursor: Option<VtCursor>,
     row_cache_style: Option<RowCacheStyleKey>,
     row_cache_shape: Option<(u16, u16)>,
+    kitty_images: HashMap<KittyImageKey, Arc<RenderImage>>,
+    failed_kitty_images: HashSet<KittyImageKey>,
     /// Latched after the first PTY snapshot that contained any
     /// printable content. Used to gate the "Waiting for shell
     /// prompt…" placeholder so it disappears the moment bash echoes
@@ -195,6 +213,8 @@ impl GhosttyView {
             row_cache_cursor: None,
             row_cache_style: None,
             row_cache_shape: None,
+            kitty_images: HashMap::new(),
+            failed_kitty_images: HashSet::new(),
             seen_any_output: false,
             pane_bounds: None,
             scale_factor: 1.0,
@@ -299,6 +319,8 @@ impl GhosttyView {
         self.row_cache_cursor = None;
         self.row_cache_style = None;
         self.row_cache_shape = None;
+        self.kitty_images.clear();
+        self.failed_kitty_images.clear();
         self.seen_any_output = false;
         self.ime_marked_text = None;
         self.ime_selected_range = None;
@@ -491,15 +513,20 @@ impl GhosttyView {
         {
             return false;
         }
-        // Latch once the parser has handed us any printable cell.
+        // Latch once the parser has handed us any visible terminal output.
         // Used to suppress the "Waiting for shell prompt…" placeholder
         // for the lifetime of the PTY session — important for TUIs
         // (htop, vim, less, fzf, …) that switch to the alternate
         // screen and leave the grid empty for ~hundreds of ms before
         // drawing their UI. Without this latch the placeholder would
         // briefly flash over a black backdrop on every alt-screen
-        // entry and look like a regression in shell readiness.
-        if !self.seen_any_output && snapshot.cells.iter().any(|c| c.codepoint != 0) {
+        // entry and look like a regression in shell readiness. Image-only
+        // applications count too, otherwise the placeholder would shift
+        // their Kitty placements down by one synthetic row indefinitely.
+        if !self.seen_any_output
+            && (snapshot.cells.iter().any(|c| c.codepoint != 0)
+                || !snapshot.kitty_placements.is_empty())
+        {
             self.seen_any_output = true;
         }
         self.clear_selection();
@@ -539,9 +566,13 @@ impl GhosttyView {
         // actually paint at — picking different floors here would
         // make text overrun the estimated column count and lines
         // wrap unexpectedly on the alternate screen.
-        let font_size_px = effective_font_size(self.initial_font_size) * scale_factor;
-        let cell_width = cell_width_px(font_size_px) as u32;
-        let cell_height = cell_height_px(font_size_px) as u32;
+        let font_size_px = effective_font_size(self.initial_font_size);
+        // GPUI paints in logical pixels and applies the display scale after
+        // layout. Scale those exact logical cell metrics for libghostty too;
+        // recalculating the ratios from an already-scaled font can round to a
+        // different device size (for example 9 px logical became 17 px at 2x),
+        // which makes Kitty placements drift away from their text columns.
+        let (cell_width, cell_height) = physical_cell_size(font_size_px, scale_factor);
         let columns = (width_px / cell_width.max(1))
             .max(1)
             .min(u32::from(u16::MAX)) as u16;
@@ -1075,6 +1106,35 @@ impl GhosttyView {
         ))
     }
 
+    fn sync_kitty_image_cache(&mut self, placements: &[KittyPlacement]) {
+        let active = placements
+            .iter()
+            .map(|placement| KittyImageKey::from(placement.image.as_ref()))
+            .collect::<HashSet<_>>();
+        self.kitty_images.retain(|key, _| active.contains(key));
+        self.failed_kitty_images.retain(|key| active.contains(key));
+
+        for placement in placements {
+            let key = KittyImageKey::from(placement.image.as_ref());
+            if self.kitty_images.contains_key(&key) || self.failed_kitty_images.contains(&key) {
+                continue;
+            }
+            if let Some(image) = kitty_image_to_render_image(&placement.image) {
+                self.kitty_images.insert(key, image);
+            } else {
+                log::warn!(
+                    "ignoring invalid Kitty image {} generation {} ({}x{}, {} bytes)",
+                    key.id,
+                    key.generation,
+                    placement.image.width,
+                    placement.image.height,
+                    placement.image.rgba.len()
+                );
+                self.failed_kitty_images.insert(key);
+            }
+        }
+    }
+
     fn sync_row_cache(
         &mut self,
         default_fg: Hsla,
@@ -1253,6 +1313,27 @@ impl Render for GhosttyView {
         let pane_background = theme.background.opacity(pane_opacity);
         let selection = self.selection;
         let selection_bg = theme.selection.opacity(0.42);
+        let kitty_placements = self
+            .snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.kitty_placements.clone())
+            .unwrap_or_default();
+        self.sync_kitty_image_cache(&kitty_placements);
+        let mut has_kitty_images = false;
+        let mut split_terminal_rows = false;
+        for placement in kitty_placements.iter() {
+            let key = KittyImageKey::from(placement.image.as_ref());
+            let valid = self.kitty_images.contains_key(&key)
+                && kitty_placement_geometry(
+                    placement,
+                    cell_width_px,
+                    line_height_px,
+                    self.scale_factor,
+                )
+                .is_some();
+            has_kitty_images |= valid;
+            split_terminal_rows |= valid && placement.z < 0;
+        }
         self.sync_row_cache(
             foreground,
             theme.background,
@@ -1265,6 +1346,9 @@ impl Render for GhosttyView {
             usize::from(self.snapshot.as_ref().map_or(0, |snapshot| snapshot.rows))
                 + if status_message.is_some() { 1 } else { 0 },
         );
+        let mut cell_backgrounds = split_terminal_rows.then(Vec::new);
+        let mut overlay_backgrounds = split_terminal_rows.then(Vec::new);
+        let status_row_offset = usize::from(status_message.is_some());
         if let Some(message) = status_message {
             rows.push(
                 div()
@@ -1295,18 +1379,50 @@ impl Render for GhosttyView {
                             Some(selection_cols),
                             selection_bg,
                         );
+                        if let (Some(backgrounds), Some(overlays)) =
+                            (cell_backgrounds.as_mut(), overlay_backgrounds.as_mut())
+                        {
+                            append_terminal_backgrounds(
+                                &row,
+                                row_idx + status_row_offset,
+                                backgrounds,
+                                overlays,
+                            );
+                            rows.push(render_terminal_foreground_row(
+                                &row,
+                                px(font_size_px),
+                                px(line_height_px),
+                            ));
+                        } else {
+                            rows.push(render_cached_terminal_row(
+                                &row,
+                                px(font_size_px),
+                                px(line_height_px),
+                            ));
+                        }
+                    }
+                } else if let Some(row) = self.row_cache.get(row_idx) {
+                    if let (Some(backgrounds), Some(overlays)) =
+                        (cell_backgrounds.as_mut(), overlay_backgrounds.as_mut())
+                    {
+                        append_terminal_backgrounds(
+                            row,
+                            row_idx + status_row_offset,
+                            backgrounds,
+                            overlays,
+                        );
+                        rows.push(render_terminal_foreground_row(
+                            row,
+                            px(font_size_px),
+                            px(line_height_px),
+                        ));
+                    } else {
                         rows.push(render_cached_terminal_row(
-                            &row,
+                            row,
                             px(font_size_px),
                             px(line_height_px),
                         ));
                     }
-                } else if let Some(row) = self.row_cache.get(row_idx) {
-                    rows.push(render_cached_terminal_row(
-                        row,
-                        px(font_size_px),
-                        px(line_height_px),
-                    ));
                 }
             }
         }
@@ -1323,20 +1439,105 @@ impl Render for GhosttyView {
             );
         }
 
-        let terminal_content = div()
-            .flex()
-            .flex_col()
-            .size_full()
-            .min_w_0()
-            .min_h_0()
-            .overflow_hidden()
-            .bg(pane_background)
-            .px(px(TERMINAL_PADDING_X_PX))
-            .py(px(TERMINAL_PADDING_Y_PX))
-            .text_color(foreground)
-            .items_start()
-            .justify_start()
-            .children(rows);
+        let terminal_content = if has_kitty_images {
+            let row_layer = div()
+                .absolute()
+                .flex()
+                .flex_col()
+                .size_full()
+                .items_start()
+                .justify_start()
+                .text_color(foreground)
+                .children(rows);
+            let content_viewport = if split_terminal_rows {
+                div()
+                    .absolute()
+                    .left(px(TERMINAL_PADDING_X_PX))
+                    .right(px(TERMINAL_PADDING_X_PX))
+                    .top(px(TERMINAL_PADDING_Y_PX))
+                    .bottom(px(TERMINAL_PADDING_Y_PX))
+                    .overflow_hidden()
+                    .child(render_kitty_image_layer(
+                        &kitty_placements,
+                        &self.kitty_images,
+                        KittyImageLayer::BelowBackground,
+                        cell_width_px,
+                        line_height_px,
+                        self.scale_factor,
+                        status_row_offset as f32 * line_height_px,
+                    ))
+                    .child(render_terminal_background_layer(
+                        cell_backgrounds.unwrap_or_default(),
+                        px(cell_width_px),
+                        px(line_height_px),
+                    ))
+                    .child(render_kitty_image_layer(
+                        &kitty_placements,
+                        &self.kitty_images,
+                        KittyImageLayer::BelowText,
+                        cell_width_px,
+                        line_height_px,
+                        self.scale_factor,
+                        status_row_offset as f32 * line_height_px,
+                    ))
+                    .child(render_terminal_background_layer(
+                        overlay_backgrounds.unwrap_or_default(),
+                        px(cell_width_px),
+                        px(line_height_px),
+                    ))
+                    .child(row_layer)
+                    .child(render_kitty_image_layer(
+                        &kitty_placements,
+                        &self.kitty_images,
+                        KittyImageLayer::AboveText,
+                        cell_width_px,
+                        line_height_px,
+                        self.scale_factor,
+                        status_row_offset as f32 * line_height_px,
+                    ))
+            } else {
+                div()
+                    .absolute()
+                    .left(px(TERMINAL_PADDING_X_PX))
+                    .right(px(TERMINAL_PADDING_X_PX))
+                    .top(px(TERMINAL_PADDING_Y_PX))
+                    .bottom(px(TERMINAL_PADDING_Y_PX))
+                    .overflow_hidden()
+                    .child(row_layer)
+                    .child(render_kitty_image_layer(
+                        &kitty_placements,
+                        &self.kitty_images,
+                        KittyImageLayer::AboveText,
+                        cell_width_px,
+                        line_height_px,
+                        self.scale_factor,
+                        status_row_offset as f32 * line_height_px,
+                    ))
+            };
+            div()
+                .relative()
+                .size_full()
+                .min_w_0()
+                .min_h_0()
+                .overflow_hidden()
+                .bg(pane_background)
+                .child(content_viewport)
+        } else {
+            div()
+                .flex()
+                .flex_col()
+                .size_full()
+                .min_w_0()
+                .min_h_0()
+                .overflow_hidden()
+                .bg(pane_background)
+                .px(px(TERMINAL_PADDING_X_PX))
+                .py(px(TERMINAL_PADDING_Y_PX))
+                .text_color(foreground)
+                .items_start()
+                .justify_start()
+                .children(rows)
+        };
         let mut terminal_children = vec![terminal_content.into_any_element()];
         if let Some(overlay) = self.render_link_cursor_overlay(cell_width_px, line_height_px) {
             terminal_children.push(overlay);
@@ -1631,6 +1832,178 @@ impl Drop for GhosttyView {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct KittyImageKey {
+    id: u32,
+    generation: u64,
+}
+
+impl From<&KittyImage> for KittyImageKey {
+    fn from(image: &KittyImage) -> Self {
+        Self {
+            id: image.id,
+            generation: image.generation,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum KittyImageLayer {
+    BelowBackground,
+    BelowText,
+    AboveText,
+}
+
+impl KittyImageLayer {
+    fn contains(self, z: i32) -> bool {
+        match self {
+            Self::BelowBackground => z < KITTY_BELOW_BACKGROUND_LIMIT,
+            Self::BelowText => (KITTY_BELOW_BACKGROUND_LIMIT..0).contains(&z),
+            Self::AboveText => z >= 0,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct KittyPlacementGeometry {
+    left: f32,
+    top: f32,
+    width: f32,
+    height: f32,
+    image_left: f32,
+    image_top: f32,
+    image_width: f32,
+    image_height: f32,
+}
+
+fn kitty_placement_geometry(
+    placement: &KittyPlacement,
+    cell_width: f32,
+    cell_height: f32,
+    scale_factor: f32,
+) -> Option<KittyPlacementGeometry> {
+    let image = &placement.image;
+    let source_right = placement.source_x.checked_add(placement.source_width)?;
+    let source_bottom = placement.source_y.checked_add(placement.source_height)?;
+    if placement.pixel_width == 0
+        || placement.pixel_height == 0
+        || placement.source_width == 0
+        || placement.source_height == 0
+        || image.width == 0
+        || image.height == 0
+        || source_right > image.width
+        || source_bottom > image.height
+        || !cell_width.is_finite()
+        || !cell_height.is_finite()
+        || !scale_factor.is_finite()
+        || cell_width <= 0.0
+        || cell_height <= 0.0
+        || scale_factor <= 0.0
+    {
+        return None;
+    }
+
+    let device_to_logical = 1.0_f64 / scale_factor as f64;
+    let width = placement.pixel_width as f64 * device_to_logical;
+    let height = placement.pixel_height as f64 * device_to_logical;
+    let source_scale_x = width / placement.source_width as f64;
+    let source_scale_y = height / placement.source_height as f64;
+    let values = KittyPlacementGeometry {
+        left: (placement.viewport_col as f64 * cell_width as f64
+            + placement.cell_x_offset as f64 * device_to_logical) as f32,
+        top: (placement.viewport_row as f64 * cell_height as f64
+            + placement.cell_y_offset as f64 * device_to_logical) as f32,
+        width: width as f32,
+        height: height as f32,
+        image_left: (-(placement.source_x as f64) * source_scale_x) as f32,
+        image_top: (-(placement.source_y as f64) * source_scale_y) as f32,
+        image_width: (image.width as f64 * source_scale_x) as f32,
+        image_height: (image.height as f64 * source_scale_y) as f32,
+    };
+    if [
+        values.left,
+        values.top,
+        values.width,
+        values.height,
+        values.image_left,
+        values.image_top,
+        values.image_width,
+        values.image_height,
+    ]
+    .iter()
+    .all(|value| value.is_finite())
+    {
+        Some(values)
+    } else {
+        None
+    }
+}
+
+fn kitty_image_to_render_image(image: &KittyImage) -> Option<Arc<RenderImage>> {
+    let expected_len = (image.width as usize)
+        .checked_mul(image.height as usize)?
+        .checked_mul(4)?;
+    if image.width == 0 || image.height == 0 || image.rgba.len() != expected_len {
+        return None;
+    }
+
+    // GPUI's `RenderImage` byte contract is BGRA even though the image crate
+    // buffer type is named `RgbaImage`. Keep the shared VT snapshot in its
+    // renderer-neutral RGBA form and swizzle only once per image generation.
+    let mut bgra = image.rgba.to_vec();
+    for pixel in bgra.chunks_exact_mut(4) {
+        pixel.swap(0, 2);
+    }
+    let buffer = RgbaImage::from_raw(image.width, image.height, bgra)?;
+    let frame = Frame::new(buffer);
+    let frames: SmallVec<[Frame; 1]> = SmallVec::from_buf([frame]);
+    Some(Arc::new(RenderImage::new(frames)))
+}
+
+fn render_kitty_image_layer(
+    placements: &[KittyPlacement],
+    images: &HashMap<KittyImageKey, Arc<RenderImage>>,
+    layer: KittyImageLayer,
+    cell_width: f32,
+    cell_height: f32,
+    scale_factor: f32,
+    top_offset: f32,
+) -> AnyElement {
+    div()
+        .absolute()
+        .size_full()
+        .overflow_hidden()
+        .children(placements.iter().filter_map(|placement| {
+            if !layer.contains(placement.z) {
+                return None;
+            }
+            let key = KittyImageKey::from(placement.image.as_ref());
+            let image = images.get(&key)?.clone();
+            let geometry =
+                kitty_placement_geometry(placement, cell_width, cell_height, scale_factor)?;
+            Some(
+                div()
+                    .absolute()
+                    .left(px(geometry.left))
+                    .top(px(geometry.top + top_offset))
+                    .w(px(geometry.width))
+                    .h(px(geometry.height))
+                    .overflow_hidden()
+                    .child(
+                        img(ImageSource::Render(image))
+                            .absolute()
+                            .left(px(geometry.image_left))
+                            .top(px(geometry.image_top))
+                            .w(px(geometry.image_width))
+                            .h(px(geometry.image_height))
+                            .object_fit(ObjectFit::Fill),
+                    )
+                    .into_any_element(),
+            )
+        }))
+        .into_any_element()
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct TerminalSelection {
     anchor: (u16, u64),
@@ -1726,6 +2099,23 @@ fn extract_selection_text(
 struct CachedTerminalRow {
     text: SharedString,
     runs: Vec<TextRun>,
+    backgrounds: Vec<TerminalBackgroundRun>,
+}
+
+#[derive(Clone, Copy)]
+struct TerminalBackgroundRun {
+    start_col: usize,
+    len: usize,
+    color: Hsla,
+    overlay: bool,
+}
+
+#[derive(Clone, Copy)]
+struct TerminalBackgroundQuad {
+    row: usize,
+    start_col: usize,
+    len: usize,
+    color: Hsla,
 }
 
 #[derive(Clone, PartialEq)]
@@ -1796,6 +2186,76 @@ fn render_cached_terminal_row(
         .into_any_element()
 }
 
+fn append_terminal_backgrounds(
+    row: &CachedTerminalRow,
+    display_row: usize,
+    backgrounds: &mut Vec<TerminalBackgroundQuad>,
+    overlays: &mut Vec<TerminalBackgroundQuad>,
+) {
+    for run in &row.backgrounds {
+        let quad = TerminalBackgroundQuad {
+            row: display_row,
+            start_col: run.start_col,
+            len: run.len,
+            color: run.color,
+        };
+        if run.overlay {
+            overlays.push(quad);
+        } else {
+            backgrounds.push(quad);
+        }
+    }
+}
+
+fn render_terminal_background_layer(
+    backgrounds: Vec<TerminalBackgroundQuad>,
+    cell_width: Pixels,
+    line_height: Pixels,
+) -> AnyElement {
+    canvas(
+        |_, _, _| {},
+        move |bounds, _, window, _| {
+            for background in backgrounds {
+                window.paint_quad(fill(
+                    Bounds::new(
+                        point(
+                            bounds.origin.x + cell_width * background.start_col as f32,
+                            bounds.origin.y + line_height * background.row as f32,
+                        ),
+                        size(cell_width * background.len as f32, line_height),
+                    ),
+                    background.color,
+                ));
+            }
+        },
+    )
+    .absolute()
+    .size_full()
+    .into_any_element()
+}
+
+fn render_terminal_foreground_row(
+    row: &CachedTerminalRow,
+    font_size: Pixels,
+    line_height: Pixels,
+) -> AnyElement {
+    let mut runs = row.runs.clone();
+    for run in &mut runs {
+        run.background_color = None;
+    }
+
+    div()
+        .w_full()
+        .h(line_height)
+        .min_h(line_height)
+        .overflow_hidden()
+        .whitespace_nowrap()
+        .text_size(font_size)
+        .line_height(line_height)
+        .child(StyledText::new(row.text.clone()).with_runs(runs))
+        .into_any_element()
+}
+
 /// Build a single GPUI row element from a slice of `VtCell`s. We
 /// collapse runs of cells that share `(fg, bg, attrs)` into one
 /// `TextRun` so each row is a single `StyledText` element. That keeps
@@ -1842,9 +2302,11 @@ fn build_terminal_row(
 
     let mut text = String::with_capacity(kept.len());
     let mut runs: Vec<TextRun> = Vec::new();
+    let mut backgrounds = Vec::new();
     let mut last_signature: Option<(u32, u32, u8, bool, bool)> = None;
     let mut active_run_len: usize = 0;
     let mut active_style: Option<RowStyle> = None;
+    let mut active_background: Option<(usize, Hsla, bool)> = None;
 
     fn flush_run(
         runs: &mut Vec<TextRun>,
@@ -1881,6 +2343,19 @@ fn build_terminal_row(
             selection_bg,
         );
 
+        let background = style.bg.map(|color| (color, is_cursor || is_selected));
+        if active_background.map(|(_, color, overlay)| (color, overlay)) != background {
+            if let Some((start_col, color, overlay)) = active_background.take() {
+                backgrounds.push(TerminalBackgroundRun {
+                    start_col,
+                    len: col_idx - start_col,
+                    color,
+                    overlay,
+                });
+            }
+            active_background = background.map(|(color, overlay)| (col_idx, color, overlay));
+        }
+
         let glyph: char = match cell.codepoint {
             0 => ' ',
             cp => char::from_u32(cp).unwrap_or('\u{FFFD}'),
@@ -1897,6 +2372,14 @@ fn build_terminal_row(
     }
 
     flush_run(&mut runs, &mut active_style, &mut active_run_len);
+    if let Some((start_col, color, overlay)) = active_background {
+        backgrounds.push(TerminalBackgroundRun {
+            start_col,
+            len: kept.len() - start_col,
+            color,
+            overlay,
+        });
+    }
 
     let text = if text.is_empty() {
         let mut fallback = String::with_capacity(1);
@@ -1917,6 +2400,7 @@ fn build_terminal_row(
     CachedTerminalRow {
         text: text.into(),
         runs,
+        backgrounds,
     }
 }
 
@@ -2023,12 +2507,17 @@ fn vt_color_to_hsla(packed: u32) -> Option<Hsla> {
 #[cfg(test)]
 mod tests {
     use super::{
-        DEFAULT_FONT_SIZE, MIN_FONT_SIZE_PX, TerminalSelection, build_terminal_row, cell_height_px,
-        cell_width_px, effective_font_size, extract_selection_text, rows_needing_refresh,
-        vt_color_to_hsla,
+        DEFAULT_FONT_SIZE, KITTY_BELOW_BACKGROUND_LIMIT, KittyImageLayer, MIN_FONT_SIZE_PX,
+        TerminalSelection, build_terminal_row, cell_height_px, cell_width_px, effective_font_size,
+        extract_selection_text, kitty_image_to_render_image, kitty_placement_geometry,
+        physical_cell_size, rows_needing_refresh, vt_color_to_hsla,
     };
-    use con_ghostty::{ATTR_BOLD, ATTR_INVERSE, ATTR_UNDERLINE, ScreenSnapshot, VtCell, VtCursor};
+    use con_ghostty::{
+        ATTR_BOLD, ATTR_INVERSE, ATTR_UNDERLINE, KittyImage, KittyPlacement, ScreenSnapshot,
+        VtCell, VtCursor,
+    };
     use gpui::{Font, FontFeatures, FontStyle, FontWeight, Hsla, Rgba};
+    use std::sync::Arc;
 
     fn base_font() -> Font {
         Font {
@@ -2082,6 +2571,68 @@ mod tests {
         assert_eq!(effective_font_size(8.0), MIN_FONT_SIZE_PX);
         assert_eq!(cell_width_px(14.0), 9.0);
         assert_eq!(cell_height_px(14.0), 20.0);
+        assert_eq!(physical_cell_size(14.0, 2.0), (18, 40));
+    }
+
+    #[test]
+    fn kitty_placement_maps_device_pixels_and_source_crop() {
+        let placement = KittyPlacement {
+            image: Arc::new(KittyImage {
+                id: 1,
+                generation: 2,
+                width: 4,
+                height: 2,
+                rgba: vec![0; 4 * 2 * 4].into(),
+            }),
+            placement_id: 3,
+            z: 0,
+            viewport_col: -1,
+            viewport_row: 2,
+            cell_x_offset: 4,
+            cell_y_offset: 6,
+            pixel_width: 20,
+            pixel_height: 10,
+            source_x: 1,
+            source_y: 0,
+            source_width: 2,
+            source_height: 1,
+        };
+
+        let geometry = kitty_placement_geometry(&placement, 10.0, 20.0, 2.0).unwrap();
+        assert_eq!(geometry.left, -8.0);
+        assert_eq!(geometry.top, 43.0);
+        assert_eq!(geometry.width, 10.0);
+        assert_eq!(geometry.height, 5.0);
+        assert_eq!(geometry.image_left, -5.0);
+        assert_eq!(geometry.image_top, 0.0);
+        assert_eq!(geometry.image_width, 20.0);
+        assert_eq!(geometry.image_height, 10.0);
+    }
+
+    #[test]
+    fn kitty_layers_match_protocol_z_boundaries() {
+        assert!(KittyImageLayer::BelowBackground.contains(i32::MIN));
+        assert!(!KittyImageLayer::BelowBackground.contains(KITTY_BELOW_BACKGROUND_LIMIT));
+        assert!(KittyImageLayer::BelowText.contains(KITTY_BELOW_BACKGROUND_LIMIT));
+        assert!(KittyImageLayer::BelowText.contains(-1));
+        assert!(!KittyImageLayer::BelowText.contains(0));
+        assert!(KittyImageLayer::AboveText.contains(0));
+    }
+
+    #[test]
+    fn kitty_rgba_is_swizzled_for_gpui_render_images() {
+        let image = KittyImage {
+            id: 1,
+            generation: 1,
+            width: 1,
+            height: 1,
+            rgba: vec![0x11, 0x22, 0x33, 0x44].into(),
+        };
+        let render_image = kitty_image_to_render_image(&image).unwrap();
+        assert_eq!(
+            render_image.as_bytes(0),
+            Some(&[0x33, 0x22, 0x11, 0x44][..])
+        );
     }
 
     #[test]
@@ -2095,6 +2646,40 @@ mod tests {
         let _no_cursor = build_terminal_row(&cells, fg(), bg(), &base_font(), None, None, bg());
         let _with_cursor =
             build_terminal_row(&cells, fg(), bg(), &base_font(), Some(2), None, bg());
+    }
+
+    #[test]
+    fn cursor_and_selection_backgrounds_render_above_negative_z_images() {
+        let cells = [
+            make_cell('a', 0, 0, 0x112233FF),
+            make_cell('b', 0, 0, 0x112233FF),
+            make_cell('c', 0, 0, 0x112233FF),
+        ];
+        let row = build_terminal_row(
+            &cells,
+            fg(),
+            bg(),
+            &base_font(),
+            Some(2),
+            Some((1, 1)),
+            bg(),
+        );
+
+        assert!(
+            row.backgrounds
+                .iter()
+                .any(|run| run.start_col == 0 && run.len == 1 && !run.overlay)
+        );
+        assert!(
+            row.backgrounds
+                .iter()
+                .any(|run| run.start_col == 1 && run.len == 1 && run.overlay)
+        );
+        assert!(
+            row.backgrounds
+                .iter()
+                .any(|run| run.start_col == 2 && run.len == 1 && run.overlay)
+        );
     }
 
     #[test]

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -129,7 +129,7 @@ pub struct GhosttyView {
     scale_factor: f32,
     ime_marked_text: Option<String>,
     ime_selected_range: Option<Range<usize>>,
-    last_surface_size: Option<(u32, u32, u16, u16)>,
+    last_surface_size: Option<SurfaceSize>,
     mouse_down_link: Option<TerminalLink>,
     suppress_link_mouse_up: bool,
     hovered_link: Option<TerminalLink>,
@@ -304,7 +304,7 @@ impl GhosttyView {
         true
     }
 
-    pub fn shutdown_surface(&mut self) {
+    pub fn shutdown_surface(&mut self, mut window: Option<&mut Window>, cx: &mut App) {
         self.release_tracked_keys();
         if let Some(terminal) = &self.terminal {
             terminal.request_close();
@@ -319,7 +319,9 @@ impl GhosttyView {
         self.row_cache_cursor = None;
         self.row_cache_style = None;
         self.row_cache_shape = None;
-        self.kitty_images.clear();
+        for image in self.kitty_images.drain().map(|(_, image)| image) {
+            cx.drop_image(image, window.as_deref_mut());
+        }
         self.failed_kitty_images.clear();
         self.seen_any_output = false;
         self.ime_marked_text = None;
@@ -543,14 +545,13 @@ impl GhosttyView {
         };
 
         let size = self.estimate_surface_size(bounds, scale_factor);
-        let signature = (size.width_px, size.height_px, size.columns, size.rows);
-        if self.last_surface_size == Some(signature) {
+        if self.last_surface_size == Some(size) {
             return false;
         }
 
         self.clear_selection();
         terminal.resize_surface(size);
-        self.last_surface_size = Some(signature);
+        self.last_surface_size = Some(size);
         false
     }
 
@@ -1106,12 +1107,27 @@ impl GhosttyView {
         ))
     }
 
-    fn sync_kitty_image_cache(&mut self, placements: &[KittyPlacement]) {
+    fn sync_kitty_image_cache(
+        &mut self,
+        placements: &[KittyPlacement],
+        window: &mut Window,
+        cx: &mut App,
+    ) {
         let active = placements
             .iter()
             .map(|placement| KittyImageKey::from(placement.image.as_ref()))
             .collect::<HashSet<_>>();
-        self.kitty_images.retain(|key, _| active.contains(key));
+        let mut stale = Vec::new();
+        self.kitty_images.retain(|key, image| {
+            let keep = active.contains(key);
+            if !keep {
+                stale.push(image.clone());
+            }
+            keep
+        });
+        for image in stale {
+            cx.drop_image(image, Some(window));
+        }
         self.failed_kitty_images.retain(|key| active.contains(key));
 
         for placement in placements {
@@ -1261,8 +1277,15 @@ impl TerminalImeView for GhosttyView {
 }
 
 impl Render for GhosttyView {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let unsafe_paste_confirmation = self.render_unsafe_paste_confirmation(cx);
+        let kitty_placements = self
+            .snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.kitty_placements.clone())
+            .unwrap_or_default();
+        self.sync_kitty_image_cache(&kitty_placements, window, cx);
+
         let theme = cx.theme();
         let focus = self.focus_handle.clone();
         let input_focus = focus.clone();
@@ -1274,6 +1297,10 @@ impl Render for GhosttyView {
         let font_size_px = effective_font_size(self.initial_font_size);
         let line_height_px = cell_height_px(font_size_px);
         let cell_width_px = cell_width_px(font_size_px);
+        let physical_cell = self
+            .last_surface_size
+            .map(|size| (size.cell_width_px, size.cell_height_px))
+            .unwrap_or_else(|| physical_cell_size(font_size_px, self.scale_factor));
         let mono_font = Font {
             family: theme.mono_font_family.clone(),
             features: FontFeatures::default(),
@@ -1313,12 +1340,6 @@ impl Render for GhosttyView {
         let pane_background = theme.background.opacity(pane_opacity);
         let selection = self.selection;
         let selection_bg = theme.selection.opacity(0.42);
-        let kitty_placements = self
-            .snapshot
-            .as_ref()
-            .map(|snapshot| snapshot.kitty_placements.clone())
-            .unwrap_or_default();
-        self.sync_kitty_image_cache(&kitty_placements);
         let mut has_kitty_images = false;
         let mut split_terminal_rows = false;
         for placement in kitty_placements.iter() {
@@ -1328,7 +1349,8 @@ impl Render for GhosttyView {
                     placement,
                     cell_width_px,
                     line_height_px,
-                    self.scale_factor,
+                    physical_cell.0,
+                    physical_cell.1,
                 )
                 .is_some();
             has_kitty_images |= valid;
@@ -1463,7 +1485,8 @@ impl Render for GhosttyView {
                         KittyImageLayer::BelowBackground,
                         cell_width_px,
                         line_height_px,
-                        self.scale_factor,
+                        physical_cell.0,
+                        physical_cell.1,
                         status_row_offset as f32 * line_height_px,
                     ))
                     .child(render_terminal_background_layer(
@@ -1477,7 +1500,8 @@ impl Render for GhosttyView {
                         KittyImageLayer::BelowText,
                         cell_width_px,
                         line_height_px,
-                        self.scale_factor,
+                        physical_cell.0,
+                        physical_cell.1,
                         status_row_offset as f32 * line_height_px,
                     ))
                     .child(render_terminal_background_layer(
@@ -1492,7 +1516,8 @@ impl Render for GhosttyView {
                         KittyImageLayer::AboveText,
                         cell_width_px,
                         line_height_px,
-                        self.scale_factor,
+                        physical_cell.0,
+                        physical_cell.1,
                         status_row_offset as f32 * line_height_px,
                     ))
             } else {
@@ -1510,7 +1535,8 @@ impl Render for GhosttyView {
                         KittyImageLayer::AboveText,
                         cell_width_px,
                         line_height_px,
-                        self.scale_factor,
+                        physical_cell.0,
+                        physical_cell.1,
                         status_row_offset as f32 * line_height_px,
                     ))
             };
@@ -1880,7 +1906,8 @@ fn kitty_placement_geometry(
     placement: &KittyPlacement,
     cell_width: f32,
     cell_height: f32,
-    scale_factor: f32,
+    physical_cell_width: u32,
+    physical_cell_height: u32,
 ) -> Option<KittyPlacementGeometry> {
     let image = &placement.image;
     let source_right = placement.source_x.checked_add(placement.source_width)?;
@@ -1895,24 +1922,29 @@ fn kitty_placement_geometry(
         || source_bottom > image.height
         || !cell_width.is_finite()
         || !cell_height.is_finite()
-        || !scale_factor.is_finite()
         || cell_width <= 0.0
         || cell_height <= 0.0
-        || scale_factor <= 0.0
+        || physical_cell_width == 0
+        || physical_cell_height == 0
     {
         return None;
     }
 
-    let device_to_logical = 1.0_f64 / scale_factor as f64;
-    let width = placement.pixel_width as f64 * device_to_logical;
-    let height = placement.pixel_height as f64 * device_to_logical;
+    // libghostty positions placements in the integer physical cell geometry
+    // supplied by `resize_surface`. Derive each axis from that exact quantized
+    // size instead of dividing by the fractional display scale, which drifts
+    // away from GPUI's logical text grid after several columns.
+    let device_to_logical_x = cell_width as f64 / physical_cell_width as f64;
+    let device_to_logical_y = cell_height as f64 / physical_cell_height as f64;
+    let width = placement.pixel_width as f64 * device_to_logical_x;
+    let height = placement.pixel_height as f64 * device_to_logical_y;
     let source_scale_x = width / placement.source_width as f64;
     let source_scale_y = height / placement.source_height as f64;
     let values = KittyPlacementGeometry {
         left: (placement.viewport_col as f64 * cell_width as f64
-            + placement.cell_x_offset as f64 * device_to_logical) as f32,
+            + placement.cell_x_offset as f64 * device_to_logical_x) as f32,
         top: (placement.viewport_row as f64 * cell_height as f64
-            + placement.cell_y_offset as f64 * device_to_logical) as f32,
+            + placement.cell_y_offset as f64 * device_to_logical_y) as f32,
         width: width as f32,
         height: height as f32,
         image_left: (-(placement.source_x as f64) * source_scale_x) as f32,
@@ -1966,7 +1998,8 @@ fn render_kitty_image_layer(
     layer: KittyImageLayer,
     cell_width: f32,
     cell_height: f32,
-    scale_factor: f32,
+    physical_cell_width: u32,
+    physical_cell_height: u32,
     top_offset: f32,
 ) -> AnyElement {
     let paint_records = placements
@@ -1977,8 +2010,13 @@ fn render_kitty_image_layer(
             }
             let key = KittyImageKey::from(placement.image.as_ref());
             let image = images.get(&key)?.clone();
-            let geometry =
-                kitty_placement_geometry(placement, cell_width, cell_height, scale_factor)?;
+            let geometry = kitty_placement_geometry(
+                placement,
+                cell_width,
+                cell_height,
+                physical_cell_width,
+                physical_cell_height,
+            )?;
             Some((image, geometry))
         })
         .collect::<Vec<_>>();
@@ -2619,7 +2657,7 @@ mod tests {
             source_height: 1,
         };
 
-        let geometry = kitty_placement_geometry(&placement, 10.0, 20.0, 2.0).unwrap();
+        let geometry = kitty_placement_geometry(&placement, 10.0, 20.0, 20, 40).unwrap();
         assert_eq!(geometry.left, -8.0);
         assert_eq!(geometry.top, 43.0);
         assert_eq!(geometry.width, 10.0);
@@ -2628,6 +2666,40 @@ mod tests {
         assert_eq!(geometry.image_top, 0.0);
         assert_eq!(geometry.image_width, 20.0);
         assert_eq!(geometry.image_height, 10.0);
+    }
+
+    #[test]
+    fn kitty_placement_stays_aligned_after_fractional_cell_rounding() {
+        let placement = KittyPlacement {
+            image: Arc::new(KittyImage {
+                id: 1,
+                generation: 2,
+                width: 140,
+                height: 30,
+                rgba: vec![0; 140 * 30 * 4].into(),
+            }),
+            placement_id: 3,
+            z: 0,
+            viewport_col: 40,
+            viewport_row: 2,
+            cell_x_offset: 14,
+            cell_y_offset: 0,
+            pixel_width: 140,
+            pixel_height: 30,
+            source_x: 0,
+            source_y: 0,
+            source_width: 140,
+            source_height: 30,
+        };
+
+        // A 9px logical cell rounds to 14 physical pixels at 1.5x. The
+        // placement must advance exactly one logical cell for every 14 device
+        // pixels rather than using 1 / 1.5 and accumulating column drift.
+        let geometry = kitty_placement_geometry(&placement, 9.0, 20.0, 14, 30).unwrap();
+        assert_eq!(geometry.left, 369.0);
+        assert_eq!(geometry.top, 40.0);
+        assert_eq!(geometry.width, 90.0);
+        assert_eq!(geometry.height, 20.0);
     }
 
     #[test]

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -799,6 +799,7 @@ impl GhosttyView {
         for (key, tracked) in tracked_keys {
             let release = tracked.release(&key);
             if let Err(err) = terminal.send_key(&release) {
+                self.keys_awaiting_release.insert(key, tracked);
                 log::debug!("linux terminal key release failed: {err}");
             }
         }

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -1969,11 +1969,9 @@ fn render_kitty_image_layer(
     scale_factor: f32,
     top_offset: f32,
 ) -> AnyElement {
-    div()
-        .absolute()
-        .size_full()
-        .overflow_hidden()
-        .children(placements.iter().filter_map(|placement| {
+    let paint_records = placements
+        .iter()
+        .filter_map(|placement| {
             if !layer.contains(placement.z) {
                 return None;
             }
@@ -1981,27 +1979,50 @@ fn render_kitty_image_layer(
             let image = images.get(&key)?.clone();
             let geometry =
                 kitty_placement_geometry(placement, cell_width, cell_height, scale_factor)?;
-            Some(
-                div()
-                    .absolute()
-                    .left(px(geometry.left))
-                    .top(px(geometry.top + top_offset))
-                    .w(px(geometry.width))
-                    .h(px(geometry.height))
-                    .overflow_hidden()
-                    .child(
-                        img(ImageSource::Render(image))
-                            .absolute()
-                            .left(px(geometry.image_left))
-                            .top(px(geometry.image_top))
-                            .w(px(geometry.image_width))
-                            .h(px(geometry.image_height))
-                            .object_fit(ObjectFit::Fill),
-                    )
-                    .into_any_element(),
-            )
-        }))
-        .into_any_element()
+            Some((image, geometry))
+        })
+        .collect::<Vec<_>>();
+
+    canvas(
+        |_, _, _| {},
+        move |bounds, _, window, _| {
+            for (image, geometry) in paint_records {
+                let crop_bounds = Bounds::new(
+                    point(
+                        bounds.origin.x + px(geometry.left),
+                        bounds.origin.y + px(geometry.top + top_offset),
+                    ),
+                    size(px(geometry.width), px(geometry.height)),
+                );
+                if !crop_bounds.intersects(&bounds) {
+                    continue;
+                }
+
+                let image_bounds = Bounds::new(
+                    point(
+                        crop_bounds.origin.x + px(geometry.image_left),
+                        crop_bounds.origin.y + px(geometry.image_top),
+                    ),
+                    size(px(geometry.image_width), px(geometry.image_height)),
+                );
+                window.with_content_mask(
+                    Some(ContentMask {
+                        bounds: crop_bounds.intersect(&bounds),
+                    }),
+                    |window| {
+                        if let Err(err) =
+                            window.paint_image(image_bounds, Default::default(), image, 0, false)
+                        {
+                            log::debug!("failed to paint Kitty image placement: {err:#}");
+                        }
+                    },
+                );
+            }
+        },
+    )
+    .absolute()
+    .size_full()
+    .into_any_element()
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -757,25 +757,25 @@ impl GhosttyView {
         &mut self,
         tracking_key: &str,
         event: &VtKeyEvent<'_>,
-    ) -> Result<con_ghostty::vt::VtKeySend, String> {
+    ) -> Result<con_ghostty::vt::VtKeyOutcome, String> {
         let Some(terminal) = self.terminal.as_ref().cloned() else {
-            return Ok(con_ghostty::vt::VtKeySend::default());
+            return Ok(con_ghostty::vt::VtKeyOutcome::default());
         };
-        let sent = terminal.send_key(event)?;
-        if sent.wrote {
+        let outcome = terminal.send_key(event)?;
+        if outcome.output_accepted {
             self.clear_restored_screen_text();
             self.clear_selection();
-            if sent.report_releases
+            if outcome.report_releases
                 && event.action != VtKeyAction::Release
                 && !self.keys_awaiting_release.contains_key(tracking_key)
             {
                 self.keys_awaiting_release.insert(
                     tracking_key.to_owned(),
-                    crate::terminal_keys::TrackedVtKey::from_press(event),
+                    crate::terminal_keys::TrackedVtKey::from_non_release_event(event),
                 );
             }
         }
-        Ok(sent)
+        Ok(outcome)
     }
 
     fn handle_key_up(&mut self, event: &KeyUpEvent) -> bool {
@@ -785,7 +785,7 @@ impl GhosttyView {
         let release =
             tracked.release_with_modifiers(&event.keystroke.key, &event.keystroke.modifiers);
         match self.send_vt_key(&event.keystroke.key, &release) {
-            Ok(sent) => sent.wrote,
+            Ok(outcome) => outcome.output_accepted,
             Err(err) => {
                 // Preserve the press so focus loss can retry the release if
                 // this was a transient PTY write failure.
@@ -828,7 +828,7 @@ impl GhosttyView {
             consumed_modifiers: VtKeyModifiers::default(),
         };
         match self.send_vt_key("tab", &event) {
-            Ok(sent) => sent.wrote,
+            Ok(outcome) => outcome.output_accepted,
             Err(err) => {
                 log::debug!("linux terminal key encoding failed: {err}");
                 false
@@ -926,7 +926,7 @@ impl GhosttyView {
             return false;
         };
         match self.send_vt_key(&keystroke.key, &vt_event) {
-            Ok(sent) => sent.wrote,
+            Ok(outcome) => outcome.output_accepted,
             Err(err) => {
                 log::debug!("linux terminal key encoding failed: {err}");
                 false
@@ -934,7 +934,7 @@ impl GhosttyView {
         }
     }
 
-    fn send_terminal_paste_payload(
+    fn handle_terminal_paste_payload(
         &mut self,
         payload: TerminalPastePayload,
         source: VtPasteSource,
@@ -949,7 +949,7 @@ impl GhosttyView {
         match payload {
             TerminalPastePayload::Text(text) if !text.is_empty() => {
                 match terminal.paste_text(&text, source, false) {
-                    Ok(VtPasteResult::Written) => {
+                    Ok(VtPasteResult::Accepted) => {
                         self.clear_restored_screen_text();
                         self.clear_selection();
                         true
@@ -983,7 +983,8 @@ impl GhosttyView {
         else {
             return replaced_confirmation;
         };
-        self.send_terminal_paste_payload(payload, VtPasteSource::Clipboard) || replaced_confirmation
+        self.handle_terminal_paste_payload(payload, VtPasteSource::Clipboard)
+            || replaced_confirmation
     }
 
     fn confirm_unsafe_paste(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -996,7 +997,7 @@ impl GhosttyView {
         };
 
         match terminal.paste_text(&text, source, true) {
-            Ok(VtPasteResult::Written) => {
+            Ok(VtPasteResult::Accepted) => {
                 self.clear_restored_screen_text();
                 self.clear_selection();
             }
@@ -1629,7 +1630,7 @@ impl Render for GhosttyView {
                 window.focus(&this.focus_handle, cx);
                 cx.emit(GhosttyFocusChanged);
                 let _ = this.ensure_session(cx);
-                if this.send_terminal_paste_payload(payload, VtPasteSource::Text) {
+                if this.handle_terminal_paste_payload(payload, VtPasteSource::Text) {
                     cx.notify();
                 }
             }))
@@ -1899,22 +1900,22 @@ impl KittyImageLayer {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct KittyPlacementGeometry {
-    left: f32,
-    top: f32,
-    width: f32,
-    height: f32,
-    image_left: f32,
-    image_top: f32,
-    image_width: f32,
-    image_height: f32,
+    left_px: f32,
+    top_px: f32,
+    width_px: f32,
+    height_px: f32,
+    image_left_px: f32,
+    image_top_px: f32,
+    image_width_px: f32,
+    image_height_px: f32,
 }
 
 fn kitty_placement_geometry(
     placement: &KittyPlacement,
-    cell_width: f32,
-    cell_height: f32,
-    physical_cell_width: u32,
-    physical_cell_height: u32,
+    logical_cell_width_px: f32,
+    logical_cell_height_px: f32,
+    physical_cell_width_px: u32,
+    physical_cell_height_px: u32,
 ) -> Option<KittyPlacementGeometry> {
     let image = &placement.image;
     let source_right = placement.source_x.checked_add(placement.source_width)?;
@@ -1927,12 +1928,12 @@ fn kitty_placement_geometry(
         || image.height == 0
         || source_right > image.width
         || source_bottom > image.height
-        || !cell_width.is_finite()
-        || !cell_height.is_finite()
-        || cell_width <= 0.0
-        || cell_height <= 0.0
-        || physical_cell_width == 0
-        || physical_cell_height == 0
+        || !logical_cell_width_px.is_finite()
+        || !logical_cell_height_px.is_finite()
+        || logical_cell_width_px <= 0.0
+        || logical_cell_height_px <= 0.0
+        || physical_cell_width_px == 0
+        || physical_cell_height_px == 0
     {
         return None;
     }
@@ -1941,33 +1942,33 @@ fn kitty_placement_geometry(
     // supplied by `resize_surface`. Derive each axis from that exact quantized
     // size instead of dividing by the fractional display scale, which drifts
     // away from GPUI's logical text grid after several columns.
-    let device_to_logical_x = cell_width as f64 / physical_cell_width as f64;
-    let device_to_logical_y = cell_height as f64 / physical_cell_height as f64;
-    let width = placement.pixel_width as f64 * device_to_logical_x;
-    let height = placement.pixel_height as f64 * device_to_logical_y;
-    let source_scale_x = width / placement.source_width as f64;
-    let source_scale_y = height / placement.source_height as f64;
+    let device_to_logical_x = logical_cell_width_px as f64 / physical_cell_width_px as f64;
+    let device_to_logical_y = logical_cell_height_px as f64 / physical_cell_height_px as f64;
+    let width_px = placement.pixel_width as f64 * device_to_logical_x;
+    let height_px = placement.pixel_height as f64 * device_to_logical_y;
+    let source_scale_x = width_px / placement.source_width as f64;
+    let source_scale_y = height_px / placement.source_height as f64;
     let values = KittyPlacementGeometry {
-        left: (placement.viewport_col as f64 * cell_width as f64
+        left_px: (placement.viewport_col as f64 * logical_cell_width_px as f64
             + placement.cell_x_offset as f64 * device_to_logical_x) as f32,
-        top: (placement.viewport_row as f64 * cell_height as f64
+        top_px: (placement.viewport_row as f64 * logical_cell_height_px as f64
             + placement.cell_y_offset as f64 * device_to_logical_y) as f32,
-        width: width as f32,
-        height: height as f32,
-        image_left: (-(placement.source_x as f64) * source_scale_x) as f32,
-        image_top: (-(placement.source_y as f64) * source_scale_y) as f32,
-        image_width: (image.width as f64 * source_scale_x) as f32,
-        image_height: (image.height as f64 * source_scale_y) as f32,
+        width_px: width_px as f32,
+        height_px: height_px as f32,
+        image_left_px: (-(placement.source_x as f64) * source_scale_x) as f32,
+        image_top_px: (-(placement.source_y as f64) * source_scale_y) as f32,
+        image_width_px: (image.width as f64 * source_scale_x) as f32,
+        image_height_px: (image.height as f64 * source_scale_y) as f32,
     };
     if [
-        values.left,
-        values.top,
-        values.width,
-        values.height,
-        values.image_left,
-        values.image_top,
-        values.image_width,
-        values.image_height,
+        values.left_px,
+        values.top_px,
+        values.width_px,
+        values.height_px,
+        values.image_left_px,
+        values.image_top_px,
+        values.image_width_px,
+        values.image_height_px,
     ]
     .iter()
     .all(|value| value.is_finite())
@@ -2003,11 +2004,11 @@ fn render_kitty_image_layer(
     placements: &[KittyPlacement],
     images: &HashMap<KittyImageKey, Arc<RenderImage>>,
     layer: KittyImageLayer,
-    cell_width: f32,
-    cell_height: f32,
-    physical_cell_width: u32,
-    physical_cell_height: u32,
-    top_offset: f32,
+    logical_cell_width_px: f32,
+    logical_cell_height_px: f32,
+    physical_cell_width_px: u32,
+    physical_cell_height_px: u32,
+    top_offset_px: f32,
 ) -> AnyElement {
     let paint_records = placements
         .iter()
@@ -2019,10 +2020,10 @@ fn render_kitty_image_layer(
             let image = images.get(&key)?.clone();
             let geometry = kitty_placement_geometry(
                 placement,
-                cell_width,
-                cell_height,
-                physical_cell_width,
-                physical_cell_height,
+                logical_cell_width_px,
+                logical_cell_height_px,
+                physical_cell_width_px,
+                physical_cell_height_px,
             )?;
             Some((image, geometry))
         })
@@ -2034,10 +2035,10 @@ fn render_kitty_image_layer(
             for (image, geometry) in paint_records {
                 let crop_bounds = Bounds::new(
                     point(
-                        bounds.origin.x + px(geometry.left),
-                        bounds.origin.y + px(geometry.top + top_offset),
+                        bounds.origin.x + px(geometry.left_px),
+                        bounds.origin.y + px(geometry.top_px + top_offset_px),
                     ),
-                    size(px(geometry.width), px(geometry.height)),
+                    size(px(geometry.width_px), px(geometry.height_px)),
                 );
                 if !crop_bounds.intersects(&bounds) {
                     continue;
@@ -2045,10 +2046,10 @@ fn render_kitty_image_layer(
 
                 let image_bounds = Bounds::new(
                     point(
-                        crop_bounds.origin.x + px(geometry.image_left),
-                        crop_bounds.origin.y + px(geometry.image_top),
+                        crop_bounds.origin.x + px(geometry.image_left_px),
+                        crop_bounds.origin.y + px(geometry.image_top_px),
                     ),
-                    size(px(geometry.image_width), px(geometry.image_height)),
+                    size(px(geometry.image_width_px), px(geometry.image_height_px)),
                 );
                 window.with_content_mask(
                     Some(ContentMask {
@@ -2665,14 +2666,14 @@ mod tests {
         };
 
         let geometry = kitty_placement_geometry(&placement, 10.0, 20.0, 20, 40).unwrap();
-        assert_eq!(geometry.left, -8.0);
-        assert_eq!(geometry.top, 43.0);
-        assert_eq!(geometry.width, 10.0);
-        assert_eq!(geometry.height, 5.0);
-        assert_eq!(geometry.image_left, -5.0);
-        assert_eq!(geometry.image_top, 0.0);
-        assert_eq!(geometry.image_width, 20.0);
-        assert_eq!(geometry.image_height, 10.0);
+        assert_eq!(geometry.left_px, -8.0);
+        assert_eq!(geometry.top_px, 43.0);
+        assert_eq!(geometry.width_px, 10.0);
+        assert_eq!(geometry.height_px, 5.0);
+        assert_eq!(geometry.image_left_px, -5.0);
+        assert_eq!(geometry.image_top_px, 0.0);
+        assert_eq!(geometry.image_width_px, 20.0);
+        assert_eq!(geometry.image_height_px, 10.0);
     }
 
     #[test]
@@ -2703,10 +2704,10 @@ mod tests {
         // placement must advance exactly one logical cell for every 14 device
         // pixels rather than using 1 / 1.5 and accumulating column drift.
         let geometry = kitty_placement_geometry(&placement, 9.0, 20.0, 14, 30).unwrap();
-        assert_eq!(geometry.left, 369.0);
-        assert_eq!(geometry.top, 40.0);
-        assert_eq!(geometry.width, 90.0);
-        assert_eq!(geometry.height, 20.0);
+        assert_eq!(geometry.left_px, 369.0);
+        assert_eq!(geometry.top_px, 40.0);
+        assert_eq!(geometry.width_px, 90.0);
+        assert_eq!(geometry.height_px, 20.0);
     }
 
     #[test]

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -13,9 +13,11 @@
 //! and layout state. The Windows D3D11 path remains the model for the
 //! eventual native renderer.
 
+use std::collections::HashMap;
 use std::ops::Range;
 use std::sync::Arc;
 
+use con_ghostty::vt::{VtKeyAction, VtKeyEvent, VtKeyModifiers};
 use con_ghostty::{
     ATTR_BOLD, ATTR_INVERSE, ATTR_ITALIC, ATTR_STRIKE, ATTR_UNDERLINE, GhosttyApp,
     GhosttySplitDirection, GhosttyTerminal, ScreenSnapshot, SurfaceSize, VtCell, VtCursor,
@@ -31,7 +33,7 @@ use crate::terminal_links::{self, TerminalLink};
 use crate::terminal_paste::{
     TerminalPastePayload, payload_from_clipboard, payload_from_external_paths,
 };
-use crate::terminal_restore::{key_down_may_write_terminal, restored_terminal_output};
+use crate::terminal_restore::restored_terminal_output;
 
 const DEFAULT_FONT_SIZE: f32 = 14.0;
 const MIN_FONT_SIZE_PX: f32 = 12.0;
@@ -122,6 +124,7 @@ pub struct GhosttyView {
     /// Shift state at the right-button press, reused for the matching
     /// release so a modifier change in between doesn't break pairing.
     terminal_mouse_right_shift: bool,
+    keys_awaiting_release: HashMap<String, crate::terminal_keys::TrackedVtKey>,
 }
 
 pub fn init(cx: &mut App) {
@@ -204,6 +207,7 @@ impl GhosttyView {
             drag_anchor: None,
             terminal_mouse_right_consumed: None,
             terminal_mouse_right_shift: false,
+            keys_awaiting_release: HashMap::new(),
         }
     }
 
@@ -278,6 +282,7 @@ impl GhosttyView {
     }
 
     pub fn shutdown_surface(&mut self) {
+        self.release_tracked_keys();
         if let Some(terminal) = &self.terminal {
             terminal.request_close();
         }
@@ -303,9 +308,13 @@ impl GhosttyView {
         self.drag_anchor = None;
         self.terminal_mouse_right_consumed = None;
         self.terminal_mouse_right_shift = false;
+        self.keys_awaiting_release.clear();
     }
 
     pub fn set_surface_focus_state(&mut self, focused: bool) {
+        if !focused {
+            self.release_tracked_keys();
+        }
         if let Some(terminal) = &self.terminal {
             terminal.set_focus(focused);
         }
@@ -702,6 +711,88 @@ impl GhosttyView {
         )
     }
 
+    fn send_vt_key(
+        &mut self,
+        tracking_key: &str,
+        event: &VtKeyEvent<'_>,
+    ) -> Result<con_ghostty::vt::VtKeySend, String> {
+        let Some(terminal) = self.terminal.as_ref().cloned() else {
+            return Ok(con_ghostty::vt::VtKeySend::default());
+        };
+        let sent = terminal.send_key(event)?;
+        if sent.wrote {
+            self.clear_restored_screen_text();
+            self.clear_selection();
+            if sent.report_releases
+                && event.action != VtKeyAction::Release
+                && !self.keys_awaiting_release.contains_key(tracking_key)
+            {
+                self.keys_awaiting_release.insert(
+                    tracking_key.to_owned(),
+                    crate::terminal_keys::TrackedVtKey::from_press(event),
+                );
+            }
+        }
+        Ok(sent)
+    }
+
+    fn handle_key_up(&mut self, event: &KeyUpEvent) -> bool {
+        let Some(tracked) = self.keys_awaiting_release.remove(&event.keystroke.key) else {
+            return false;
+        };
+        let release =
+            tracked.release_with_modifiers(&event.keystroke.key, &event.keystroke.modifiers);
+        match self.send_vt_key(&event.keystroke.key, &release) {
+            Ok(sent) => sent.wrote,
+            Err(err) => {
+                // Preserve the press so focus loss can retry the release if
+                // this was a transient PTY write failure.
+                self.keys_awaiting_release
+                    .insert(event.keystroke.key.clone(), tracked);
+                log::debug!("linux terminal key release failed: {err}");
+                false
+            }
+        }
+    }
+
+    fn release_tracked_keys(&mut self) {
+        let tracked_keys = std::mem::take(&mut self.keys_awaiting_release);
+        let Some(terminal) = self.terminal.as_ref().cloned() else {
+            return;
+        };
+        for (key, tracked) in tracked_keys {
+            let release = tracked.release(&key);
+            if let Err(err) = terminal.send_key(&release) {
+                log::debug!("linux terminal key release failed: {err}");
+            }
+        }
+    }
+
+    fn send_tab_key(&mut self, shift: bool) -> bool {
+        let event = VtKeyEvent {
+            key: "tab",
+            text: "",
+            unshifted_codepoint: None,
+            action: if self.keys_awaiting_release.contains_key("tab") {
+                VtKeyAction::Repeat
+            } else {
+                VtKeyAction::Press
+            },
+            modifiers: VtKeyModifiers {
+                shift,
+                ..VtKeyModifiers::default()
+            },
+            consumed_modifiers: VtKeyModifiers::default(),
+        };
+        match self.send_vt_key("tab", &event) {
+            Ok(sent) => sent.wrote,
+            Err(err) => {
+                log::debug!("linux terminal key encoding failed: {err}");
+                false
+            }
+        }
+    }
+
     fn handle_key_down(
         &mut self,
         event: &KeyDownEvent,
@@ -775,14 +866,11 @@ impl GhosttyView {
             }
         }
 
-        let decckm = terminal.is_decckm();
-        if let Some(bytes) = encode_special_key(&keystroke.key, &keystroke.modifiers, decckm) {
-            terminal.send_text(&bytes);
-            return true;
-        }
-
-        if event.prefer_character_input
-            && !keystroke.modifiers.control
+        // XKB compose and IME completion can arrive as a normal keydown
+        // while GPUI still owns marked text. Its InputHandler must commit
+        // the text and clear that state; encoding here would leave the
+        // preedit overlay stale even though the character reached the PTY.
+        if self.ime_marked_text.is_some()
             && keystroke
                 .key_char
                 .as_deref()
@@ -791,64 +879,16 @@ impl GhosttyView {
             return false;
         }
 
-        if keystroke.modifiers.control
-            && !keystroke.modifiers.alt
-            && (keystroke.key.len() == 1
-                || keystroke
-                    .key_char
-                    .as_deref()
-                    .is_some_and(|text| text.len() == 1))
-        {
-            if let Some(code) = crate::terminal_keys::ctrl_keystroke_to_c0(
-                &keystroke.key,
-                keystroke.key_char.as_deref(),
-                keystroke.modifiers.shift,
-            ) {
-                let control = [code];
-                let text = std::str::from_utf8(&control)
-                    .expect("terminal C0 control bytes are always valid UTF-8");
-                terminal.send_text(text);
-                return true;
+        let Some(vt_event) = crate::terminal_keys::vt_key_down_event(event) else {
+            return false;
+        };
+        match self.send_vt_key(&keystroke.key, &vt_event) {
+            Ok(sent) => sent.wrote,
+            Err(err) => {
+                log::debug!("linux terminal key encoding failed: {err}");
+                false
             }
         }
-
-        if keystroke.modifiers.alt && !keystroke.modifiers.control && !keystroke.modifiers.shift {
-            if let Some(ch) = keystroke.key_char.as_deref().filter(|ch| !ch.is_empty()) {
-                let mut out = String::with_capacity(1 + ch.len());
-                out.push('\x1b');
-                out.push_str(ch);
-                terminal.send_text(&out);
-                return true;
-            }
-        }
-
-        if let Some(text) = keystroke
-            .key_char
-            .as_deref()
-            .filter(|text| !text.is_empty())
-        {
-            if !keystroke.modifiers.control
-                && !keystroke.modifiers.alt
-                && !keystroke.modifiers.platform
-            {
-                return false;
-            }
-            terminal.send_text(text);
-            return true;
-        }
-
-        if keystroke.key.len() == 1 {
-            if !keystroke.modifiers.control
-                && !keystroke.modifiers.alt
-                && !keystroke.modifiers.platform
-            {
-                return false;
-            }
-            terminal.send_text(&keystroke.key);
-            return true;
-        }
-
-        false
     }
 
     fn ime_cursor_bounds(&self) -> Option<Bounds<Pixels>> {
@@ -1193,10 +1233,7 @@ impl Render for GhosttyView {
                     return;
                 }
                 let _ = this.ensure_session(cx);
-                this.clear_restored_screen_text();
-                if let Some(terminal) = &this.terminal {
-                    terminal.send_text("\t");
-                }
+                this.send_tab_key(false);
                 cx.notify();
             }))
             .on_action(cx.listener(|this, _: &ConsumeTabPrev, window, cx| {
@@ -1204,10 +1241,7 @@ impl Render for GhosttyView {
                     return;
                 }
                 let _ = this.ensure_session(cx);
-                this.clear_restored_screen_text();
-                if let Some(terminal) = &this.terminal {
-                    terminal.send_text("\x1b[Z");
-                }
+                this.send_tab_key(true);
                 cx.notify();
             }))
             .on_action(cx.listener(|this, _: &crate::Copy, _window, cx| {
@@ -1242,22 +1276,18 @@ impl Render for GhosttyView {
                 if !this.focus_handle.is_focused(window) {
                     return;
                 }
-                let special_key_writes =
-                    encode_special_key(&event.keystroke.key, &event.keystroke.modifiers, false)
-                        .is_some();
-                let clears_restore = key_down_may_write_terminal(event, special_key_writes);
-                let copy_shortcut = event.keystroke.modifiers.control
-                    && !event.keystroke.modifiers.alt
-                    && !event.keystroke.modifiers.platform
-                    && event.keystroke.key == "c";
                 let _ = this.ensure_session(cx);
-                if clears_restore {
-                    this.clear_restored_screen_text();
-                }
-                if clears_restore && !copy_shortcut {
-                    this.clear_selection();
-                }
                 if this.handle_key_down(event, window, cx) {
+                    window.prevent_default();
+                    cx.stop_propagation();
+                    cx.notify();
+                }
+            }))
+            .on_key_up(cx.listener(|this, event: &KeyUpEvent, window, cx| {
+                if !this.focus_handle.is_focused(window) {
+                    return;
+                }
+                if this.handle_key_up(event) {
                     window.prevent_default();
                     cx.stop_propagation();
                     cx.notify();
@@ -1466,6 +1496,7 @@ impl Render for GhosttyView {
 
 impl Drop for GhosttyView {
     fn drop(&mut self) {
+        self.release_tracked_keys();
         if let Some(terminal) = &self.terminal {
             terminal.request_close();
         }
@@ -1859,63 +1890,6 @@ fn vt_color_to_hsla(packed: u32) -> Option<Hsla> {
     let b = ((packed >> 8) & 0xFF) as f32 / 255.0;
     let a = a as f32 / 255.0;
     Some(Rgba { r, g, b, a }.into())
-}
-
-fn xterm_modifier_param(modifiers: &Modifiers) -> Option<u8> {
-    let mask = u8::from(modifiers.shift)
-        | (u8::from(modifiers.alt) << 1)
-        | (u8::from(modifiers.control) << 2);
-    if mask == 0 { None } else { Some(1 + mask) }
-}
-
-fn encode_special_key(key: &str, modifiers: &Modifiers, decckm: bool) -> Option<String> {
-    let m = xterm_modifier_param(modifiers);
-
-    let tilde = |code: u8| match m {
-        Some(m) => format!("\x1b[{};{}~", code, m),
-        None => format!("\x1b[{}~", code),
-    };
-
-    let csi1 = |final_byte: char, ss3_when_plain: bool, decckm_arrow: bool| match m {
-        Some(m) => format!("\x1b[1;{}{}", m, final_byte),
-        None if decckm_arrow && decckm => format!("\x1bO{}", final_byte),
-        None if ss3_when_plain => format!("\x1bO{}", final_byte),
-        None => format!("\x1b[{}", final_byte),
-    };
-
-    Some(match key {
-        "up" => csi1('A', false, true),
-        "down" => csi1('B', false, true),
-        "right" => csi1('C', false, true),
-        "left" => csi1('D', false, true),
-        "home" => csi1('H', false, false),
-        "end" => csi1('F', false, false),
-        "pageup" => tilde(5),
-        "pagedown" => tilde(6),
-        "insert" => tilde(2),
-        "delete" => tilde(3),
-        "f1" => csi1('P', true, false),
-        "f2" => csi1('Q', true, false),
-        "f3" => csi1('R', true, false),
-        "f4" => csi1('S', true, false),
-        "f5" => tilde(15),
-        "f6" => tilde(17),
-        "f7" => tilde(18),
-        "f8" => tilde(19),
-        "f9" => tilde(20),
-        "f10" => tilde(21),
-        "f11" => tilde(23),
-        "f12" => tilde(24),
-        "enter" | "return" => "\r".into(),
-        "escape" => "\x1b".into(),
-        "backspace" if modifiers.alt && !modifiers.control && !modifiers.platform => {
-            "\x1b\x7f".into()
-        }
-        "backspace" => "\x7f".into(),
-        "tab" if modifiers.shift && !modifiers.control && !modifiers.platform => "\x1b[Z".into(),
-        "tab" => "\t".into(),
-        _ => return None,
-    })
 }
 
 #[cfg(test)]

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 use std::ops::Range;
 use std::sync::Arc;
 
-use con_ghostty::vt::{VtKeyAction, VtKeyEvent, VtKeyModifiers};
+use con_ghostty::vt::{VtKeyAction, VtKeyEvent, VtKeyModifiers, VtPasteResult, VtPasteSource};
 use con_ghostty::{
     ATTR_BOLD, ATTR_INVERSE, ATTR_ITALIC, ATTR_STRIKE, ATTR_UNDERLINE, GhosttyApp,
     GhosttySplitDirection, GhosttyTerminal, ScreenSnapshot, SurfaceSize, VtCell, VtCursor,
@@ -25,13 +25,14 @@ use con_ghostty::{
 use futures::StreamExt;
 use futures::channel::mpsc::unbounded;
 use gpui::*;
-use gpui_component::ActiveTheme;
+use gpui_component::button::{Button, ButtonVariants as _};
 use gpui_component::menu::ContextMenuExt;
+use gpui_component::{ActiveTheme, Sizable as _};
 
 use crate::terminal_ime::{TerminalImeInputHandler, TerminalImeView};
 use crate::terminal_links::{self, TerminalLink};
 use crate::terminal_paste::{
-    TerminalPastePayload, payload_from_clipboard, payload_from_external_paths,
+    TerminalPastePayload, payload_from_clipboard, payload_from_external_paths, unsafe_paste_preview,
 };
 use crate::terminal_restore::restored_terminal_output;
 
@@ -125,6 +126,7 @@ pub struct GhosttyView {
     /// release so a modifier change in between doesn't break pairing.
     terminal_mouse_right_shift: bool,
     keys_awaiting_release: HashMap<String, crate::terminal_keys::TrackedVtKey>,
+    pending_unsafe_paste: Option<(String, VtPasteSource)>,
 }
 
 pub fn init(cx: &mut App) {
@@ -208,6 +210,7 @@ impl GhosttyView {
             terminal_mouse_right_consumed: None,
             terminal_mouse_right_shift: false,
             keys_awaiting_release: HashMap::new(),
+            pending_unsafe_paste: None,
         }
     }
 
@@ -309,6 +312,7 @@ impl GhosttyView {
         self.terminal_mouse_right_consumed = None;
         self.terminal_mouse_right_shift = false;
         self.keys_awaiting_release.clear();
+        self.pending_unsafe_paste = None;
     }
 
     pub fn set_surface_focus_state(&mut self, focused: bool) {
@@ -799,9 +803,9 @@ impl GhosttyView {
         window: &Window,
         cx: &mut Context<Self>,
     ) -> bool {
-        let Some(terminal) = self.terminal.as_ref().cloned() else {
+        if self.terminal.is_none() {
             return false;
-        };
+        }
 
         let keystroke = &event.keystroke;
         if keystroke.modifiers.platform {
@@ -859,7 +863,7 @@ impl GhosttyView {
                     return true;
                 }
                 "v" => {
-                    paste_from_clipboard(&terminal, cx);
+                    self.paste_from_clipboard(cx);
                     return true;
                 }
                 _ => {}
@@ -889,6 +893,168 @@ impl GhosttyView {
                 false
             }
         }
+    }
+
+    fn send_terminal_paste_payload(
+        &mut self,
+        payload: TerminalPastePayload,
+        source: VtPasteSource,
+    ) -> bool {
+        // A new paste intent invalidates any confirmation for older text,
+        // even when this attempt later turns out to be empty or fails.
+        let replaced_confirmation = self.pending_unsafe_paste.take().is_some();
+        let Some(terminal) = self.terminal.as_ref().cloned() else {
+            return replaced_confirmation;
+        };
+
+        match payload {
+            TerminalPastePayload::Text(text) if !text.is_empty() => {
+                match terminal.paste_text(&text, source, false) {
+                    Ok(VtPasteResult::Written) => {
+                        self.clear_restored_screen_text();
+                        self.clear_selection();
+                        true
+                    }
+                    Ok(VtPasteResult::RequiresConfirmation) => {
+                        self.pending_unsafe_paste = Some((text, source));
+                        true
+                    }
+                    Ok(VtPasteResult::Empty) => replaced_confirmation,
+                    Err(err) => {
+                        log::debug!("linux terminal paste failed: {err}");
+                        replaced_confirmation
+                    }
+                }
+            }
+            TerminalPastePayload::ForwardCtrlV => {
+                self.clear_restored_screen_text();
+                self.clear_selection();
+                terminal.send_text("\x16");
+                true
+            }
+            TerminalPastePayload::Text(_) => replaced_confirmation,
+        }
+    }
+
+    fn paste_from_clipboard(&mut self, cx: &mut App) -> bool {
+        let replaced_confirmation = self.pending_unsafe_paste.take().is_some();
+        let Some(payload) = cx
+            .read_from_clipboard()
+            .and_then(|item| payload_from_clipboard(&item))
+        else {
+            return replaced_confirmation;
+        };
+        self.send_terminal_paste_payload(payload, VtPasteSource::Clipboard) || replaced_confirmation
+    }
+
+    fn confirm_unsafe_paste(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some((text, source)) = self.pending_unsafe_paste.take() else {
+            return;
+        };
+        let Some(terminal) = self.terminal.as_ref().cloned() else {
+            self.pending_unsafe_paste = Some((text, source));
+            return;
+        };
+
+        match terminal.paste_text(&text, source, true) {
+            Ok(VtPasteResult::Written) => {
+                self.clear_restored_screen_text();
+                self.clear_selection();
+            }
+            Ok(VtPasteResult::Empty) => {}
+            Ok(VtPasteResult::RequiresConfirmation) => {
+                self.pending_unsafe_paste = Some((text, source));
+            }
+            Err(err) => {
+                log::debug!("linux confirmed terminal paste failed: {err}");
+                self.pending_unsafe_paste = Some((text, source));
+            }
+        }
+        window.focus(&self.focus_handle, cx);
+        cx.notify();
+    }
+
+    fn cancel_unsafe_paste(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.pending_unsafe_paste = None;
+        window.focus(&self.focus_handle, cx);
+        cx.notify();
+    }
+
+    fn render_unsafe_paste_confirmation(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
+        let text = self.pending_unsafe_paste.as_ref()?.0.as_str();
+        let preview = unsafe_paste_preview(text);
+        let theme = cx.theme();
+
+        Some(
+            div()
+                .absolute()
+                .left(px(12.0))
+                .right(px(12.0))
+                .bottom(px(12.0))
+                .flex()
+                .justify_center()
+                .child(
+                    div()
+                        .occlude()
+                        .w_full()
+                        .max_w(px(620.0))
+                        .flex()
+                        .flex_col()
+                        .gap(px(8.0))
+                        .p(px(10.0))
+                        .rounded(px(8.0))
+                        .bg(theme
+                            .warning
+                            .opacity(if theme.is_dark() { 0.18 } else { 0.12 }))
+                        .child(
+                            div()
+                                .text_size(px(12.0))
+                                .font_weight(FontWeight::MEDIUM)
+                                .text_color(theme.foreground)
+                                .child("This paste can run commands. Review it before continuing."),
+                        )
+                        .child(
+                            div()
+                                .max_h(px(88.0))
+                                .overflow_hidden()
+                                .px(px(8.0))
+                                .py(px(6.0))
+                                .rounded(px(6.0))
+                                .bg(theme.foreground.opacity(0.06))
+                                .font_family(theme.mono_font_family.clone())
+                                .text_size(px(11.0))
+                                .line_height(px(15.0))
+                                .text_color(theme.foreground.opacity(0.82))
+                                .child(preview),
+                        )
+                        .child(
+                            div()
+                                .flex()
+                                .justify_end()
+                                .items_center()
+                                .gap(px(6.0))
+                                .child(
+                                    Button::new("linux-cancel-unsafe-paste")
+                                        .label("Cancel")
+                                        .small()
+                                        .ghost()
+                                        .on_click(cx.listener(|this, _, window, cx| {
+                                            this.cancel_unsafe_paste(window, cx);
+                                        })),
+                                )
+                                .child(
+                                    Button::new("linux-confirm-unsafe-paste")
+                                        .label("Paste")
+                                        .small()
+                                        .primary()
+                                        .on_click(cx.listener(|this, _, window, cx| {
+                                            this.confirm_unsafe_paste(window, cx);
+                                        })),
+                                ),
+                        ),
+                )
+                .into_any_element(),
+        )
     }
 
     fn ime_cursor_bounds(&self) -> Option<Bounds<Pixels>> {
@@ -984,41 +1150,6 @@ impl GhosttyView {
     }
 }
 
-fn send_paste(terminal: &GhosttyTerminal, text: &str) {
-    if text.is_empty() {
-        return;
-    }
-
-    if terminal.is_bracketed_paste() {
-        let mut wrapped = String::with_capacity(text.len() + 12);
-        wrapped.push_str("\x1b[200~");
-        wrapped.push_str(text);
-        wrapped.push_str("\x1b[201~");
-        terminal.send_text(&wrapped);
-    } else {
-        terminal.send_text(text);
-    }
-}
-
-fn send_terminal_paste_payload(terminal: &GhosttyTerminal, payload: TerminalPastePayload) {
-    match payload {
-        TerminalPastePayload::Text(text) => send_paste(terminal, &text),
-        TerminalPastePayload::ForwardCtrlV => terminal.send_text("\x16"),
-    }
-}
-
-fn paste_from_clipboard(terminal: &GhosttyTerminal, cx: &mut App) -> bool {
-    let Some(payload) = cx
-        .read_from_clipboard()
-        .and_then(|item| payload_from_clipboard(&item))
-    else {
-        return false;
-    };
-
-    send_terminal_paste_payload(terminal, payload);
-    true
-}
-
 impl Focusable for GhosttyView {
     fn focus_handle(&self, _cx: &App) -> FocusHandle {
         self.focus_handle.clone()
@@ -1071,6 +1202,7 @@ impl TerminalImeView for GhosttyView {
 
 impl Render for GhosttyView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let unsafe_paste_confirmation = self.render_unsafe_paste_confirmation(cx);
         let theme = cx.theme();
         let focus = self.focus_handle.clone();
         let input_focus = focus.clone();
@@ -1251,10 +1383,7 @@ impl Render for GhosttyView {
             }))
             .on_action(cx.listener(|this, _: &crate::Paste, _window, cx| {
                 let _ = this.ensure_session(cx);
-                this.clear_restored_screen_text();
-                if let Some(terminal) = &this.terminal
-                    && paste_from_clipboard(terminal, cx)
-                {
+                if this.paste_from_clipboard(cx) {
                     cx.notify();
                 }
             }))
@@ -1266,9 +1395,7 @@ impl Render for GhosttyView {
                 window.focus(&this.focus_handle, cx);
                 cx.emit(GhosttyFocusChanged);
                 let _ = this.ensure_session(cx);
-                this.clear_restored_screen_text();
-                if let Some(terminal) = &this.terminal {
-                    send_terminal_paste_payload(terminal, payload);
+                if this.send_terminal_paste_payload(payload, VtPasteSource::Text) {
                     cx.notify();
                 }
             }))
@@ -1474,7 +1601,8 @@ impl Render for GhosttyView {
                         )
                         .absolute()
                         .size_full(),
-                    ),
+                    )
+                    .children(unsafe_paste_confirmation),
             )
             .context_menu(move |menu, window, cx| {
                 // Empty PopupMenu renders nothing; suppress con's menu only

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -550,7 +550,13 @@ impl GhosttyView {
         }
 
         self.clear_selection();
-        terminal.resize_surface(size);
+        if let Err(err) = terminal.resize_surface(size) {
+            // Do not cache a resize that never reached the PTY. A later layout
+            // or render pass can retry the same dimensions after backpressure
+            // on the Flatpak host bridge clears.
+            log::debug!("linux pty resize failed: {err}");
+            return false;
+        }
         self.last_surface_size = Some(size);
         false
     }

--- a/crates/con-app/src/stub_view.rs
+++ b/crates/con-app/src/stub_view.rs
@@ -94,7 +94,7 @@ impl GhosttyView {
         None
     }
 
-    pub fn shutdown_surface(&mut self) {}
+    pub fn shutdown_surface(&mut self, _window: Option<&mut Window>, _cx: &mut App) {}
 
     pub fn set_surface_focus_state(&mut self, _focused: bool) {}
 

--- a/crates/con-app/src/terminal_keys.rs
+++ b/crates/con-app/src/terminal_keys.rs
@@ -128,7 +128,7 @@ fn printable_text(keystroke: &Keystroke) -> Option<&str> {
         })
 }
 
-#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[cfg(any(target_os = "windows", target_os = "linux", test))]
 fn conservative_unshifted_codepoint(text: &str, shift: bool) -> Option<char> {
     let mut chars = text.chars();
     let ch = chars.next()?;
@@ -139,10 +139,15 @@ fn conservative_unshifted_codepoint(text: &str, shift: bool) -> Option<char> {
         return Some(ch);
     }
 
-    // GPUI retains Shift for cased letters but commonly consumes it for
-    // shifted punctuation. Lowercase a single cased codepoint so Kitty can
-    // identify and release non-ASCII keys such as Ä/ä without guessing a
-    // keyboard layout. Multi-codepoint case mappings stay unidentified.
+    // GPUI can retain Shift while reporting an already-lowercase key_char for
+    // shortcut chords such as Ctrl+Shift+P. Preserve that cased identity so
+    // Kitty does not fall back to emitting bare text. Shifted punctuation is
+    // intentionally excluded because its physical unshifted key is layout-
+    // dependent. Otherwise lowercase one cased codepoint so non-ASCII keys
+    // such as Ä/ä remain identifiable without guessing a keyboard layout.
+    if ch.is_lowercase() {
+        return Some(ch);
+    }
     let mut lowercase = ch.to_lowercase();
     let unshifted = lowercase.next()?;
     (lowercase.next().is_none() && unshifted != ch).then_some(unshifted)
@@ -202,7 +207,15 @@ pub fn ctrl_chord_to_c0(key: &str) -> Option<u8> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ctrl_chord_to_c0, ctrl_key_to_c0};
+    use super::{conservative_unshifted_codepoint, ctrl_chord_to_c0, ctrl_key_to_c0};
+
+    #[test]
+    fn shifted_lowercase_retains_kitty_key_identity() {
+        assert_eq!(conservative_unshifted_codepoint("p", true), Some('p'));
+        assert_eq!(conservative_unshifted_codepoint("Ä", true), Some('ä'));
+        assert_eq!(conservative_unshifted_codepoint("*", true), None);
+        assert_eq!(conservative_unshifted_codepoint("ss", true), None);
+    }
 
     #[test]
     fn ctrl_key_maps_letters_to_c0() {

--- a/crates/con-app/src/terminal_keys.rs
+++ b/crates/con-app/src/terminal_keys.rs
@@ -1,3 +1,153 @@
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+use con_ghostty::vt::{VtKeyAction, VtKeyEvent, VtKeyModifiers, is_supported_functional_key};
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+use gpui::{KeyDownEvent, Keystroke, Modifiers};
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[derive(Debug, Clone)]
+pub struct TrackedVtKey {
+    text: String,
+    unshifted_codepoint: Option<char>,
+    modifiers: VtKeyModifiers,
+    consumed_modifiers: VtKeyModifiers,
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+impl TrackedVtKey {
+    pub fn from_press(event: &VtKeyEvent<'_>) -> Self {
+        Self {
+            text: event.text.to_owned(),
+            unshifted_codepoint: event.unshifted_codepoint,
+            modifiers: event.modifiers,
+            consumed_modifiers: event.consumed_modifiers,
+        }
+    }
+
+    pub fn release<'a>(&'a self, key: &'a str) -> VtKeyEvent<'a> {
+        VtKeyEvent {
+            key,
+            text: &self.text,
+            unshifted_codepoint: self.unshifted_codepoint,
+            action: VtKeyAction::Release,
+            modifiers: self.modifiers,
+            consumed_modifiers: self.consumed_modifiers,
+        }
+    }
+
+    pub fn release_with_modifiers<'a>(
+        &'a self,
+        key: &'a str,
+        modifiers: &Modifiers,
+    ) -> VtKeyEvent<'a> {
+        let modifiers = vt_modifiers(modifiers);
+        VtKeyEvent {
+            key,
+            text: &self.text,
+            unshifted_codepoint: self.unshifted_codepoint,
+            action: VtKeyAction::Release,
+            modifiers,
+            consumed_modifiers: VtKeyModifiers {
+                shift: modifiers.shift && self.consumed_modifiers.shift,
+                control: modifiers.control && self.consumed_modifiers.control,
+                alt: modifiers.alt && self.consumed_modifiers.alt,
+                platform: modifiers.platform && self.consumed_modifiers.platform,
+            },
+        }
+    }
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+pub fn vt_key_down_event(event: &KeyDownEvent) -> Option<VtKeyEvent<'_>> {
+    let keystroke = &event.keystroke;
+    let functional = is_supported_functional_key(&keystroke.key);
+
+    // GPUI explicitly sets this for character-producing input such as
+    // Windows AltGr. Let the InputHandler deliver the committed text so
+    // the encoder cannot turn Ctrl+Alt into a terminal chord or duplicate
+    // an IME/dead-key commit.
+    if event.prefer_character_input && !functional {
+        return None;
+    }
+
+    Some(vt_key_event(
+        keystroke,
+        if event.is_held {
+            VtKeyAction::Repeat
+        } else {
+            VtKeyAction::Press
+        },
+    ))
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+pub fn vt_key_event(keystroke: &Keystroke, action: VtKeyAction) -> VtKeyEvent<'_> {
+    let functional = is_supported_functional_key(&keystroke.key);
+    // Space has a physical-key identity but still requires its layout text
+    // for legacy and Kitty encoding (including Ctrl-Space -> NUL).
+    let text = if functional && keystroke.key != "space" {
+        ""
+    } else {
+        printable_text(keystroke).unwrap_or("")
+    };
+    let modifiers = vt_modifiers(&keystroke.modifiers);
+    let consumed_modifiers = VtKeyModifiers {
+        shift: !functional && modifiers.shift && !text.is_empty(),
+        ..VtKeyModifiers::default()
+    };
+
+    VtKeyEvent {
+        key: &keystroke.key,
+        text,
+        unshifted_codepoint: conservative_unshifted_codepoint(text, modifiers.shift),
+        action,
+        modifiers,
+        consumed_modifiers,
+    }
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+fn vt_modifiers(modifiers: &Modifiers) -> VtKeyModifiers {
+    VtKeyModifiers {
+        shift: modifiers.shift,
+        control: modifiers.control,
+        alt: modifiers.alt,
+        platform: modifiers.platform,
+    }
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+fn printable_text(keystroke: &Keystroke) -> Option<&str> {
+    keystroke
+        .key_char
+        .as_deref()
+        .filter(|text| !text.is_empty() && text.chars().all(|ch| !ch.is_control()))
+        .or_else(|| {
+            let mut chars = keystroke.key.chars();
+            let ch = chars.next()?;
+            (chars.next().is_none() && !ch.is_control()).then_some(keystroke.key.as_str())
+        })
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+fn conservative_unshifted_codepoint(text: &str, shift: bool) -> Option<char> {
+    let mut chars = text.chars();
+    let ch = chars.next()?;
+    if chars.next().is_some() {
+        return None;
+    }
+    if !shift {
+        return Some(ch);
+    }
+
+    // GPUI retains Shift for cased letters but commonly consumes it for
+    // shifted punctuation. Lowercase a single cased codepoint so Kitty can
+    // identify and release non-ASCII keys such as Ä/ä without guessing a
+    // keyboard layout. Multi-codepoint case mappings stay unidentified.
+    let mut lowercase = ch.to_lowercase();
+    let unshifted = lowercase.next()?;
+    (lowercase.next().is_none() && unshifted != ch).then_some(unshifted)
+}
+
 /// Map legacy terminal Ctrl-key aliases to the C0/DEL byte they emit.
 ///
 /// This intentionally covers the classic byte layer only. Modern protocols
@@ -50,36 +200,9 @@ pub fn ctrl_chord_to_c0(key: &str) -> Option<u8> {
     None
 }
 
-#[cfg(any(target_os = "windows", target_os = "linux", test))]
-fn ctrl_keystroke_key_to_c0(key: &str) -> Option<u8> {
-    let trimmed = key.trim();
-    // The surface API accepts legacy ctrl-2..8 byte aliases, but human
-    // Windows/Linux keyboard input reserves Ctrl+1..9 for app tab selection.
-    if trimmed.len() == 1 && trimmed.as_bytes()[0].is_ascii_digit() {
-        return None;
-    }
-
-    ctrl_key_to_c0(trimmed)
-}
-
-#[cfg(any(target_os = "windows", target_os = "linux", test))]
-pub fn ctrl_keystroke_to_c0(key: &str, key_char: Option<&str>, shift: bool) -> Option<u8> {
-    if shift {
-        return key_char
-            .filter(|text| !text.chars().all(|ch| ch.is_ascii_alphabetic()))
-            .and_then(ctrl_key_to_c0)
-            .or_else(|| match key {
-                "@" | "^" | "_" | "?" | "~" => ctrl_key_to_c0(key),
-                _ => None,
-            });
-    }
-
-    ctrl_keystroke_key_to_c0(key).or_else(|| key_char.and_then(ctrl_keystroke_key_to_c0))
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{ctrl_chord_to_c0, ctrl_key_to_c0, ctrl_keystroke_to_c0};
+    use super::{ctrl_chord_to_c0, ctrl_key_to_c0};
 
     #[test]
     fn ctrl_key_maps_letters_to_c0() {
@@ -126,20 +249,37 @@ mod tests {
         assert_eq!(ctrl_chord_to_c0("ctrl-2"), Some(0x00));
         assert_eq!(ctrl_chord_to_c0("ctrl-~"), Some(0x1e));
     }
+}
+
+#[cfg(all(test, any(target_os = "windows", target_os = "linux")))]
+mod vt_tests {
+    use super::vt_key_event;
+    use con_ghostty::vt::VtKeyAction;
+    use gpui::{Keystroke, Modifiers};
 
     #[test]
-    fn ctrl_keystroke_uses_shifted_punctuation_without_breaking_tab_shortcuts() {
-        assert_eq!(ctrl_keystroke_to_c0("2", Some("2"), false), None);
-        assert_eq!(ctrl_keystroke_to_c0("3", Some("3"), false), None);
-        assert_eq!(ctrl_keystroke_to_c0("8", Some("8"), false), None);
-        assert_eq!(ctrl_keystroke_to_c0("2", Some("@"), true), Some(0x00));
-        assert_eq!(ctrl_keystroke_to_c0("6", Some("^"), true), Some(0x1e));
-        assert_eq!(ctrl_keystroke_to_c0("-", Some("_"), true), Some(0x1f));
-        assert_eq!(ctrl_keystroke_to_c0("`", Some("~"), true), Some(0x1e));
-        assert_eq!(ctrl_keystroke_to_c0("~", None, true), Some(0x1e));
-        assert_eq!(ctrl_keystroke_to_c0("a", Some("A"), true), None);
-        assert_eq!(ctrl_keystroke_to_c0("]", Some("}"), true), None);
-        assert_eq!(ctrl_keystroke_to_c0("]", None, false), Some(0x1d));
-        assert_eq!(ctrl_keystroke_to_c0("/", Some("/"), false), Some(0x1f));
+    fn space_keeps_text_for_the_ghostty_encoder() {
+        let keystroke = Keystroke {
+            modifiers: Modifiers::default(),
+            key: "space".into(),
+            key_char: Some(" ".into()),
+        };
+
+        let event = vt_key_event(&keystroke, VtKeyAction::Press);
+        assert_eq!(event.key, "space");
+        assert_eq!(event.text, " ");
+        assert_eq!(event.unshifted_codepoint, Some(' '));
+
+        let shifted_non_ascii = Keystroke {
+            modifiers: Modifiers {
+                shift: true,
+                ..Modifiers::default()
+            },
+            key: "adiaeresis".into(),
+            key_char: Some("Ä".into()),
+        };
+        let event = vt_key_event(&shifted_non_ascii, VtKeyAction::Press);
+        assert_eq!(event.text, "Ä");
+        assert_eq!(event.unshifted_codepoint, Some('ä'));
     }
 }

--- a/crates/con-app/src/terminal_keys.rs
+++ b/crates/con-app/src/terminal_keys.rs
@@ -14,7 +14,7 @@ pub struct TrackedVtKey {
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 impl TrackedVtKey {
-    pub fn from_press(event: &VtKeyEvent<'_>) -> Self {
+    pub fn from_non_release_event(event: &VtKeyEvent<'_>) -> Self {
         Self {
             text: event.text.to_owned(),
             unshifted_codepoint: event.unshifted_codepoint,

--- a/crates/con-app/src/terminal_pane.rs
+++ b/crates/con-app/src/terminal_pane.rs
@@ -132,8 +132,9 @@ impl TerminalPane {
             .set_transition_underlay_visible(visible);
     }
 
-    pub fn shutdown_surface(&self, cx: &mut App) {
-        self.entity.update(cx, |view, _| view.shutdown_surface());
+    pub fn shutdown_surface(&self, window: Option<&mut Window>, cx: &mut App) {
+        self.entity
+            .update(cx, |view, cx| view.shutdown_surface(window, cx));
     }
 
     pub fn set_focus_state(&self, focused: bool, cx: &mut App) {

--- a/crates/con-app/src/terminal_paste.rs
+++ b/crates/con-app/src/terminal_paste.rs
@@ -10,6 +10,69 @@ pub enum TerminalPastePayload {
     ForwardCtrlV,
 }
 
+/// Produce a bounded, inert preview for the unsafe-paste confirmation UI.
+/// Terminal controls, Unicode directional controls, and invisible formatting
+/// characters are replaced so text cannot alter the UI or disguise a command.
+pub fn unsafe_paste_preview(text: &str) -> String {
+    const MAX_CHARS: usize = 240;
+    const MAX_LINES: usize = 4;
+
+    let mut preview = String::with_capacity(text.len().min(MAX_CHARS));
+    let mut chars = text.chars();
+    let mut consumed = 0;
+    let mut lines = 1;
+    let mut truncated = false;
+
+    for ch in chars.by_ref() {
+        if consumed == MAX_CHARS {
+            truncated = true;
+            break;
+        }
+        consumed += 1;
+
+        match ch {
+            '\n' if lines < MAX_LINES => {
+                preview.push('↵');
+                preview.push('\n');
+                lines += 1;
+            }
+            '\n' => {
+                truncated = true;
+                break;
+            }
+            '\r' => preview.push('␍'),
+            '\t' => preview.push('⇥'),
+            ch if is_unsafe_preview_control(ch) => preview.push('�'),
+            ch => preview.push(ch),
+        }
+    }
+
+    if !truncated && chars.next().is_some() {
+        truncated = true;
+    }
+    if truncated {
+        preview.push('…');
+    }
+    preview
+}
+
+fn is_unsafe_preview_control(ch: char) -> bool {
+    ch.is_control()
+        || matches!(
+            ch,
+            // Soft hyphen, Arabic letter mark, and Mongolian vowel separator.
+            '\u{00ad}' | '\u{061c}' | '\u{180e}'
+            // Zero-width controls plus left-to-right/right-to-left marks.
+            | '\u{200b}'..='\u{200f}'
+            // Unicode line/paragraph separators and bidi embeddings/overrides.
+            | '\u{2028}'..='\u{202e}'
+            // Word joiner, bidi isolates, and deprecated directional controls.
+            | '\u{2060}'..='\u{206f}'
+            | '\u{feff}'
+            | '\u{fff9}'..='\u{fffb}'
+        )
+}
+
 pub fn payload_from_clipboard(item: &ClipboardItem) -> Option<TerminalPastePayload> {
     let paths = external_paths_from_entries(item.entries());
     if !paths.is_empty() {
@@ -212,7 +275,7 @@ mod tests {
 
     use super::{
         CopySelectionDecision, TerminalPastePayload, copy_selection_decision,
-        payload_from_clipboard, quoted_paths_text,
+        payload_from_clipboard, quoted_paths_text, unsafe_paste_preview,
     };
 
     #[test]
@@ -397,6 +460,23 @@ mod tests {
         };
 
         assert_eq!(payload_from_clipboard(&item), None);
+    }
+
+    #[test]
+    fn unsafe_paste_preview_is_bounded_and_neutralizes_control_text() {
+        let text = format!(
+            "echo ok\n\x1b[31mhidden\u{202e}\u{200b}\u{2028}{}",
+            "x".repeat(300)
+        );
+        let preview = unsafe_paste_preview(&text);
+
+        assert!(preview.starts_with("echo ok↵\n�[31mhidden���"));
+        assert!(preview.ends_with('…'));
+        assert!(!preview.contains('\x1b'));
+        assert!(!preview.contains('\u{202e}'));
+        assert!(!preview.contains('\u{200b}'));
+        assert!(!preview.contains('\u{2028}'));
+        assert!(preview.chars().count() <= 245);
     }
 
     #[cfg(windows)]

--- a/crates/con-app/src/terminal_paste.rs
+++ b/crates/con-app/src/terminal_paste.rs
@@ -13,6 +13,7 @@ pub enum TerminalPastePayload {
 /// Produce a bounded, inert preview for the unsafe-paste confirmation UI.
 /// Terminal controls, Unicode directional controls, and invisible formatting
 /// characters are replaced so text cannot alter the UI or disguise a command.
+#[cfg(any(target_os = "windows", target_os = "linux", test))]
 pub fn unsafe_paste_preview(text: &str) -> String {
     const MAX_CHARS: usize = 240;
     const MAX_LINES: usize = 4;
@@ -56,6 +57,7 @@ pub fn unsafe_paste_preview(text: &str) -> String {
     preview
 }
 
+#[cfg(any(target_os = "windows", target_os = "linux", test))]
 fn is_unsafe_preview_control(ch: char) -> bool {
     ch.is_control()
         || matches!(

--- a/crates/con-app/src/terminal_restore.rs
+++ b/crates/con-app/src/terminal_restore.rs
@@ -1,3 +1,4 @@
+#[cfg(target_os = "macos")]
 use gpui::KeyDownEvent;
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]
@@ -5,6 +6,7 @@ pub(crate) fn restored_terminal_output(lines: Option<&[String]>) -> Option<Vec<u
     con_ghostty::restored_terminal_output_text(lines?).map(String::into_bytes)
 }
 
+#[cfg(target_os = "macos")]
 pub(crate) fn key_down_may_write_terminal(event: &KeyDownEvent, special_key_writes: bool) -> bool {
     let keystroke = &event.keystroke;
     if keystroke.modifiers.platform {

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -1164,24 +1164,24 @@ impl GhosttyView {
         &mut self,
         tracking_key: &str,
         event: &VtKeyEvent<'_>,
-    ) -> Result<con_ghostty::vt::VtKeySend, String> {
+    ) -> Result<con_ghostty::vt::VtKeyOutcome, String> {
         let Some(terminal) = self.terminal.as_ref().cloned() else {
-            return Ok(con_ghostty::vt::VtKeySend::default());
+            return Ok(con_ghostty::vt::VtKeyOutcome::default());
         };
-        let sent = terminal.send_key(event)?;
-        if sent.wrote {
+        let outcome = terminal.send_key(event)?;
+        if outcome.output_accepted {
             self.clear_restored_screen_text();
-            if sent.report_releases
+            if outcome.report_releases
                 && event.action != VtKeyAction::Release
                 && !self.keys_awaiting_release.contains_key(tracking_key)
             {
                 self.keys_awaiting_release.insert(
                     tracking_key.to_owned(),
-                    crate::terminal_keys::TrackedVtKey::from_press(event),
+                    crate::terminal_keys::TrackedVtKey::from_non_release_event(event),
                 );
             }
         }
-        Ok(sent)
+        Ok(outcome)
     }
 
     fn handle_key_up(&mut self, event: &KeyUpEvent) -> bool {
@@ -1191,7 +1191,7 @@ impl GhosttyView {
         let release =
             tracked.release_with_modifiers(&event.keystroke.key, &event.keystroke.modifiers);
         match self.send_vt_key(&event.keystroke.key, &release) {
-            Ok(sent) => sent.wrote,
+            Ok(outcome) => outcome.output_accepted,
             Err(err) => {
                 // Preserve the press so focus loss can retry the release if
                 // this was a transient PTY write failure.
@@ -1234,7 +1234,7 @@ impl GhosttyView {
             consumed_modifiers: VtKeyModifiers::default(),
         };
         match self.send_vt_key("tab", &event) {
-            Ok(sent) => sent.wrote,
+            Ok(outcome) => outcome.output_accepted,
             Err(err) => {
                 log::debug!("windows terminal key encoding failed: {err}");
                 false
@@ -1347,7 +1347,7 @@ impl GhosttyView {
             return false;
         };
         match self.send_vt_key(&keystroke.key, &vt_event) {
-            Ok(sent) => sent.wrote,
+            Ok(outcome) => outcome.output_accepted,
             Err(err) => {
                 log::debug!("windows terminal key encoding failed: {err}");
                 false
@@ -1355,7 +1355,7 @@ impl GhosttyView {
         }
     }
 
-    fn send_terminal_paste_payload(
+    fn handle_terminal_paste_payload(
         &mut self,
         payload: TerminalPastePayload,
         source: VtPasteSource,
@@ -1370,7 +1370,7 @@ impl GhosttyView {
         match payload {
             TerminalPastePayload::Text(text) if !text.is_empty() => {
                 match terminal.paste_text(&text, source, false) {
-                    Ok(VtPasteResult::Written) => {
+                    Ok(VtPasteResult::Accepted) => {
                         self.clear_restored_screen_text();
                         true
                     }
@@ -1402,7 +1402,8 @@ impl GhosttyView {
         else {
             return replaced_confirmation;
         };
-        self.send_terminal_paste_payload(payload, VtPasteSource::Clipboard) || replaced_confirmation
+        self.handle_terminal_paste_payload(payload, VtPasteSource::Clipboard)
+            || replaced_confirmation
     }
 
     fn confirm_unsafe_paste(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -1415,7 +1416,7 @@ impl GhosttyView {
         };
 
         match terminal.paste_text(&text, source, true) {
-            Ok(VtPasteResult::Written) => self.clear_restored_screen_text(),
+            Ok(VtPasteResult::Accepted) => self.clear_restored_screen_text(),
             Ok(VtPasteResult::Empty) => {}
             Ok(VtPasteResult::RequiresConfirmation) => {
                 self.pending_unsafe_paste = Some((text, source));
@@ -1703,7 +1704,7 @@ impl Render for GhosttyView {
                 };
                 window.focus(&this.focus_handle, cx);
                 cx.emit(GhosttyFocusChanged);
-                if this.send_terminal_paste_payload(payload, VtPasteSource::Text) {
+                if this.handle_terminal_paste_payload(payload, VtPasteSource::Text) {
                     cx.notify();
                 }
             }))

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -1211,6 +1211,7 @@ impl GhosttyView {
         for (key, tracked) in tracked_keys {
             let release = tracked.release(&key);
             if let Err(err) = terminal.send_key(&release) {
+                self.keys_awaiting_release.insert(key, tracked);
                 log::debug!("windows terminal key release failed: {err}");
             }
         }

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -42,13 +42,14 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
-use con_ghostty::vt::{VtKeyAction, VtKeyEvent, VtKeyModifiers};
+use con_ghostty::vt::{VtKeyAction, VtKeyEvent, VtKeyModifiers, VtPasteResult, VtPasteSource};
 use con_ghostty::{GhosttyApp, GhosttyScrollbar, GhosttySplitDirection, GhosttyTerminal};
 use futures::StreamExt;
 use futures::channel::mpsc::{UnboundedSender, unbounded};
 use gpui::*;
-use gpui_component::ActiveTheme;
+use gpui_component::button::{Button, ButtonVariants as _};
 use gpui_component::menu::ContextMenuExt;
+use gpui_component::{ActiveTheme, Sizable as _};
 use image::{Frame, RgbaImage};
 use smallvec::SmallVec;
 
@@ -56,7 +57,7 @@ use crate::terminal_ime::{TerminalImeInputHandler, TerminalImeView};
 use crate::terminal_links::{self, TerminalLink};
 use crate::terminal_paste::{
     TerminalPastePayload, copy_selection_to_clipboard, payload_from_clipboard,
-    payload_from_external_paths,
+    payload_from_external_paths, unsafe_paste_preview,
 };
 use crate::terminal_restore::restored_terminal_output;
 use con_ghostty::windows::host_view::{MouseEventMods, RenderSession};
@@ -169,6 +170,7 @@ pub struct GhosttyView {
     hovered_link: Option<TerminalLink>,
     last_mouse_position: Option<Point<Pixels>>,
     keys_awaiting_release: HashMap<String, crate::terminal_keys::TrackedVtKey>,
+    pending_unsafe_paste: Option<(String, VtPasteSource)>,
     /// Cloned and handed to `RenderSession::new`; the ConPTY reader
     /// thread sends at most one queued signal while a repaint wake is
     /// pending. The coalescer task spawned in `new()` consumes that
@@ -256,6 +258,7 @@ impl GhosttyView {
             hovered_link: None,
             last_mouse_position: None,
             keys_awaiting_release: HashMap::new(),
+            pending_unsafe_paste: None,
             wake_tx,
             wake_pending,
         }
@@ -325,6 +328,7 @@ impl GhosttyView {
         self.hovered_link = None;
         self.last_mouse_position = None;
         self.keys_awaiting_release.clear();
+        self.pending_unsafe_paste = None;
         self.images_to_drop.clear();
         self.last_physical_size = None;
     }
@@ -1245,9 +1249,9 @@ impl GhosttyView {
         window: &Window,
         cx: &mut Context<Self>,
     ) -> bool {
-        let Some(terminal) = self.terminal.as_ref() else {
+        if self.terminal.is_none() {
             return false;
-        };
+        }
         let keystroke = &event.keystroke;
 
         if crate::terminal_shortcuts::key_down_starts_action_binding(
@@ -1287,7 +1291,10 @@ impl GhosttyView {
             && !keystroke.modifiers.alt
             && !keystroke.modifiers.platform
             && keystroke.key == "c"
-            && copy_selection_to_clipboard(terminal, cx)
+            && self
+                .terminal
+                .as_ref()
+                .is_some_and(|terminal| copy_selection_to_clipboard(terminal, cx))
         {
             cx.notify();
             return true;
@@ -1303,13 +1310,17 @@ impl GhosttyView {
         {
             match keystroke.key.as_str() {
                 "c" => {
-                    if copy_selection_to_clipboard(terminal, cx) {
+                    if self
+                        .terminal
+                        .as_ref()
+                        .is_some_and(|terminal| copy_selection_to_clipboard(terminal, cx))
+                    {
                         cx.notify();
                     }
                     return true;
                 }
                 "v" => {
-                    paste_from_clipboard(terminal, cx);
+                    self.paste_from_clipboard(cx);
                     return true;
                 }
                 _ => {}
@@ -1339,6 +1350,163 @@ impl GhosttyView {
                 false
             }
         }
+    }
+
+    fn send_terminal_paste_payload(
+        &mut self,
+        payload: TerminalPastePayload,
+        source: VtPasteSource,
+    ) -> bool {
+        // A new paste intent invalidates any confirmation for older text,
+        // even when this attempt later turns out to be empty or fails.
+        let replaced_confirmation = self.pending_unsafe_paste.take().is_some();
+        let Some(terminal) = self.terminal.as_ref().cloned() else {
+            return replaced_confirmation;
+        };
+
+        match payload {
+            TerminalPastePayload::Text(text) if !text.is_empty() => {
+                match terminal.paste_text(&text, source, false) {
+                    Ok(VtPasteResult::Written) => {
+                        self.clear_restored_screen_text();
+                        true
+                    }
+                    Ok(VtPasteResult::RequiresConfirmation) => {
+                        self.pending_unsafe_paste = Some((text, source));
+                        true
+                    }
+                    Ok(VtPasteResult::Empty) => replaced_confirmation,
+                    Err(err) => {
+                        log::debug!("windows terminal paste failed: {err}");
+                        replaced_confirmation
+                    }
+                }
+            }
+            TerminalPastePayload::ForwardCtrlV => {
+                self.clear_restored_screen_text();
+                terminal.send_text("\x16");
+                true
+            }
+            TerminalPastePayload::Text(_) => replaced_confirmation,
+        }
+    }
+
+    fn paste_from_clipboard(&mut self, cx: &mut App) -> bool {
+        let replaced_confirmation = self.pending_unsafe_paste.take().is_some();
+        let Some(payload) = cx
+            .read_from_clipboard()
+            .and_then(|item| payload_from_clipboard(&item))
+        else {
+            return replaced_confirmation;
+        };
+        self.send_terminal_paste_payload(payload, VtPasteSource::Clipboard) || replaced_confirmation
+    }
+
+    fn confirm_unsafe_paste(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some((text, source)) = self.pending_unsafe_paste.take() else {
+            return;
+        };
+        let Some(terminal) = self.terminal.as_ref().cloned() else {
+            self.pending_unsafe_paste = Some((text, source));
+            return;
+        };
+
+        match terminal.paste_text(&text, source, true) {
+            Ok(VtPasteResult::Written) => self.clear_restored_screen_text(),
+            Ok(VtPasteResult::Empty) => {}
+            Ok(VtPasteResult::RequiresConfirmation) => {
+                self.pending_unsafe_paste = Some((text, source));
+            }
+            Err(err) => {
+                log::debug!("windows confirmed terminal paste failed: {err}");
+                self.pending_unsafe_paste = Some((text, source));
+            }
+        }
+        window.focus(&self.focus_handle, cx);
+        cx.notify();
+    }
+
+    fn cancel_unsafe_paste(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.pending_unsafe_paste = None;
+        window.focus(&self.focus_handle, cx);
+        cx.notify();
+    }
+
+    fn render_unsafe_paste_confirmation(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
+        let text = self.pending_unsafe_paste.as_ref()?.0.as_str();
+        let preview = unsafe_paste_preview(text);
+        let theme = cx.theme();
+
+        Some(
+            div()
+                .absolute()
+                .left(px(12.0))
+                .right(px(12.0))
+                .bottom(px(12.0))
+                .flex()
+                .justify_center()
+                .child(
+                    div()
+                        .occlude()
+                        .w_full()
+                        .max_w(px(620.0))
+                        .flex()
+                        .flex_col()
+                        .gap(px(8.0))
+                        .p(px(10.0))
+                        .rounded(px(8.0))
+                        .bg(theme
+                            .warning
+                            .opacity(if theme.is_dark() { 0.18 } else { 0.12 }))
+                        .child(
+                            div()
+                                .text_size(px(12.0))
+                                .font_weight(FontWeight::MEDIUM)
+                                .text_color(theme.foreground)
+                                .child("This paste can run commands. Review it before continuing."),
+                        )
+                        .child(
+                            div()
+                                .max_h(px(88.0))
+                                .overflow_hidden()
+                                .px(px(8.0))
+                                .py(px(6.0))
+                                .rounded(px(6.0))
+                                .bg(theme.foreground.opacity(0.06))
+                                .font_family(theme.mono_font_family.clone())
+                                .text_size(px(11.0))
+                                .line_height(px(15.0))
+                                .text_color(theme.foreground.opacity(0.82))
+                                .child(preview),
+                        )
+                        .child(
+                            div()
+                                .flex()
+                                .justify_end()
+                                .items_center()
+                                .gap(px(6.0))
+                                .child(
+                                    Button::new("windows-cancel-unsafe-paste")
+                                        .label("Cancel")
+                                        .small()
+                                        .ghost()
+                                        .on_click(cx.listener(|this, _, window, cx| {
+                                            this.cancel_unsafe_paste(window, cx);
+                                        })),
+                                )
+                                .child(
+                                    Button::new("windows-confirm-unsafe-paste")
+                                        .label("Paste")
+                                        .small()
+                                        .primary()
+                                        .on_click(cx.listener(|this, _, window, cx| {
+                                            this.confirm_unsafe_paste(window, cx);
+                                        })),
+                                ),
+                        ),
+                )
+                .into_any_element(),
+        )
     }
 
     fn ime_cursor_bounds(&self) -> Option<Bounds<Pixels>> {
@@ -1407,44 +1575,6 @@ fn bgra_frame_to_image(bytes: Vec<u8>, width: u32, height: u32) -> Option<Arc<Re
     let frame = Frame::new(buffer);
     let data: SmallVec<[Frame; 1]> = SmallVec::from_buf([frame]);
     Some(Arc::new(RenderImage::new(data)))
-}
-
-fn send_paste(terminal: &GhosttyTerminal, text: &str) {
-    // Bracketed paste lets the shell tell pasted text apart from real
-    // typing, so vim / readline can disable auto-indent. Hold the lock
-    // across both wrapper writes so the session can't be swapped out
-    // mid-paste (which would strip the trailing `ESC[201~`).
-    let inner = terminal.inner();
-    let guard = inner.lock();
-    if let Some(session) = guard.as_ref() {
-        if session.is_bracketed_paste() {
-            session.write_pty_raw(b"\x1b[200~");
-            session.write_input(text);
-            session.write_pty_raw(b"\x1b[201~");
-        } else {
-            session.write_input(text);
-        }
-    }
-}
-
-fn send_terminal_paste_payload(terminal: &GhosttyTerminal, payload: TerminalPastePayload) {
-    match payload {
-        TerminalPastePayload::Text(text) if !text.is_empty() => send_paste(terminal, &text),
-        TerminalPastePayload::ForwardCtrlV => terminal.send_text("\x16"),
-        TerminalPastePayload::Text(_) => {}
-    }
-}
-
-fn paste_from_clipboard(terminal: &GhosttyTerminal, cx: &mut App) -> bool {
-    let Some(payload) = cx
-        .read_from_clipboard()
-        .and_then(|item| payload_from_clipboard(&item))
-    else {
-        return false;
-    };
-
-    send_terminal_paste_payload(terminal, payload);
-    true
 }
 
 impl Focusable for GhosttyView {
@@ -1520,6 +1650,7 @@ impl Render for GhosttyView {
         if let Some(scrollbar) = self.render_terminal_scrollbar(cx) {
             terminal_children.push(scrollbar);
         }
+        let unsafe_paste_confirmation = self.render_unsafe_paste_confirmation(cx);
 
         let focus = self.focus_handle.clone();
         let input_focus = focus.clone();
@@ -1558,10 +1689,7 @@ impl Render for GhosttyView {
                 }
             }))
             .on_action(cx.listener(|this, _: &crate::Paste, _window, cx| {
-                this.clear_restored_screen_text();
-                if let Some(terminal) = &this.terminal
-                    && paste_from_clipboard(terminal, cx)
-                {
+                if this.paste_from_clipboard(cx) {
                     cx.notify();
                 }
             }))
@@ -1572,9 +1700,7 @@ impl Render for GhosttyView {
                 };
                 window.focus(&this.focus_handle, cx);
                 cx.emit(GhosttyFocusChanged);
-                this.clear_restored_screen_text();
-                if let Some(terminal) = &this.terminal {
-                    send_terminal_paste_payload(terminal, payload);
+                if this.send_terminal_paste_payload(payload, VtPasteSource::Text) {
                     cx.notify();
                 }
             }))
@@ -1939,7 +2065,8 @@ impl Render for GhosttyView {
                             .bottom(px(TERMINAL_PADDING_Y_PX))
                             .w(px(TERMINAL_PADDING_X_PX))
                             .bg(padding_background),
-                    ),
+                    )
+                    .children(unsafe_paste_confirmation),
             )
             .context_menu(move |menu, window, cx| {
                 // Empty PopupMenu renders nothing; suppress con's menu only

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -1320,7 +1320,9 @@ impl GhosttyView {
                     return true;
                 }
                 "v" => {
-                    self.paste_from_clipboard(cx);
+                    if self.paste_from_clipboard(cx) {
+                        cx.notify();
+                    }
                     return true;
                 }
                 _ => {}

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -36,11 +36,13 @@
 //!    stalling GPUI's thread.
 //! 4. Drop releases the `RenderSession` and ends the child shell.
 
+use std::collections::HashMap;
 use std::ops::Range;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
+use con_ghostty::vt::{VtKeyAction, VtKeyEvent, VtKeyModifiers};
 use con_ghostty::{GhosttyApp, GhosttyScrollbar, GhosttySplitDirection, GhosttyTerminal};
 use futures::StreamExt;
 use futures::channel::mpsc::{UnboundedSender, unbounded};
@@ -56,7 +58,7 @@ use crate::terminal_paste::{
     TerminalPastePayload, copy_selection_to_clipboard, payload_from_clipboard,
     payload_from_external_paths,
 };
-use crate::terminal_restore::{key_down_may_write_terminal, restored_terminal_output};
+use crate::terminal_restore::restored_terminal_output;
 use con_ghostty::windows::host_view::{MouseEventMods, RenderSession};
 use con_ghostty::windows::render::{FrameBgra, RenderOutcome};
 
@@ -166,6 +168,7 @@ pub struct GhosttyView {
     suppress_link_mouse_up: bool,
     hovered_link: Option<TerminalLink>,
     last_mouse_position: Option<Point<Pixels>>,
+    keys_awaiting_release: HashMap<String, crate::terminal_keys::TrackedVtKey>,
     /// Cloned and handed to `RenderSession::new`; the ConPTY reader
     /// thread sends at most one queued signal while a repaint wake is
     /// pending. The coalescer task spawned in `new()` consumes that
@@ -252,6 +255,7 @@ impl GhosttyView {
             suppress_link_mouse_up: false,
             hovered_link: None,
             last_mouse_position: None,
+            keys_awaiting_release: HashMap::new(),
             wake_tx,
             wake_pending,
         }
@@ -296,6 +300,7 @@ impl GhosttyView {
     }
 
     pub fn shutdown_surface(&mut self) {
+        self.release_tracked_keys();
         if let Some(terminal) = &self.terminal {
             terminal.request_close();
         }
@@ -319,11 +324,15 @@ impl GhosttyView {
         self.suppress_link_mouse_up = false;
         self.hovered_link = None;
         self.last_mouse_position = None;
+        self.keys_awaiting_release.clear();
         self.images_to_drop.clear();
         self.last_physical_size = None;
     }
 
     pub fn set_surface_focus_state(&mut self, focused: bool) {
+        if !focused {
+            self.release_tracked_keys();
+        }
         if let Some(terminal) = &self.terminal {
             terminal.set_focus(focused);
         }
@@ -1147,16 +1156,91 @@ impl GhosttyView {
         )
     }
 
-    /// Translate a GPUI `KeyDownEvent` into bytes and forward to the
-    /// ConPTY. Returns `true` if the key was handled (so GPUI can stop
-    /// propagation).
-    ///
-    /// GPUI owns keyboard focus on Windows — there's no child HWND in
-    /// the focus chain — so we translate at this layer into byte
-    /// sequences a terminal emulator expects. DECCKM-aware arrows live
-    /// alongside the printable / Ctrl-letter paths.
+    fn send_vt_key(
+        &mut self,
+        tracking_key: &str,
+        event: &VtKeyEvent<'_>,
+    ) -> Result<con_ghostty::vt::VtKeySend, String> {
+        let Some(terminal) = self.terminal.as_ref().cloned() else {
+            return Ok(con_ghostty::vt::VtKeySend::default());
+        };
+        let sent = terminal.send_key(event)?;
+        if sent.wrote {
+            self.clear_restored_screen_text();
+            if sent.report_releases
+                && event.action != VtKeyAction::Release
+                && !self.keys_awaiting_release.contains_key(tracking_key)
+            {
+                self.keys_awaiting_release.insert(
+                    tracking_key.to_owned(),
+                    crate::terminal_keys::TrackedVtKey::from_press(event),
+                );
+            }
+        }
+        Ok(sent)
+    }
+
+    fn handle_key_up(&mut self, event: &KeyUpEvent) -> bool {
+        let Some(tracked) = self.keys_awaiting_release.remove(&event.keystroke.key) else {
+            return false;
+        };
+        let release =
+            tracked.release_with_modifiers(&event.keystroke.key, &event.keystroke.modifiers);
+        match self.send_vt_key(&event.keystroke.key, &release) {
+            Ok(sent) => sent.wrote,
+            Err(err) => {
+                // Preserve the press so focus loss can retry the release if
+                // this was a transient PTY write failure.
+                self.keys_awaiting_release
+                    .insert(event.keystroke.key.clone(), tracked);
+                log::debug!("windows terminal key release failed: {err}");
+                false
+            }
+        }
+    }
+
+    fn release_tracked_keys(&mut self) {
+        let tracked_keys = std::mem::take(&mut self.keys_awaiting_release);
+        let Some(terminal) = self.terminal.as_ref().cloned() else {
+            return;
+        };
+        for (key, tracked) in tracked_keys {
+            let release = tracked.release(&key);
+            if let Err(err) = terminal.send_key(&release) {
+                log::debug!("windows terminal key release failed: {err}");
+            }
+        }
+    }
+
+    fn send_tab_key(&mut self, shift: bool) -> bool {
+        let event = VtKeyEvent {
+            key: "tab",
+            text: "",
+            unshifted_codepoint: None,
+            action: if self.keys_awaiting_release.contains_key("tab") {
+                VtKeyAction::Repeat
+            } else {
+                VtKeyAction::Press
+            },
+            modifiers: VtKeyModifiers {
+                shift,
+                ..VtKeyModifiers::default()
+            },
+            consumed_modifiers: VtKeyModifiers::default(),
+        };
+        match self.send_vt_key("tab", &event) {
+            Ok(sent) => sent.wrote,
+            Err(err) => {
+                log::debug!("windows terminal key encoding failed: {err}");
+                false
+            }
+        }
+    }
+
+    /// Translate a GPUI key event with libghostty-vt and forward the
+    /// encoded bytes to ConPTY. App shortcuts remain ahead of this path.
     fn handle_key_down(
-        &self,
+        &mut self,
         event: &KeyDownEvent,
         window: &Window,
         cx: &mut Context<Self>,
@@ -1232,23 +1316,11 @@ impl GhosttyView {
             }
         }
 
-        let decckm = {
-            let inner = terminal.inner();
-            inner.lock().as_ref().is_some_and(|s| s.is_decckm())
-        };
-
-        // Named / special keys — arrows, home/end, page nav, insert,
-        // delete, F1-F12, tab/shift-tab, enter, backspace, escape. Each
-        // honours DECCKM (arrows) and xterm modifier-parameter encoding
-        // for Ctrl/Shift/Alt (CSI 1;m<X> for arrows + F1-F4, CSI n;m~
-        // for tilde-terminated keys).
-        if let Some(bytes) = encode_special_key(&keystroke.key, &keystroke.modifiers, decckm) {
-            terminal.send_text(&bytes);
-            return true;
-        }
-
-        if event.prefer_character_input
-            && !keystroke.modifiers.control
+        // A dead-key/IME composition may complete as an ordinary keydown
+        // while GPUI still owns marked text. Let its InputHandler commit the
+        // text and clear that state instead of bypassing it through the VT
+        // encoder and leaving a stale preedit overlay behind.
+        if self.ime_marked_text.is_some()
             && keystroke
                 .key_char
                 .as_deref()
@@ -1257,74 +1329,16 @@ impl GhosttyView {
             return false;
         }
 
-        // Ctrl + defined ASCII keys → C0 control bytes. This includes
-        // punctuation controls terminals rely on, such as Ctrl+] for tmux's
-        // `C-]` prefix (GS / 0x1d), not just Ctrl+A-Z.
-        if keystroke.modifiers.control
-            && !keystroke.modifiers.alt
-            && !keystroke.modifiers.platform
-            && (keystroke.key.len() == 1
-                || keystroke
-                    .key_char
-                    .as_deref()
-                    .is_some_and(|text| text.len() == 1))
-        {
-            if let Some(code) = crate::terminal_keys::ctrl_keystroke_to_c0(
-                &keystroke.key,
-                keystroke.key_char.as_deref(),
-                keystroke.modifiers.shift,
-            ) {
-                let byte = [code];
-                let text = std::str::from_utf8(&byte)
-                    .expect("terminal C0 control bytes are always valid UTF-8");
-                terminal.send_text(text);
-                return true;
+        let Some(vt_event) = crate::terminal_keys::vt_key_down_event(event) else {
+            return false;
+        };
+        match self.send_vt_key(&keystroke.key, &vt_event) {
+            Ok(sent) => sent.wrote,
+            Err(err) => {
+                log::debug!("windows terminal key encoding failed: {err}");
+                false
             }
         }
-
-        // Alt + printable ASCII → ESC + char (meta-prefix convention
-        // readline / vim / tmux / fzf all recognise: Alt+B word-back,
-        // Alt+F word-forward, Alt+D word-delete, Alt+. last-arg, …).
-        // Only when Alt is the only app-consumable modifier — AltGr-
-        // produced characters already arrive decoded via `key_char`
-        // without the `alt` flag on most layouts, and Ctrl+Alt is left
-        // for the terminal's own modifyOtherKeys semantics if added
-        // later.
-        if keystroke.modifiers.alt && !keystroke.modifiers.control && !keystroke.modifiers.platform
-        {
-            if let Some(ch) = keystroke.key_char.as_deref().filter(|s| !s.is_empty()) {
-                let mut out = String::with_capacity(1 + ch.len());
-                out.push('\x1b');
-                out.push_str(ch);
-                terminal.send_text(&out);
-                return true;
-            }
-        }
-
-        if let Some(ch) = keystroke.key_char.as_deref() {
-            if !ch.is_empty() {
-                if !keystroke.modifiers.control
-                    && !keystroke.modifiers.alt
-                    && !keystroke.modifiers.platform
-                {
-                    return false;
-                }
-                terminal.send_text(ch);
-                return true;
-            }
-        }
-        if keystroke.key.len() == 1 {
-            if !keystroke.modifiers.control
-                && !keystroke.modifiers.alt
-                && !keystroke.modifiers.platform
-            {
-                return false;
-            }
-            terminal.send_text(&keystroke.key);
-            return true;
-        }
-
-        false
     }
 
     fn ime_cursor_bounds(&self) -> Option<Bounds<Pixels>> {
@@ -1393,83 +1407,6 @@ fn bgra_frame_to_image(bytes: Vec<u8>, width: u32, height: u32) -> Option<Arc<Re
     let frame = Frame::new(buffer);
     let data: SmallVec<[Frame; 1]> = SmallVec::from_buf([frame]);
     Some(Arc::new(RenderImage::new(data)))
-}
-
-/// xterm modifier parameter (`m`) — `1 + (shift | alt<<1 | ctrl<<2)`,
-/// where `1` itself means "no modifier" (so the encoder omits it).
-///
-/// Used in CSI `1;m{A|B|C|D|H|F|P|Q|R|S}` and CSI `{n};m~` sequences.
-/// Source: xterm's "PC-Style Function Keys" encoding.
-fn xterm_modifier_param(modifiers: &Modifiers) -> Option<u8> {
-    let mask = u8::from(modifiers.shift)
-        | (u8::from(modifiers.alt) << 1)
-        | (u8::from(modifiers.control) << 2);
-    if mask == 0 { None } else { Some(1 + mask) }
-}
-
-/// Translate a GPUI key name + modifiers into the byte sequence the
-/// shell / TUI expects. Returns `None` for keys that should flow
-/// through the printable-character path (letters, digits, symbols).
-///
-/// Covers arrows (DECCKM-aware and modifier-aware), home/end, pageup/
-/// pagedown, insert/delete, F1-F12, enter, backspace, tab/shift-tab,
-/// escape. xterm modifier encoding is applied uniformly: any combination
-/// of Shift/Alt/Ctrl shifts the sequence into its CSI `1;m<final>`
-/// (arrows, home/end, F1-F4) or CSI `n;m~` (tilde-terminated) form.
-fn encode_special_key(key: &str, modifiers: &Modifiers, decckm: bool) -> Option<String> {
-    let m = xterm_modifier_param(modifiers);
-
-    let tilde = |code: u8| match m {
-        Some(m) => format!("\x1b[{};{}~", code, m),
-        None => format!("\x1b[{}~", code),
-    };
-
-    // CSI-1-final covers arrows + home/end + F1-F4. For the no-modifier
-    // case: arrows honour DECCKM, F1-F4 use SS3 (ESC O x), home/end use
-    // plain CSI.
-    let csi1 = |final_byte: char, ss3_when_plain: bool, decckm_arrow: bool| match m {
-        Some(m) => format!("\x1b[1;{}{}", m, final_byte),
-        None if decckm_arrow && decckm => format!("\x1bO{}", final_byte),
-        None if ss3_when_plain => format!("\x1bO{}", final_byte),
-        None => format!("\x1b[{}", final_byte),
-    };
-
-    Some(match key {
-        "up" => csi1('A', false, true),
-        "down" => csi1('B', false, true),
-        "right" => csi1('C', false, true),
-        "left" => csi1('D', false, true),
-        "home" => csi1('H', false, false),
-        "end" => csi1('F', false, false),
-        "pageup" => tilde(5),
-        "pagedown" => tilde(6),
-        "insert" => tilde(2),
-        "delete" => tilde(3),
-        "f1" => csi1('P', true, false),
-        "f2" => csi1('Q', true, false),
-        "f3" => csi1('R', true, false),
-        "f4" => csi1('S', true, false),
-        "f5" => tilde(15),
-        "f6" => tilde(17),
-        "f7" => tilde(18),
-        "f8" => tilde(19),
-        "f9" => tilde(20),
-        "f10" => tilde(21),
-        "f11" => tilde(23),
-        "f12" => tilde(24),
-        "enter" | "return" => "\r".into(),
-        "escape" => "\x1b".into(),
-        // Alt+Backspace is readline's word-delete (ESC + DEL).
-        "backspace" if modifiers.alt && !modifiers.control && !modifiers.platform => {
-            "\x1b\x7f".into()
-        }
-        "backspace" => "\x7f".into(),
-        // Shift+Tab is the xterm "back-tab" CSI Z — bash/zsh completion
-        // menus and fzf use it to cycle backwards.
-        "tab" if modifiers.shift && !modifiers.control && !modifiers.platform => "\x1b[Z".into(),
-        "tab" => "\t".into(),
-        _ => return None,
-    })
 }
 
 fn send_paste(terminal: &GhosttyTerminal, text: &str) {
@@ -1605,19 +1542,13 @@ impl Render for GhosttyView {
                 if !this.focus_handle.is_focused(window) {
                     return;
                 }
-                this.clear_restored_screen_text();
-                if let Some(terminal) = &this.terminal {
-                    terminal.send_text("\t");
-                }
+                this.send_tab_key(false);
             }))
             .on_action(cx.listener(|this, _: &ConsumeTabPrev, window, _cx| {
                 if !this.focus_handle.is_focused(window) {
                     return;
                 }
-                this.clear_restored_screen_text();
-                if let Some(terminal) = &this.terminal {
-                    terminal.send_text("\x1b[Z");
-                }
+                this.send_tab_key(true);
             }))
             .on_action(cx.listener(|this, _: &crate::Copy, _window, cx| {
                 if let Some(terminal) = &this.terminal {
@@ -1651,13 +1582,16 @@ impl Render for GhosttyView {
                 if !this.focus_handle.is_focused(window) {
                     return;
                 }
-                let special_key_writes =
-                    encode_special_key(&event.keystroke.key, &event.keystroke.modifiers, false)
-                        .is_some();
-                if key_down_may_write_terminal(event, special_key_writes) {
-                    this.clear_restored_screen_text();
-                }
                 if this.handle_key_down(event, window, cx) {
+                    window.prevent_default();
+                    cx.stop_propagation();
+                }
+            }))
+            .on_key_up(cx.listener(|this, event: &KeyUpEvent, window, cx| {
+                if !this.focus_handle.is_focused(window) {
+                    return;
+                }
+                if this.handle_key_up(event) {
                     window.prevent_default();
                     cx.stop_propagation();
                 }
@@ -2027,6 +1961,7 @@ impl Render for GhosttyView {
 
 impl Drop for GhosttyView {
     fn drop(&mut self) {
+        self.release_tracked_keys();
         if let Some(terminal) = &self.terminal {
             terminal.request_close();
         }

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -302,7 +302,7 @@ impl GhosttyView {
         self.terminal.as_ref().and_then(|t| t.selection_text())
     }
 
-    pub fn shutdown_surface(&mut self) {
+    pub fn shutdown_surface(&mut self, _window: Option<&mut Window>, _cx: &mut App) {
         self.release_tracked_keys();
         if let Some(terminal) = &self.terminal {
             terminal.request_close();

--- a/crates/con-app/src/workspace/control_surfaces.rs
+++ b/crates/con-app/src/workspace/control_surfaces.rs
@@ -360,7 +360,7 @@ impl ConWorkspace {
                     let closing = close_outcome.terminal.clone();
                     closing.set_focus_state(false, cx);
                     closing.set_native_view_visible(false, cx);
-                    closing.shutdown_surface(cx);
+                    closing.shutdown_surface(Some(window), cx);
                     if tab_idx == self.active_tab {
                         if close_outcome.closed_pane {
                             #[cfg(target_os = "macos")]

--- a/crates/con-app/src/workspace/pane_actions.rs
+++ b/crates/con-app/src/workspace/pane_actions.rs
@@ -337,7 +337,7 @@ impl ConWorkspace {
         let closing = close_outcome.terminal.clone();
         closing.set_focus_state(false, cx);
         closing.set_native_view_visible(false, cx);
-        closing.shutdown_surface(cx);
+        closing.shutdown_surface(Some(window), cx);
 
         #[cfg(target_os = "macos")]
         self.mark_tab_terminal_native_layout_pending(tab_idx, cx);
@@ -937,9 +937,9 @@ impl ConWorkspace {
             }
 
             if shutdown_closing_terminals {
-                cx.on_next_frame(window, move |_workspace, _window, cx| {
+                cx.on_next_frame(window, move |_workspace, window, cx| {
                     for terminal in &closing_terminals {
-                        terminal.shutdown_surface(cx);
+                        terminal.shutdown_surface(Some(&mut *window), cx);
                     }
                     if tab_is_visible {
                         for terminal in &surviving_terminals {

--- a/crates/con-app/src/workspace/tab_actions.rs
+++ b/crates/con-app/src/workspace/tab_actions.rs
@@ -483,7 +483,7 @@ impl ConWorkspace {
             {
                 let terminal = outcome.terminal;
                 terminal.set_native_view_visible(false, cx);
-                terminal.shutdown_surface(cx);
+                terminal.shutdown_surface(Some(window), cx);
             }
             if tab_idx == self.active_tab {
                 self.sync_active_tab_native_view_visibility(cx);

--- a/crates/con-app/src/workspace/window_actions.rs
+++ b/crates/con-app/src/workspace/window_actions.rs
@@ -535,9 +535,9 @@ impl ConWorkspace {
                 self.workspace_focus.clone().focus(window, cx);
             }
             self.sync_active_terminal_focus_states(cx);
-            cx.on_next_frame(window, move |_workspace, _window, cx| {
+            cx.on_next_frame(window, move |_workspace, window, cx| {
                 for terminal in &closing_terminals {
-                    terminal.shutdown_surface(cx);
+                    terminal.shutdown_surface(Some(&mut *window), cx);
                 }
                 for terminal in &surviving_terminals {
                     terminal.notify(cx);
@@ -612,9 +612,9 @@ impl ConWorkspace {
             terminal.ensure_surface(window, cx);
         }
         self.sync_active_tab_native_view_visibility(cx);
-        cx.on_next_frame(window, move |_workspace, _window, cx| {
+        cx.on_next_frame(window, move |_workspace, window, cx| {
             for terminal in &closing_terminals {
-                terminal.shutdown_surface(cx);
+                terminal.shutdown_surface(Some(&mut *window), cx);
             }
         });
         let focused = self.tabs[self.active_tab].pane_tree.try_focused_terminal();
@@ -740,7 +740,9 @@ impl ConWorkspace {
             let _ = conv.lock().save();
 
             for terminal in tab.pane_tree.all_surface_terminals() {
-                terminal.shutdown_surface(cx);
+                // The platform window is already closing and will release its
+                // sprite atlas; no current Window handle is available here.
+                terminal.shutdown_surface(None, cx);
             }
         }
     }

--- a/crates/con-cli/src/pty_bridge.rs
+++ b/crates/con-cli/src/pty_bridge.rs
@@ -24,7 +24,8 @@ pub struct PtyBridgeArgs {
 }
 
 #[cfg(unix)]
-const MAX_FRAME_BYTES: usize = 16 * 1024 * 1024;
+// A 16 MiB Kitty clipboard response expands to about 22 MiB after base64.
+const MAX_FRAME_BYTES: usize = 32 * 1024 * 1024;
 
 #[cfg(unix)]
 fn configure_shell_startup(program: &str, command: &mut portable_pty::CommandBuilder) {

--- a/crates/con-ghostty/Cargo.toml
+++ b/crates/con-ghostty/Cargo.toml
@@ -24,6 +24,7 @@ dispatch = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 serde_json.workspace = true
+image = { version = "0.25", default-features = false, features = ["png"] }
 # Win32 API surface for the Windows terminal backend (Phase 3).
 # See docs/impl/windows-port.md for the staged plan.
 windows = { version = "0.61", features = [
@@ -63,5 +64,6 @@ etagere = "0.2"
 unicode-width.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
+image = { version = "0.25", default-features = false, features = ["png"] }
 portable-pty = "0.9"
 uuid.workspace = true

--- a/crates/con-ghostty/Cargo.toml
+++ b/crates/con-ghostty/Cargo.toml
@@ -65,5 +65,6 @@ unicode-width.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 image = { version = "0.25", default-features = false, features = ["png"] }
+libc = "0.2"
 portable-pty = "0.9"
 uuid.workspace = true

--- a/crates/con-ghostty/Cargo.toml
+++ b/crates/con-ghostty/Cargo.toml
@@ -14,6 +14,9 @@ parking_lot.workspace = true
 [build-dependencies]
 cc = "1"
 
+[dev-dependencies]
+serde_json.workspace = true
+
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.10"
 objc = "0.2"

--- a/crates/con-ghostty/build.rs
+++ b/crates/con-ghostty/build.rs
@@ -283,16 +283,22 @@ fn build_vt_backend(target_os: &str) {
     // Windows, so default it on regardless of cargo profile and let
     // `CON_GHOSTTY_OPTIMIZE=Debug` opt back in for VT-debugging.
     //
-    // `-Dsimd`: Ghostty vendors `simdutf` (a C++ SIMD UTF-8 library)
-    // when SIMD is on, but the produced static archive does not yet
-    // bundle the required `simdutf` objects reliably across our target
-    // environments. Default SIMD off for now so the resulting
-    // `libghostty-vt` archive is self-contained on both Windows and
-    // Linux. Keep the env override for experimentation once the native
-    // link surface is understood well enough to ship.
-    let simd_on = env::var("CON_GHOSTTY_VT_SIMD")
-        .map(|s| matches!(s.as_str(), "1" | "true" | "yes" | "on"))
-        .unwrap_or(false);
+    // `-Dsimd`: the pinned Ghostty revision must build Linux libghostty-vt
+    // with libc enabled. Its non-libc Wuffs module exports hidden weak
+    // `calloc`/`free` fallbacks; when that archive is linked into a Rust
+    // executable, the hidden fallbacks capture the process-wide symbols and
+    // make every zeroed Rust allocation fail. Enabling SIMD also enables libc
+    // on Ghostty's root module, suppressing those fallbacks, and the current
+    // Linux archive contains the required simdutf/highway objects.
+    //
+    // Windows keeps the conservative non-SIMD default because its static
+    // archive has a different C++ link surface. The override remains useful
+    // there for targeted toolchain experiments; Linux always takes the only
+    // runtime-safe path.
+    let simd_on = target_os == "linux"
+        || env::var("CON_GHOSTTY_VT_SIMD")
+            .map(|s| matches!(s.as_str(), "1" | "true" | "yes" | "on"))
+            .unwrap_or(false);
     let simd_flag = if simd_on {
         "-Dsimd=true"
     } else {

--- a/crates/con-ghostty/build.rs
+++ b/crates/con-ghostty/build.rs
@@ -128,7 +128,24 @@ fn build_macos() {
     // carries Zig compiler-rt memcpy/memmove. The final archive applies
     // Ghostty's libSystem override, which avoids a measured PTY throughput
     // regression in scroll-heavy workloads.
-    let lib_path = find_lib(&ghostty_dir, "libghostty-internal.a");
+    let xcframework_arch = match env::var("CARGO_CFG_TARGET_ARCH").as_deref() {
+        Ok("aarch64") => "arm64",
+        Ok("x86_64") => "x86_64",
+        Ok(arch) => panic!("unsupported macOS Ghostty architecture: {arch}"),
+        Err(err) => panic!("CARGO_CFG_TARGET_ARCH is not set: {err}"),
+    };
+    let lib_path = ghostty_dir
+        .join("macos")
+        .join("GhosttyKit.xcframework")
+        .join(format!("macos-{xcframework_arch}"))
+        .join("libghostty-internal.a");
+    if !lib_path.is_file() {
+        panic!(
+            "Could not find installed final archive {} after building ghostty source at {}",
+            lib_path.display(),
+            ghostty_dir.display()
+        );
+    }
     println!(
         "cargo:rustc-link-search=native={}",
         lib_path.parent().unwrap().display()
@@ -377,47 +394,27 @@ fn build_vt_backend(target_os: &str) {
         }
     }
 
-    // Zig produces both a shared library (`ghostty-vt.dll` +
-    // `ghostty-vt.lib` import-stub on MSVC) and a static archive
-    // (`ghostty-vt-static.lib`). We want the static archive — linking
-    // the import stub would leave `con-app.exe` dependent on
-    // `ghostty-vt.dll` at runtime, which we don't ship.
-    //
-    // `cfg!()` at build.rs compile time reflects the *host*, not the
-    // target. Use the runtime env the cargo build passes us.
-    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
-    let (static_lib_name, static_link_name, fallback_lib_name, fallback_link_name) =
-        if target_env == "msvc" {
-            (
-                "ghostty-vt-static.lib",
-                "ghostty-vt-static",
-                "ghostty-vt.lib",
-                "ghostty-vt",
-            )
-        } else {
-            (
-                "libghostty-vt-static.a",
-                "ghostty-vt-static",
-                "libghostty-vt.a",
-                "ghostty-vt",
-            )
-        };
-
-    // Prefer static; fall back to the import-lib variant with a loud
-    // warning so the user notices the runtime DLL dependency.
-    let (lib_path, link_name) = match try_find_lib(&ghostty_dir, static_lib_name) {
-        Some(p) => (p, static_link_name),
-        None => {
-            println!(
-                "cargo:warning=libghostty-vt-static not found; linking shared `{fallback_lib_name}` \
-                 instead. The resulting executable will depend on ghostty-vt.dll at runtime — \
-                 ship it alongside the .exe or bump the Ghostty pin to a revision that emits \
-                 the static archive."
-            );
-            let path = find_lib(&ghostty_dir, fallback_lib_name);
-            (path, fallback_link_name)
-        }
+    // Link the static archive installed by the build we just ran. Do not scan
+    // `.zig-cache`: one Ghostty checkout can contain cached archives for many
+    // targets, and mtime cannot tell a Linux archive from a newer Mach-O one.
+    // On Windows the distinct name also prevents accidentally linking the DLL
+    // import library, which would create an unshipped runtime dependency.
+    let (static_lib_name, link_name) = if target_os == "windows" {
+        ("ghostty-vt-static.lib", "ghostty-vt-static")
+    } else {
+        ("libghostty-vt.a", "ghostty-vt")
     };
+    let lib_path = ghostty_dir
+        .join("zig-out")
+        .join("lib")
+        .join(static_lib_name);
+    if !lib_path.is_file() {
+        panic!(
+            "Could not find installed static archive {} after building ghostty source at {}",
+            lib_path.display(),
+            ghostty_dir.display()
+        );
+    }
 
     println!(
         "cargo:rustc-link-search=native={}",
@@ -852,80 +849,6 @@ fn write_file_atomic(path: &Path, text: &str) -> Result<(), String> {
         let _ = fs::remove_file(&tmp);
         format!("failed to replace {}: {err}", path.display())
     })
-}
-
-fn try_find_lib(ghostty_dir: &PathBuf, lib_name: &str) -> Option<PathBuf> {
-    let zig_cache = ghostty_dir.join(".zig-cache");
-    if zig_cache.exists() {
-        if let Ok(output) = Command::new("find")
-            .args([zig_cache.to_str().unwrap(), "-name", lib_name, "-type", "f"])
-            .output()
-        {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let mut candidates: Vec<PathBuf> = stdout
-                .lines()
-                .map(PathBuf::from)
-                .filter(|p| p.exists())
-                .collect();
-            candidates.sort_by(|a, b| {
-                let a_time = std::fs::metadata(a).and_then(|m| m.modified()).ok();
-                let b_time = std::fs::metadata(b).and_then(|m| m.modified()).ok();
-                b_time.cmp(&a_time)
-            });
-            if let Some(path) = candidates.first() {
-                return Some(path.clone());
-            }
-        }
-    }
-    for relative in ["zig-out/lib", "zig-out\\lib", "macos/build/Debug"] {
-        let candidate = ghostty_dir.join(relative).join(lib_name);
-        if candidate.exists() {
-            return Some(candidate);
-        }
-    }
-    None
-}
-
-fn find_lib(ghostty_dir: &PathBuf, lib_name: &str) -> PathBuf {
-    let zig_cache = ghostty_dir.join(".zig-cache");
-    if zig_cache.exists() {
-        let output = Command::new("find")
-            .args([zig_cache.to_str().unwrap(), "-name", lib_name, "-type", "f"])
-            .output();
-
-        if let Ok(output) = output {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let mut candidates: Vec<PathBuf> = stdout
-                .lines()
-                .map(PathBuf::from)
-                .filter(|p| p.exists())
-                .collect();
-
-            candidates.sort_by(|a, b| {
-                let a_time = std::fs::metadata(a).and_then(|m| m.modified()).ok();
-                let b_time = std::fs::metadata(b).and_then(|m| m.modified()).ok();
-                b_time.cmp(&a_time)
-            });
-
-            if let Some(path) = candidates.first() {
-                return path.clone();
-            }
-        }
-    }
-
-    // Cross-platform fallback walk for systems without `find` (e.g.
-    // Windows without WSL). Manual scan of common output dirs.
-    for relative in ["zig-out/lib", "macos/build/Debug"] {
-        let candidate = ghostty_dir.join(relative).join(lib_name);
-        if candidate.exists() {
-            return candidate;
-        }
-    }
-
-    panic!(
-        "Could not find {lib_name} after building ghostty source at {}",
-        ghostty_dir.display()
-    );
 }
 
 fn current_git_rev(repo_dir: &PathBuf) -> Option<String> {

--- a/crates/con-ghostty/build.rs
+++ b/crates/con-ghostty/build.rs
@@ -11,15 +11,15 @@ const GHOSTTY_REPO: &str = "https://github.com/ghostty-org/ghostty.git";
 /// macOS full-libghostty build or the Windows libghostty-vt build —
 /// both consume the same source tree to keep VT semantics in sync.
 ///
-/// 2026-08-25 bump: from `ca7516bea6...` to `8867c37c55...`. This is the
-/// exact upstream revision audited for the Zig 0.16 migration and the
-/// portable Kitty protocol work; do not replace it with a moving branch.
+/// 2026-08-26 bump: from `8867c37c55...` to `5f5b988c52...`. The 27 upstream
+/// commits were audited with unchanged public C headers and revalidated
+/// against Con's private embedding patch and portable VT bindings.
 ///
 /// Ghostty's internal macOS embedding API and libghostty-vt API are not
 /// stable. Future bumps must update the handwritten FFI bindings, compile
 /// the ABI assertions, and run real build/link/runtime checks on all three
 /// platforms rather than treating this as a source-only dependency bump.
-const GHOSTTY_REV: &str = "8867c37c55b578b9eb4cfaba41cb9023e557176d";
+const GHOSTTY_REV: &str = "5f5b988c5236facfe8d2439203d9ee9d5b636cf8";
 const GHOSTTY_ENV: &str = "CON_GHOSTTY_SOURCE_DIR";
 const GHOSTTY_INITIAL_OUTPUT_REQUIRE_ENV: &str = "CON_REQUIRE_GHOSTTY_INITIAL_OUTPUT";
 const GHOSTTY_VT_TARGET_ENV: &str = "CON_GHOSTTY_VT_TARGET";

--- a/crates/con-ghostty/build.rs
+++ b/crates/con-ghostty/build.rs
@@ -23,6 +23,9 @@ const GHOSTTY_REV: &str = "8867c37c55b578b9eb4cfaba41cb9023e557176d";
 const GHOSTTY_ENV: &str = "CON_GHOSTTY_SOURCE_DIR";
 const GHOSTTY_INITIAL_OUTPUT_REQUIRE_ENV: &str = "CON_REQUIRE_GHOSTTY_INITIAL_OUTPUT";
 const GHOSTTY_VT_TARGET_ENV: &str = "CON_GHOSTTY_VT_TARGET";
+const REQUIRED_ZIG_VERSION: &str = "0.16.0";
+const MAX_PREFETCH_PACKAGES: usize = 256;
+const MAX_PREFETCH_ARCHIVE_BYTES: &str = "134217728";
 
 fn main() {
     // Rerun the build script when any of our own env vars flip — cargo
@@ -59,13 +62,15 @@ fn main() {
 // ── macOS ─────────────────────────────────────────────────────────────
 
 fn build_macos() {
+    let zig_bin = env::var_os("CON_ZIG_BIN").unwrap_or_else(|| std::ffi::OsString::from("zig"));
+    let zig_global_cache_dir = zig_global_cache_dir("macos");
+    require_zig_version(&zig_bin, zig_global_cache_dir.as_deref(), "macos");
+
     let ghostty_dir = resolve_ghostty_source();
     let ghostty_dir = patchable_ghostty_source(ghostty_dir);
     let initial_output_restore_enabled = apply_embedded_initial_output_patch(&ghostty_dir);
     let include_dir = ghostty_dir.join("include");
     let optimize = ghostty_optimize();
-    let zig_bin = env::var_os("CON_ZIG_BIN").unwrap_or_else(|| std::ffi::OsString::from("zig"));
-    let zig_global_cache_dir = zig_global_cache_dir("macos");
 
     let mut ffi_abi = cc::Build::new();
     ffi_abi
@@ -255,50 +260,7 @@ fn build_vt_backend(target_os: &str) {
         println!("cargo:warning=using zig global cache dir {}", dir.display());
     }
 
-    let mut zig_probe_cmd = Command::new(&zig_bin);
-    configure_zig_command(&mut zig_probe_cmd, zig_global_cache_dir.as_deref());
-    let zig_probe = zig_probe_cmd.arg("version").output();
-    match zig_probe {
-        Ok(output) if output.status.success() => {
-            let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            println!(
-                "cargo:warning=using zig {} (from `{}`)",
-                version,
-                zig_bin.to_string_lossy()
-            );
-        }
-        Ok(output) => {
-            let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
-            panic!(
-                "\n\n========================================================\n\
-                 con-ghostty: `{bin} version` exited with status {status}.\n\
-                 stderr:\n{stderr}\n\
-                 ========================================================\n",
-                bin = zig_bin.to_string_lossy(),
-                status = output.status,
-                stderr = stderr,
-            );
-        }
-        Err(err) => {
-            let path = env::var("PATH").unwrap_or_default();
-            panic!(
-                "\n\n========================================================\n\
-                 con-ghostty: could not spawn `{bin} version`: {err}\n\n\
-                 Zig 0.16.0 exactly is required to build libghostty-vt for {target_os}.\n\
-                 Install it from https://ziglang.org/download/ and ensure\n\
-                 the `zig` executable is on PATH, or set CON_ZIG_BIN to\n\
-                 the absolute path of the zig executable.\n\n\
-                 Current PATH: {path}\n\n\
-                 To skip this step entirely (the terminal backend will\n\
-                 fail to link), set CON_SKIP_GHOSTTY_VT=1.\n\
-                 ========================================================\n",
-                bin = zig_bin.to_string_lossy(),
-                err = err,
-                target_os = target_os,
-                path = path,
-            );
-        }
-    }
+    require_zig_version(&zig_bin, zig_global_cache_dir.as_deref(), target_os);
 
     let ghostty_dir = resolve_ghostty_source();
 
@@ -717,10 +679,14 @@ fn try_apply_embedded_initial_output_patch(ghostty_dir: &Path) -> Result<(), Str
     // bump can invalidate any one of these anchors; validating the complete
     // patch first prevents an anchor mismatch from leaving the cached checkout
     // in a partially patched, internally inconsistent state.
-    let mut embedded_text = read_file_text(&embedded)?;
-    let mut surface_text = read_file_text(&surface)?;
-    let mut exec_text = read_file_text(&exec)?;
-    let mut header_text = read_file_text(&header)?;
+    let embedded_original = read_file_text(&embedded)?;
+    let surface_original = read_file_text(&surface)?;
+    let exec_original = read_file_text(&exec)?;
+    let header_original = read_file_text(&header)?;
+    let mut embedded_text = embedded_original.clone();
+    let mut surface_text = surface_original.clone();
+    let mut exec_text = exec_original.clone();
+    let mut header_text = header_original.clone();
 
     patch_text_once(
         &embedded,
@@ -792,14 +758,16 @@ fn try_apply_embedded_initial_output_patch(ghostty_dir: &Path) -> Result<(), Str
         )],
     )?;
 
-    for (path, text) in [
-        (&embedded, embedded_text.as_str()),
-        (&surface, surface_text.as_str()),
-        (&exec, exec_text.as_str()),
-        (&header, header_text.as_str()),
-    ] {
-        write_file_atomic(path, text)?;
-    }
+    write_patch_files_with_rollback(&[
+        (
+            &embedded,
+            embedded_original.as_str(),
+            embedded_text.as_str(),
+        ),
+        (&surface, surface_original.as_str(), surface_text.as_str()),
+        (&exec, exec_original.as_str(), exec_text.as_str()),
+        (&header, header_original.as_str(), header_text.as_str()),
+    ])?;
 
     println!("cargo:rustc-cfg=con_ghostty_embedded_initial_output");
     println!("cargo:rerun-if-changed={}", embedded.display());
@@ -849,6 +817,71 @@ fn write_file_atomic(path: &Path, text: &str) -> Result<(), String> {
         let _ = fs::remove_file(&tmp);
         format!("failed to replace {}: {err}", path.display())
     })
+}
+
+fn write_patch_files_with_rollback(files: &[(&Path, &str, &str)]) -> Result<(), String> {
+    let mut replaced = 0;
+    for (path, _, patched) in files {
+        if let Err(write_err) = write_file_atomic(path, patched) {
+            let mut rollback_errors = Vec::new();
+            for (rollback_path, original, _) in files[..replaced].iter().rev() {
+                if let Err(err) = write_file_atomic(rollback_path, original) {
+                    rollback_errors.push(err);
+                }
+            }
+            if !rollback_errors.is_empty() {
+                panic!(
+                    "con-ghostty: Ghostty patch write failed and rollback could not restore the \
+                     cached source tree. Refusing to continue with mixed source files. Write error: \
+                     {write_err}. Rollback error(s): {}",
+                    rollback_errors.join("; ")
+                );
+            }
+            return Err(write_err);
+        }
+        replaced += 1;
+    }
+    Ok(())
+}
+
+fn require_zig_version(zig_bin: &OsStr, zig_global_cache_dir: Option<&Path>, target_os: &str) {
+    let mut command = Command::new(zig_bin);
+    configure_zig_command(&mut command, zig_global_cache_dir);
+    let output = command.arg("version").output().unwrap_or_else(|err| {
+        let path = env::var("PATH").unwrap_or_default();
+        panic!(
+            "\n\n========================================================\n\
+             con-ghostty: could not spawn `{bin} version`: {err}\n\n\
+             Zig {required} exactly is required to build Ghostty for {target_os}.\n\
+             Install it from https://ziglang.org/download/ and ensure the `zig`\n\
+             executable is on PATH, or set CON_ZIG_BIN to its absolute path.\n\n\
+             Current PATH: {path}\n\n\
+             ========================================================\n",
+            bin = zig_bin.to_string_lossy(),
+            required = REQUIRED_ZIG_VERSION,
+        )
+    });
+    if !output.status.success() {
+        panic!(
+            "con-ghostty: `{}` version failed with status {}: {}",
+            zig_bin.to_string_lossy(),
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+
+    let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if version != REQUIRED_ZIG_VERSION {
+        panic!(
+            "con-ghostty: Zig {REQUIRED_ZIG_VERSION} exactly is required for {target_os}, \
+             but `{}` reports {version}. Set CON_ZIG_BIN to the validated Zig executable.",
+            zig_bin.to_string_lossy()
+        );
+    }
+    println!(
+        "cargo:warning=using zig {version} (from `{}`)",
+        zig_bin.to_string_lossy()
+    );
 }
 
 fn current_git_rev(repo_dir: &PathBuf) -> Option<String> {
@@ -942,6 +975,15 @@ fn prefetch_zig_dependencies(zig_bin: &OsStr, root: &Path, zig_global_cache_dir:
         for url in extract_zon_urls(&text) {
             if !seen_urls.insert(url.clone()) {
                 continue;
+            }
+            if seen_urls.len() > MAX_PREFETCH_PACKAGES {
+                println!(
+                    "cargo:warning=con-ghostty: refusing to prefetch more than \
+                     {MAX_PREFETCH_PACKAGES} unique Zig packages"
+                );
+                failed += 1;
+                zon_queue.clear();
+                break;
             }
 
             match prefetch_zig_url(zig_bin, root, &url, zig_global_cache_dir) {
@@ -1039,7 +1081,25 @@ fn prefetch_zig_url(
     ));
 
     let curl_status = Command::new("curl")
-        .args(["-fL", "--retry", "3", "--retry-delay", "1", url, "-o"])
+        .args([
+            "-fL",
+            "--retry",
+            "3",
+            "--retry-delay",
+            "1",
+            "--connect-timeout",
+            "15",
+            "--max-time",
+            "300",
+            "--speed-limit",
+            "1024",
+            "--speed-time",
+            "30",
+            "--max-filesize",
+            MAX_PREFETCH_ARCHIVE_BYTES,
+            url,
+            "-o",
+        ])
         .arg(&tmp)
         .status();
     match curl_status {

--- a/crates/con-ghostty/build.rs
+++ b/crates/con-ghostty/build.rs
@@ -11,17 +11,15 @@ const GHOSTTY_REPO: &str = "https://github.com/ghostty-org/ghostty.git";
 /// macOS full-libghostty build or the Windows libghostty-vt build —
 /// both consume the same source tree to keep VT semantics in sync.
 ///
-/// 2026-04-17 bump: from `e740f6fc1...` to `ca7516bea6...`. The older
-/// pin predated libghostty-vt's render-state implementation on
-/// Windows — `ghostty_render_state_new` was exported as a symbol but
-/// dereferenced a null internal function pointer at runtime. The new
-/// pin is tip-of-main on 2026-04-17; see the postmortem in
-/// docs/impl/windows-port.md.
+/// 2026-08-25 bump: from `ca7516bea6...` to `8867c37c55...`. This is the
+/// exact upstream revision audited for the Zig 0.16 migration and the
+/// portable Kitty protocol work; do not replace it with a moving branch.
 ///
-/// If a bump breaks the macOS libghostty build (different zig flags
-/// needed), revert by re-pinning to `e740f6fc117971da9df9fc957a706e6d96554aa5`
-/// — that's known-good on macOS.
-const GHOSTTY_REV: &str = "ca7516bea60190ee2e9a4f9182b61d318d107c6e";
+/// Ghostty's internal macOS embedding API and libghostty-vt API are not
+/// stable. Future bumps must update the handwritten FFI bindings, compile
+/// the ABI assertions, and run real build/link/runtime checks on all three
+/// platforms rather than treating this as a source-only dependency bump.
+const GHOSTTY_REV: &str = "8867c37c55b578b9eb4cfaba41cb9023e557176d";
 const GHOSTTY_ENV: &str = "CON_GHOSTTY_SOURCE_DIR";
 const GHOSTTY_INITIAL_OUTPUT_REQUIRE_ENV: &str = "CON_REQUIRE_GHOSTTY_INITIAL_OUTPUT";
 const GHOSTTY_VT_TARGET_ENV: &str = "CON_GHOSTTY_VT_TARGET";
@@ -63,10 +61,22 @@ fn main() {
 fn build_macos() {
     let ghostty_dir = resolve_ghostty_source();
     let ghostty_dir = patchable_ghostty_source(ghostty_dir);
-    let _initial_output_restore_enabled = apply_embedded_initial_output_patch(&ghostty_dir);
+    let initial_output_restore_enabled = apply_embedded_initial_output_patch(&ghostty_dir);
+    let include_dir = ghostty_dir.join("include");
     let optimize = ghostty_optimize();
     let zig_bin = env::var_os("CON_ZIG_BIN").unwrap_or_else(|| std::ffi::OsString::from("zig"));
     let zig_global_cache_dir = zig_global_cache_dir("macos");
+
+    let mut ffi_abi = cc::Build::new();
+    ffi_abi
+        .file("src/ffi_abi.c")
+        .include(&include_dir)
+        .flag("-std=c11");
+    if initial_output_restore_enabled {
+        ffi_abi.define("CON_GHOSTTY_EMBEDDED_INITIAL_OUTPUT", None);
+    }
+    ffi_abi.compile("con_ghostty_ffi_abi");
+    println!("cargo:rerun-if-changed=src/ffi_abi.c");
 
     cc::Build::new()
         .file("src/objc/desktop_notification.m")
@@ -114,12 +124,16 @@ fn build_macos() {
         }
     }
 
-    let lib_path = find_lib(&ghostty_dir, "libghostty-fat.a");
+    // `libghostty-internal-fat.a` is an intermediate archive that still
+    // carries Zig compiler-rt memcpy/memmove. The final archive applies
+    // Ghostty's libSystem override, which avoids a measured PTY throughput
+    // regression in scroll-heavy workloads.
+    let lib_path = find_lib(&ghostty_dir, "libghostty-internal.a");
     println!(
         "cargo:rustc-link-search=native={}",
         lib_path.parent().unwrap().display()
     );
-    println!("cargo:rustc-link-lib=static=ghostty-fat");
+    println!("cargo:rustc-link-lib=static=ghostty-internal");
 
     for framework in &[
         "AppKit",
@@ -149,7 +163,6 @@ fn build_macos() {
         );
     }
 
-    let include_dir = ghostty_dir.join("include");
     println!("cargo:include={}", include_dir.display());
     println!(
         "cargo:rustc-env=CON_GHOSTTY_RESOURCES_DIR={}",
@@ -254,7 +267,7 @@ fn build_vt_backend(target_os: &str) {
             panic!(
                 "\n\n========================================================\n\
                  con-ghostty: could not spawn `{bin} version`: {err}\n\n\
-                 Zig 0.13+ is required to build libghostty-vt for {target_os}.\n\
+                 Zig 0.16.0 exactly is required to build libghostty-vt for {target_os}.\n\
                  Install it from https://ziglang.org/download/ and ensure\n\
                  the `zig` executable is on PATH, or set CON_ZIG_BIN to\n\
                  the absolute path of the zig executable.\n\n\
@@ -735,8 +748,8 @@ fn try_apply_embedded_initial_output_patch(ghostty_dir: &Path) -> Result<(), Str
         &mut embedded_text,
         "Con: macOS may deny directory open/stat preflight for privacy-protected cwd",
         &[(
-            "            const wd = std.mem.sliceTo(c_wd, 0);\n            if (wd.len > 0) wd: {\n                var dir = std.fs.openDirAbsolute(wd, .{}) catch |err| {\n                    log.warn(\n                        \"error opening requested working directory dir={s} err={}\",\n                        .{ wd, err },\n                    );\n                    break :wd;\n                };\n                defer dir.close();\n\n                const stat = dir.stat() catch |err| {\n                    log.warn(\n                        \"failed to stat requested working directory dir={s} err={}\",\n                        .{ wd, err },\n                    );\n                    break :wd;\n                };\n\n                if (stat.kind != .directory) {\n                    log.warn(\n                        \"requested working directory is not a directory dir={s}\",\n                        .{wd},\n                    );\n                    break :wd;\n                }\n\n                var wd_val: configpkg.WorkingDirectory = .{ .path = wd };\n                if (wd_val.finalize(config.arenaAlloc())) |_| {\n                    config.@\"working-directory\" = wd_val;\n                } else |err| {\n                    log.warn(\n                        \"error finalizing working directory config dir={s} err={}\",\n                        .{ wd_val.path, err },\n                    );\n                }\n            }\n",
-            "            const wd = std.mem.sliceTo(c_wd, 0);\n            if (wd.len > 0) wd: {\n                if (comptime builtin.os.tag.isDarwin()) {\n                    // Con: macOS may deny directory open/stat preflight for privacy-protected cwd\n                    // (Documents, Downloads) even though chdir in the spawned shell succeeds. The\n                    // embedder already passes an absolute cwd captured from shell integration, so\n                    // trust it here and let process spawn be the authoritative failure boundary.\n                    var wd_val: configpkg.WorkingDirectory = .{ .path = wd };\n                    if (wd_val.finalize(config.arenaAlloc())) |_| {\n                        config.@\"working-directory\" = wd_val;\n                    } else |err| {\n                        log.warn(\n                            \"error finalizing working directory config dir={s} err={}\",\n                            .{ wd_val.path, err },\n                        );\n                    }\n                    break :wd;\n                }\n\n                var dir = std.fs.openDirAbsolute(wd, .{}) catch |err| {\n                    log.warn(\n                        \"error opening requested working directory dir={s} err={}\",\n                        .{ wd, err },\n                    );\n                    break :wd;\n                };\n                defer dir.close();\n\n                const stat = dir.stat() catch |err| {\n                    log.warn(\n                        \"failed to stat requested working directory dir={s} err={}\",\n                        .{ wd, err },\n                    );\n                    break :wd;\n                };\n\n                if (stat.kind != .directory) {\n                    log.warn(\n                        \"requested working directory is not a directory dir={s}\",\n                        .{wd},\n                    );\n                    break :wd;\n                }\n\n                var wd_val: configpkg.WorkingDirectory = .{ .path = wd };\n                if (wd_val.finalize(config.arenaAlloc())) |_| {\n                    config.@\"working-directory\" = wd_val;\n                } else |err| {\n                    log.warn(\n                        \"error finalizing working directory config dir={s} err={}\",\n                        .{ wd_val.path, err },\n                    );\n                }\n            }\n",
+            "            const wd = std.mem.sliceTo(c_wd, 0);\n            if (wd.len > 0) wd: {\n",
+            "            const wd = std.mem.sliceTo(c_wd, 0);\n            if (wd.len > 0) wd: {\n                if (comptime builtin.os.tag.isDarwin()) {\n                    // Con: macOS may deny directory open/stat preflight for privacy-protected cwd\n                    // (Documents, Downloads) even though chdir in the spawned shell succeeds. The\n                    // embedder already passes an absolute cwd captured from shell integration, so\n                    // trust it here and let process spawn be the authoritative failure boundary.\n                    var wd_val: configpkg.WorkingDirectory = .{ .path = wd };\n                    if (wd_val.finalize(config.arenaAlloc())) |_| {\n                        config.@\"working-directory\" = wd_val;\n                    } else |err| {\n                        log.warn(\n                            \"error finalizing working directory config dir={s} err={}\",\n                            .{ wd_val.path, err },\n                        );\n                    }\n                    break :wd;\n                }\n\n",
         )],
     )?;
     patch_text_once(
@@ -753,8 +766,8 @@ fn try_apply_embedded_initial_output_patch(ghostty_dir: &Path) -> Result<(), Str
         &mut exec_text,
         "Con: trust macOS cwd after embedded surface validation",
         &[(
-            "            if (std.fs.cwd().access(proposed, .{})) {\n                break :cwd proposed;\n            } else |err| {\n                log.warn(\"cannot access cwd, ignoring: {}\", .{err});\n                break :cwd null;\n            }\n",
-            "            if (comptime builtin.os.tag.isDarwin()) {\n                // Con: trust macOS cwd after embedded surface validation. Privacy-protected\n                // directories can fail access/open preflight while the child shell can still\n                // chdir there and preserve the user's restored working directory.\n                break :cwd proposed;\n            }\n\n            if (std.fs.cwd().access(proposed, .{})) {\n                break :cwd proposed;\n            } else |err| {\n                log.warn(\"cannot access cwd, ignoring: {}\", .{err});\n                break :cwd null;\n            }\n",
+            "            if (std.Io.Dir.cwd().access(global.io(), proposed, .{})) {\n                break :cwd proposed;\n            } else |err| {\n                log.warn(\"cannot access cwd, ignoring: {}\", .{err});\n                break :cwd null;\n            }\n",
+            "            if (comptime builtin.os.tag.isDarwin()) {\n                // Con: trust macOS cwd after embedded surface validation. Privacy-protected\n                // directories can fail access/open preflight while the child shell can still\n                // chdir there and preserve the user's restored working directory.\n                break :cwd proposed;\n            }\n\n            if (std.Io.Dir.cwd().access(global.io(), proposed, .{})) {\n                break :cwd proposed;\n            } else |err| {\n                log.warn(\"cannot access cwd, ignoring: {}\", .{err});\n                break :cwd null;\n            }\n",
         )],
     )?;
     patch_text_once(
@@ -1008,7 +1021,7 @@ fn prefetch_zig_dependencies(zig_bin: &OsStr, root: &Path, zig_global_cache_dir:
                 continue;
             }
 
-            match prefetch_zig_url(zig_bin, &url, zig_global_cache_dir) {
+            match prefetch_zig_url(zig_bin, root, &url, zig_global_cache_dir) {
                 Some(package_hash) => {
                     fetched += 1;
                     let package_root = cache_dir.join("p").join(package_hash);
@@ -1081,11 +1094,18 @@ fn extract_zon_urls(text: &str) -> Vec<String> {
 
 fn prefetch_zig_url(
     zig_bin: &OsStr,
+    project_root: &Path,
     url: &str,
     zig_global_cache_dir: Option<&Path>,
 ) -> Option<String> {
     if let Some((repo_url, revision)) = parse_git_package_url(url) {
-        return prefetch_zig_git_url(zig_bin, &repo_url, &revision, zig_global_cache_dir);
+        return prefetch_zig_git_url(
+            zig_bin,
+            project_root,
+            &repo_url,
+            &revision,
+            zig_global_cache_dir,
+        );
     }
 
     let package_name = url.rsplit('/').next().unwrap_or("package.tar.gz");
@@ -1101,7 +1121,7 @@ fn prefetch_zig_url(
         .status();
     match curl_status {
         Ok(status) if status.success() => {
-            let hash = zig_fetch_path(zig_bin, &tmp, zig_global_cache_dir);
+            let hash = zig_fetch_path(zig_bin, project_root, &tmp, zig_global_cache_dir);
             let _ = fs::remove_file(&tmp);
             hash
         }
@@ -1135,6 +1155,7 @@ fn parse_git_package_url(url: &str) -> Option<(String, String)> {
 
 fn prefetch_zig_git_url(
     zig_bin: &OsStr,
+    project_root: &Path,
     repo_url: &str,
     revision: &str,
     zig_global_cache_dir: Option<&Path>,
@@ -1178,7 +1199,7 @@ fn prefetch_zig_git_url(
                 .arg("HEAD")
                 .current_dir(&checkout),
         )?;
-        zig_fetch_path(zig_bin, &archive, zig_global_cache_dir)
+        zig_fetch_path(zig_bin, project_root, &archive, zig_global_cache_dir)
     })();
 
     let _ = fs::remove_dir_all(&tmp_root);
@@ -1192,12 +1213,20 @@ fn run_status(command: &mut Command) -> Option<()> {
 
 fn zig_fetch_path(
     zig_bin: &OsStr,
+    project_root: &Path,
     path: &Path,
     zig_global_cache_dir: Option<&Path>,
 ) -> Option<String> {
     let mut cmd = Command::new(zig_bin);
     configure_zig_command(&mut cmd, zig_global_cache_dir);
-    let output = cmd.arg("fetch").arg(path).output().ok()?;
+    // Zig 0.16 resolves fetch configuration through the surrounding build
+    // project even without `--save`, so invoke it from Ghostty's root.
+    let output = cmd
+        .arg("fetch")
+        .arg(path)
+        .current_dir(project_root)
+        .output()
+        .ok()?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         println!(

--- a/crates/con-ghostty/build.rs
+++ b/crates/con-ghostty/build.rs
@@ -703,68 +703,93 @@ fn try_apply_embedded_initial_output_patch(ghostty_dir: &Path) -> Result<(), Str
     let exec = ghostty_dir.join("src/termio/Exec.zig");
     let header = ghostty_dir.join("include/ghostty.h");
 
-    patch_file_once(
+    // Prepare every source change in memory before writing anything. A Ghostty
+    // bump can invalidate any one of these anchors; validating the complete
+    // patch first prevents an anchor mismatch from leaving the cached checkout
+    // in a partially patched, internally inconsistent state.
+    let mut embedded_text = read_file_text(&embedded)?;
+    let mut surface_text = read_file_text(&surface)?;
+    let mut exec_text = read_file_text(&exec)?;
+    let mut header_text = read_file_text(&header)?;
+
+    patch_text_once(
         &embedded,
+        &mut embedded_text,
         "initial_output: ?[*:0]const u8",
         &[(
             "        /// Input to send to the command after it is started.\n        initial_input: ?[*:0]const u8 = null,\n\n        /// Wait after the command exits\n",
             "        /// Input to send to the command after it is started.\n        initial_input: ?[*:0]const u8 = null,\n\n        /// Output to seed into the terminal state before the command starts.\n        /// This is an embedding-only hook used for visual scrollback restore;\n        /// it is parsed as terminal output and is never written to the pty.\n        initial_output: ?[*:0]const u8 = null,\n\n        /// Wait after the command exits\n",
         )],
     )?;
-    patch_file_once(
+    patch_text_once(
         &embedded,
+        &mut embedded_text,
         "initial_output_restore = if (opts.initial_output)",
         &[(
             "        // Initialize our surface right away. We're given a view that is\n        // ready to use.\n        try self.core_surface.init(\n            app.core_app.alloc,\n            &config,\n            app.core_app,\n            app,\n            self,\n        );\n",
             "        // Initialize our surface right away. We're given a view that is\n        // ready to use. `initial_output_restore` is parsed into Ghostty's\n        // terminal state before the child process starts.\n        const initial_output_restore = if (opts.initial_output) |c_output|\n            std.mem.sliceTo(c_output, 0)\n        else\n            null;\n        try self.core_surface.init(\n            app.core_app.alloc,\n            &config,\n            app.core_app,\n            app,\n            self,\n            initial_output_restore,\n        );\n",
         )],
     )?;
-    patch_file_once(
+    patch_text_once(
         &embedded,
+        &mut embedded_text,
         "Con: macOS may deny directory open/stat preflight for privacy-protected cwd",
         &[(
             "            const wd = std.mem.sliceTo(c_wd, 0);\n            if (wd.len > 0) wd: {\n                var dir = std.fs.openDirAbsolute(wd, .{}) catch |err| {\n                    log.warn(\n                        \"error opening requested working directory dir={s} err={}\",\n                        .{ wd, err },\n                    );\n                    break :wd;\n                };\n                defer dir.close();\n\n                const stat = dir.stat() catch |err| {\n                    log.warn(\n                        \"failed to stat requested working directory dir={s} err={}\",\n                        .{ wd, err },\n                    );\n                    break :wd;\n                };\n\n                if (stat.kind != .directory) {\n                    log.warn(\n                        \"requested working directory is not a directory dir={s}\",\n                        .{wd},\n                    );\n                    break :wd;\n                }\n\n                var wd_val: configpkg.WorkingDirectory = .{ .path = wd };\n                if (wd_val.finalize(config.arenaAlloc())) |_| {\n                    config.@\"working-directory\" = wd_val;\n                } else |err| {\n                    log.warn(\n                        \"error finalizing working directory config dir={s} err={}\",\n                        .{ wd_val.path, err },\n                    );\n                }\n            }\n",
             "            const wd = std.mem.sliceTo(c_wd, 0);\n            if (wd.len > 0) wd: {\n                if (comptime builtin.os.tag.isDarwin()) {\n                    // Con: macOS may deny directory open/stat preflight for privacy-protected cwd\n                    // (Documents, Downloads) even though chdir in the spawned shell succeeds. The\n                    // embedder already passes an absolute cwd captured from shell integration, so\n                    // trust it here and let process spawn be the authoritative failure boundary.\n                    var wd_val: configpkg.WorkingDirectory = .{ .path = wd };\n                    if (wd_val.finalize(config.arenaAlloc())) |_| {\n                        config.@\"working-directory\" = wd_val;\n                    } else |err| {\n                        log.warn(\n                            \"error finalizing working directory config dir={s} err={}\",\n                            .{ wd_val.path, err },\n                        );\n                    }\n                    break :wd;\n                }\n\n                var dir = std.fs.openDirAbsolute(wd, .{}) catch |err| {\n                    log.warn(\n                        \"error opening requested working directory dir={s} err={}\",\n                        .{ wd, err },\n                    );\n                    break :wd;\n                };\n                defer dir.close();\n\n                const stat = dir.stat() catch |err| {\n                    log.warn(\n                        \"failed to stat requested working directory dir={s} err={}\",\n                        .{ wd, err },\n                    );\n                    break :wd;\n                };\n\n                if (stat.kind != .directory) {\n                    log.warn(\n                        \"requested working directory is not a directory dir={s}\",\n                        .{wd},\n                    );\n                    break :wd;\n                }\n\n                var wd_val: configpkg.WorkingDirectory = .{ .path = wd };\n                if (wd_val.finalize(config.arenaAlloc())) |_| {\n                    config.@\"working-directory\" = wd_val;\n                } else |err| {\n                    log.warn(\n                        \"error finalizing working directory config dir={s} err={}\",\n                        .{ wd_val.path, err },\n                    );\n                }\n            }\n",
         )],
     )?;
-    patch_file_once(
+    patch_text_once(
         &surface,
+        &mut surface_text,
         "initial_output_restore: ?[]const u8",
         &[(
             "    rt_surface: *apprt.runtime.Surface,\n) !void {\n",
             "    rt_surface: *apprt.runtime.Surface,\n    initial_output_restore: ?[]const u8,\n) !void {\n",
         )],
     )?;
-    patch_file_once(
+    patch_text_once(
         &exec,
+        &mut exec_text,
         "Con: trust macOS cwd after embedded surface validation",
         &[(
             "            if (std.fs.cwd().access(proposed, .{})) {\n                break :cwd proposed;\n            } else |err| {\n                log.warn(\"cannot access cwd, ignoring: {}\", .{err});\n                break :cwd null;\n            }\n",
             "            if (comptime builtin.os.tag.isDarwin()) {\n                // Con: trust macOS cwd after embedded surface validation. Privacy-protected\n                // directories can fail access/open preflight while the child shell can still\n                // chdir there and preserve the user's restored working directory.\n                break :cwd proposed;\n            }\n\n            if (std.fs.cwd().access(proposed, .{})) {\n                break :cwd proposed;\n            } else |err| {\n                log.warn(\"cannot access cwd, ignoring: {}\", .{err});\n                break :cwd null;\n            }\n",
         )],
     )?;
-    patch_file_once(
+    patch_text_once(
         &surface,
+        &mut surface_text,
         "This keeps restored text in Ghostty's",
         &[(
             "    // Start our IO thread\n    self.io_thr = try std.Thread.spawn(\n",
             "    // Seed restored output after the renderer is alive but before the IO\n    // thread starts the child process. This keeps restored text in Ghostty's\n    // own terminal screen/scrollback layer without ever feeding it to the shell.\n    if (initial_output_restore) |initial_output| {\n        if (initial_output.len > 0) self.io.processOutput(initial_output);\n    }\n\n    // Start our IO thread\n    self.io_thr = try std.Thread.spawn(\n",
         )],
     )?;
-    replace_file_text_if_present(
-        &surface,
+    replace_text_if_present(
+        &mut surface_text,
         "    if (opts.initial_output) |c_output| {\n        const initial_output = std.mem.sliceTo(c_output, 0);\n        if (initial_output.len > 0) self.io.processOutput(initial_output);\n    }\n",
         "    if (initial_output_restore) |initial_output| {\n        if (initial_output.len > 0) self.io.processOutput(initial_output);\n    }\n",
-    )?;
+    );
 
-    patch_file_once(
+    patch_text_once(
         &header,
+        &mut header_text,
         "const char* initial_output;",
         &[(
             "  const char* initial_input;\n  bool wait_after_command;\n",
             "  const char* initial_input;\n  const char* initial_output;\n  bool wait_after_command;\n",
         )],
     )?;
+
+    for (path, text) in [
+        (&embedded, embedded_text.as_str()),
+        (&surface, surface_text.as_str()),
+        (&exec, exec_text.as_str()),
+        (&header, header_text.as_str()),
+    ] {
+        write_file_atomic(path, text)?;
+    }
 
     println!("cargo:rustc-cfg=con_ghostty_embedded_initial_output");
     println!("cargo:rerun-if-changed={}", embedded.display());
@@ -774,9 +799,16 @@ fn try_apply_embedded_initial_output_patch(ghostty_dir: &Path) -> Result<(), Str
     Ok(())
 }
 
-fn patch_file_once(path: &Path, marker: &str, replacements: &[(&str, &str)]) -> Result<(), String> {
-    let mut text = fs::read_to_string(path)
-        .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
+fn read_file_text(path: &Path) -> Result<String, String> {
+    fs::read_to_string(path).map_err(|err| format!("failed to read {}: {err}", path.display()))
+}
+
+fn patch_text_once(
+    path: &Path,
+    text: &mut String,
+    marker: &str,
+    replacements: &[(&str, &str)],
+) -> Result<(), String> {
     if text.contains(marker) {
         return Ok(());
     }
@@ -788,19 +820,16 @@ fn patch_file_once(path: &Path, marker: &str, replacements: &[(&str, &str)]) -> 
                 path.display()
             ));
         }
-        text = text.replacen(from, to, 1);
+        *text = text.replacen(from, to, 1);
     }
 
-    write_file_atomic(path, &text)
+    Ok(())
 }
 
-fn replace_file_text_if_present(path: &Path, from: &str, to: &str) -> Result<(), String> {
-    let text = fs::read_to_string(path)
-        .map_err(|err| format!("failed to read {}: {err}", path.display()))?;
-    if !text.contains(from) {
-        return Ok(());
+fn replace_text_if_present(text: &mut String, from: &str, to: &str) {
+    if text.contains(from) {
+        *text = text.replace(from, to);
     }
-    write_file_atomic(path, &text.replace(from, to))
 }
 
 fn write_file_atomic(path: &Path, text: &str) -> Result<(), String> {

--- a/crates/con-ghostty/build.rs
+++ b/crates/con-ghostty/build.rs
@@ -826,11 +826,10 @@ fn write_file_atomic(path: &Path, text: &str) -> Result<(), String> {
 }
 
 fn write_patch_files_with_rollback(files: &[(&Path, &str, &str)]) -> Result<(), String> {
-    let mut replaced = 0;
-    for (path, _, patched) in files {
+    for (written_count, (path, _, patched)) in files.iter().enumerate() {
         if let Err(write_err) = write_file_atomic(path, patched) {
             let mut rollback_errors = Vec::new();
-            for (rollback_path, original, _) in files[..replaced].iter().rev() {
+            for (rollback_path, original, _) in files[..written_count].iter().rev() {
                 if let Err(err) = write_file_atomic(rollback_path, original) {
                     rollback_errors.push(err);
                 }
@@ -845,7 +844,6 @@ fn write_patch_files_with_rollback(files: &[(&Path, &str, &str)]) -> Result<(), 
             }
             return Err(write_err);
         }
-        replaced += 1;
     }
     Ok(())
 }

--- a/crates/con-ghostty/src/ffi.rs
+++ b/crates/con-ghostty/src/ffi.rs
@@ -142,6 +142,11 @@ pub struct ghostty_surface_config_s {
     pub context: ghostty_surface_context_e,
 }
 
+#[cfg(con_ghostty_embedded_initial_output)]
+const _: [(); 96] = [(); std::mem::size_of::<ghostty_surface_config_s>()];
+#[cfg(not(con_ghostty_embedded_initial_output))]
+const _: [(); 88] = [(); std::mem::size_of::<ghostty_surface_config_s>()];
+
 #[repr(C)]
 pub struct ghostty_env_var_s {
     pub key: *const c_char,
@@ -270,70 +275,74 @@ pub struct ghostty_action_resize_split_s {
 #[allow(clippy::upper_case_acronyms)]
 pub enum ghostty_action_tag_e {
     GHOSTTY_ACTION_QUIT = 0,
-    GHOSTTY_ACTION_NEW_WINDOW,
-    GHOSTTY_ACTION_NEW_TAB,
-    GHOSTTY_ACTION_CLOSE_TAB,
-    GHOSTTY_ACTION_NEW_SPLIT,
-    GHOSTTY_ACTION_CLOSE_ALL_WINDOWS,
-    GHOSTTY_ACTION_TOGGLE_MAXIMIZE,
-    GHOSTTY_ACTION_TOGGLE_FULLSCREEN,
-    GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW,
-    GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS,
-    GHOSTTY_ACTION_TOGGLE_QUICK_TERMINAL,
-    GHOSTTY_ACTION_TOGGLE_COMMAND_PALETTE,
-    GHOSTTY_ACTION_TOGGLE_VISIBILITY,
-    GHOSTTY_ACTION_TOGGLE_BACKGROUND_OPACITY,
-    GHOSTTY_ACTION_MOVE_TAB,
-    GHOSTTY_ACTION_GOTO_TAB,
-    GHOSTTY_ACTION_GOTO_SPLIT,
-    GHOSTTY_ACTION_GOTO_WINDOW,
-    GHOSTTY_ACTION_RESIZE_SPLIT,
-    GHOSTTY_ACTION_EQUALIZE_SPLITS,
-    GHOSTTY_ACTION_TOGGLE_SPLIT_ZOOM,
-    GHOSTTY_ACTION_PRESENT_TERMINAL,
-    GHOSTTY_ACTION_SIZE_LIMIT,
-    GHOSTTY_ACTION_RESET_WINDOW_SIZE,
-    GHOSTTY_ACTION_INITIAL_SIZE,
-    GHOSTTY_ACTION_CELL_SIZE,
-    GHOSTTY_ACTION_SCROLLBAR,
-    GHOSTTY_ACTION_RENDER,
-    GHOSTTY_ACTION_INSPECTOR,
-    GHOSTTY_ACTION_SHOW_GTK_INSPECTOR,
-    GHOSTTY_ACTION_RENDER_INSPECTOR,
-    GHOSTTY_ACTION_DESKTOP_NOTIFICATION,
-    GHOSTTY_ACTION_SET_TITLE,
-    GHOSTTY_ACTION_SET_TAB_TITLE,
-    GHOSTTY_ACTION_PROMPT_TITLE,
-    GHOSTTY_ACTION_PWD,
-    GHOSTTY_ACTION_MOUSE_SHAPE,
-    GHOSTTY_ACTION_MOUSE_VISIBILITY,
-    GHOSTTY_ACTION_MOUSE_OVER_LINK,
-    GHOSTTY_ACTION_RENDERER_HEALTH,
-    GHOSTTY_ACTION_OPEN_CONFIG,
-    GHOSTTY_ACTION_QUIT_TIMER,
-    GHOSTTY_ACTION_FLOAT_WINDOW,
-    GHOSTTY_ACTION_SECURE_INPUT,
-    GHOSTTY_ACTION_KEY_SEQUENCE,
-    GHOSTTY_ACTION_KEY_TABLE,
-    GHOSTTY_ACTION_COLOR_CHANGE,
-    GHOSTTY_ACTION_RELOAD_CONFIG,
-    GHOSTTY_ACTION_CONFIG_CHANGE,
-    GHOSTTY_ACTION_CLOSE_WINDOW,
-    GHOSTTY_ACTION_RING_BELL,
-    GHOSTTY_ACTION_UNDO,
-    GHOSTTY_ACTION_REDO,
-    GHOSTTY_ACTION_CHECK_FOR_UPDATES,
-    GHOSTTY_ACTION_OPEN_URL,
-    GHOSTTY_ACTION_SHOW_CHILD_EXITED,
-    GHOSTTY_ACTION_PROGRESS_REPORT,
-    GHOSTTY_ACTION_SHOW_ON_SCREEN_KEYBOARD,
-    GHOSTTY_ACTION_COMMAND_FINISHED,
-    GHOSTTY_ACTION_START_SEARCH,
-    GHOSTTY_ACTION_END_SEARCH,
-    GHOSTTY_ACTION_SEARCH_TOTAL,
-    GHOSTTY_ACTION_SEARCH_SELECTED,
-    GHOSTTY_ACTION_READONLY,
-    GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD,
+    GHOSTTY_ACTION_NEW_WINDOW = 1,
+    GHOSTTY_ACTION_NEW_TAB = 2,
+    GHOSTTY_ACTION_CLOSE_TAB = 3,
+    GHOSTTY_ACTION_NEW_SPLIT = 4,
+    GHOSTTY_ACTION_CLOSE_ALL_WINDOWS = 5,
+    GHOSTTY_ACTION_TOGGLE_MAXIMIZE = 6,
+    GHOSTTY_ACTION_TOGGLE_FULLSCREEN = 7,
+    GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW = 8,
+    GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS = 9,
+    GHOSTTY_ACTION_TOGGLE_QUICK_TERMINAL = 10,
+    GHOSTTY_ACTION_TOGGLE_COMMAND_PALETTE = 11,
+    GHOSTTY_ACTION_TOGGLE_VISIBILITY = 12,
+    GHOSTTY_ACTION_TOGGLE_BACKGROUND_OPACITY = 13,
+    GHOSTTY_ACTION_MOVE_TAB = 14,
+    GHOSTTY_ACTION_GOTO_TAB = 15,
+    GHOSTTY_ACTION_GOTO_SPLIT = 16,
+    GHOSTTY_ACTION_GOTO_WINDOW = 17,
+    GHOSTTY_ACTION_RESIZE_SPLIT = 18,
+    GHOSTTY_ACTION_EQUALIZE_SPLITS = 19,
+    GHOSTTY_ACTION_TOGGLE_SPLIT_ZOOM = 20,
+    GHOSTTY_ACTION_PRESENT_TERMINAL = 21,
+    GHOSTTY_ACTION_SIZE_LIMIT = 22,
+    GHOSTTY_ACTION_RESET_WINDOW_SIZE = 23,
+    GHOSTTY_ACTION_INITIAL_SIZE = 24,
+    GHOSTTY_ACTION_CELL_SIZE = 25,
+    GHOSTTY_ACTION_SCROLLBAR = 26,
+    GHOSTTY_ACTION_RENDER = 27,
+    GHOSTTY_ACTION_INSPECTOR = 28,
+    GHOSTTY_ACTION_SHOW_GTK_INSPECTOR = 29,
+    GHOSTTY_ACTION_RENDER_INSPECTOR = 30,
+    GHOSTTY_ACTION_EXPORT_TERMINAL_IO = 31,
+    GHOSTTY_ACTION_DESKTOP_NOTIFICATION = 32,
+    GHOSTTY_ACTION_SET_TITLE = 33,
+    GHOSTTY_ACTION_SET_TAB_TITLE = 34,
+    GHOSTTY_ACTION_SET_WINDOW_TITLE = 35,
+    GHOSTTY_ACTION_PROMPT_TITLE = 36,
+    GHOSTTY_ACTION_PWD = 37,
+    GHOSTTY_ACTION_MOUSE_SHAPE = 38,
+    GHOSTTY_ACTION_MOUSE_VISIBILITY = 39,
+    GHOSTTY_ACTION_MOUSE_OVER_LINK = 40,
+    GHOSTTY_ACTION_RENDERER_HEALTH = 41,
+    GHOSTTY_ACTION_OPEN_CONFIG = 42,
+    GHOSTTY_ACTION_QUIT_TIMER = 43,
+    GHOSTTY_ACTION_FLOAT_WINDOW = 44,
+    GHOSTTY_ACTION_SECURE_INPUT = 45,
+    GHOSTTY_ACTION_KEY_SEQUENCE = 46,
+    GHOSTTY_ACTION_KEY_TABLE = 47,
+    GHOSTTY_ACTION_COLOR_CHANGE = 48,
+    GHOSTTY_ACTION_RELOAD_CONFIG = 49,
+    GHOSTTY_ACTION_CONFIG_CHANGE = 50,
+    GHOSTTY_ACTION_CLOSE_WINDOW = 51,
+    GHOSTTY_ACTION_RING_BELL = 52,
+    GHOSTTY_ACTION_SELECTION_CHANGED = 53,
+    GHOSTTY_ACTION_UNDO = 54,
+    GHOSTTY_ACTION_REDO = 55,
+    GHOSTTY_ACTION_CHECK_FOR_UPDATES = 56,
+    GHOSTTY_ACTION_OPEN_URL = 57,
+    GHOSTTY_ACTION_SHOW_CHILD_EXITED = 58,
+    GHOSTTY_ACTION_PROGRESS_REPORT = 59,
+    GHOSTTY_ACTION_SHOW_ON_SCREEN_KEYBOARD = 60,
+    GHOSTTY_ACTION_COMMAND_FINISHED = 61,
+    GHOSTTY_ACTION_START_SEARCH = 62,
+    GHOSTTY_ACTION_END_SEARCH = 63,
+    GHOSTTY_ACTION_SEARCH_TOTAL = 64,
+    GHOSTTY_ACTION_SEARCH_SELECTED = 65,
+    GHOSTTY_ACTION_READONLY = 66,
+    GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD = 67,
+    GHOSTTY_ACTION_MOVE_TAB_TO_NEW_WINDOW = 68,
 }
 
 /// Action payload for DESKTOP_NOTIFICATION (OSC 9 and OSC 777).
@@ -384,6 +393,7 @@ pub enum ghostty_action_open_url_kind_e {
     GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN = 0,
     GHOSTTY_ACTION_OPEN_URL_KIND_TEXT = 1,
     GHOSTTY_ACTION_OPEN_URL_KIND_HTML = 2,
+    GHOSTTY_ACTION_OPEN_URL_KIND_OSC8 = 3,
 }
 
 /// Action payload for OPEN_URL.
@@ -393,6 +403,15 @@ pub struct ghostty_action_open_url_s {
     pub kind: ghostty_action_open_url_kind_e,
     pub url: *const c_char,
     pub len: usize,
+}
+
+/// Action payload for SHOW_CHILD_EXITED.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct ghostty_surface_message_childexited_s {
+    pub exit_code: u32,
+    /// Runtime in milliseconds. The pinned C header calls this `timetime_ms`.
+    pub runtime_ms: u64,
 }
 
 /// Action union — only relevant fields are accessed based on tag.
@@ -407,6 +426,7 @@ pub union ghostty_action_u {
     pub pwd: ghostty_action_pwd_s,
     pub command_finished: ghostty_action_command_finished_s,
     pub open_url: ghostty_action_open_url_s,
+    pub child_exited: ghostty_surface_message_childexited_s,
 }
 
 #[repr(C)]
@@ -418,6 +438,7 @@ pub struct ghostty_action_s {
 // The action is passed by value to ghostty_runtime_action_cb, so these sizes
 // must exactly match ghostty.h at the pinned Ghostty revision.
 const _: [(); 16] = [(); std::mem::size_of::<ghostty_action_desktop_notification_s>()];
+const _: [(); 16] = [(); std::mem::size_of::<ghostty_surface_message_childexited_s>()];
 const _: [(); 24] = [(); std::mem::size_of::<ghostty_action_u>()];
 const _: [(); 32] = [(); std::mem::size_of::<ghostty_action_s>()];
 
@@ -428,12 +449,34 @@ const _: [(); 32] = [(); std::mem::size_of::<ghostty_action_s>()];
 pub enum ghostty_clipboard_e {
     GHOSTTY_CLIPBOARD_STANDARD = 0,
     GHOSTTY_CLIPBOARD_SELECTION = 1,
+    GHOSTTY_CLIPBOARD_PRIMARY = 2,
 }
 
 #[repr(C)]
 pub struct ghostty_clipboard_content_s {
     pub mime: *const c_char,
     pub data: *const c_char,
+    pub len: usize,
+}
+
+#[repr(C)]
+pub struct ghostty_clipboard_complete_s {
+    pub contents: *const ghostty_clipboard_content_s,
+    pub contents_len: usize,
+    pub available: *const *const c_char,
+    pub available_len: usize,
+    pub confirmed: bool,
+    pub remember: bool,
+}
+
+#[repr(C)]
+pub struct ghostty_clipboard_confirm_s {
+    pub contents: *const ghostty_clipboard_content_s,
+    pub contents_len: usize,
+    pub available: *const *const c_char,
+    pub available_len: usize,
+    pub name: *const c_char,
+    pub can_remember: bool,
 }
 
 #[repr(C)]
@@ -442,7 +485,22 @@ pub enum ghostty_clipboard_request_e {
     GHOSTTY_CLIPBOARD_REQUEST_PASTE = 0,
     GHOSTTY_CLIPBOARD_REQUEST_OSC_52_READ = 1,
     GHOSTTY_CLIPBOARD_REQUEST_OSC_52_WRITE = 2,
+    GHOSTTY_CLIPBOARD_REQUEST_KITTY_READ = 3,
+    GHOSTTY_CLIPBOARD_REQUEST_KITTY_WRITE = 4,
+    GHOSTTY_CLIPBOARD_REQUEST_LIST = 5,
 }
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ghostty_clipboard_read_result_e {
+    GHOSTTY_CLIPBOARD_READ_STARTED = 0,
+    GHOSTTY_CLIPBOARD_READ_UNAVAILABLE = 1,
+    GHOSTTY_CLIPBOARD_READ_UNSUPPORTED = 2,
+}
+
+const _: [(); 24] = [(); std::mem::size_of::<ghostty_clipboard_content_s>()];
+const _: [(); 40] = [(); std::mem::size_of::<ghostty_clipboard_complete_s>()];
+const _: [(); 48] = [(); std::mem::size_of::<ghostty_clipboard_confirm_s>()];
 
 // ── Runtime config (callbacks for embedded apprt) ───────────
 
@@ -461,13 +519,16 @@ pub type ghostty_runtime_read_clipboard_cb = Option<
         userdata: *mut c_void,
         clipboard: ghostty_clipboard_e,
         request: *mut c_void,
-    ) -> bool,
+        mime_types: *const *const c_char,
+        mime_types_len: usize,
+        needs_listing: bool,
+    ) -> ghostty_clipboard_read_result_e,
 >;
 
 pub type ghostty_runtime_confirm_read_clipboard_cb = Option<
     unsafe extern "C" fn(
         userdata: *mut c_void,
-        text: *const c_char,
+        confirm: *const ghostty_clipboard_confirm_s,
         request: *mut c_void,
         request_type: ghostty_clipboard_request_e,
     ),
@@ -497,6 +558,8 @@ pub struct ghostty_runtime_config_s {
     pub write_clipboard_cb: ghostty_runtime_write_clipboard_cb,
     pub close_surface_cb: ghostty_runtime_close_surface_cb,
 }
+
+const _: [(); 64] = [(); std::mem::size_of::<ghostty_runtime_config_s>()];
 
 // ── C API functions ─────────────────────────────────────────
 
@@ -626,10 +689,10 @@ unsafe extern "C" {
     // Clipboard
     pub fn ghostty_surface_complete_clipboard_request(
         surface: ghostty_surface_t,
-        text: *const c_char,
+        complete: *const ghostty_clipboard_complete_s,
         request: *mut c_void,
-        confirmed: bool,
     );
+    pub fn ghostty_surface_deny_clipboard_request(surface: ghostty_surface_t, request: *mut c_void);
 
     // macOS-specific
     #[cfg(target_os = "macos")]

--- a/crates/con-ghostty/src/ffi_abi.c
+++ b/crates/con-ghostty/src/ffi_abi.c
@@ -1,0 +1,154 @@
+#include <stddef.h>
+
+#include <ghostty.h>
+
+/*
+ * Con handwrites the internal macOS Ghostty ABI in ffi.rs. Most action-tag
+ * changes do not alter the enclosing union size, so Rust layout assertions
+ * alone cannot detect enum drift. Keep every tag value explicit here so a
+ * Ghostty revision bump fails while compiling instead of misdispatching an
+ * unrelated payload at runtime.
+ */
+#define ASSERT_ACTION(name, value) \
+    _Static_assert((name) == (value), #name " changed value")
+
+ASSERT_ACTION(GHOSTTY_ACTION_QUIT, 0);
+ASSERT_ACTION(GHOSTTY_ACTION_NEW_WINDOW, 1);
+ASSERT_ACTION(GHOSTTY_ACTION_NEW_TAB, 2);
+ASSERT_ACTION(GHOSTTY_ACTION_CLOSE_TAB, 3);
+ASSERT_ACTION(GHOSTTY_ACTION_NEW_SPLIT, 4);
+ASSERT_ACTION(GHOSTTY_ACTION_CLOSE_ALL_WINDOWS, 5);
+ASSERT_ACTION(GHOSTTY_ACTION_TOGGLE_MAXIMIZE, 6);
+ASSERT_ACTION(GHOSTTY_ACTION_TOGGLE_FULLSCREEN, 7);
+ASSERT_ACTION(GHOSTTY_ACTION_TOGGLE_TAB_OVERVIEW, 8);
+ASSERT_ACTION(GHOSTTY_ACTION_TOGGLE_WINDOW_DECORATIONS, 9);
+ASSERT_ACTION(GHOSTTY_ACTION_TOGGLE_QUICK_TERMINAL, 10);
+ASSERT_ACTION(GHOSTTY_ACTION_TOGGLE_COMMAND_PALETTE, 11);
+ASSERT_ACTION(GHOSTTY_ACTION_TOGGLE_VISIBILITY, 12);
+ASSERT_ACTION(GHOSTTY_ACTION_TOGGLE_BACKGROUND_OPACITY, 13);
+ASSERT_ACTION(GHOSTTY_ACTION_MOVE_TAB, 14);
+ASSERT_ACTION(GHOSTTY_ACTION_GOTO_TAB, 15);
+ASSERT_ACTION(GHOSTTY_ACTION_GOTO_SPLIT, 16);
+ASSERT_ACTION(GHOSTTY_ACTION_GOTO_WINDOW, 17);
+ASSERT_ACTION(GHOSTTY_ACTION_RESIZE_SPLIT, 18);
+ASSERT_ACTION(GHOSTTY_ACTION_EQUALIZE_SPLITS, 19);
+ASSERT_ACTION(GHOSTTY_ACTION_TOGGLE_SPLIT_ZOOM, 20);
+ASSERT_ACTION(GHOSTTY_ACTION_PRESENT_TERMINAL, 21);
+ASSERT_ACTION(GHOSTTY_ACTION_SIZE_LIMIT, 22);
+ASSERT_ACTION(GHOSTTY_ACTION_RESET_WINDOW_SIZE, 23);
+ASSERT_ACTION(GHOSTTY_ACTION_INITIAL_SIZE, 24);
+ASSERT_ACTION(GHOSTTY_ACTION_CELL_SIZE, 25);
+ASSERT_ACTION(GHOSTTY_ACTION_SCROLLBAR, 26);
+ASSERT_ACTION(GHOSTTY_ACTION_RENDER, 27);
+ASSERT_ACTION(GHOSTTY_ACTION_INSPECTOR, 28);
+ASSERT_ACTION(GHOSTTY_ACTION_SHOW_GTK_INSPECTOR, 29);
+ASSERT_ACTION(GHOSTTY_ACTION_RENDER_INSPECTOR, 30);
+ASSERT_ACTION(GHOSTTY_ACTION_EXPORT_TERMINAL_IO, 31);
+ASSERT_ACTION(GHOSTTY_ACTION_DESKTOP_NOTIFICATION, 32);
+ASSERT_ACTION(GHOSTTY_ACTION_SET_TITLE, 33);
+ASSERT_ACTION(GHOSTTY_ACTION_SET_TAB_TITLE, 34);
+ASSERT_ACTION(GHOSTTY_ACTION_SET_WINDOW_TITLE, 35);
+ASSERT_ACTION(GHOSTTY_ACTION_PROMPT_TITLE, 36);
+ASSERT_ACTION(GHOSTTY_ACTION_PWD, 37);
+ASSERT_ACTION(GHOSTTY_ACTION_MOUSE_SHAPE, 38);
+ASSERT_ACTION(GHOSTTY_ACTION_MOUSE_VISIBILITY, 39);
+ASSERT_ACTION(GHOSTTY_ACTION_MOUSE_OVER_LINK, 40);
+ASSERT_ACTION(GHOSTTY_ACTION_RENDERER_HEALTH, 41);
+ASSERT_ACTION(GHOSTTY_ACTION_OPEN_CONFIG, 42);
+ASSERT_ACTION(GHOSTTY_ACTION_QUIT_TIMER, 43);
+ASSERT_ACTION(GHOSTTY_ACTION_FLOAT_WINDOW, 44);
+ASSERT_ACTION(GHOSTTY_ACTION_SECURE_INPUT, 45);
+ASSERT_ACTION(GHOSTTY_ACTION_KEY_SEQUENCE, 46);
+ASSERT_ACTION(GHOSTTY_ACTION_KEY_TABLE, 47);
+ASSERT_ACTION(GHOSTTY_ACTION_COLOR_CHANGE, 48);
+ASSERT_ACTION(GHOSTTY_ACTION_RELOAD_CONFIG, 49);
+ASSERT_ACTION(GHOSTTY_ACTION_CONFIG_CHANGE, 50);
+ASSERT_ACTION(GHOSTTY_ACTION_CLOSE_WINDOW, 51);
+ASSERT_ACTION(GHOSTTY_ACTION_RING_BELL, 52);
+ASSERT_ACTION(GHOSTTY_ACTION_SELECTION_CHANGED, 53);
+ASSERT_ACTION(GHOSTTY_ACTION_UNDO, 54);
+ASSERT_ACTION(GHOSTTY_ACTION_REDO, 55);
+ASSERT_ACTION(GHOSTTY_ACTION_CHECK_FOR_UPDATES, 56);
+ASSERT_ACTION(GHOSTTY_ACTION_OPEN_URL, 57);
+ASSERT_ACTION(GHOSTTY_ACTION_SHOW_CHILD_EXITED, 58);
+ASSERT_ACTION(GHOSTTY_ACTION_PROGRESS_REPORT, 59);
+ASSERT_ACTION(GHOSTTY_ACTION_SHOW_ON_SCREEN_KEYBOARD, 60);
+ASSERT_ACTION(GHOSTTY_ACTION_COMMAND_FINISHED, 61);
+ASSERT_ACTION(GHOSTTY_ACTION_START_SEARCH, 62);
+ASSERT_ACTION(GHOSTTY_ACTION_END_SEARCH, 63);
+ASSERT_ACTION(GHOSTTY_ACTION_SEARCH_TOTAL, 64);
+ASSERT_ACTION(GHOSTTY_ACTION_SEARCH_SELECTED, 65);
+ASSERT_ACTION(GHOSTTY_ACTION_READONLY, 66);
+ASSERT_ACTION(GHOSTTY_ACTION_COPY_TITLE_TO_CLIPBOARD, 67);
+ASSERT_ACTION(GHOSTTY_ACTION_MOVE_TAB_TO_NEW_WINDOW, 68);
+
+#undef ASSERT_ACTION
+
+_Static_assert(sizeof(ghostty_action_u) == 24, "ghostty_action_u changed layout");
+_Static_assert(sizeof(ghostty_action_s) == 32, "ghostty_action_s changed layout");
+_Static_assert(sizeof(ghostty_surface_message_childexited_s) == 16,
+               "ghostty child-exited payload changed layout");
+_Static_assert(offsetof(ghostty_surface_message_childexited_s, timetime_ms) == 8,
+               "ghostty child-exited runtime changed offset");
+_Static_assert(sizeof(ghostty_action_command_finished_s) == 16,
+               "ghostty command-finished payload changed layout");
+_Static_assert(offsetof(ghostty_action_command_finished_s, duration) == 8,
+               "ghostty command-finished duration changed offset");
+
+_Static_assert(GHOSTTY_CLIPBOARD_STANDARD == 0,
+               "ghostty standard clipboard changed value");
+_Static_assert(GHOSTTY_CLIPBOARD_SELECTION == 1,
+               "ghostty selection clipboard changed value");
+_Static_assert(GHOSTTY_CLIPBOARD_PRIMARY == 2,
+               "ghostty primary clipboard changed value");
+_Static_assert(GHOSTTY_CLIPBOARD_REQUEST_PASTE == 0,
+               "ghostty paste request changed value");
+_Static_assert(GHOSTTY_CLIPBOARD_REQUEST_OSC_52_READ == 1,
+               "ghostty OSC 52 read request changed value");
+_Static_assert(GHOSTTY_CLIPBOARD_REQUEST_OSC_52_WRITE == 2,
+               "ghostty OSC 52 write request changed value");
+_Static_assert(GHOSTTY_CLIPBOARD_REQUEST_KITTY_READ == 3,
+               "ghostty Kitty read request changed value");
+_Static_assert(GHOSTTY_CLIPBOARD_REQUEST_KITTY_WRITE == 4,
+               "ghostty Kitty write request changed value");
+_Static_assert(GHOSTTY_CLIPBOARD_REQUEST_LIST == 5,
+               "ghostty clipboard list request changed value");
+_Static_assert(GHOSTTY_CLIPBOARD_READ_STARTED == 0,
+               "ghostty started result changed value");
+_Static_assert(GHOSTTY_CLIPBOARD_READ_UNAVAILABLE == 1,
+               "ghostty unavailable result changed value");
+_Static_assert(GHOSTTY_CLIPBOARD_READ_UNSUPPORTED == 2,
+               "ghostty unsupported result changed value");
+
+_Static_assert(sizeof(ghostty_clipboard_content_s) == 24,
+               "ghostty clipboard content changed layout");
+_Static_assert(offsetof(ghostty_clipboard_content_s, len) == 16,
+               "ghostty clipboard content length changed offset");
+_Static_assert(sizeof(ghostty_clipboard_complete_s) == 40,
+               "ghostty clipboard completion changed layout");
+_Static_assert(offsetof(ghostty_clipboard_complete_s, available) == 16,
+               "ghostty clipboard completion listing changed offset");
+_Static_assert(offsetof(ghostty_clipboard_complete_s, confirmed) == 32,
+               "ghostty clipboard completion confirmation changed offset");
+_Static_assert(sizeof(ghostty_clipboard_confirm_s) == 48,
+               "ghostty clipboard confirmation changed layout");
+_Static_assert(offsetof(ghostty_clipboard_confirm_s, name) == 32,
+               "ghostty clipboard confirmation name changed offset");
+_Static_assert(sizeof(ghostty_runtime_config_s) == 64,
+               "ghostty runtime config changed layout");
+_Static_assert(offsetof(ghostty_runtime_config_s, read_clipboard_cb) == 32,
+               "ghostty runtime clipboard callback changed offset");
+_Static_assert(offsetof(ghostty_runtime_config_s, close_surface_cb) == 56,
+               "ghostty runtime close callback changed offset");
+
+#ifdef CON_GHOSTTY_EMBEDDED_INITIAL_OUTPUT
+_Static_assert(sizeof(ghostty_surface_config_s) == 96,
+               "patched ghostty surface config changed layout");
+_Static_assert(offsetof(ghostty_surface_config_s, wait_after_command) == 88,
+               "patched initial_output changed position");
+#else
+_Static_assert(sizeof(ghostty_surface_config_s) == 88,
+               "ghostty surface config changed layout");
+_Static_assert(offsetof(ghostty_surface_config_s, wait_after_command) == 80,
+               "ghostty surface config fields changed position");
+#endif

--- a/crates/con-ghostty/src/lib.rs
+++ b/crates/con-ghostty/src/lib.rs
@@ -37,6 +37,9 @@ pub fn restored_terminal_output_text(lines: &[String]) -> Option<String> {
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 mod transcript;
 
+#[cfg(any(target_os = "windows", target_os = "linux", test))]
+mod pty_write;
+
 #[cfg(target_os = "macos")]
 pub mod ffi;
 #[cfg(target_os = "macos")]

--- a/crates/con-ghostty/src/lib.rs
+++ b/crates/con-ghostty/src/lib.rs
@@ -34,6 +34,17 @@ pub fn restored_terminal_output_text(lines: &[String]) -> Option<String> {
     (!output.trim().is_empty()).then_some(output)
 }
 
+pub(crate) fn clipboard_mime_is_text(mime: &[u8]) -> bool {
+    let media_type = mime
+        .iter()
+        .position(|byte| *byte == b';')
+        .map_or(mime, |separator| &mime[..separator]);
+    mime.eq_ignore_ascii_case(b"UTF8_STRING")
+        || mime.eq_ignore_ascii_case(b"TEXT")
+        || mime.eq_ignore_ascii_case(b"STRING")
+        || media_type.eq_ignore_ascii_case(b"text/plain")
+}
+
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 mod transcript;
 
@@ -105,3 +116,20 @@ pub use stub::{
     GhosttySplitDirection, GhosttySurfaceEvent, GhosttyTerminal, MouseButton, SurfaceSize,
     TerminalColors,
 };
+
+#[cfg(test)]
+mod tests {
+    use super::clipboard_mime_is_text;
+
+    #[test]
+    fn clipboard_text_mime_matching_is_exact_and_case_insensitive() {
+        assert!(clipboard_mime_is_text(b"text/plain"));
+        assert!(clipboard_mime_is_text(b"TEXT/PLAIN"));
+        assert!(clipboard_mime_is_text(b"text/plain;charset=utf-8"));
+        assert!(clipboard_mime_is_text(b"UTF8_STRING"));
+        assert!(clipboard_mime_is_text(b"text"));
+        assert!(clipboard_mime_is_text(b"STRING"));
+        assert!(!clipboard_mime_is_text(b"text/plainEVIL"));
+        assert!(!clipboard_mime_is_text(b"image/png"));
+    }
+}

--- a/crates/con-ghostty/src/lib.rs
+++ b/crates/con-ghostty/src/lib.rs
@@ -89,7 +89,7 @@ pub use stub::{
 #[cfg(target_os = "linux")]
 pub use vt::{
     ATTR_BOLD, ATTR_INVERSE, ATTR_ITALIC, ATTR_STRIKE, ATTR_UNDERLINE, Cell as VtCell,
-    Cursor as VtCursor, ScreenSnapshot,
+    Cursor as VtCursor, KittyImage, KittyPlacement, ScreenSnapshot,
 };
 
 #[cfg(all(

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -241,12 +241,12 @@ impl LinuxGhosttyTerminal {
         }
     }
 
-    pub fn resize_surface(&self, size: SurfaceSize) {
-        if let Some(session) = self.inner.lock().as_ref() {
-            if let Err(err) = session.resize(size) {
-                log::debug!("linux pty resize failed: {err:#}");
-            }
-        }
+    pub fn resize_surface(&self, size: SurfaceSize) -> Result<(), String> {
+        let guard = self.inner.lock();
+        let Some(session) = guard.as_ref() else {
+            return Err("linux terminal is not attached".to_string());
+        };
+        session.resize(size).map_err(|err| format!("{err:#}"))
     }
 
     pub fn size(&self) -> SurfaceSize {

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -338,11 +338,19 @@ impl LinuxGhosttyTerminal {
         session.send_key(event).map_err(|err| err.to_string())
     }
 
-    pub fn is_bracketed_paste(&self) -> bool {
-        self.inner
-            .lock()
-            .as_ref()
-            .is_some_and(LinuxPtySession::is_bracketed_paste)
+    pub fn paste_text(
+        &self,
+        text: &str,
+        source: crate::vt::VtPasteSource,
+        allow_unsafe: bool,
+    ) -> Result<crate::vt::VtPasteResult, String> {
+        let guard = self.inner.lock();
+        let Some(session) = guard.as_ref() else {
+            return Ok(crate::vt::VtPasteResult::Empty);
+        };
+        session
+            .paste_text(text, source, allow_unsafe)
+            .map_err(|err| err.to_string())
     }
 
     pub fn is_decckm(&self) -> bool {

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -10,7 +10,7 @@ use crate::stub::{
     CommandFinishedSignal, CommandRecord, GhosttyConfigPatch, GhosttySplitDirection,
     GhosttySurfaceEvent, MouseButton, SurfaceSize, TerminalColors,
 };
-use crate::vt::{ScreenSnapshot, VtKeyEvent, VtKeySend};
+use crate::vt::{ScreenSnapshot, VtKeyEvent, VtKeyOutcome};
 
 #[derive(Debug, Clone)]
 pub struct LinuxBackendConfig {
@@ -330,10 +330,10 @@ impl LinuxGhosttyTerminal {
         self.write_to_pty(text.as_bytes());
     }
 
-    pub fn send_key(&self, event: &VtKeyEvent<'_>) -> Result<VtKeySend, String> {
+    pub fn send_key(&self, event: &VtKeyEvent<'_>) -> Result<VtKeyOutcome, String> {
         let guard = self.inner.lock();
         let Some(session) = guard.as_ref() else {
-            return Ok(VtKeySend::default());
+            return Ok(VtKeyOutcome::default());
         };
         session.send_key(event).map_err(|err| err.to_string())
     }
@@ -342,14 +342,14 @@ impl LinuxGhosttyTerminal {
         &self,
         text: &str,
         source: crate::vt::VtPasteSource,
-        allow_unsafe: bool,
+        confirm_unsafe_paste: bool,
     ) -> Result<crate::vt::VtPasteResult, String> {
         let guard = self.inner.lock();
         let Some(session) = guard.as_ref() else {
             return Ok(crate::vt::VtPasteResult::Empty);
         };
         session
-            .paste_text(text, source, allow_unsafe)
+            .paste_text(text, source, confirm_unsafe_paste)
             .map_err(|err| err.to_string())
     }
 

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -10,7 +10,7 @@ use crate::stub::{
     CommandFinishedSignal, CommandRecord, GhosttyConfigPatch, GhosttySplitDirection,
     GhosttySurfaceEvent, MouseButton, SurfaceSize, TerminalColors,
 };
-use crate::vt::ScreenSnapshot;
+use crate::vt::{ScreenSnapshot, VtKeyEvent, VtKeySend};
 
 #[derive(Debug, Clone)]
 pub struct LinuxBackendConfig {
@@ -328,6 +328,14 @@ impl LinuxGhosttyTerminal {
 
     pub fn send_text(&self, text: &str) {
         self.write_to_pty(text.as_bytes());
+    }
+
+    pub fn send_key(&self, event: &VtKeyEvent<'_>) -> Result<VtKeySend, String> {
+        let guard = self.inner.lock();
+        let Some(session) = guard.as_ref() else {
+            return Ok(VtKeySend::default());
+        };
+        session.send_key(event).map_err(|err| err.to_string())
     }
 
     pub fn is_bracketed_paste(&self) -> bool {

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -413,7 +413,7 @@ impl LinuxGhosttyTerminal {
             return false;
         }
         let seq = sgr_mouse_sequence(button, col, row, false);
-        match session.write_input(seq.as_bytes()) {
+        match session.write_control(seq.as_bytes()) {
             Ok(()) => true,
             Err(err) => {
                 log::debug!("linux pty mouse release write failed: {err:#}");

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -10,7 +10,7 @@ use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 
 use crate::stub::{CommandFinishedSignal, SurfaceSize, TerminalColors};
 use crate::transcript::{TranscriptBuffer, snapshot_to_lines};
-use crate::vt::{ScreenSnapshot, ThemeColors, VtScreen};
+use crate::vt::{ScreenSnapshot, ThemeColors, VtKeyEvent, VtKeySend, VtScreen};
 
 const DEFAULT_COLUMNS: u16 = 80;
 const DEFAULT_ROWS: u16 = 24;
@@ -297,6 +297,15 @@ impl LinuxPtySession {
         Ok(())
     }
 
+    pub fn send_key(&self, event: &VtKeyEvent<'_>) -> Result<VtKeySend> {
+        let sent = self.shared.screen.send_key(event)?;
+        if sent.wrote {
+            self.scroll_viewport_to_bottom();
+            self.input_generation.fetch_add(1, Ordering::Relaxed);
+        }
+        Ok(sent)
+    }
+
     pub fn clear_screen_and_scrollback(&self) {
         self.shared.screen.clear_screen_and_scrollback();
         self.mark_needs_render();
@@ -478,11 +487,7 @@ fn spawn_local(options: LinuxPtyOptions) -> Result<LinuxPtySession> {
             theme_owned.as_ref(),
             Some({
                 let writer = writer.clone();
-                Arc::new(move |data: &[u8]| {
-                    if let Err(err) = writer.lock().write_all(data) {
-                        log::debug!("linux vt write_pty failed: {err:#}");
-                    }
-                })
+                Arc::new(move |data: &[u8]| writer.lock().write_all(data))
             }),
         )
         .context("failed to create linux vt screen")?,
@@ -639,15 +644,17 @@ fn spawn_host_bridge(options: LinuxPtyOptions) -> Result<LinuxPtySession> {
             theme_owned.as_ref(),
             Some(Arc::new(move |data: &[u8]| {
                 if data.len() > MAX_BRIDGE_FRAME_BYTES {
-                    log::warn!("dropping oversized host PTY input frame");
-                    return;
+                    return Err(std::io::Error::new(
+                        ErrorKind::InvalidInput,
+                        "host PTY input frame is too large",
+                    ));
                 }
                 let len = data.len() as u32;
                 let mut guard = writer_for_vt.lock();
-                let _ = guard.write_all(&[0x00]);
-                let _ = guard.write_all(&len.to_be_bytes());
-                let _ = guard.write_all(data);
-                let _ = guard.flush();
+                guard.write_all(&[0x00])?;
+                guard.write_all(&len.to_be_bytes())?;
+                guard.write_all(data)?;
+                guard.flush()
             })),
         )
         .context("failed to create linux vt screen")?,

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -1,4 +1,6 @@
-use std::io::{ErrorKind, Read, Write};
+use std::io::{self, ErrorKind, Read, Write};
+use std::os::fd::{AsRawFd, BorrowedFd, OwnedFd, RawFd};
+use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -61,9 +63,10 @@ enum LinuxPtyBackend {
     Local {
         master: Mutex<Box<dyn portable_pty::MasterPty + Send>>,
         child: Mutex<Box<dyn portable_pty::Child + Send + Sync>>,
+        io_shutdown: UnixStream,
     },
     HostBridge {
-        stream_shutdown: std::os::unix::net::UnixStream,
+        stream_shutdown: UnixStream,
         socket_path: PathBuf,
         child: Mutex<std::process::Child>,
     },
@@ -113,6 +116,87 @@ impl LinuxPtyInput {
         frame[7..9].copy_from_slice(&height_px.to_be_bytes());
         queue.enqueue(&frame)
     }
+}
+
+fn duplicate_fd(fd: RawFd) -> io::Result<OwnedFd> {
+    // SAFETY: `fd` remains owned by portable_pty for this call. The returned
+    // descriptor has independent ownership and is closed by `OwnedFd`.
+    unsafe { BorrowedFd::borrow_raw(fd) }.try_clone_to_owned()
+}
+
+fn set_fd_nonblocking(fd: RawFd) -> io::Result<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Wait for one non-blocking PTY operation or an explicit session shutdown.
+/// The cancellation socket is never consumed, so both reader and writer wake
+/// when the owner shuts down its peer endpoint.
+fn wait_for_pty_io(pty_fd: RawFd, cancel_fd: RawFd, events: i16) -> io::Result<bool> {
+    let mut fds = [
+        libc::pollfd {
+            fd: cancel_fd,
+            events: libc::POLLIN,
+            revents: 0,
+        },
+        libc::pollfd {
+            fd: pty_fd,
+            events,
+            revents: 0,
+        },
+    ];
+    loop {
+        let result = unsafe { libc::poll(fds.as_mut_ptr(), fds.len() as libc::nfds_t, -1) };
+        if result == -1 {
+            let err = io::Error::last_os_error();
+            if err.kind() == ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(err);
+        }
+
+        if fds[0].revents != 0 {
+            return Ok(false);
+        }
+        if fds[1].revents & (events | libc::POLLERR | libc::POLLHUP | libc::POLLNVAL) != 0 {
+            return Ok(true);
+        }
+    }
+}
+
+fn write_all_cancellable(
+    writer: &mut dyn Write,
+    readiness: &OwnedFd,
+    cancel: &UnixStream,
+    mut data: &[u8],
+) -> io::Result<()> {
+    while !data.is_empty() {
+        if !wait_for_pty_io(readiness.as_raw_fd(), cancel.as_raw_fd(), libc::POLLOUT)? {
+            return Err(io::Error::new(
+                ErrorKind::BrokenPipe,
+                "PTY input writer was cancelled",
+            ));
+        }
+
+        match writer.write(data) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    ErrorKind::WriteZero,
+                    "PTY input accepted zero bytes",
+                ));
+            }
+            Ok(written) => data = &data[written..],
+            Err(err) if matches!(err.kind(), ErrorKind::Interrupted | ErrorKind::WouldBlock) => {}
+            Err(err) => return Err(err),
+        }
+    }
+    Ok(())
 }
 
 pub struct LinuxPtySession {
@@ -446,15 +530,14 @@ impl LinuxPtySession {
 impl Drop for LinuxPtySession {
     fn drop(&mut self) {
         match &self.backend {
-            LinuxPtyBackend::Local { child, .. } => {
+            LinuxPtyBackend::Local {
+                child, io_shutdown, ..
+            } => {
+                let _ = io_shutdown.shutdown(std::net::Shutdown::Both);
                 if let Err(err) = child.lock().kill() {
                     log::debug!("failed to terminate linux pty child during drop: {err}");
                 }
-                // portable_pty exposes the master writer only as `dyn Write`,
-                // so there is no safe way to cancel a syscall blocked by a
-                // descendant that inherited the slave. Close the queue and
-                // detach the worker rather than hanging the UI during teardown.
-                self.input_worker.close_without_join();
+                self.input_worker.shutdown();
             }
             LinuxPtyBackend::HostBridge {
                 child,
@@ -481,6 +564,20 @@ fn spawn_local(options: LinuxPtyOptions) -> Result<LinuxPtySession> {
     let pair = pty_system
         .openpty(pty_size)
         .context("failed to open linux pty")?;
+    let master_fd = pair
+        .master
+        .as_raw_fd()
+        .context("linux pty master did not expose a file descriptor")?;
+    let reader_readiness =
+        duplicate_fd(master_fd).context("failed to clone linux pty reader fd")?;
+    let writer_readiness =
+        duplicate_fd(master_fd).context("failed to clone linux pty writer fd")?;
+    set_fd_nonblocking(master_fd).context("failed to make linux pty non-blocking")?;
+    let (io_shutdown, io_cancel) =
+        UnixStream::pair().context("failed to create linux pty cancellation socket")?;
+    let writer_cancel = io_cancel
+        .try_clone()
+        .context("failed to clone linux pty writer cancellation socket")?;
 
     let target_program = options
         .program
@@ -503,9 +600,10 @@ fn spawn_local(options: LinuxPtyOptions) -> Result<LinuxPtySession> {
         .master
         .take_writer()
         .context("failed to take linux pty writer")?;
-    let (input_queue, input_worker) =
-        PtyWriteQueue::spawn("con-linux-pty-writer", move |data| writer.write_all(data))
-            .context("failed to spawn linux pty writer")?;
+    let (input_queue, input_worker) = PtyWriteQueue::spawn("con-linux-pty-writer", move |data| {
+        write_all_cancellable(writer.as_mut(), &writer_readiness, &writer_cancel, data)
+    })
+    .context("failed to spawn linux pty writer")?;
     let input = LinuxPtyInput::Local(input_queue);
     let theme_owned = options.theme.as_ref().map(theme_colors_to_vt);
     let screen = Arc::new(
@@ -543,12 +641,19 @@ fn spawn_local(options: LinuxPtyOptions) -> Result<LinuxPtySession> {
         shared.transcript.lock().push(text);
     }
     let started_at = Instant::now();
-    spawn_reader_thread(reader, shared.clone(), started_at);
+    spawn_reader_thread(
+        reader,
+        reader_readiness,
+        io_cancel,
+        shared.clone(),
+        started_at,
+    );
 
     Ok(LinuxPtySession {
         backend: LinuxPtyBackend::Local {
             master: Mutex::new(pair.master),
             child: Mutex::new(child),
+            io_shutdown,
         },
         input,
         input_worker,
@@ -783,6 +888,8 @@ fn spawn_bridge_reader_thread(
 
 fn spawn_reader_thread(
     mut reader: Box<dyn Read + Send>,
+    readiness: OwnedFd,
+    cancel: UnixStream,
     shared: Arc<SessionShared>,
     started_at: Instant,
 ) {
@@ -791,6 +898,15 @@ fn spawn_reader_thread(
         .spawn(move || {
             let mut buffer = [0_u8; 8192];
             loop {
+                match wait_for_pty_io(readiness.as_raw_fd(), cancel.as_raw_fd(), libc::POLLIN) {
+                    Ok(true) => {}
+                    Ok(false) => break,
+                    Err(err) => {
+                        log::debug!("linux pty reader poll terminated: {err}");
+                        shared.mark_exited(None, started_at.elapsed());
+                        break;
+                    }
+                }
                 match reader.read(&mut buffer) {
                     Ok(0) => {
                         shared.mark_exited(None, started_at.elapsed());
@@ -801,7 +917,11 @@ fn spawn_reader_thread(
                         let chunk = String::from_utf8_lossy(&buffer[..read]);
                         shared.push_output(chunk.as_ref());
                     }
-                    Err(err) if err.kind() == ErrorKind::Interrupted => continue,
+                    Err(err)
+                        if matches!(err.kind(), ErrorKind::Interrupted | ErrorKind::WouldBlock) =>
+                    {
+                        continue;
+                    }
                     Err(err) => {
                         log::debug!("linux pty reader terminated: {err}");
                         shared.mark_exited(None, started_at.elapsed());
@@ -1025,13 +1145,62 @@ fn pty_size_from_surface(size: &SurfaceSize) -> PtySize {
 
 #[cfg(test)]
 mod tests {
+    use std::io::{ErrorKind, Write};
+    use std::os::fd::AsRawFd;
+    use std::os::unix::net::UnixStream;
     use std::sync::Arc;
+    use std::sync::mpsc;
     use std::time::Duration;
 
     use crate::transcript::{TranscriptBuffer, sanitize_terminal_output};
     use crate::vt::VtScreen;
 
-    use super::SessionShared;
+    use super::{SessionShared, duplicate_fd, set_fd_nonblocking, write_all_cancellable};
+
+    #[test]
+    fn blocked_writer_stops_when_session_is_cancelled() {
+        let (mut writer, _unread_peer) = UnixStream::pair().expect("create blocked writer socket");
+        set_fd_nonblocking(writer.as_raw_fd()).expect("make test writer non-blocking");
+        let readiness = duplicate_fd(writer.as_raw_fd()).expect("clone test writer fd");
+
+        let fill = [0_u8; 8 * 1024];
+        loop {
+            match writer.write(&fill) {
+                Ok(0) => panic!("test writer accepted zero bytes"),
+                Ok(_) => {}
+                Err(err) if err.kind() == ErrorKind::WouldBlock => break,
+                Err(err) => panic!("failed to fill test writer: {err}"),
+            }
+        }
+
+        let (shutdown, cancel) = UnixStream::pair().expect("create cancellation socket");
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (result_tx, result_rx) = mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            entered_tx.send(()).expect("signal writer entry");
+            result_tx
+                .send(write_all_cancellable(
+                    &mut writer,
+                    &readiness,
+                    &cancel,
+                    b"blocked",
+                ))
+                .expect("send writer result");
+        });
+
+        entered_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("writer thread started");
+        shutdown
+            .shutdown(std::net::Shutdown::Both)
+            .expect("cancel writer");
+        let err = result_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("cancelled writer returned")
+            .expect_err("cancelled writer must fail");
+        assert_eq!(err.kind(), ErrorKind::BrokenPipe);
+        handle.join().expect("writer thread joined");
+    }
 
     #[test]
     fn transcript_buffer_returns_recent_lines_in_order() {

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -14,7 +14,7 @@ use crate::pty_write::{PtyWriteQueue, PtyWriteWorker};
 use crate::stub::{CommandFinishedSignal, SurfaceSize, TerminalColors};
 use crate::transcript::{TranscriptBuffer, snapshot_to_lines};
 use crate::vt::{
-    PtyWritePriority, ScreenSnapshot, ThemeColors, VtKeyEvent, VtKeySend, VtPasteResult,
+    PtyWriteClass, ScreenSnapshot, ThemeColors, VtKeyEvent, VtKeyOutcome, VtPasteResult,
     VtPasteSource, VtScreen,
 };
 
@@ -81,11 +81,11 @@ enum LinuxPtyInput {
 }
 
 impl LinuxPtyInput {
-    fn write_data(&self, data: &[u8], priority: PtyWritePriority) -> std::io::Result<()> {
+    fn write_data(&self, data: &[u8], class: PtyWriteClass) -> std::io::Result<()> {
         match self {
-            Self::Local(queue) => match priority {
-                PtyWritePriority::UserInput => queue.enqueue(data),
-                PtyWritePriority::TerminalControl => queue.enqueue_control(data),
+            Self::Local(queue) => match class {
+                PtyWriteClass::Regular => queue.enqueue(data),
+                PtyWriteClass::ReservedControl => queue.enqueue_with_reserved_capacity(data),
             },
             Self::HostBridge(queue) => {
                 if data.len() > MAX_BRIDGE_FRAME_BYTES {
@@ -99,10 +99,10 @@ impl LinuxPtyInput {
                 frame.push(0x00); // TAG_DATA
                 frame.extend_from_slice(&(data.len() as u32).to_be_bytes());
                 frame.extend_from_slice(data);
-                match priority {
-                    PtyWritePriority::UserInput => queue.enqueue_owned(frame.into_boxed_slice()),
-                    PtyWritePriority::TerminalControl => {
-                        queue.enqueue_control_owned(frame.into_boxed_slice())
+                match class {
+                    PtyWriteClass::Regular => queue.enqueue_owned(frame.into_boxed_slice()),
+                    PtyWriteClass::ReservedControl => {
+                        queue.enqueue_owned_with_reserved_capacity(frame.into_boxed_slice())
                     }
                 }
             }
@@ -124,7 +124,7 @@ impl LinuxPtyInput {
         frame[3..5].copy_from_slice(&rows.to_be_bytes());
         frame[5..7].copy_from_slice(&width_px.to_be_bytes());
         frame[7..9].copy_from_slice(&height_px.to_be_bytes());
-        queue.enqueue_control(&frame)
+        queue.enqueue_with_reserved_capacity(&frame)
     }
 }
 
@@ -408,23 +408,26 @@ impl LinuxPtySession {
         Ok(())
     }
 
-    pub fn send_key(&self, event: &VtKeyEvent<'_>) -> Result<VtKeySend> {
-        let sent = self.shared.screen.send_key(event)?;
-        if sent.wrote {
+    pub fn send_key(&self, event: &VtKeyEvent<'_>) -> Result<VtKeyOutcome> {
+        let outcome = self.shared.screen.send_key(event)?;
+        if outcome.output_accepted {
             self.scroll_viewport_to_bottom();
             self.input_generation.fetch_add(1, Ordering::Relaxed);
         }
-        Ok(sent)
+        Ok(outcome)
     }
 
     pub fn paste_text(
         &self,
         text: &str,
         source: VtPasteSource,
-        allow_unsafe: bool,
+        confirm_unsafe_paste: bool,
     ) -> Result<VtPasteResult> {
-        let result = self.shared.screen.paste_text(text, source, allow_unsafe)?;
-        if result == VtPasteResult::Written {
+        let result = self
+            .shared
+            .screen
+            .paste_text(text, source, confirm_unsafe_paste)?;
+        if result == VtPasteResult::Accepted {
             self.scroll_viewport_to_bottom();
             self.input_generation.fetch_add(1, Ordering::Relaxed);
         }
@@ -455,7 +458,7 @@ impl LinuxPtySession {
 
     pub fn is_alive(&self) -> bool {
         self.poll_child_status();
-        self.shared.alive.load(Ordering::Acquire) && !self.shared.screen.has_write_failure()
+        self.shared.alive.load(Ordering::Acquire) && !self.shared.screen.is_write_desynchronized()
     }
 
     pub fn take_command_finished(&self) -> Option<CommandFinishedSignal> {

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -10,7 +10,9 @@ use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 
 use crate::stub::{CommandFinishedSignal, SurfaceSize, TerminalColors};
 use crate::transcript::{TranscriptBuffer, snapshot_to_lines};
-use crate::vt::{ScreenSnapshot, ThemeColors, VtKeyEvent, VtKeySend, VtScreen};
+use crate::vt::{
+    ScreenSnapshot, ThemeColors, VtKeyEvent, VtKeySend, VtPasteResult, VtPasteSource, VtScreen,
+};
 
 const DEFAULT_COLUMNS: u16 = 80;
 const DEFAULT_ROWS: u16 = 24;
@@ -306,6 +308,20 @@ impl LinuxPtySession {
         Ok(sent)
     }
 
+    pub fn paste_text(
+        &self,
+        text: &str,
+        source: VtPasteSource,
+        allow_unsafe: bool,
+    ) -> Result<VtPasteResult> {
+        let result = self.shared.screen.paste_text(text, source, allow_unsafe)?;
+        if result == VtPasteResult::Written {
+            self.scroll_viewport_to_bottom();
+            self.input_generation.fetch_add(1, Ordering::Relaxed);
+        }
+        Ok(result)
+    }
+
     pub fn clear_screen_and_scrollback(&self) {
         self.shared.screen.clear_screen_and_scrollback();
         self.mark_needs_render();
@@ -378,10 +394,6 @@ impl LinuxPtySession {
 
     pub fn search_text(&self, pattern: &str, limit: usize) -> Vec<(usize, String)> {
         self.shared.transcript.lock().search(pattern, limit)
-    }
-
-    pub fn is_bracketed_paste(&self) -> bool {
-        self.shared.screen.is_bracketed_paste()
     }
 
     pub fn is_decckm(&self) -> bool {

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -124,7 +124,7 @@ impl LinuxPtyInput {
         frame[3..5].copy_from_slice(&rows.to_be_bytes());
         frame[5..7].copy_from_slice(&width_px.to_be_bytes());
         frame[7..9].copy_from_slice(&height_px.to_be_bytes());
-        queue.enqueue(&frame)
+        queue.enqueue_control(&frame)
     }
 }
 

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -4,10 +4,11 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use parking_lot::Mutex;
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 
+use crate::pty_write::{PtyWriteQueue, PtyWriteWorker};
 use crate::stub::{CommandFinishedSignal, SurfaceSize, TerminalColors};
 use crate::transcript::{TranscriptBuffer, snapshot_to_lines};
 use crate::vt::{
@@ -59,18 +60,65 @@ fn theme_colors_to_vt(colors: &TerminalColors) -> ThemeColors {
 enum LinuxPtyBackend {
     Local {
         master: Mutex<Box<dyn portable_pty::MasterPty + Send>>,
-        writer: Arc<Mutex<Box<dyn Write + Send>>>,
         child: Mutex<Box<dyn portable_pty::Child + Send + Sync>>,
     },
     HostBridge {
-        stream_writer: Arc<Mutex<std::os::unix::net::UnixStream>>,
+        stream_shutdown: std::os::unix::net::UnixStream,
         socket_path: PathBuf,
         child: Mutex<std::process::Child>,
     },
 }
 
+#[derive(Clone)]
+enum LinuxPtyInput {
+    Local(PtyWriteQueue),
+    HostBridge(PtyWriteQueue),
+}
+
+impl LinuxPtyInput {
+    fn write_data(&self, data: &[u8]) -> std::io::Result<()> {
+        match self {
+            Self::Local(queue) => queue.enqueue(data),
+            Self::HostBridge(queue) => {
+                if data.len() > MAX_BRIDGE_FRAME_BYTES {
+                    return Err(std::io::Error::new(
+                        ErrorKind::InvalidInput,
+                        "host PTY input frame is too large",
+                    ));
+                }
+
+                let mut frame = Vec::with_capacity(5 + data.len());
+                frame.push(0x00); // TAG_DATA
+                frame.extend_from_slice(&(data.len() as u32).to_be_bytes());
+                frame.extend_from_slice(data);
+                queue.enqueue_owned(frame.into_boxed_slice())
+            }
+        }
+    }
+
+    fn resize(&self, size: &SurfaceSize) -> std::io::Result<()> {
+        let Self::HostBridge(queue) = self else {
+            return Ok(());
+        };
+
+        let cols = size.columns.max(1);
+        let rows = size.rows.max(1);
+        let width_px = size.width_px.min(u32::from(u16::MAX)) as u16;
+        let height_px = size.height_px.min(u32::from(u16::MAX)) as u16;
+        let mut frame = [0u8; 9];
+        frame[0] = 0x01; // TAG_RESIZE
+        frame[1..3].copy_from_slice(&cols.to_be_bytes());
+        frame[3..5].copy_from_slice(&rows.to_be_bytes());
+        frame[5..7].copy_from_slice(&width_px.to_be_bytes());
+        frame[7..9].copy_from_slice(&height_px.to_be_bytes());
+        queue.enqueue(&frame)
+    }
+}
+
 pub struct LinuxPtySession {
     backend: LinuxPtyBackend,
+    input: LinuxPtyInput,
+    input_worker: PtyWriteWorker,
     shared: Arc<SessionShared>,
     size: Mutex<SurfaceSize>,
     title: Option<String>,
@@ -200,22 +248,11 @@ impl LinuxPtySession {
                     .resize(pty_size_from_surface(&size))
                     .context("failed to resize linux pty")?;
             }
-            LinuxPtyBackend::HostBridge { stream_writer, .. } => {
-                let cols = size.columns.max(1);
-                let rows = size.rows.max(1);
-                let wp = size.width_px.min(u32::from(u16::MAX)) as u16;
-                let hp = size.height_px.min(u32::from(u16::MAX)) as u16;
-                let mut buf = [0u8; 9];
-                buf[0] = 0x01; // TAG_RESIZE
-                buf[1..3].copy_from_slice(&cols.to_be_bytes());
-                buf[3..5].copy_from_slice(&rows.to_be_bytes());
-                buf[5..7].copy_from_slice(&wp.to_be_bytes());
-                buf[7..9].copy_from_slice(&hp.to_be_bytes());
-                let mut guard = stream_writer.lock();
-                let _ = guard.write_all(&buf);
-                let _ = guard.flush();
-            }
+            LinuxPtyBackend::HostBridge { .. } => {}
         }
+        self.input
+            .resize(&size)
+            .context("failed to queue linux pty resize")?;
 
         self.mark_needs_render();
         Ok(())
@@ -240,22 +277,11 @@ impl LinuxPtySession {
                     .resize(pty_size_from_surface(&size))
                     .context("failed to resize linux pty")?;
             }
-            LinuxPtyBackend::HostBridge { stream_writer, .. } => {
-                let cols = size.columns.max(1);
-                let rows = size.rows.max(1);
-                let wp = size.width_px.min(u32::from(u16::MAX)) as u16;
-                let hp = size.height_px.min(u32::from(u16::MAX)) as u16;
-                let mut buf = [0u8; 9];
-                buf[0] = 0x01; // TAG_RESIZE
-                buf[1..3].copy_from_slice(&cols.to_be_bytes());
-                buf[3..5].copy_from_slice(&rows.to_be_bytes());
-                buf[5..7].copy_from_slice(&wp.to_be_bytes());
-                buf[7..9].copy_from_slice(&hp.to_be_bytes());
-                let mut guard = stream_writer.lock();
-                let _ = guard.write_all(&buf);
-                let _ = guard.flush();
-            }
+            LinuxPtyBackend::HostBridge { .. } => {}
         }
+        self.input
+            .resize(&size)
+            .context("failed to queue linux pty resize")?;
 
         self.mark_needs_render();
         Ok(())
@@ -270,31 +296,9 @@ impl LinuxPtySession {
 
     pub fn write_input(&self, data: &[u8]) -> Result<()> {
         self.scroll_viewport_to_bottom();
-        match &self.backend {
-            LinuxPtyBackend::Local { writer, .. } => {
-                writer
-                    .lock()
-                    .write_all(data)
-                    .context("failed to write to linux pty")?;
-            }
-            LinuxPtyBackend::HostBridge { stream_writer, .. } => {
-                if data.len() > MAX_BRIDGE_FRAME_BYTES {
-                    bail!("host PTY input frame is too large");
-                }
-                let len = data.len() as u32;
-                let mut guard = stream_writer.lock();
-                guard
-                    .write_all(&[0x00])
-                    .context("failed to write data tag")?;
-                guard
-                    .write_all(&len.to_be_bytes())
-                    .context("failed to write data len")?;
-                guard
-                    .write_all(data)
-                    .context("failed to write data payload")?;
-                guard.flush().context("failed to flush socket")?;
-            }
-        }
+        self.input
+            .write_data(data)
+            .context("failed to queue linux pty input")?;
         self.input_generation.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
@@ -446,13 +450,22 @@ impl Drop for LinuxPtySession {
                 if let Err(err) = child.lock().kill() {
                     log::debug!("failed to terminate linux pty child during drop: {err}");
                 }
+                // portable_pty exposes the master writer only as `dyn Write`,
+                // so there is no safe way to cancel a syscall blocked by a
+                // descendant that inherited the slave. Close the queue and
+                // detach the worker rather than hanging the UI during teardown.
+                self.input_worker.close_without_join();
             }
             LinuxPtyBackend::HostBridge {
-                child, socket_path, ..
+                child,
+                stream_shutdown,
+                socket_path,
             } => {
                 if let Err(err) = child.lock().kill() {
                     log::debug!("failed to terminate host pty bridge child during drop: {err}");
                 }
+                let _ = stream_shutdown.shutdown(std::net::Shutdown::Both);
+                self.input_worker.shutdown();
                 let _ = std::fs::remove_file(socket_path);
             }
         }
@@ -486,11 +499,14 @@ fn spawn_local(options: LinuxPtyOptions) -> Result<LinuxPtySession> {
         .master
         .try_clone_reader()
         .context("failed to clone linux pty reader")?;
-    let writer = Arc::new(Mutex::new(
-        pair.master
-            .take_writer()
-            .context("failed to take linux pty writer")?,
-    ));
+    let mut writer = pair
+        .master
+        .take_writer()
+        .context("failed to take linux pty writer")?;
+    let (input_queue, input_worker) =
+        PtyWriteQueue::spawn("con-linux-pty-writer", move |data| writer.write_all(data))
+            .context("failed to spawn linux pty writer")?;
+    let input = LinuxPtyInput::Local(input_queue);
     let theme_owned = options.theme.as_ref().map(theme_colors_to_vt);
     let screen = Arc::new(
         VtScreen::new_with_write_pty(
@@ -498,8 +514,8 @@ fn spawn_local(options: LinuxPtyOptions) -> Result<LinuxPtySession> {
             options.size.rows.max(1),
             theme_owned.as_ref(),
             Some({
-                let writer = writer.clone();
-                Arc::new(move |data: &[u8]| writer.lock().write_all(data))
+                let input = input.clone();
+                Arc::new(move |data: &[u8]| input.write_data(data))
             }),
         )
         .context("failed to create linux vt screen")?,
@@ -532,9 +548,10 @@ fn spawn_local(options: LinuxPtyOptions) -> Result<LinuxPtySession> {
     Ok(LinuxPtySession {
         backend: LinuxPtyBackend::Local {
             master: Mutex::new(pair.master),
-            writer,
             child: Mutex::new(child),
         },
+        input,
+        input_worker,
         shared,
         size: Mutex::new(options.size),
         title: Some(default_title(
@@ -645,8 +662,14 @@ fn spawn_host_bridge(options: LinuxPtyOptions) -> Result<LinuxPtySession> {
         stream.ok_or_else(|| anyhow::anyhow!("timeout waiting for host pty bridge connection"))?;
     let stream_writer = stream.try_clone().context("clone socket writer")?;
     let stream_reader = stream.try_clone().context("clone socket reader")?;
-    let stream_writer_mutex = Arc::new(Mutex::new(stream_writer));
-    let writer_for_vt = stream_writer_mutex.clone();
+    let mut stream_writer = stream_writer;
+    let (input_queue, input_worker) =
+        PtyWriteQueue::spawn("con-linux-pty-bridge-writer", move |frame| {
+            stream_writer.write_all(frame)?;
+            stream_writer.flush()
+        })
+        .context("failed to spawn host pty bridge writer")?;
+    let input = LinuxPtyInput::HostBridge(input_queue);
 
     let theme_owned = options.theme.as_ref().map(theme_colors_to_vt);
     let screen = Arc::new(
@@ -654,20 +677,10 @@ fn spawn_host_bridge(options: LinuxPtyOptions) -> Result<LinuxPtySession> {
             options.size.columns.max(1),
             options.size.rows.max(1),
             theme_owned.as_ref(),
-            Some(Arc::new(move |data: &[u8]| {
-                if data.len() > MAX_BRIDGE_FRAME_BYTES {
-                    return Err(std::io::Error::new(
-                        ErrorKind::InvalidInput,
-                        "host PTY input frame is too large",
-                    ));
-                }
-                let len = data.len() as u32;
-                let mut guard = writer_for_vt.lock();
-                guard.write_all(&[0x00])?;
-                guard.write_all(&len.to_be_bytes())?;
-                guard.write_all(data)?;
-                guard.flush()
-            })),
+            Some({
+                let input = input.clone();
+                Arc::new(move |data: &[u8]| input.write_data(data))
+            }),
         )
         .context("failed to create linux vt screen")?,
     );
@@ -695,10 +708,12 @@ fn spawn_host_bridge(options: LinuxPtyOptions) -> Result<LinuxPtySession> {
 
     Ok(LinuxPtySession {
         backend: LinuxPtyBackend::HostBridge {
-            stream_writer: stream_writer_mutex,
+            stream_shutdown: stream,
             socket_path,
             child: Mutex::new(child),
         },
+        input,
+        input_worker,
         shared,
         size: Mutex::new(options.size),
         title: Some(default_title(

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -14,12 +14,14 @@ use crate::pty_write::{PtyWriteQueue, PtyWriteWorker};
 use crate::stub::{CommandFinishedSignal, SurfaceSize, TerminalColors};
 use crate::transcript::{TranscriptBuffer, snapshot_to_lines};
 use crate::vt::{
-    ScreenSnapshot, ThemeColors, VtKeyEvent, VtKeySend, VtPasteResult, VtPasteSource, VtScreen,
+    PtyWritePriority, ScreenSnapshot, ThemeColors, VtKeyEvent, VtKeySend, VtPasteResult,
+    VtPasteSource, VtScreen,
 };
 
 const DEFAULT_COLUMNS: u16 = 80;
 const DEFAULT_ROWS: u16 = 24;
-const MAX_BRIDGE_FRAME_BYTES: usize = 16 * 1024 * 1024;
+// A 16 MiB Kitty clipboard response expands to about 22 MiB after base64.
+const MAX_BRIDGE_FRAME_BYTES: usize = 32 * 1024 * 1024;
 
 pub type LinuxWakeCallback = Arc<dyn Fn() + Send + Sync + 'static>;
 
@@ -79,9 +81,12 @@ enum LinuxPtyInput {
 }
 
 impl LinuxPtyInput {
-    fn write_data(&self, data: &[u8]) -> std::io::Result<()> {
+    fn write_data(&self, data: &[u8], priority: PtyWritePriority) -> std::io::Result<()> {
         match self {
-            Self::Local(queue) => queue.enqueue(data),
+            Self::Local(queue) => match priority {
+                PtyWritePriority::UserInput => queue.enqueue(data),
+                PtyWritePriority::TerminalControl => queue.enqueue_control(data),
+            },
             Self::HostBridge(queue) => {
                 if data.len() > MAX_BRIDGE_FRAME_BYTES {
                     return Err(std::io::Error::new(
@@ -94,7 +99,12 @@ impl LinuxPtyInput {
                 frame.push(0x00); // TAG_DATA
                 frame.extend_from_slice(&(data.len() as u32).to_be_bytes());
                 frame.extend_from_slice(data);
-                queue.enqueue_owned(frame.into_boxed_slice())
+                match priority {
+                    PtyWritePriority::UserInput => queue.enqueue_owned(frame.into_boxed_slice()),
+                    PtyWritePriority::TerminalControl => {
+                        queue.enqueue_control_owned(frame.into_boxed_slice())
+                    }
+                }
             }
         }
     }
@@ -380,9 +390,20 @@ impl LinuxPtySession {
 
     pub fn write_input(&self, data: &[u8]) -> Result<()> {
         self.scroll_viewport_to_bottom();
-        self.input
-            .write_data(data)
+        self.shared
+            .screen
+            .write_input(data)
             .context("failed to queue linux pty input")?;
+        self.input_generation.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    pub fn write_control(&self, data: &[u8]) -> Result<()> {
+        self.scroll_viewport_to_bottom();
+        self.shared
+            .screen
+            .write_control(data)
+            .context("failed to queue linux pty control input")?;
         self.input_generation.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
@@ -434,7 +455,7 @@ impl LinuxPtySession {
 
     pub fn is_alive(&self) -> bool {
         self.poll_child_status();
-        self.shared.alive.load(Ordering::Acquire)
+        self.shared.alive.load(Ordering::Acquire) && !self.shared.screen.has_write_failure()
     }
 
     pub fn take_command_finished(&self) -> Option<CommandFinishedSignal> {
@@ -613,7 +634,7 @@ fn spawn_local(options: LinuxPtyOptions) -> Result<LinuxPtySession> {
             theme_owned.as_ref(),
             Some({
                 let input = input.clone();
-                Arc::new(move |data: &[u8]| input.write_data(data))
+                Arc::new(move |data: &[u8], priority| input.write_data(data, priority))
             }),
         )
         .context("failed to create linux vt screen")?,
@@ -784,7 +805,7 @@ fn spawn_host_bridge(options: LinuxPtyOptions) -> Result<LinuxPtySession> {
             theme_owned.as_ref(),
             Some({
                 let input = input.clone();
-                Arc::new(move |data: &[u8]| input.write_data(data))
+                Arc::new(move |data: &[u8], priority| input.write_data(data, priority))
             }),
         )
         .context("failed to create linux vt screen")?,

--- a/crates/con-ghostty/src/pty_write.rs
+++ b/crates/con-ghostty/src/pty_write.rs
@@ -135,7 +135,7 @@ impl PtyWriteQueue {
         self.enqueue_owned_with_limit(payload, self.shared.max_regular_bytes)
     }
 
-    pub(crate) fn enqueue_control(&self, bytes: &[u8]) -> io::Result<()> {
+    pub(crate) fn enqueue_with_reserved_capacity(&self, bytes: &[u8]) -> io::Result<()> {
         if bytes.is_empty() {
             return Ok(());
         }
@@ -143,7 +143,10 @@ impl PtyWriteQueue {
     }
 
     #[cfg(target_os = "linux")]
-    pub(crate) fn enqueue_control_owned(&self, payload: Box<[u8]>) -> io::Result<()> {
+    pub(crate) fn enqueue_owned_with_reserved_capacity(
+        &self,
+        payload: Box<[u8]>,
+    ) -> io::Result<()> {
         self.enqueue_owned_with_limit(payload, self.shared.max_queued_bytes)
     }
 
@@ -298,11 +301,11 @@ mod tests {
             ErrorKind::WouldBlock
         );
         queue
-            .enqueue_control(b"ok")
+            .enqueue_with_reserved_capacity(b"ok")
             .expect("control write must use reserved capacity");
         assert_eq!(
             queue
-                .enqueue_control(b"x")
+                .enqueue_with_reserved_capacity(b"x")
                 .expect_err("control write must remain bounded")
                 .kind(),
             ErrorKind::WouldBlock

--- a/crates/con-ghostty/src/pty_write.rs
+++ b/crates/con-ghostty/src/pty_write.rs
@@ -175,14 +175,6 @@ impl PtyWriteWorker {
         self.shared.ready.notify_all();
     }
 
-    /// Stop accepting input without joining an in-flight OS write. Use this
-    /// only when the platform writer has no safe cross-thread cancellation;
-    /// dropping the worker then detaches it until its peer eventually closes.
-    #[cfg(target_os = "linux")]
-    pub(crate) fn close_without_join(&self) {
-        self.close_queue();
-    }
-
     /// Stop accepting input and join the writer. The platform owner must close
     /// or terminate the PTY peer first so an already-running OS write unblocks.
     pub(crate) fn shutdown(&mut self) {

--- a/crates/con-ghostty/src/pty_write.rs
+++ b/crates/con-ghostty/src/pty_write.rs
@@ -7,7 +7,11 @@ use std::thread::{self, JoinHandle};
 
 use parking_lot::{Condvar, Mutex};
 
-const DEFAULT_MAX_QUEUED_BYTES: usize = 32 * 1024 * 1024;
+// A maximally expanded 16 MiB paste can occupy 32 MiB of ordinary output,
+// while a simultaneous Kitty clipboard reply can base64-expand to about
+// 22 MiB. Keep enough bounded headroom for both without reordering the FIFO.
+const DEFAULT_MAX_QUEUED_BYTES: usize = 64 * 1024 * 1024;
+const DEFAULT_CONTROL_RESERVE_BYTES: usize = 24 * 1024 * 1024;
 
 struct QueueState {
     payloads: VecDeque<Box<[u8]>>,
@@ -20,6 +24,7 @@ struct Shared {
     state: Mutex<QueueState>,
     ready: Condvar,
     max_queued_bytes: usize,
+    max_regular_bytes: usize,
 }
 
 /// Cloneable, non-blocking producer for one ordered PTY input stream.
@@ -27,7 +32,9 @@ struct Shared {
 /// libghostty invokes WRITE_PTY while its parser lock is held, so callbacks
 /// must never perform pipe or socket I/O directly. This queue bounds retained
 /// memory and hands all writes to one worker, preserving byte ordering between
-/// terminal replies, keyboard input, paste, and resize control frames.
+/// terminal replies, keyboard input, paste, and resize control frames. Regular
+/// input cannot consume the reserved tail of the budget, so a terminal reply
+/// or key release can still enter the same FIFO behind an accepted large paste.
 pub(crate) struct PtyWriteQueue {
     shared: Arc<Shared>,
 }
@@ -42,17 +49,24 @@ impl PtyWriteQueue {
     where
         F: FnMut(&[u8]) -> io::Result<()> + Send + 'static,
     {
-        Self::spawn_with_limit(thread_name, DEFAULT_MAX_QUEUED_BYTES, write)
+        Self::spawn_with_limits(
+            thread_name,
+            DEFAULT_MAX_QUEUED_BYTES,
+            DEFAULT_CONTROL_RESERVE_BYTES,
+            write,
+        )
     }
 
-    fn spawn_with_limit<F>(
+    fn spawn_with_limits<F>(
         thread_name: &str,
         max_queued_bytes: usize,
+        control_reserve_bytes: usize,
         mut write: F,
     ) -> io::Result<(Self, PtyWriteWorker)>
     where
         F: FnMut(&[u8]) -> io::Result<()> + Send + 'static,
     {
+        let max_regular_bytes = max_queued_bytes.saturating_sub(control_reserve_bytes);
         let shared = Arc::new(Shared {
             state: Mutex::new(QueueState {
                 payloads: VecDeque::new(),
@@ -62,6 +76,7 @@ impl PtyWriteQueue {
             }),
             ready: Condvar::new(),
             max_queued_bytes,
+            max_regular_bytes,
         });
         let worker_shared = shared.clone();
         let handle = thread::Builder::new()
@@ -112,10 +127,27 @@ impl PtyWriteQueue {
         if bytes.is_empty() {
             return Ok(());
         }
-        self.enqueue_owned(bytes.into())
+        self.enqueue_owned_with_limit(bytes.into(), self.shared.max_regular_bytes)
     }
 
+    #[cfg(target_os = "linux")]
     pub(crate) fn enqueue_owned(&self, payload: Box<[u8]>) -> io::Result<()> {
+        self.enqueue_owned_with_limit(payload, self.shared.max_regular_bytes)
+    }
+
+    pub(crate) fn enqueue_control(&self, bytes: &[u8]) -> io::Result<()> {
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        self.enqueue_owned_with_limit(bytes.into(), self.shared.max_queued_bytes)
+    }
+
+    #[cfg(target_os = "linux")]
+    pub(crate) fn enqueue_control_owned(&self, payload: Box<[u8]>) -> io::Result<()> {
+        self.enqueue_owned_with_limit(payload, self.shared.max_queued_bytes)
+    }
+
+    fn enqueue_owned_with_limit(&self, payload: Box<[u8]>, limit: usize) -> io::Result<()> {
         if payload.is_empty() {
             return Ok(());
         }
@@ -132,7 +164,7 @@ impl PtyWriteQueue {
                 "PTY input queue byte count overflowed",
             ));
         };
-        if total > self.shared.max_queued_bytes {
+        if total > limit {
             return Err(io::Error::new(
                 io::ErrorKind::WouldBlock,
                 "PTY input queue is full",
@@ -208,16 +240,17 @@ mod tests {
         let gate = Arc::new((Mutex::new(false), Condvar::new()));
         let worker_gate = gate.clone();
         let (entered_tx, entered_rx) = mpsc::channel();
-        let (queue, mut worker) = PtyWriteQueue::spawn_with_limit("pty-write-test", 4, move |_| {
-            entered_tx.send(()).expect("signal writer entry");
-            let (open, ready) = &*worker_gate;
-            let mut open = open.lock();
-            while !*open {
-                ready.wait(&mut open);
-            }
-            Ok(())
-        })
-        .expect("spawn writer");
+        let (queue, mut worker) =
+            PtyWriteQueue::spawn_with_limits("pty-write-test", 4, 0, move |_| {
+                entered_tx.send(()).expect("signal writer entry");
+                let (open, ready) = &*worker_gate;
+                let mut open = open.lock();
+                while !*open {
+                    ready.wait(&mut open);
+                }
+                Ok(())
+            })
+            .expect("spawn writer");
 
         queue.enqueue(b"full").expect("fill queue budget");
         entered_rx
@@ -229,6 +262,70 @@ mod tests {
         let (open, ready) = &*gate;
         *open.lock() = true;
         ready.notify_all();
+        worker.shutdown();
+    }
+
+    #[test]
+    fn control_writes_use_reserved_capacity_without_reordering_the_fifo() {
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let worker_gate = gate.clone();
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (written_tx, written_rx) = mpsc::channel();
+        let (queue, mut worker) =
+            PtyWriteQueue::spawn_with_limits("pty-write-reserve-test", 6, 2, move |bytes| {
+                entered_tx.send(()).expect("signal writer entry");
+                let (open, ready) = &*worker_gate;
+                let mut open = open.lock();
+                while !*open {
+                    ready.wait(&mut open);
+                }
+                written_tx
+                    .send(bytes.to_vec())
+                    .expect("record completed write");
+                Ok(())
+            })
+            .expect("spawn writer");
+
+        queue.enqueue(b"user").expect("fill regular budget");
+        entered_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("writer must start");
+        assert_eq!(
+            queue
+                .enqueue(b"x")
+                .expect_err("regular input must preserve the reserve")
+                .kind(),
+            ErrorKind::WouldBlock
+        );
+        queue
+            .enqueue_control(b"ok")
+            .expect("control write must use reserved capacity");
+        assert_eq!(
+            queue
+                .enqueue_control(b"x")
+                .expect_err("control write must remain bounded")
+                .kind(),
+            ErrorKind::WouldBlock
+        );
+
+        let (open, ready) = &*gate;
+        *open.lock() = true;
+        ready.notify_all();
+        entered_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("reserved control write must reach the worker");
+        assert_eq!(
+            written_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("regular write must complete first"),
+            b"user"
+        );
+        assert_eq!(
+            written_rx
+                .recv_timeout(Duration::from_secs(2))
+                .expect("control write must complete second"),
+            b"ok"
+        );
         worker.shutdown();
     }
 }

--- a/crates/con-ghostty/src/pty_write.rs
+++ b/crates/con-ghostty/src/pty_write.rs
@@ -1,0 +1,242 @@
+#![cfg_attr(not(any(target_os = "windows", target_os = "linux")), allow(dead_code))]
+
+use std::collections::VecDeque;
+use std::io;
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+
+use parking_lot::{Condvar, Mutex};
+
+const DEFAULT_MAX_QUEUED_BYTES: usize = 32 * 1024 * 1024;
+
+struct QueueState {
+    payloads: VecDeque<Box<[u8]>>,
+    queued_bytes: usize,
+    senders: usize,
+    closed: bool,
+}
+
+struct Shared {
+    state: Mutex<QueueState>,
+    ready: Condvar,
+    max_queued_bytes: usize,
+}
+
+/// Cloneable, non-blocking producer for one ordered PTY input stream.
+///
+/// libghostty invokes WRITE_PTY while its parser lock is held, so callbacks
+/// must never perform pipe or socket I/O directly. This queue bounds retained
+/// memory and hands all writes to one worker, preserving byte ordering between
+/// terminal replies, keyboard input, paste, and resize control frames.
+pub(crate) struct PtyWriteQueue {
+    shared: Arc<Shared>,
+}
+
+pub(crate) struct PtyWriteWorker {
+    shared: Arc<Shared>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl PtyWriteQueue {
+    pub(crate) fn spawn<F>(thread_name: &str, write: F) -> io::Result<(Self, PtyWriteWorker)>
+    where
+        F: FnMut(&[u8]) -> io::Result<()> + Send + 'static,
+    {
+        Self::spawn_with_limit(thread_name, DEFAULT_MAX_QUEUED_BYTES, write)
+    }
+
+    fn spawn_with_limit<F>(
+        thread_name: &str,
+        max_queued_bytes: usize,
+        mut write: F,
+    ) -> io::Result<(Self, PtyWriteWorker)>
+    where
+        F: FnMut(&[u8]) -> io::Result<()> + Send + 'static,
+    {
+        let shared = Arc::new(Shared {
+            state: Mutex::new(QueueState {
+                payloads: VecDeque::new(),
+                queued_bytes: 0,
+                senders: 1,
+                closed: false,
+            }),
+            ready: Condvar::new(),
+            max_queued_bytes,
+        });
+        let worker_shared = shared.clone();
+        let handle = thread::Builder::new()
+            .name(thread_name.into())
+            .spawn(move || {
+                loop {
+                    let payload = {
+                        let mut state = worker_shared.state.lock();
+                        while state.payloads.is_empty() && !state.closed {
+                            worker_shared.ready.wait(&mut state);
+                        }
+                        if state.closed {
+                            state.payloads.clear();
+                            state.queued_bytes = 0;
+                            return;
+                        }
+                        state.payloads.pop_front().expect("queue checked non-empty")
+                    };
+
+                    let payload_len = payload.len();
+                    if let Err(err) = write(&payload) {
+                        log::debug!("PTY writer thread stopped after host I/O failure: {err}");
+                        let mut state = worker_shared.state.lock();
+                        state.closed = true;
+                        state.payloads.clear();
+                        state.queued_bytes = 0;
+                        worker_shared.ready.notify_all();
+                        return;
+                    }
+
+                    let mut state = worker_shared.state.lock();
+                    state.queued_bytes = state.queued_bytes.saturating_sub(payload_len);
+                }
+            })?;
+
+        Ok((
+            Self {
+                shared: shared.clone(),
+            },
+            PtyWriteWorker {
+                shared,
+                handle: Some(handle),
+            },
+        ))
+    }
+
+    pub(crate) fn enqueue(&self, bytes: &[u8]) -> io::Result<()> {
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        self.enqueue_owned(bytes.into())
+    }
+
+    pub(crate) fn enqueue_owned(&self, payload: Box<[u8]>) -> io::Result<()> {
+        if payload.is_empty() {
+            return Ok(());
+        }
+        let mut state = self.shared.state.lock();
+        if state.closed {
+            return Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "PTY input queue is closed",
+            ));
+        }
+        let Some(total) = state.queued_bytes.checked_add(payload.len()) else {
+            return Err(io::Error::new(
+                io::ErrorKind::OutOfMemory,
+                "PTY input queue byte count overflowed",
+            ));
+        };
+        if total > self.shared.max_queued_bytes {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "PTY input queue is full",
+            ));
+        }
+
+        state.payloads.push_back(payload);
+        state.queued_bytes = total;
+        self.shared.ready.notify_one();
+        Ok(())
+    }
+}
+
+impl Clone for PtyWriteQueue {
+    fn clone(&self) -> Self {
+        self.shared.state.lock().senders += 1;
+        Self {
+            shared: self.shared.clone(),
+        }
+    }
+}
+
+impl Drop for PtyWriteQueue {
+    fn drop(&mut self) {
+        let mut state = self.shared.state.lock();
+        state.senders = state.senders.saturating_sub(1);
+        if state.senders == 0 {
+            state.closed = true;
+            self.shared.ready.notify_all();
+        }
+    }
+}
+
+impl PtyWriteWorker {
+    fn close_queue(&self) {
+        let mut state = self.shared.state.lock();
+        state.closed = true;
+        state.payloads.clear();
+        state.queued_bytes = 0;
+        self.shared.ready.notify_all();
+    }
+
+    /// Stop accepting input without joining an in-flight OS write. Use this
+    /// only when the platform writer has no safe cross-thread cancellation;
+    /// dropping the worker then detaches it until its peer eventually closes.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn close_without_join(&self) {
+        self.close_queue();
+    }
+
+    /// Stop accepting input and join the writer. The platform owner must close
+    /// or terminate the PTY peer first so an already-running OS write unblocks.
+    pub(crate) fn shutdown(&mut self) {
+        self.close_queue();
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for PtyWriteWorker {
+    fn drop(&mut self) {
+        // Error paths may drop a prepared session before a child exists. Wake
+        // the worker but do not implicitly join: platform session Drop owns the
+        // required peer-close-before-join ordering for live PTYs.
+        self.close_queue();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PtyWriteQueue;
+    use parking_lot::{Condvar, Mutex};
+    use std::io::ErrorKind;
+    use std::sync::Arc;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    #[test]
+    fn queue_bounds_in_flight_bytes_without_blocking_the_producer() {
+        let gate = Arc::new((Mutex::new(false), Condvar::new()));
+        let worker_gate = gate.clone();
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let (queue, mut worker) = PtyWriteQueue::spawn_with_limit("pty-write-test", 4, move |_| {
+            entered_tx.send(()).expect("signal writer entry");
+            let (open, ready) = &*worker_gate;
+            let mut open = open.lock();
+            while !*open {
+                ready.wait(&mut open);
+            }
+            Ok(())
+        })
+        .expect("spawn writer");
+
+        queue.enqueue(b"full").expect("fill queue budget");
+        entered_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("writer must start");
+        let err = queue.enqueue(b"x").expect_err("queue must reject overflow");
+        assert_eq!(err.kind(), ErrorKind::WouldBlock);
+
+        let (open, ready) = &*gate;
+        *open.lock() = true;
+        ready.notify_all();
+        worker.shutdown();
+    }
+}

--- a/crates/con-ghostty/src/stub.rs
+++ b/crates/con-ghostty/src/stub.rs
@@ -69,7 +69,7 @@ pub enum MouseButton {
     Five,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SurfaceSize {
     pub columns: u16,
     pub rows: u16,

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -1603,14 +1603,19 @@ unsafe extern "C" fn read_clipboard_callback(
             // NSPasteboardTypeString = @"public.utf8-plain-text"
             let ns_type: *mut Object = msg_send![class!(NSString), stringWithUTF8String: c"public.utf8-plain-text".as_ptr()];
             let text: *mut Object = msg_send![pb, stringForType: ns_type];
-            if text.is_null() {
-                return ffi::ghostty_clipboard_read_result_e::GHOSTTY_CLIPBOARD_READ_UNAVAILABLE;
-            }
-            let data: *const std::os::raw::c_char = msg_send![text, UTF8String];
-            if data.is_null() {
-                return ffi::ghostty_clipboard_read_result_e::GHOSTTY_CLIPBOARD_READ_UNAVAILABLE;
-            }
-            let len: usize = msg_send![text, lengthOfBytesUsingEncoding: 4usize];
+            let (data, len) = if text.is_null() {
+                // A started OSC 52 read must complete even when the pasteboard
+                // has no text representation. Upstream serializes an empty
+                // completion as the protocol's empty clipboard response.
+                (c"".as_ptr(), 0)
+            } else {
+                let data: *const std::os::raw::c_char = msg_send![text, UTF8String];
+                if data.is_null() {
+                    return ffi::ghostty_clipboard_read_result_e::GHOSTTY_CLIPBOARD_READ_UNAVAILABLE;
+                }
+                let len: usize = msg_send![text, lengthOfBytesUsingEncoding: 4usize];
+                (data, len)
+            };
             let mime = c"text/plain";
             let content = ffi::ghostty_clipboard_content_s {
                 mime: mime.as_ptr(),

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -1594,7 +1594,7 @@ unsafe extern "C" fn read_clipboard_callback(
             let wants_text = requested
                 .iter()
                 .copied()
-                .any(|mime| clipboard_mime_is_text(mime));
+                .any(|mime| clipboard_c_mime_is_text(mime));
             if !wants_text {
                 return ffi::ghostty_clipboard_read_result_e::GHOSTTY_CLIPBOARD_READ_UNAVAILABLE;
             }
@@ -1708,7 +1708,7 @@ unsafe extern "C" fn write_clipboard_callback(
             let items = std::slice::from_raw_parts(content, content_count);
 
             for item in items {
-                if !clipboard_mime_is_text(item.mime) || (item.data.is_null() && item.len > 0) {
+                if !clipboard_c_mime_is_text(item.mime) || (item.data.is_null() && item.len > 0) {
                     continue;
                 }
                 let data = if item.len == 0 {
@@ -1737,14 +1737,11 @@ unsafe extern "C" fn write_clipboard_callback(
     }
 }
 
-unsafe fn clipboard_mime_is_text(mime: *const std::os::raw::c_char) -> bool {
+unsafe fn clipboard_c_mime_is_text(mime: *const std::os::raw::c_char) -> bool {
     if mime.is_null() {
         return false;
     }
-    matches!(
-        unsafe { CStr::from_ptr(mime) }.to_bytes(),
-        b"text/plain" | b"text/plain;charset=utf-8" | b"UTF8_STRING" | b"TEXT" | b"STRING"
-    )
+    crate::clipboard_mime_is_text(unsafe { CStr::from_ptr(mime) }.to_bytes())
 }
 
 unsafe extern "C" fn close_surface_callback(userdata: *mut c_void, _process_alive: bool) {

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -1279,7 +1279,7 @@ unsafe impl Sync for GhosttyTerminal {}
 
 // ── Public types ────────────────────────────────────────────
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SurfaceSize {
     pub columns: u16,
     pub rows: u16,

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -164,6 +164,14 @@ impl GhosttyConfigPatch {
         s.push_str("shell-integration-features = ");
         s.push_str(CON_SHELL_INTEGRATION_FEATURES);
         s.push('\n');
+        // Force Kitty writes through Ghostty's confirmation request so Con can
+        // reject them until it has a user-visible permission flow. OSC 52 uses
+        // the write callback's `confirm` flag instead; that callback preserves
+        // Con's existing unconditional-write behavior during this migration.
+        s.push_str("clipboard-write = ask\n");
+        // This limit applies only to Kitty OSC 5522, not OSC 52. Avoid buffering
+        // an untrusted 64 MiB transaction just to reject it at confirmation.
+        s.push_str("clipboard-write-limit-bytes = 0\n");
         if let Some(background_image) = &self.background_image {
             s.push_str(&format!("background-image = {:?}\n", background_image));
             if let Some(background_image_opacity) = self.background_image_opacity {
@@ -1540,18 +1548,26 @@ unsafe extern "C" {
 /// Clipboard read — ghostty wants to paste. Read from macOS pasteboard and complete the request.
 unsafe extern "C" fn read_clipboard_callback(
     userdata: *mut c_void,
-    _clipboard: ffi::ghostty_clipboard_e,
+    clipboard: ffi::ghostty_clipboard_e,
     request: *mut c_void,
-) -> bool {
+    mime_types: *const *const std::os::raw::c_char,
+    mime_types_len: usize,
+    needs_listing: bool,
+) -> ffi::ghostty_clipboard_read_result_e {
     unsafe {
-        if userdata.is_null() {
-            return false;
+        // macOS has no X11-style primary clipboard. Keep the pre-migration
+        // behavior that maps standard and selection requests to NSPasteboard.
+        if userdata.is_null()
+            || request.is_null()
+            || clipboard == ffi::ghostty_clipboard_e::GHOSTTY_CLIPBOARD_PRIMARY
+        {
+            return ffi::ghostty_clipboard_read_result_e::GHOSTTY_CLIPBOARD_READ_UNSUPPORTED;
         }
 
         let state = &*(userdata as *const StateRef);
         let surface = state.lock().surface;
         if surface.is_null() {
-            return false;
+            return ffi::ghostty_clipboard_read_result_e::GHOSTTY_CLIPBOARD_READ_UNSUPPORTED;
         }
 
         #[cfg(target_os = "macos")]
@@ -1559,61 +1575,123 @@ unsafe extern "C" fn read_clipboard_callback(
             use objc::runtime::Object;
             use objc::{class, msg_send, sel, sel_impl};
 
+            if mime_types_len > 0 && mime_types.is_null() {
+                return ffi::ghostty_clipboard_read_result_e::GHOSTTY_CLIPBOARD_READ_UNAVAILABLE;
+            }
+            // MIME listings are used by Kitty OSC 5522 reads and paste events.
+            // Keep that protocol unavailable until its permission flow lands;
+            // otherwise an `ask` policy still exposes clipboard metadata for
+            // listing-only requests that upstream intentionally exempts from a
+            // content confirmation prompt.
+            if needs_listing {
+                return ffi::ghostty_clipboard_read_result_e::GHOSTTY_CLIPBOARD_READ_UNSUPPORTED;
+            }
+            let requested = if mime_types_len == 0 {
+                &[][..]
+            } else {
+                std::slice::from_raw_parts(mime_types, mime_types_len)
+            };
+            let wants_text = requested
+                .iter()
+                .copied()
+                .any(|mime| clipboard_mime_is_text(mime));
+            if !wants_text {
+                return ffi::ghostty_clipboard_read_result_e::GHOSTTY_CLIPBOARD_READ_UNAVAILABLE;
+            }
+
             let pb: *mut Object = msg_send![class!(NSPasteboard), generalPasteboard];
             // NSPasteboardTypeString = @"public.utf8-plain-text"
-            let type_str = CString::new("public.utf8-plain-text").unwrap();
-            let ns_type: *mut Object =
-                msg_send![class!(NSString), stringWithUTF8String: type_str.as_ptr()];
+            let ns_type: *mut Object = msg_send![class!(NSString), stringWithUTF8String: c"public.utf8-plain-text".as_ptr()];
             let text: *mut Object = msg_send![pb, stringForType: ns_type];
             if text.is_null() {
-                let empty = c"";
-                ffi::ghostty_surface_complete_clipboard_request(
-                    surface,
-                    empty.as_ptr(),
-                    request,
-                    false,
-                );
-                return true;
+                return ffi::ghostty_clipboard_read_result_e::GHOSTTY_CLIPBOARD_READ_UNAVAILABLE;
             }
-            let utf8: *const std::os::raw::c_char = msg_send![text, UTF8String];
-            ffi::ghostty_surface_complete_clipboard_request(surface, utf8, request, false);
-            return true;
+            let data: *const std::os::raw::c_char = msg_send![text, UTF8String];
+            if data.is_null() {
+                return ffi::ghostty_clipboard_read_result_e::GHOSTTY_CLIPBOARD_READ_UNAVAILABLE;
+            }
+            let len: usize = msg_send![text, lengthOfBytesUsingEncoding: 4usize];
+            let mime = c"text/plain";
+            let content = ffi::ghostty_clipboard_content_s {
+                mime: mime.as_ptr(),
+                data,
+                len,
+            };
+            let complete = ffi::ghostty_clipboard_complete_s {
+                contents: &content,
+                contents_len: 1,
+                available: std::ptr::null(),
+                available_len: 0,
+                confirmed: false,
+                remember: false,
+            };
+            ffi::ghostty_surface_complete_clipboard_request(surface, &complete, request);
+            return ffi::ghostty_clipboard_read_result_e::GHOSTTY_CLIPBOARD_READ_STARTED;
         }
 
         #[cfg(not(target_os = "macos"))]
-        false
+        ffi::ghostty_clipboard_read_result_e::GHOSTTY_CLIPBOARD_READ_UNSUPPORTED
     }
 }
 
 /// Clipboard confirmation — ghostty confirmed a clipboard read (e.g. OSC 52).
 unsafe extern "C" fn confirm_read_clipboard_callback(
     userdata: *mut c_void,
-    text: *const std::os::raw::c_char,
+    confirm: *const ffi::ghostty_clipboard_confirm_s,
     request: *mut c_void,
-    _request_type: ffi::ghostty_clipboard_request_e,
+    request_type: ffi::ghostty_clipboard_request_e,
 ) {
     unsafe {
-        if userdata.is_null() || text.is_null() {
+        if userdata.is_null() || request.is_null() {
             return;
         }
         let state = &*(userdata as *const StateRef);
         let surface = state.lock().surface;
-        if !surface.is_null() {
-            ffi::ghostty_surface_complete_clipboard_request(surface, text, request, true);
+        if surface.is_null() {
+            return;
         }
+
+        if matches!(
+            request_type,
+            ffi::ghostty_clipboard_request_e::GHOSTTY_CLIPBOARD_REQUEST_KITTY_READ
+                | ffi::ghostty_clipboard_request_e::GHOSTTY_CLIPBOARD_REQUEST_KITTY_WRITE
+        ) || confirm.is_null()
+        {
+            // Kitty grants require a real user-visible permission flow. Until
+            // Con can present one, deny instead of silently granting a shell
+            // persistent access to the system clipboard.
+            ffi::ghostty_surface_deny_clipboard_request(surface, request);
+            return;
+        }
+
+        let confirm = &*confirm;
+        let complete = ffi::ghostty_clipboard_complete_s {
+            contents: confirm.contents,
+            contents_len: confirm.contents_len,
+            available: confirm.available,
+            available_len: confirm.available_len,
+            confirmed: true,
+            remember: false,
+        };
+        ffi::ghostty_surface_complete_clipboard_request(surface, &complete, request);
     }
 }
 
 /// Clipboard write — ghostty wants to copy (selection, OSC 52). Write to macOS pasteboard.
 unsafe extern "C" fn write_clipboard_callback(
     _userdata: *mut c_void,
-    _clipboard: ffi::ghostty_clipboard_e,
+    clipboard: ffi::ghostty_clipboard_e,
     content: *const ffi::ghostty_clipboard_content_s,
     content_count: usize,
     _confirm: bool,
 ) {
     unsafe {
-        if content.is_null() || content_count == 0 {
+        // Standard and selection both map to the macOS general pasteboard;
+        // primary is unsupported on this platform.
+        if clipboard == ffi::ghostty_clipboard_e::GHOSTTY_CLIPBOARD_PRIMARY
+            || content.is_null()
+            || content_count == 0
+        {
             return;
         }
 
@@ -1625,30 +1703,43 @@ unsafe extern "C" fn write_clipboard_callback(
             let items = std::slice::from_raw_parts(content, content_count);
 
             for item in items {
-                if item.data.is_null() {
+                if !clipboard_mime_is_text(item.mime) || (item.data.is_null() && item.len > 0) {
                     continue;
                 }
-                let text = CStr::from_ptr(item.data).to_string_lossy();
-                if text.is_empty() {
+                let data = if item.len == 0 {
+                    c"".as_ptr()
+                } else {
+                    item.data
+                };
+                let ns_str: *mut Object = msg_send![
+                    class!(NSString),
+                    stringWithBytes: data
+                    length: item.len
+                    encoding: 4usize
+                ];
+                if ns_str.is_null() {
                     continue;
                 }
-
-                let pb: *mut Object = msg_send![class!(NSPasteboard), generalPasteboard];
-                let _: () = msg_send![pb, clearContents];
-
-                let cstr = CString::new(text.as_ref()).unwrap_or_default();
-                let ns_str: *mut Object =
-                    msg_send![class!(NSString), stringWithUTF8String: cstr.as_ptr()];
 
                 // NSPasteboardTypeString = @"public.utf8-plain-text"
-                let type_cstr = CString::new("public.utf8-plain-text").unwrap();
-                let ns_type: *mut Object =
-                    msg_send![class!(NSString), stringWithUTF8String: type_cstr.as_ptr()];
+                let ns_type: *mut Object = msg_send![class!(NSString), stringWithUTF8String: c"public.utf8-plain-text".as_ptr()];
+                let pb: *mut Object = msg_send![class!(NSPasteboard), generalPasteboard];
+                let _: () = msg_send![pb, clearContents];
                 let _success: bool = msg_send![pb, setString: ns_str forType: ns_type];
                 return;
             }
         }
     }
+}
+
+unsafe fn clipboard_mime_is_text(mime: *const std::os::raw::c_char) -> bool {
+    if mime.is_null() {
+        return false;
+    }
+    matches!(
+        unsafe { CStr::from_ptr(mime) }.to_bytes(),
+        b"text/plain" | b"text/plain;charset=utf-8" | b"UTF8_STRING" | b"TEXT" | b"STRING"
+    )
 }
 
 unsafe extern "C" fn close_surface_callback(userdata: *mut c_void, _process_alive: bool) {
@@ -1770,6 +1861,14 @@ mod tests {
         let config = GhosttyConfigPatch::default().to_config_string();
 
         assert!(config.contains("shell-integration-features = no-cursor,ssh-env,ssh-terminfo"));
+    }
+
+    #[test]
+    fn ghostty_config_rejects_kitty_clipboard_writes_until_permission_ui_exists() {
+        let config = GhosttyConfigPatch::default().to_config_string();
+
+        assert!(config.contains("clipboard-write = ask"));
+        assert!(config.contains("clipboard-write-limit-bytes = 0"));
     }
 
     #[test]

--- a/crates/con-ghostty/src/transcript.rs
+++ b/crates/con-ghostty/src/transcript.rs
@@ -272,6 +272,7 @@ mod tests {
             cols: 3,
             rows: 2,
             cells,
+            kitty_placements: Default::default(),
             dirty_rows: vec![0, 1],
             cursor: Cursor::default(),
             alternate_screen: false,

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -1173,9 +1173,9 @@ struct VtCallbackState {
     /// a parser reply therefore cannot overtake the already-encoded key.
     write_order: Arc<Mutex<()>>,
     enquiry_response: Box<[u8]>,
-    /// Last clipboard text the user explicitly chose to paste. Only a
-    /// Kitty one-time paste grant can read this through the terminal
-    /// clipboard effect; unsolicited OSC reads are denied.
+    /// Last clipboard text the user explicitly chose to paste. Kitty grants
+    /// are one-time capabilities, but multiple outstanding grants read this
+    /// shared current value. Unsolicited OSC reads remain denied.
     clipboard_text: Mutex<Option<Arc<str>>>,
     /// Active only during `ghostty_terminal_paste`. The C callback cannot
     /// return an I/O result, so buffer the complete logical paste and perform
@@ -1886,10 +1886,6 @@ impl VtScreen {
         let Some(callback_state) = inner.callback_state.as_ref() else {
             anyhow::bail!("terminal paste requires a WRITE_PTY callback");
         };
-        // Every new paste intent invalidates an older Kitty clipboard grant.
-        // A fresh grant is minted only after this exact clipboard-origin paste
-        // emits a Kitty event and its complete output reaches the host queue.
-        callback_state.clipboard_text.lock().take();
         let previous = callback_state
             .pending_paste_write
             .lock()
@@ -2588,12 +2584,6 @@ unsafe extern "C" fn vt_clipboard_read_callback(
         remember: false,
     };
     unsafe { reply(read, &reply_value) };
-    if contents_len > 0 {
-        // The reply callback consumes the borrowed content synchronously. Drop
-        // the host copy immediately so the one-time Ghostty password is backed
-        // by one-time data ownership as well.
-        state.clipboard_text.lock().take();
-    }
 }
 
 fn ghostty_string_eq(value: GhosttyString, expected: &[u8]) -> bool {
@@ -3825,88 +3815,102 @@ mod tests {
     }
 
     #[test]
-    fn kitty_paste_event_exposes_only_the_user_pasted_text_once() {
-        let output = Arc::new(Mutex::new(Vec::new()));
-        let output_for_callback = output.clone();
-        let screen = VtScreen::new_with_write_pty(
-            80,
-            24,
-            None,
-            Some(Arc::new(move |bytes| {
-                output_for_callback.lock().extend_from_slice(bytes);
-                Ok(())
-            })),
-        )
-        .expect("create vt screen");
-        screen.feed(b"\x1b[?5522h");
+    fn kitty_paste_grants_share_the_current_clipboard_without_becoming_reusable() {
+        fn grant_read(event: &[u8]) -> Vec<u8> {
+            let password_prefix = b"\x1b]5522;type=read:status=OK:pw=";
+            assert!(event.starts_with(password_prefix));
+            let password_end = event[password_prefix.len()..]
+                .windows(2)
+                .position(|window| window == b"\x1b\\")
+                .expect("paste event password terminator")
+                + password_prefix.len();
 
-        assert_eq!(
-            screen
-                .paste_text("dropped path", VtPasteSource::Text, false)
-                .expect("text insertion with Kitty paste events enabled"),
-            VtPasteResult::Written
-        );
-        assert_eq!(output.lock().as_slice(), b"dropped path");
-        output.lock().clear();
+            let mut read = b"\x1b]5522;type=read:pw=".to_vec();
+            read.extend_from_slice(&event[password_prefix.len()..password_end]);
+            read.extend_from_slice(b":name=UGFzdGUgZXZlbnQ=;dGV4dC9wbGFpbg==\x1b\\");
+            read
+        }
 
-        assert_eq!(
-            screen
-                .paste_text("event secret", VtPasteSource::Clipboard, false)
-                .expect("Kitty paste event"),
-            VtPasteResult::Written
-        );
-        let event = output.lock().clone();
-        assert!(!event.windows(6).any(|window| window == b"secret"));
+        fn verify_redemption_order(order: [usize; 2]) {
+            let output = Arc::new(Mutex::new(Vec::new()));
+            let output_for_callback = output.clone();
+            let screen = VtScreen::new_with_write_pty(
+                80,
+                24,
+                None,
+                Some(Arc::new(move |bytes| {
+                    output_for_callback.lock().extend_from_slice(bytes);
+                    Ok(())
+                })),
+            )
+            .expect("create vt screen");
+            screen.feed(b"\x1b[?5522h");
 
-        let password_prefix = b"\x1b]5522;type=read:status=OK:pw=";
-        assert!(event.starts_with(password_prefix));
-        let password_end = event[password_prefix.len()..]
-            .windows(2)
-            .position(|window| window == b"\x1b\\")
-            .expect("paste event password terminator")
-            + password_prefix.len();
-        let password = &event[password_prefix.len()..password_end];
+            assert_eq!(
+                screen
+                    .paste_text("dropped path", VtPasteSource::Text, false)
+                    .expect("text insertion with Kitty paste events enabled"),
+                VtPasteResult::Written
+            );
+            assert_eq!(output.lock().as_slice(), b"dropped path");
 
-        let mut read = b"\x1b]5522;type=read:pw=".to_vec();
-        read.extend_from_slice(password);
-        read.extend_from_slice(b":name=UGFzdGUgZXZlbnQ=;dGV4dC9wbGFpbg==\x1b\\");
+            let mut reads = Vec::new();
+            for text in ["first clipboard", "current clipboard"] {
+                output.lock().clear();
+                assert_eq!(
+                    screen
+                        .paste_text(text, VtPasteSource::Clipboard, false)
+                        .expect("Kitty paste event"),
+                    VtPasteResult::Written
+                );
+                let event = output.lock().clone();
+                assert!(
+                    !event
+                        .windows(text.len())
+                        .any(|window| window == text.as_bytes())
+                );
+                reads.push(grant_read(&event));
+            }
 
-        output.lock().clear();
-        screen.feed(&read);
-        let first_read = output.lock().clone();
-        assert!(
-            first_read
-                .windows(b"ZXZlbnQgc2VjcmV0".len())
-                .any(|window| window == b"ZXZlbnQgc2VjcmV0"),
-            "one-time paste grant did not expose cached text"
-        );
-        assert!(
-            screen
-                .inner
-                .lock()
-                .callback_state
-                .as_ref()
-                .expect("callback state")
-                .clipboard_text
-                .lock()
-                .is_none(),
-            "host retained clipboard text after the granted read"
-        );
+            for index in order {
+                output.lock().clear();
+                screen.feed(&reads[index]);
+                let response = output.lock().clone();
+                assert!(
+                    response
+                        .windows(b"Y3VycmVudCBjbGlwYm9hcmQ=".len())
+                        .any(|window| window == b"Y3VycmVudCBjbGlwYm9hcmQ="),
+                    "valid paste grant did not expose the current clipboard"
+                );
 
-        output.lock().clear();
-        screen.feed(&read);
-        let second_read = output.lock().clone();
-        assert!(
-            second_read
-                .windows(b"status=EPERM".len())
-                .any(|window| window == b"status=EPERM"),
-            "one-time paste grant was reusable"
-        );
-        assert!(
-            !second_read
-                .windows(b"ZXZlbnQgc2VjcmV0".len())
-                .any(|window| window == b"ZXZlbnQgc2VjcmV0")
-        );
+                output.lock().clear();
+                screen.feed(&reads[index]);
+                assert!(
+                    output
+                        .lock()
+                        .windows(b"status=EPERM".len())
+                        .any(|window| window == b"status=EPERM"),
+                    "one-time paste grant was reusable"
+                );
+            }
+
+            assert_eq!(
+                screen
+                    .inner
+                    .lock()
+                    .callback_state
+                    .as_ref()
+                    .expect("callback state")
+                    .clipboard_text
+                    .lock()
+                    .as_deref(),
+                Some("current clipboard"),
+                "grant redemption discarded the current clipboard"
+            );
+        }
+
+        verify_redemption_order([0, 1]);
+        verify_redemption_order([1, 0]);
     }
 
     #[test]

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -58,8 +58,19 @@ pub type GhosttyTerminal = *mut c_void;
 pub type GhosttyRenderState = *mut c_void;
 pub type GhosttyRowIterator = *mut c_void;
 pub type GhosttyRowCells = *mut c_void;
+pub type GhosttyKeyEncoder = *mut c_void;
+pub type GhosttyKeyEvent = *mut c_void;
 pub type GhosttyAllocator = c_void;
 pub type GhosttyResult = c_int;
+
+const GHOSTTY_SUCCESS: GhosttyResult = 0;
+const GHOSTTY_OUT_OF_SPACE: GhosttyResult = -3;
+
+const GHOSTTY_MODS_SHIFT: u16 = 1 << 0;
+const GHOSTTY_MODS_CTRL: u16 = 1 << 1;
+const GHOSTTY_MODS_ALT: u16 = 1 << 2;
+const GHOSTTY_MODS_SUPER: u16 = 1 << 3;
+const GHOSTTY_KITTY_KEY_REPORT_EVENTS: u8 = 1 << 1;
 
 // ── Enums (keys) ───────────────────────────────────────────────────────
 //
@@ -78,6 +89,7 @@ pub enum GhosttyTerminalData {
     CursorPendingWrap = 5,
     ActiveScreen = 6,
     CursorVisible = 7,
+    KittyKeyboardFlags = 8,
     Scrollbar = 9,
     Title = 12,
     Pwd = 13,
@@ -468,6 +480,38 @@ unsafe extern "C" {
         out: *mut c_void,
     ) -> GhosttyResult;
 
+    // Key encoder (`key/{encoder,event}.h`). The encoder and reusable
+    // event live under `VtInner`'s mutex with the terminal whose mode
+    // state they snapshot.
+    pub fn ghostty_key_encoder_new(
+        allocator: *const GhosttyAllocator,
+        out_encoder: *mut GhosttyKeyEncoder,
+    ) -> GhosttyResult;
+    pub fn ghostty_key_encoder_free(encoder: GhosttyKeyEncoder);
+    pub fn ghostty_key_encoder_setopt_from_terminal(
+        encoder: GhosttyKeyEncoder,
+        terminal: GhosttyTerminal,
+    );
+    pub fn ghostty_key_encoder_encode(
+        encoder: GhosttyKeyEncoder,
+        event: GhosttyKeyEvent,
+        out_buf: *mut c_char,
+        out_buf_size: usize,
+        out_len: *mut usize,
+    ) -> GhosttyResult;
+    pub fn ghostty_key_event_new(
+        allocator: *const GhosttyAllocator,
+        out_event: *mut GhosttyKeyEvent,
+    ) -> GhosttyResult;
+    pub fn ghostty_key_event_free(event: GhosttyKeyEvent);
+    pub fn ghostty_key_event_set_action(event: GhosttyKeyEvent, action: c_int);
+    pub fn ghostty_key_event_set_key(event: GhosttyKeyEvent, key: c_int);
+    pub fn ghostty_key_event_set_mods(event: GhosttyKeyEvent, mods: u16);
+    pub fn ghostty_key_event_set_consumed_mods(event: GhosttyKeyEvent, mods: u16);
+    pub fn ghostty_key_event_set_composing(event: GhosttyKeyEvent, composing: bool);
+    pub fn ghostty_key_event_set_utf8(event: GhosttyKeyEvent, utf8: *const c_char, len: usize);
+    pub fn ghostty_key_event_set_unshifted_codepoint(event: GhosttyKeyEvent, codepoint: u32);
+
     // Render state (`render.h`)
     pub fn ghostty_render_state_new(
         allocator: *const GhosttyAllocator,
@@ -650,7 +694,42 @@ pub struct VtScreen {
     inner: Arc<Mutex<VtInner>>,
 }
 
-pub type PtyWriteCallback = Arc<dyn Fn(&[u8]) + Send + Sync + 'static>;
+pub type PtyWriteCallback = Arc<dyn Fn(&[u8]) -> std::io::Result<()> + Send + Sync + 'static>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VtKeyAction {
+    Release,
+    Press,
+    Repeat,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct VtKeyModifiers {
+    pub shift: bool,
+    pub control: bool,
+    pub alt: bool,
+    pub platform: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct VtKeyEvent<'a> {
+    /// GPUI's normalized logical key name. Only unambiguous functional
+    /// names are promoted to a physical Ghostty key; printable keys stay
+    /// unidentified because GPUI doesn't expose a scan code/W3C code.
+    pub key: &'a str,
+    /// Layout-produced UTF-8 before Ctrl/Alt transformations.
+    pub text: &'a str,
+    pub unshifted_codepoint: Option<char>,
+    pub action: VtKeyAction,
+    pub modifiers: VtKeyModifiers,
+    pub consumed_modifiers: VtKeyModifiers,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct VtKeySend {
+    pub wrote: bool,
+    pub report_releases: bool,
+}
 
 struct VtCallbackState {
     write_pty: PtyWriteCallback,
@@ -668,6 +747,8 @@ struct VtInner {
     render_state: GhosttyRenderState,
     row_iter: GhosttyRowIterator,
     row_cells: GhosttyRowCells,
+    key_encoder: GhosttyKeyEncoder,
+    key_event: GhosttyKeyEvent,
     callback_state: Option<Box<VtCallbackState>>,
     cols: u16,
     rows: u16,
@@ -680,6 +761,151 @@ struct VtInner {
 }
 
 unsafe impl Send for VtInner {}
+
+#[repr(i32)]
+#[derive(Debug, Clone, Copy)]
+enum GhosttyKey {
+    Unidentified = 0,
+    AltLeft = 51,
+    AltRight = 52,
+    Backspace = 53,
+    CapsLock = 54,
+    ContextMenu = 55,
+    ControlLeft = 56,
+    ControlRight = 57,
+    Enter = 58,
+    MetaLeft = 59,
+    MetaRight = 60,
+    ShiftLeft = 61,
+    ShiftRight = 62,
+    Space = 63,
+    Tab = 64,
+    Delete = 68,
+    End = 69,
+    Help = 70,
+    Home = 71,
+    Insert = 72,
+    PageDown = 73,
+    PageUp = 74,
+    ArrowDown = 75,
+    ArrowLeft = 76,
+    ArrowRight = 77,
+    ArrowUp = 78,
+    Escape = 120,
+    F1 = 121,
+    F2 = 122,
+    F3 = 123,
+    F4 = 124,
+    F5 = 125,
+    F6 = 126,
+    F7 = 127,
+    F8 = 128,
+    F9 = 129,
+    F10 = 130,
+    F11 = 131,
+    F12 = 132,
+    F13 = 133,
+    F14 = 134,
+    F15 = 135,
+    F16 = 136,
+    F17 = 137,
+    F18 = 138,
+    F19 = 139,
+    F20 = 140,
+    F21 = 141,
+    F22 = 142,
+    F23 = 143,
+    F24 = 144,
+    F25 = 145,
+    PrintScreen = 148,
+    ScrollLock = 149,
+    Pause = 150,
+}
+
+fn ghostty_key_action(action: VtKeyAction) -> c_int {
+    match action {
+        VtKeyAction::Release => 0,
+        VtKeyAction::Press => 1,
+        VtKeyAction::Repeat => 2,
+    }
+}
+
+fn ghostty_modifiers(modifiers: VtKeyModifiers) -> u16 {
+    (u16::from(modifiers.shift) * GHOSTTY_MODS_SHIFT)
+        | (u16::from(modifiers.control) * GHOSTTY_MODS_CTRL)
+        | (u16::from(modifiers.alt) * GHOSTTY_MODS_ALT)
+        | (u16::from(modifiers.platform) * GHOSTTY_MODS_SUPER)
+}
+
+/// Map only key names whose physical identity is unambiguous in GPUI's
+/// logical event model. Printable keys intentionally remain UNIDENTIFIED:
+/// treating a layout-normalized `"a"` as the physical KeyA position would
+/// corrupt Kitty alternate-key reporting on non-US layouts.
+fn ghostty_key(key: &str) -> c_int {
+    (match key {
+        "alt" | "alt-left" => GhosttyKey::AltLeft,
+        "alt-right" => GhosttyKey::AltRight,
+        "backspace" => GhosttyKey::Backspace,
+        "capslock" | "caps-lock" => GhosttyKey::CapsLock,
+        "context-menu" => GhosttyKey::ContextMenu,
+        "control" | "ctrl" | "control-left" => GhosttyKey::ControlLeft,
+        "control-right" => GhosttyKey::ControlRight,
+        "enter" | "return" => GhosttyKey::Enter,
+        "meta" | "super" | "win" | "meta-left" => GhosttyKey::MetaLeft,
+        "meta-right" => GhosttyKey::MetaRight,
+        "shift" | "shift-left" => GhosttyKey::ShiftLeft,
+        "shift-right" => GhosttyKey::ShiftRight,
+        "space" => GhosttyKey::Space,
+        "tab" => GhosttyKey::Tab,
+        "delete" => GhosttyKey::Delete,
+        "end" => GhosttyKey::End,
+        "help" => GhosttyKey::Help,
+        "home" => GhosttyKey::Home,
+        "insert" => GhosttyKey::Insert,
+        "pagedown" | "page-down" => GhosttyKey::PageDown,
+        "pageup" | "page-up" => GhosttyKey::PageUp,
+        "down" | "arrow-down" => GhosttyKey::ArrowDown,
+        "left" | "arrow-left" => GhosttyKey::ArrowLeft,
+        "right" | "arrow-right" => GhosttyKey::ArrowRight,
+        "up" | "arrow-up" => GhosttyKey::ArrowUp,
+        "escape" => GhosttyKey::Escape,
+        "f1" => GhosttyKey::F1,
+        "f2" => GhosttyKey::F2,
+        "f3" => GhosttyKey::F3,
+        "f4" => GhosttyKey::F4,
+        "f5" => GhosttyKey::F5,
+        "f6" => GhosttyKey::F6,
+        "f7" => GhosttyKey::F7,
+        "f8" => GhosttyKey::F8,
+        "f9" => GhosttyKey::F9,
+        "f10" => GhosttyKey::F10,
+        "f11" => GhosttyKey::F11,
+        "f12" => GhosttyKey::F12,
+        "f13" => GhosttyKey::F13,
+        "f14" => GhosttyKey::F14,
+        "f15" => GhosttyKey::F15,
+        "f16" => GhosttyKey::F16,
+        "f17" => GhosttyKey::F17,
+        "f18" => GhosttyKey::F18,
+        "f19" => GhosttyKey::F19,
+        "f20" => GhosttyKey::F20,
+        "f21" => GhosttyKey::F21,
+        "f22" => GhosttyKey::F22,
+        "f23" => GhosttyKey::F23,
+        "f24" => GhosttyKey::F24,
+        "f25" => GhosttyKey::F25,
+        "printscreen" | "print-screen" => GhosttyKey::PrintScreen,
+        "scrolllock" | "scroll-lock" => GhosttyKey::ScrollLock,
+        "pause" => GhosttyKey::Pause,
+        _ => GhosttyKey::Unidentified,
+    }) as c_int
+}
+
+/// Whether Con's GPUI bridge can identify this logical name as a physical
+/// functional key without guessing a keyboard layout or key location.
+pub fn is_supported_functional_key(key: &str) -> bool {
+    ghostty_key(key) != GhosttyKey::Unidentified as c_int
+}
 
 fn default_device_attributes() -> GhosttyDeviceAttributes {
     let mut features = [0_u16; 64];
@@ -929,6 +1155,43 @@ impl VtScreen {
             );
         }
 
+        let mut key_encoder: GhosttyKeyEncoder = std::ptr::null_mut();
+        let rc = unsafe { ghostty_key_encoder_new(std::ptr::null(), &mut key_encoder) };
+        if rc != GHOSTTY_SUCCESS || key_encoder.is_null() {
+            unsafe {
+                if !row_cells.is_null() {
+                    ghostty_render_state_row_cells_free(row_cells);
+                }
+                if !row_iter.is_null() {
+                    ghostty_render_state_row_iterator_free(row_iter);
+                }
+                if !render_state.is_null() {
+                    ghostty_render_state_free(render_state);
+                }
+                ghostty_terminal_free(terminal);
+            }
+            anyhow::bail!("ghostty_key_encoder_new failed: rc={rc}");
+        }
+
+        let mut key_event: GhosttyKeyEvent = std::ptr::null_mut();
+        let rc = unsafe { ghostty_key_event_new(std::ptr::null(), &mut key_event) };
+        if rc != GHOSTTY_SUCCESS || key_event.is_null() {
+            unsafe {
+                ghostty_key_encoder_free(key_encoder);
+                if !row_cells.is_null() {
+                    ghostty_render_state_row_cells_free(row_cells);
+                }
+                if !row_iter.is_null() {
+                    ghostty_render_state_row_iterator_free(row_iter);
+                }
+                if !render_state.is_null() {
+                    ghostty_render_state_free(render_state);
+                }
+                ghostty_terminal_free(terminal);
+            }
+            anyhow::bail!("ghostty_key_event_new failed: rc={rc}");
+        }
+
         if let Some(theme) = theme {
             unsafe { apply_theme_to_terminal(terminal, theme) };
         }
@@ -939,6 +1202,8 @@ impl VtScreen {
                 render_state,
                 row_iter,
                 row_cells,
+                key_encoder,
+                key_event,
                 callback_state,
                 cols,
                 rows,
@@ -983,6 +1248,112 @@ impl VtScreen {
         // SAFETY: terminal valid; bytes live for the call.
         unsafe { ghostty_terminal_vt_write(inner.terminal, bytes.as_ptr(), bytes.len()) };
         inner.generation = inner.generation.wrapping_add(1);
+    }
+
+    /// Encode one platform key event against the terminal's current modes
+    /// and synchronously write the resulting bytes through WRITE_PTY.
+    ///
+    /// The mode snapshot, reusable encoder/event, and terminal are all
+    /// protected by one mutex so DECCKM/modifyOtherKeys/Kitty state cannot
+    /// change between parsing output and encoding the next key.
+    pub fn send_key(&self, event: &VtKeyEvent<'_>) -> anyhow::Result<VtKeySend> {
+        let inner = self.inner.lock();
+        let Some(callback_state) = inner.callback_state.as_ref() else {
+            anyhow::bail!("terminal key encoding requires a WRITE_PTY callback");
+        };
+        let write_pty = callback_state.write_pty.clone();
+
+        let mut kitty_flags = 0_u8;
+        let kitty_flags_rc = unsafe {
+            ghostty_terminal_get(
+                inner.terminal,
+                GhosttyTerminalData::KittyKeyboardFlags,
+                &mut kitty_flags as *mut _ as *mut c_void,
+            )
+        };
+        if kitty_flags_rc != GHOSTTY_SUCCESS {
+            kitty_flags = 0;
+        }
+
+        unsafe {
+            ghostty_key_encoder_setopt_from_terminal(inner.key_encoder, inner.terminal);
+            ghostty_key_event_set_action(inner.key_event, ghostty_key_action(event.action));
+            ghostty_key_event_set_key(inner.key_event, ghostty_key(event.key));
+            ghostty_key_event_set_mods(inner.key_event, ghostty_modifiers(event.modifiers));
+            ghostty_key_event_set_consumed_mods(
+                inner.key_event,
+                ghostty_modifiers(event.consumed_modifiers),
+            );
+            ghostty_key_event_set_composing(inner.key_event, false);
+            ghostty_key_event_set_utf8(
+                inner.key_event,
+                if event.text.is_empty() {
+                    std::ptr::null()
+                } else {
+                    event.text.as_ptr().cast()
+                },
+                event.text.len(),
+            );
+            ghostty_key_event_set_unshifted_codepoint(
+                inner.key_event,
+                event.unshifted_codepoint.map_or(0, u32::from),
+            );
+        }
+
+        let mut inline = [0_u8; 128];
+        let mut len = 0_usize;
+        let mut rc = unsafe {
+            ghostty_key_encoder_encode(
+                inner.key_encoder,
+                inner.key_event,
+                inline.as_mut_ptr().cast(),
+                inline.len(),
+                &mut len,
+            )
+        };
+
+        let mut overflow = Vec::new();
+        let bytes = if rc == GHOSTTY_OUT_OF_SPACE {
+            overflow.resize(len, 0);
+            rc = unsafe {
+                ghostty_key_encoder_encode(
+                    inner.key_encoder,
+                    inner.key_event,
+                    overflow.as_mut_ptr().cast(),
+                    overflow.len(),
+                    &mut len,
+                )
+            };
+            if rc != GHOSTTY_SUCCESS {
+                anyhow::bail!("ghostty_key_encoder_encode retry failed: rc={rc}");
+            }
+            if len > overflow.len() {
+                anyhow::bail!("ghostty key encoder exceeded its requested output size");
+            }
+            &overflow[..len]
+        } else {
+            if rc != GHOSTTY_SUCCESS {
+                anyhow::bail!("ghostty_key_encoder_encode failed: rc={rc}");
+            }
+            if len > inline.len() {
+                anyhow::bail!("ghostty key encoder returned an invalid output size");
+            }
+            &inline[..len]
+        };
+
+        // PTY writes may block. Keep the encoder and terminal mode snapshot
+        // serialized above, but release the VT mutex before entering host I/O
+        // so parser feeds and renderer snapshots cannot be stalled behind it.
+        drop(inner);
+        if !bytes.is_empty() {
+            write_pty(bytes)
+                .map_err(|err| anyhow::anyhow!("failed to write encoded key: {err}"))?;
+        }
+
+        Ok(VtKeySend {
+            wrote: !bytes.is_empty(),
+            report_releases: kitty_flags & GHOSTTY_KITTY_KEY_REPORT_EVENTS != 0,
+        })
     }
 
     pub fn clear_screen_and_scrollback(&self) {
@@ -1512,7 +1883,12 @@ unsafe extern "C" fn vt_write_pty_callback(
 
     let state = unsafe { &*(userdata as *const VtCallbackState) };
     let bytes = unsafe { std::slice::from_raw_parts(data, len) };
-    (state.write_pty)(bytes);
+    if let Err(err) = (state.write_pty)(bytes) {
+        // The libghostty callback ABI cannot return an I/O error to the
+        // parser. Keep terminal-generated replies best-effort, while direct
+        // key encoding propagates the same callback error to its caller.
+        log::debug!("vt WRITE_PTY callback failed: {err}");
+    }
 }
 
 unsafe extern "C" fn vt_enquiry_callback(
@@ -1776,8 +2152,17 @@ impl Drop for VtScreen {
     fn drop(&mut self) {
         if let Some(mutex) = Arc::get_mut(&mut self.inner) {
             let inner = mutex.get_mut();
-            // Free in reverse-creation order: cells, iter, state, terminal.
+            // Free in reverse-creation order: key event/encoder, render
+            // helpers, then terminal.
             // SAFETY: unique owner via Arc::get_mut.
+            if !inner.key_event.is_null() {
+                unsafe { ghostty_key_event_free(inner.key_event) };
+                inner.key_event = std::ptr::null_mut();
+            }
+            if !inner.key_encoder.is_null() {
+                unsafe { ghostty_key_encoder_free(inner.key_encoder) };
+                inner.key_encoder = std::ptr::null_mut();
+            }
             if !inner.row_cells.is_null() {
                 unsafe { ghostty_render_state_row_cells_free(inner.row_cells) };
                 inner.row_cells = std::ptr::null_mut();
@@ -1843,6 +2228,248 @@ mod tests {
             types["GhosttyTerminalData"]["values"]["MODE"].as_i64(),
             Some(GhosttyTerminalData::Mode as i64)
         );
+        assert_eq!(
+            types["GhosttyTerminalData"]["values"]["KITTY_KEYBOARD_FLAGS"].as_i64(),
+            Some(GhosttyTerminalData::KittyKeyboardFlags as i64)
+        );
+        assert_eq!(
+            types["GhosttyKittyKeyFlags"]["size"].as_u64(),
+            Some(std::mem::size_of::<u8>() as u64)
+        );
+        assert_eq!(
+            types["GhosttyKeyAction"]["values"]["RELEASE"].as_i64(),
+            Some(ghostty_key_action(VtKeyAction::Release) as i64)
+        );
+        assert_eq!(
+            types["GhosttyKeyAction"]["values"]["PRESS"].as_i64(),
+            Some(ghostty_key_action(VtKeyAction::Press) as i64)
+        );
+        assert_eq!(
+            types["GhosttyKeyAction"]["values"]["REPEAT"].as_i64(),
+            Some(ghostty_key_action(VtKeyAction::Repeat) as i64)
+        );
+
+        let keys = &types["GhosttyKey"]["values"];
+        for (name, key) in [
+            ("UNIDENTIFIED", GhosttyKey::Unidentified),
+            ("ALT_LEFT", GhosttyKey::AltLeft),
+            ("ALT_RIGHT", GhosttyKey::AltRight),
+            ("BACKSPACE", GhosttyKey::Backspace),
+            ("CAPS_LOCK", GhosttyKey::CapsLock),
+            ("CONTEXT_MENU", GhosttyKey::ContextMenu),
+            ("CONTROL_LEFT", GhosttyKey::ControlLeft),
+            ("CONTROL_RIGHT", GhosttyKey::ControlRight),
+            ("ENTER", GhosttyKey::Enter),
+            ("META_LEFT", GhosttyKey::MetaLeft),
+            ("META_RIGHT", GhosttyKey::MetaRight),
+            ("SHIFT_LEFT", GhosttyKey::ShiftLeft),
+            ("SHIFT_RIGHT", GhosttyKey::ShiftRight),
+            ("SPACE", GhosttyKey::Space),
+            ("TAB", GhosttyKey::Tab),
+            ("DELETE", GhosttyKey::Delete),
+            ("END", GhosttyKey::End),
+            ("HELP", GhosttyKey::Help),
+            ("HOME", GhosttyKey::Home),
+            ("INSERT", GhosttyKey::Insert),
+            ("PAGE_DOWN", GhosttyKey::PageDown),
+            ("PAGE_UP", GhosttyKey::PageUp),
+            ("ARROW_DOWN", GhosttyKey::ArrowDown),
+            ("ARROW_LEFT", GhosttyKey::ArrowLeft),
+            ("ARROW_RIGHT", GhosttyKey::ArrowRight),
+            ("ARROW_UP", GhosttyKey::ArrowUp),
+            ("ESCAPE", GhosttyKey::Escape),
+            ("F1", GhosttyKey::F1),
+            ("F2", GhosttyKey::F2),
+            ("F3", GhosttyKey::F3),
+            ("F4", GhosttyKey::F4),
+            ("F5", GhosttyKey::F5),
+            ("F6", GhosttyKey::F6),
+            ("F7", GhosttyKey::F7),
+            ("F8", GhosttyKey::F8),
+            ("F9", GhosttyKey::F9),
+            ("F10", GhosttyKey::F10),
+            ("F11", GhosttyKey::F11),
+            ("F12", GhosttyKey::F12),
+            ("F13", GhosttyKey::F13),
+            ("F14", GhosttyKey::F14),
+            ("F15", GhosttyKey::F15),
+            ("F16", GhosttyKey::F16),
+            ("F17", GhosttyKey::F17),
+            ("F18", GhosttyKey::F18),
+            ("F19", GhosttyKey::F19),
+            ("F20", GhosttyKey::F20),
+            ("F21", GhosttyKey::F21),
+            ("F22", GhosttyKey::F22),
+            ("F23", GhosttyKey::F23),
+            ("F24", GhosttyKey::F24),
+            ("F25", GhosttyKey::F25),
+            ("PRINT_SCREEN", GhosttyKey::PrintScreen),
+            ("SCROLL_LOCK", GhosttyKey::ScrollLock),
+            ("PAUSE", GhosttyKey::Pause),
+        ] {
+            assert_eq!(keys[name].as_i64(), Some(key as i64), "GhosttyKey::{key:?}");
+        }
+    }
+
+    #[test]
+    fn key_encoder_tracks_legacy_terminal_modes() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let output_for_callback = output.clone();
+        let screen = VtScreen::new_with_write_pty(
+            80,
+            24,
+            None,
+            Some(Arc::new(move |bytes| {
+                output_for_callback.lock().extend_from_slice(bytes);
+                Ok(())
+            })),
+        )
+        .expect("create vt screen");
+
+        let ctrl_c = VtKeyEvent {
+            key: "c",
+            text: "c",
+            unshifted_codepoint: Some('c'),
+            action: VtKeyAction::Press,
+            modifiers: VtKeyModifiers {
+                control: true,
+                ..VtKeyModifiers::default()
+            },
+            consumed_modifiers: VtKeyModifiers::default(),
+        };
+        assert!(screen.send_key(&ctrl_c).expect("encode Ctrl-C").wrote);
+        assert_eq!(output.lock().as_slice(), b"\x03");
+
+        output.lock().clear();
+        screen.feed(b"\x1b[?1h");
+        let up = VtKeyEvent {
+            key: "up",
+            text: "",
+            unshifted_codepoint: None,
+            action: VtKeyAction::Press,
+            modifiers: VtKeyModifiers::default(),
+            consumed_modifiers: VtKeyModifiers::default(),
+        };
+        assert!(screen.send_key(&up).expect("encode DECCKM up").wrote);
+        assert_eq!(output.lock().as_slice(), b"\x1bOA");
+
+        output.lock().clear();
+        let alt_backspace = VtKeyEvent {
+            key: "backspace",
+            text: "",
+            unshifted_codepoint: None,
+            action: VtKeyAction::Press,
+            modifiers: VtKeyModifiers {
+                alt: true,
+                ..VtKeyModifiers::default()
+            },
+            consumed_modifiers: VtKeyModifiers::default(),
+        };
+        assert!(
+            screen
+                .send_key(&alt_backspace)
+                .expect("encode Alt-Backspace")
+                .wrote
+        );
+        assert_eq!(output.lock().as_slice(), b"\x1b\x7f");
+
+        output.lock().clear();
+        let shift_tab = VtKeyEvent {
+            key: "tab",
+            text: "",
+            unshifted_codepoint: None,
+            action: VtKeyAction::Press,
+            modifiers: VtKeyModifiers {
+                shift: true,
+                ..VtKeyModifiers::default()
+            },
+            consumed_modifiers: VtKeyModifiers::default(),
+        };
+        assert!(screen.send_key(&shift_tab).expect("encode Shift-Tab").wrote);
+        assert_eq!(output.lock().as_slice(), b"\x1b[Z");
+
+        output.lock().clear();
+        let mut space = VtKeyEvent {
+            key: "space",
+            text: " ",
+            unshifted_codepoint: Some(' '),
+            action: VtKeyAction::Press,
+            modifiers: VtKeyModifiers::default(),
+            consumed_modifiers: VtKeyModifiers::default(),
+        };
+        assert!(screen.send_key(&space).expect("encode Space").wrote);
+        assert_eq!(output.lock().as_slice(), b" ");
+
+        output.lock().clear();
+        space.modifiers.control = true;
+        assert!(screen.send_key(&space).expect("encode Ctrl-Space").wrote);
+        assert_eq!(output.lock().as_slice(), b"\x00");
+    }
+
+    #[test]
+    fn key_encoder_handles_kitty_press_repeat_and_release() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let output_for_callback = output.clone();
+        let screen = VtScreen::new_with_write_pty(
+            80,
+            24,
+            None,
+            Some(Arc::new(move |bytes| {
+                output_for_callback.lock().extend_from_slice(bytes);
+                Ok(())
+            })),
+        )
+        .expect("create vt screen");
+        screen.feed(b"\x1b[>3u");
+
+        for (action, expected) in [
+            (VtKeyAction::Press, b"a".as_slice()),
+            (VtKeyAction::Repeat, b"a".as_slice()),
+            (VtKeyAction::Release, b"\x1b[97;1:3u".as_slice()),
+        ] {
+            output.lock().clear();
+            let event = VtKeyEvent {
+                key: "a",
+                text: "a",
+                unshifted_codepoint: Some('a'),
+                action,
+                modifiers: VtKeyModifiers::default(),
+                consumed_modifiers: VtKeyModifiers::default(),
+            };
+            let sent = screen.send_key(&event).expect("encode Kitty key event");
+            assert!(sent.wrote);
+            assert!(sent.report_releases);
+            assert_eq!(output.lock().as_slice(), expected);
+        }
+    }
+
+    #[test]
+    fn key_encoder_propagates_pty_write_failures() {
+        let screen = VtScreen::new_with_write_pty(
+            80,
+            24,
+            None,
+            Some(Arc::new(|_| {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "test PTY is closed",
+                ))
+            })),
+        )
+        .expect("create vt screen");
+        let event = VtKeyEvent {
+            key: "c",
+            text: "c",
+            unshifted_codepoint: Some('c'),
+            action: VtKeyAction::Press,
+            modifiers: VtKeyModifiers::default(),
+            consumed_modifiers: VtKeyModifiers::default(),
+        };
+
+        let err = screen
+            .send_key(&event)
+            .expect_err("surface write must fail");
+        assert!(err.to_string().contains("test PTY is closed"));
     }
 
     #[test]

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -1,7 +1,7 @@
 //! Shared `libghostty-vt` FFI bindings + render-state snapshot.
 //!
 //! Rewritten to match the **actual** upstream API at GHOSTTY_REV
-//! `8867c37c55b578b9eb4cfaba41cb9023e557176d` — `include/ghostty/vt/*.h`.
+//! `5f5b988c5236facfe8d2439203d9ee9d5b636cf8` — `include/ghostty/vt/*.h`.
 //! Key lifecycle:
 //!
 //! 1. `terminal = ghostty_terminal_new(NULL_alloc, cols, rows)`
@@ -1090,13 +1090,13 @@ pub struct VtScreen {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PtyWritePriority {
-    UserInput,
-    TerminalControl,
+pub enum PtyWriteClass {
+    Regular,
+    ReservedControl,
 }
 
 pub type PtyWriteCallback =
-    Arc<dyn Fn(&[u8], PtyWritePriority) -> std::io::Result<()> + Send + Sync + 'static>;
+    Arc<dyn Fn(&[u8], PtyWriteClass) -> std::io::Result<()> + Send + Sync + 'static>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VtKeyAction {
@@ -1128,15 +1128,15 @@ pub struct VtKeyEvent<'a> {
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub struct VtKeySend {
-    pub wrote: bool,
+pub struct VtKeyOutcome {
+    pub output_accepted: bool,
     pub report_releases: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VtPasteResult {
     Empty,
-    Written,
+    Accepted,
     RequiresConfirmation,
 }
 
@@ -1755,7 +1755,7 @@ impl VtScreen {
         self.inner.lock().generation
     }
 
-    pub fn has_write_failure(&self) -> bool {
+    pub fn is_write_desynchronized(&self) -> bool {
         self.inner
             .lock()
             .callback_state
@@ -1766,16 +1766,16 @@ impl VtScreen {
     /// Enqueue raw user input through the same ordering boundary as encoded
     /// keys and parser replies.
     pub fn write_input(&self, bytes: &[u8]) -> std::io::Result<()> {
-        self.write_bytes(bytes, PtyWritePriority::UserInput)
+        self.write_bytes(bytes, PtyWriteClass::Regular)
     }
 
     /// Enqueue a state-balancing host report, such as a key or mouse release,
     /// using the queue capacity reserved for terminal control traffic.
     pub fn write_control(&self, bytes: &[u8]) -> std::io::Result<()> {
-        self.write_bytes(bytes, PtyWritePriority::TerminalControl)
+        self.write_bytes(bytes, PtyWriteClass::ReservedControl)
     }
 
-    fn write_bytes(&self, bytes: &[u8], priority: PtyWritePriority) -> std::io::Result<()> {
+    fn write_bytes(&self, bytes: &[u8], class: PtyWriteClass) -> std::io::Result<()> {
         if bytes.is_empty() {
             return Ok(());
         }
@@ -1791,9 +1791,9 @@ impl VtScreen {
         let write_order = callback_state.write_order.clone();
         let write_guard = write_order.lock();
         drop(inner);
-        let result = write_pty(bytes, priority);
+        let result = write_pty(bytes, class);
         if let Err(err) = &result
-            && priority == PtyWritePriority::TerminalControl
+            && class == PtyWriteClass::ReservedControl
         {
             mark_control_write_failed(&write_failed, err);
         }
@@ -1816,7 +1816,7 @@ impl VtScreen {
     /// The mode snapshot, reusable encoder/event, and terminal are all
     /// protected by one mutex so DECCKM/modifyOtherKeys/Kitty state cannot
     /// change between parsing output and encoding the next key.
-    pub fn send_key(&self, event: &VtKeyEvent<'_>) -> anyhow::Result<VtKeySend> {
+    pub fn send_key(&self, event: &VtKeyEvent<'_>) -> anyhow::Result<VtKeyOutcome> {
         let inner = self.inner.lock();
         let Some(callback_state) = inner.callback_state.as_ref() else {
             anyhow::bail!("terminal key encoding requires a WRITE_PTY callback");
@@ -1910,13 +1910,13 @@ impl VtScreen {
             // host callbacks enqueue into a non-blocking bounded queue.
             let write_guard = write_order.lock();
             drop(inner);
-            let priority = if event.action == VtKeyAction::Release {
-                PtyWritePriority::TerminalControl
+            let class = if event.action == VtKeyAction::Release {
+                PtyWriteClass::ReservedControl
             } else {
-                PtyWritePriority::UserInput
+                PtyWriteClass::Regular
             };
-            if let Err(err) = write_pty(bytes, priority) {
-                if priority == PtyWritePriority::TerminalControl {
+            if let Err(err) = write_pty(bytes, class) {
+                if class == PtyWriteClass::ReservedControl {
                     mark_control_write_failed(&write_failed, &err);
                 }
                 return Err(anyhow::anyhow!("failed to write encoded key: {err}"));
@@ -1924,8 +1924,8 @@ impl VtScreen {
             drop(write_guard);
         }
 
-        Ok(VtKeySend {
-            wrote: !bytes.is_empty(),
+        Ok(VtKeyOutcome {
+            output_accepted: !bytes.is_empty(),
             report_releases: kitty_flags & GHOSTTY_KITTY_KEY_REPORT_EVENTS != 0,
         })
     }
@@ -1934,14 +1934,14 @@ impl VtScreen {
     /// bracketed-paste and Kitty paste-event modes.
     ///
     /// Potential command injection is rejected before any PTY write. The UI
-    /// may explicitly retry with `allow_unsafe` after showing the text to the
-    /// user. A successful Kitty paste event caches only this user-approved
+    /// may explicitly retry with `confirm_unsafe_paste` after showing the text
+    /// to the user. A successful Kitty paste event caches only this user-approved
     /// text for the event's one-time granted clipboard read.
     pub fn paste_text(
         &self,
         text: &str,
         source: VtPasteSource,
-        allow_unsafe: bool,
+        confirm_unsafe_paste: bool,
     ) -> anyhow::Result<VtPasteResult> {
         if text.len() > TERMINAL_PASTE_LIMIT_BYTES {
             anyhow::bail!(
@@ -1981,7 +1981,7 @@ impl VtScreen {
                 read: Some(vt_paste_read_callback),
                 userdata: (&mut reader as *mut VtPasteReader<'_>).cast(),
             },
-            allow_unsafe,
+            allow_unsafe: confirm_unsafe_paste,
         };
         let mut written = false;
         let rc = unsafe { ghostty_terminal_paste(inner.terminal, &paste, &mut written) };
@@ -2001,9 +2001,9 @@ impl VtScreen {
                     // one-time Kitty grant is installed before a program can
                     // react to the event and request its clipboard payload.
                     let _write_guard = callback_state.write_order.lock();
-                    (callback_state.write_pty)(&output, PtyWritePriority::UserInput).map_err(
-                        |err| anyhow::anyhow!("terminal paste failed to enqueue PTY bytes: {err}"),
-                    )?;
+                    (callback_state.write_pty)(&output, PtyWriteClass::Regular).map_err(|err| {
+                        anyhow::anyhow!("terminal paste failed to enqueue PTY bytes: {err}")
+                    })?;
                 }
                 if written && !reader.served && source == VtPasteSource::Clipboard {
                     // Ghostty does not call the MIME reader for a Kitty paste
@@ -2012,7 +2012,7 @@ impl VtScreen {
                     *callback_state.clipboard_text.lock() = Some(Arc::from(text));
                 }
                 Ok(if written {
-                    VtPasteResult::Written
+                    VtPasteResult::Accepted
                 } else {
                     VtPasteResult::Empty
                 })
@@ -2699,7 +2699,7 @@ unsafe extern "C" fn vt_write_pty_callback(
     }
 
     let _write_guard = state.write_order.lock();
-    if let Err(err) = (state.write_pty)(bytes, PtyWritePriority::TerminalControl) {
+    if let Err(err) = (state.write_pty)(bytes, PtyWriteClass::ReservedControl) {
         mark_control_write_failed(&state.write_failed, &err);
     }
 }
@@ -3663,7 +3663,12 @@ mod tests {
             },
             consumed_modifiers: VtKeyModifiers::default(),
         };
-        assert!(screen.send_key(&ctrl_c).expect("encode Ctrl-C").wrote);
+        assert!(
+            screen
+                .send_key(&ctrl_c)
+                .expect("encode Ctrl-C")
+                .output_accepted
+        );
         assert_eq!(output.lock().as_slice(), b"\x03");
 
         output.lock().clear();
@@ -3676,7 +3681,12 @@ mod tests {
             modifiers: VtKeyModifiers::default(),
             consumed_modifiers: VtKeyModifiers::default(),
         };
-        assert!(screen.send_key(&up).expect("encode DECCKM up").wrote);
+        assert!(
+            screen
+                .send_key(&up)
+                .expect("encode DECCKM up")
+                .output_accepted
+        );
         assert_eq!(output.lock().as_slice(), b"\x1bOA");
 
         output.lock().clear();
@@ -3695,7 +3705,7 @@ mod tests {
             screen
                 .send_key(&alt_backspace)
                 .expect("encode Alt-Backspace")
-                .wrote
+                .output_accepted
         );
         assert_eq!(output.lock().as_slice(), b"\x1b\x7f");
 
@@ -3711,7 +3721,12 @@ mod tests {
             },
             consumed_modifiers: VtKeyModifiers::default(),
         };
-        assert!(screen.send_key(&shift_tab).expect("encode Shift-Tab").wrote);
+        assert!(
+            screen
+                .send_key(&shift_tab)
+                .expect("encode Shift-Tab")
+                .output_accepted
+        );
         assert_eq!(output.lock().as_slice(), b"\x1b[Z");
 
         output.lock().clear();
@@ -3723,12 +3738,22 @@ mod tests {
             modifiers: VtKeyModifiers::default(),
             consumed_modifiers: VtKeyModifiers::default(),
         };
-        assert!(screen.send_key(&space).expect("encode Space").wrote);
+        assert!(
+            screen
+                .send_key(&space)
+                .expect("encode Space")
+                .output_accepted
+        );
         assert_eq!(output.lock().as_slice(), b" ");
 
         output.lock().clear();
         space.modifiers.control = true;
-        assert!(screen.send_key(&space).expect("encode Ctrl-Space").wrote);
+        assert!(
+            screen
+                .send_key(&space)
+                .expect("encode Ctrl-Space")
+                .output_accepted
+        );
         assert_eq!(output.lock().as_slice(), b"\x00");
     }
 
@@ -3762,9 +3787,9 @@ mod tests {
                 modifiers: VtKeyModifiers::default(),
                 consumed_modifiers: VtKeyModifiers::default(),
             };
-            let sent = screen.send_key(&event).expect("encode Kitty key event");
-            assert!(sent.wrote);
-            assert!(sent.report_releases);
+            let outcome = screen.send_key(&event).expect("encode Kitty key event");
+            assert!(outcome.output_accepted);
+            assert!(outcome.report_releases);
             assert_eq!(output.lock().as_slice(), expected);
         }
     }
@@ -3851,8 +3876,8 @@ mod tests {
         reply.join().expect("terminal reply thread");
 
         let writes = writes.lock();
-        assert_eq!(writes[0], (b"user".to_vec(), PtyWritePriority::UserInput));
-        assert_eq!(writes[1].1, PtyWritePriority::TerminalControl);
+        assert_eq!(writes[0], (b"user".to_vec(), PtyWriteClass::Regular));
+        assert_eq!(writes[1].1, PtyWriteClass::ReservedControl);
         assert!(writes[1].0.starts_with(b"\x1b[0n"));
     }
 
@@ -3862,8 +3887,8 @@ mod tests {
             80,
             24,
             None,
-            Some(Arc::new(|_, priority| {
-                assert_eq!(priority, PtyWritePriority::TerminalControl);
+            Some(Arc::new(|_, class| {
+                assert_eq!(class, PtyWriteClass::ReservedControl);
                 Err(std::io::Error::new(
                     std::io::ErrorKind::WouldBlock,
                     "reserved PTY capacity exhausted",
@@ -3874,7 +3899,7 @@ mod tests {
 
         screen.feed(b"\x1b[5n");
 
-        assert!(screen.has_write_failure());
+        assert!(screen.is_write_desynchronized());
     }
 
     #[test]
@@ -3927,7 +3952,7 @@ mod tests {
             screen
                 .paste_text("echo safe", VtPasteSource::Clipboard, false)
                 .expect("safe paste"),
-            VtPasteResult::Written
+            VtPasteResult::Accepted
         );
         assert_eq!(output.lock().as_slice(), b"echo safe");
 
@@ -3945,7 +3970,7 @@ mod tests {
             screen
                 .paste_text(unsafe_text, VtPasteSource::Clipboard, true)
                 .expect("confirmed paste"),
-            VtPasteResult::Written
+            VtPasteResult::Accepted
         );
         assert_eq!(output.lock().as_slice(), b"echo first\recho second");
 
@@ -3956,7 +3981,7 @@ mod tests {
             screen
                 .paste_text("first\nsecond", VtPasteSource::Clipboard, false)
                 .expect("bracketed paste"),
-            VtPasteResult::Written
+            VtPasteResult::Accepted
         );
         assert_eq!(output.lock().as_slice(), b"\x1b[200~first\nsecond\x1b[201~");
         assert_eq!(
@@ -4002,7 +4027,7 @@ mod tests {
                 screen
                     .paste_text("dropped path", VtPasteSource::Text, false)
                     .expect("text insertion with Kitty paste events enabled"),
-                VtPasteResult::Written
+                VtPasteResult::Accepted
             );
             assert_eq!(output.lock().as_slice(), b"dropped path");
 
@@ -4013,7 +4038,7 @@ mod tests {
                     screen
                         .paste_text(text, VtPasteSource::Clipboard, false)
                         .expect("Kitty paste event"),
-                    VtPasteResult::Written
+                    VtPasteResult::Accepted
                 );
                 let event = output.lock().clone();
                 assert!(

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -65,12 +65,15 @@ pub type GhosttyResult = c_int;
 
 const GHOSTTY_SUCCESS: GhosttyResult = 0;
 const GHOSTTY_OUT_OF_SPACE: GhosttyResult = -3;
+const GHOSTTY_IO_ERROR: GhosttyResult = -5;
+const GHOSTTY_REJECTED: GhosttyResult = -7;
 
 const GHOSTTY_MODS_SHIFT: u16 = 1 << 0;
 const GHOSTTY_MODS_CTRL: u16 = 1 << 1;
 const GHOSTTY_MODS_ALT: u16 = 1 << 2;
 const GHOSTTY_MODS_SUPER: u16 = 1 << 3;
 const GHOSTTY_KITTY_KEY_REPORT_EVENTS: u8 = 1 << 1;
+const TEXT_PLAIN_MIME: &[u8] = b"text/plain";
 
 // ── Enums (keys) ───────────────────────────────────────────────────────
 //
@@ -162,6 +165,7 @@ pub enum GhosttyTerminalOption {
     /// `GhosttyColorRgb[256]*` — full 256-entry palette.
     ColorPalette = 14,
     ScrollbackMaxLines = 28,
+    ClipboardRead = 38,
 }
 
 /// `GHOSTTY_RENDER_STATE_DATA_*` keys for `ghostty_render_state_get`.
@@ -309,6 +313,98 @@ pub struct GhosttyString {
     pub ptr: *const u8,
     pub len: usize,
 }
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct GhosttyWriter {
+    pub write: Option<unsafe extern "C" fn(*mut c_void, *const u8, usize) -> bool>,
+    pub userdata: *mut c_void,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct GhosttyMimeReader {
+    pub read: Option<unsafe extern "C" fn(*mut c_void, GhosttyString, GhosttyWriter) -> bool>,
+    pub userdata: *mut c_void,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GhosttyClipboardLocation {
+    Standard = 0,
+    Selection = 1,
+    Primary = 2,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GhosttyPasteSource {
+    Clipboard = 0,
+    Text = 1,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct GhosttyPaste {
+    pub size: usize,
+    pub location: GhosttyClipboardLocation,
+    pub source: GhosttyPasteSource,
+    pub mimes: *const GhosttyString,
+    pub mimes_len: usize,
+    pub reader: GhosttyMimeReader,
+    pub allow_unsafe: bool,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct GhosttyClipboardContent {
+    pub mime: GhosttyString,
+    pub data: GhosttyString,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GhosttyClipboardReadResult {
+    Success = 0,
+    Denied = 1,
+    Unsupported = 2,
+    Busy = 3,
+    IoError = 4,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct GhosttyClipboardReadReply {
+    pub size: usize,
+    pub result: GhosttyClipboardReadResult,
+    pub contents: *const GhosttyClipboardContent,
+    pub contents_len: usize,
+    pub available: *const GhosttyString,
+    pub available_len: usize,
+    pub remember: bool,
+}
+
+#[repr(C)]
+pub struct GhosttyClipboardRead {
+    pub size: usize,
+    pub location: GhosttyClipboardLocation,
+    pub mimes: *const GhosttyString,
+    pub mimes_len: usize,
+    pub list: bool,
+    pub name: GhosttyString,
+    pub granted: bool,
+    pub can_remember: bool,
+    pub ctx: *const c_void,
+    pub reply:
+        Option<unsafe extern "C" fn(*const GhosttyClipboardRead, *const GhosttyClipboardReadReply)>,
+}
+
+const _: [(); 16] = [(); std::mem::size_of::<GhosttyWriter>()];
+const _: [(); 16] = [(); std::mem::size_of::<GhosttyMimeReader>()];
+const _: [(); 56] = [(); std::mem::size_of::<GhosttyPaste>()];
+const _: [(); 32] = [(); std::mem::size_of::<GhosttyClipboardContent>()];
+const _: [(); 56] = [(); std::mem::size_of::<GhosttyClipboardReadReply>()];
+const _: [(); 80] = [(); std::mem::size_of::<GhosttyClipboardRead>()];
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -478,6 +574,11 @@ unsafe extern "C" {
         terminal: GhosttyTerminal,
         key: GhosttyTerminalData,
         out: *mut c_void,
+    ) -> GhosttyResult;
+    pub fn ghostty_terminal_paste(
+        terminal: GhosttyTerminal,
+        paste: *const GhosttyPaste,
+        out_written: *mut bool,
     ) -> GhosttyResult;
 
     // Key encoder (`key/{encoder,event}.h`). The encoder and reusable
@@ -731,9 +832,31 @@ pub struct VtKeySend {
     pub report_releases: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VtPasteResult {
+    Empty,
+    Written,
+    RequiresConfirmation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VtPasteSource {
+    Clipboard,
+    Text,
+}
+
+struct VtPasteReader<'a> {
+    text: &'a [u8],
+    served: bool,
+}
+
 struct VtCallbackState {
     write_pty: PtyWriteCallback,
     enquiry_response: Box<[u8]>,
+    /// Last clipboard text the user explicitly chose to paste. Only a
+    /// Kitty one-time paste grant can read this through the terminal
+    /// clipboard effect; unsolicited OSC reads are denied.
+    clipboard_text: Option<Box<str>>,
     rows: AtomicU16,
     cols: AtomicU16,
     cell_width: AtomicU32,
@@ -1044,6 +1167,7 @@ impl VtScreen {
             Box::new(VtCallbackState {
                 write_pty,
                 enquiry_response: b"con".to_vec().into_boxed_slice(),
+                clipboard_text: None,
                 rows: AtomicU16::new(rows),
                 cols: AtomicU16::new(cols),
                 cell_width: AtomicU32::new(1),
@@ -1099,6 +1223,11 @@ impl VtScreen {
                     GhosttyTerminalOption::Xtversion,
                     vt_xtversion_callback as *const c_void,
                     "XTVERSION",
+                ),
+                (
+                    GhosttyTerminalOption::ClipboardRead,
+                    vt_clipboard_read_callback as *const c_void,
+                    "CLIPBOARD_READ",
                 ),
             ];
 
@@ -1354,6 +1483,75 @@ impl VtScreen {
             wrote: !bytes.is_empty(),
             report_releases: kitty_flags & GHOSTTY_KITTY_KEY_REPORT_EVENTS != 0,
         })
+    }
+
+    /// Paste user-selected clipboard text according to the terminal's active
+    /// bracketed-paste and Kitty paste-event modes.
+    ///
+    /// Potential command injection is rejected before any PTY write. The UI
+    /// may explicitly retry with `allow_unsafe` after showing the text to the
+    /// user. A successful Kitty paste event caches only this user-approved
+    /// text for the event's one-time granted clipboard read.
+    pub fn paste_text(
+        &self,
+        text: &str,
+        source: VtPasteSource,
+        allow_unsafe: bool,
+    ) -> anyhow::Result<VtPasteResult> {
+        let mut inner = self.inner.lock();
+        if inner.callback_state.is_none() {
+            anyhow::bail!("terminal paste requires a WRITE_PTY callback");
+        }
+
+        let mime = GhosttyString {
+            ptr: TEXT_PLAIN_MIME.as_ptr(),
+            len: TEXT_PLAIN_MIME.len(),
+        };
+        let mut reader = VtPasteReader {
+            text: text.as_bytes(),
+            served: false,
+        };
+        let paste = GhosttyPaste {
+            size: std::mem::size_of::<GhosttyPaste>(),
+            location: GhosttyClipboardLocation::Standard,
+            source: match source {
+                VtPasteSource::Clipboard => GhosttyPasteSource::Clipboard,
+                VtPasteSource::Text => GhosttyPasteSource::Text,
+            },
+            mimes: &mime,
+            mimes_len: 1,
+            reader: GhosttyMimeReader {
+                read: Some(vt_paste_read_callback),
+                userdata: (&mut reader as *mut VtPasteReader<'_>).cast(),
+            },
+            allow_unsafe,
+        };
+        let mut written = false;
+        let rc = unsafe { ghostty_terminal_paste(inner.terminal, &paste, &mut written) };
+        match rc {
+            GHOSTTY_SUCCESS => {
+                if written && !reader.served && source == VtPasteSource::Clipboard {
+                    // Ghostty does not call the MIME reader for a Kitty paste
+                    // event. Retain the exact user-selected text for the
+                    // event's later one-time granted read.
+                    inner
+                        .callback_state
+                        .as_mut()
+                        .expect("callback state checked above")
+                        .clipboard_text = Some(text.into());
+                }
+                Ok(if written {
+                    VtPasteResult::Written
+                } else {
+                    VtPasteResult::Empty
+                })
+            }
+            GHOSTTY_REJECTED => Ok(VtPasteResult::RequiresConfirmation),
+            GHOSTTY_IO_ERROR => {
+                anyhow::bail!("ghostty_terminal_paste failed to read clipboard text")
+            }
+            _ => anyhow::bail!("ghostty_terminal_paste failed: rc={rc}"),
+        }
     }
 
     pub fn clear_screen_and_scrollback(&self) {
@@ -1871,6 +2069,143 @@ impl VtScreen {
     }
 }
 
+unsafe extern "C" fn vt_paste_read_callback(
+    userdata: *mut c_void,
+    mime: GhosttyString,
+    writer: GhosttyWriter,
+) -> bool {
+    if userdata.is_null() || !ghostty_string_eq(mime, TEXT_PLAIN_MIME) {
+        return false;
+    }
+    let Some(write) = writer.write else {
+        return false;
+    };
+    let reader = unsafe { &mut *(userdata as *mut VtPasteReader<'_>) };
+    reader.served = true;
+    if reader.text.is_empty() {
+        return true;
+    }
+    unsafe { write(writer.userdata, reader.text.as_ptr(), reader.text.len()) }
+}
+
+/// Clipboard reads initiated by a running program are denied by default.
+/// The only data-bearing read accepted here is a one-time Kitty paste grant
+/// minted by `ghostty_terminal_paste` after an explicit local paste action.
+/// This callback never enters GPUI or the system clipboard while the VT lock
+/// is held, avoiding a reader-thread/UI-thread lock inversion.
+unsafe extern "C" fn vt_clipboard_read_callback(
+    _terminal: GhosttyTerminal,
+    userdata: *mut c_void,
+    read: *const GhosttyClipboardRead,
+) {
+    if userdata.is_null() || read.is_null() {
+        return;
+    }
+    if unsafe { (*read).size } < std::mem::size_of::<GhosttyClipboardRead>() {
+        return;
+    }
+    let state = unsafe { &*(userdata as *const VtCallbackState) };
+    let read = unsafe { &*read };
+    let Some(reply) = read.reply else {
+        return;
+    };
+
+    let mut result = GhosttyClipboardReadResult::Success;
+    let mut available = GhosttyString::default();
+    let mut available_len = 0;
+    let mut content = GhosttyClipboardContent {
+        mime: GhosttyString::default(),
+        data: GhosttyString::default(),
+    };
+    let mut contents_len = 0;
+
+    let listing_only = read.list && read.mimes_len == 0;
+    if read.location != GhosttyClipboardLocation::Standard {
+        result = GhosttyClipboardReadResult::Unsupported;
+    } else if !listing_only && !read.granted {
+        result = GhosttyClipboardReadResult::Denied;
+    } else if let Some(text) = state.clipboard_text.as_deref() {
+        if read.list {
+            available = GhosttyString {
+                ptr: TEXT_PLAIN_MIME.as_ptr(),
+                len: TEXT_PLAIN_MIME.len(),
+            };
+            available_len = 1;
+        }
+
+        if read.mimes_len > 0 {
+            if read.mimes.is_null() {
+                result = GhosttyClipboardReadResult::IoError;
+            } else {
+                let requested = unsafe { std::slice::from_raw_parts(read.mimes, read.mimes_len) };
+                if let Some(mime) = requested
+                    .iter()
+                    .copied()
+                    .find(|mime| ghostty_string_is_supported_text(*mime))
+                {
+                    content = GhosttyClipboardContent {
+                        mime,
+                        data: GhosttyString {
+                            ptr: text.as_ptr(),
+                            len: text.len(),
+                        },
+                    };
+                    contents_len = 1;
+                }
+            }
+        }
+    }
+
+    let reply_value = GhosttyClipboardReadReply {
+        size: std::mem::size_of::<GhosttyClipboardReadReply>(),
+        result,
+        contents: if contents_len == 0 {
+            std::ptr::null()
+        } else {
+            &content
+        },
+        contents_len,
+        available: if available_len == 0 {
+            std::ptr::null()
+        } else {
+            &available
+        },
+        available_len,
+        remember: false,
+    };
+    unsafe { reply(read, &reply_value) };
+}
+
+fn ghostty_string_eq(value: GhosttyString, expected: &[u8]) -> bool {
+    if value.len != expected.len() || (value.ptr.is_null() && value.len > 0) {
+        return false;
+    }
+    let bytes = if value.len == 0 {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(value.ptr, value.len) }
+    };
+    bytes == expected
+}
+
+fn ghostty_string_is_supported_text(value: GhosttyString) -> bool {
+    if value.ptr.is_null() && value.len > 0 {
+        return false;
+    }
+    let bytes = if value.len == 0 {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(value.ptr, value.len) }
+    };
+    bytes.eq_ignore_ascii_case(TEXT_PLAIN_MIME)
+        || bytes.eq_ignore_ascii_case(b"UTF8_STRING")
+        || bytes.eq_ignore_ascii_case(b"text")
+        || bytes
+            .iter()
+            .position(|byte| *byte == b';')
+            .is_some_and(|separator| bytes[..separator].eq_ignore_ascii_case(TEXT_PLAIN_MIME))
+}
+
 unsafe extern "C" fn vt_write_pty_callback(
     _terminal: GhosttyTerminal,
     userdata: *mut c_void,
@@ -2225,6 +2560,95 @@ mod tests {
             Some(GhosttyTerminalOption::ScrollbackMaxLines as i64)
         );
         assert_eq!(
+            types["GhosttyTerminalOption"]["values"]["CLIPBOARD_READ"].as_i64(),
+            Some(GhosttyTerminalOption::ClipboardRead as i64)
+        );
+        for (name, size, align) in [
+            (
+                "GhosttyWriter",
+                std::mem::size_of::<GhosttyWriter>(),
+                std::mem::align_of::<GhosttyWriter>(),
+            ),
+            (
+                "GhosttyMimeReader",
+                std::mem::size_of::<GhosttyMimeReader>(),
+                std::mem::align_of::<GhosttyMimeReader>(),
+            ),
+            (
+                "GhosttyPaste",
+                std::mem::size_of::<GhosttyPaste>(),
+                std::mem::align_of::<GhosttyPaste>(),
+            ),
+            (
+                "GhosttyClipboardContent",
+                std::mem::size_of::<GhosttyClipboardContent>(),
+                std::mem::align_of::<GhosttyClipboardContent>(),
+            ),
+            (
+                "GhosttyClipboardReadReply",
+                std::mem::size_of::<GhosttyClipboardReadReply>(),
+                std::mem::align_of::<GhosttyClipboardReadReply>(),
+            ),
+            (
+                "GhosttyClipboardRead",
+                std::mem::size_of::<GhosttyClipboardRead>(),
+                std::mem::align_of::<GhosttyClipboardRead>(),
+            ),
+        ] {
+            assert_eq!(
+                types[name]["size"].as_u64(),
+                Some(size as u64),
+                "{name} size"
+            );
+            assert_eq!(
+                types[name]["align"].as_u64(),
+                Some(align as u64),
+                "{name} alignment"
+            );
+        }
+        for (name, value) in [
+            ("STANDARD", GhosttyClipboardLocation::Standard),
+            ("SELECTION", GhosttyClipboardLocation::Selection),
+            ("PRIMARY", GhosttyClipboardLocation::Primary),
+        ] {
+            assert_eq!(
+                types["GhosttyClipboardLocation"]["values"][name].as_i64(),
+                Some(value as i64),
+                "GhosttyClipboardLocation::{name}"
+            );
+        }
+        for (name, value) in [
+            ("CLIPBOARD", GhosttyPasteSource::Clipboard),
+            ("TEXT", GhosttyPasteSource::Text),
+        ] {
+            assert_eq!(
+                types["GhosttyPasteSource"]["values"][name].as_i64(),
+                Some(value as i64),
+                "GhosttyPasteSource::{name}"
+            );
+        }
+        for (name, value) in [
+            ("SUCCESS", GhosttyClipboardReadResult::Success),
+            ("DENIED", GhosttyClipboardReadResult::Denied),
+            ("UNSUPPORTED", GhosttyClipboardReadResult::Unsupported),
+            ("BUSY", GhosttyClipboardReadResult::Busy),
+            ("IO_ERROR", GhosttyClipboardReadResult::IoError),
+        ] {
+            assert_eq!(
+                types["GhosttyClipboardReadResult"]["values"][name].as_i64(),
+                Some(value as i64),
+                "GhosttyClipboardReadResult::{name}"
+            );
+        }
+        assert_eq!(
+            types["GhosttyResult"]["values"]["IO_ERROR"].as_i64(),
+            Some(GHOSTTY_IO_ERROR as i64)
+        );
+        assert_eq!(
+            types["GhosttyResult"]["values"]["REJECTED"].as_i64(),
+            Some(GHOSTTY_REJECTED as i64)
+        );
+        assert_eq!(
             types["GhosttyTerminalData"]["values"]["MODE"].as_i64(),
             Some(GhosttyTerminalData::Mode as i64)
         );
@@ -2498,6 +2922,149 @@ mod tests {
         assert!(screen.is_bracketed_paste());
         screen.feed(b"\x1b[?2004l");
         assert!(!screen.is_bracketed_paste());
+    }
+
+    #[test]
+    fn paste_applies_terminal_modes_and_requires_confirmation_for_command_injection() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let output_for_callback = output.clone();
+        let screen = VtScreen::new_with_write_pty(
+            80,
+            24,
+            None,
+            Some(Arc::new(move |bytes| {
+                output_for_callback.lock().extend_from_slice(bytes);
+                Ok(())
+            })),
+        )
+        .expect("create vt screen");
+
+        assert_eq!(
+            screen
+                .paste_text("echo safe", VtPasteSource::Clipboard, false)
+                .expect("safe paste"),
+            VtPasteResult::Written
+        );
+        assert_eq!(output.lock().as_slice(), b"echo safe");
+
+        output.lock().clear();
+        let unsafe_text = "echo first\necho second";
+        assert_eq!(
+            screen
+                .paste_text(unsafe_text, VtPasteSource::Clipboard, false)
+                .expect("check unsafe paste"),
+            VtPasteResult::RequiresConfirmation
+        );
+        assert!(output.lock().is_empty(), "rejected paste wrote to the PTY");
+
+        assert_eq!(
+            screen
+                .paste_text(unsafe_text, VtPasteSource::Clipboard, true)
+                .expect("confirmed paste"),
+            VtPasteResult::Written
+        );
+        assert_eq!(output.lock().as_slice(), b"echo first\recho second");
+
+        output.lock().clear();
+        screen.feed(b"\x1b[?2004h");
+        assert_eq!(
+            screen
+                .paste_text("first\nsecond", VtPasteSource::Clipboard, false)
+                .expect("bracketed paste"),
+            VtPasteResult::Written
+        );
+        assert_eq!(output.lock().as_slice(), b"\x1b[200~first\nsecond\x1b[201~");
+    }
+
+    #[test]
+    fn kitty_paste_event_exposes_only_the_user_pasted_text_once() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let output_for_callback = output.clone();
+        let screen = VtScreen::new_with_write_pty(
+            80,
+            24,
+            None,
+            Some(Arc::new(move |bytes| {
+                output_for_callback.lock().extend_from_slice(bytes);
+                Ok(())
+            })),
+        )
+        .expect("create vt screen");
+        screen.feed(b"\x1b[?5522h");
+
+        assert_eq!(
+            screen
+                .paste_text("dropped path", VtPasteSource::Text, false)
+                .expect("text insertion with Kitty paste events enabled"),
+            VtPasteResult::Written
+        );
+        assert_eq!(output.lock().as_slice(), b"dropped path");
+        output.lock().clear();
+
+        assert_eq!(
+            screen
+                .paste_text("event secret", VtPasteSource::Clipboard, false)
+                .expect("Kitty paste event"),
+            VtPasteResult::Written
+        );
+        let event = output.lock().clone();
+        assert!(!event.windows(6).any(|window| window == b"secret"));
+
+        let password_prefix = b"\x1b]5522;type=read:status=OK:pw=";
+        assert!(event.starts_with(password_prefix));
+        let password_end = event[password_prefix.len()..]
+            .windows(2)
+            .position(|window| window == b"\x1b\\")
+            .expect("paste event password terminator")
+            + password_prefix.len();
+        let password = &event[password_prefix.len()..password_end];
+
+        let mut read = b"\x1b]5522;type=read:pw=".to_vec();
+        read.extend_from_slice(password);
+        read.extend_from_slice(b";dGV4dC9wbGFpbg==\x1b\\");
+
+        output.lock().clear();
+        screen.feed(&read);
+        let first_read = output.lock().clone();
+        assert!(
+            first_read
+                .windows(b"ZXZlbnQgc2VjcmV0".len())
+                .any(|window| window == b"ZXZlbnQgc2VjcmV0"),
+            "one-time paste grant did not expose cached text"
+        );
+
+        output.lock().clear();
+        screen.feed(&read);
+        let second_read = output.lock().clone();
+        assert!(
+            second_read
+                .windows(b"status=EPERM".len())
+                .any(|window| window == b"status=EPERM"),
+            "one-time paste grant was reusable"
+        );
+        assert!(
+            !second_read
+                .windows(b"ZXZlbnQgc2VjcmV0".len())
+                .any(|window| window == b"ZXZlbnQgc2VjcmV0")
+        );
+    }
+
+    #[test]
+    fn clipboard_text_mime_matching_is_exact_and_case_insensitive() {
+        let supported = |value: &[u8]| {
+            ghostty_string_is_supported_text(GhosttyString {
+                ptr: value.as_ptr(),
+                len: value.len(),
+            })
+        };
+
+        assert!(supported(b"text/plain"));
+        assert!(supported(b"TEXT/PLAIN"));
+        assert!(supported(b"text/plain;charset=utf-8"));
+        assert!(supported(b"UTF8_STRING"));
+        assert!(supported(b"text"));
+        assert!(!supported(b"text/plainEVIL"));
+        assert!(!supported(b"image/png"));
     }
 
     #[test]

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -3807,7 +3807,7 @@ mod tests {
 
         let mut read = b"\x1b]5522;type=read:pw=".to_vec();
         read.extend_from_slice(password);
-        read.extend_from_slice(b";dGV4dC9wbGFpbg==\x1b\\");
+        read.extend_from_slice(b":name=UGFzdGUgZXZlbnQ=;dGV4dC9wbGFpbg==\x1b\\");
 
         output.lock().clear();
         screen.feed(&read);

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -1,10 +1,10 @@
 //! Shared `libghostty-vt` FFI bindings + render-state snapshot.
 //!
 //! Rewritten to match the **actual** upstream API at GHOSTTY_REV
-//! `ca7516bea60190ee2e9a4f9182b61d318d107c6e` — `include/ghostty/vt/*.h`.
+//! `8867c37c55b578b9eb4cfaba41cb9023e557176d` — `include/ghostty/vt/*.h`.
 //! Key lifecycle:
 //!
-//! 1. `terminal = ghostty_terminal_new(NULL_alloc, opts)`
+//! 1. `terminal = ghostty_terminal_new(NULL_alloc, cols, rows)`
 //! 2. `state    = ghostty_render_state_new(NULL_alloc)`
 //! 3. `iter     = ghostty_render_state_row_iterator_new(NULL_alloc)`
 //! 4. `cells    = ghostty_render_state_row_cells_new(NULL_alloc)`
@@ -28,7 +28,7 @@
 
 #![allow(non_camel_case_types, dead_code)]
 
-use std::os::raw::{c_int, c_void};
+use std::os::raw::{c_char, c_int, c_void};
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU32, AtomicU64, Ordering};
@@ -81,6 +81,8 @@ pub enum GhosttyTerminalData {
     Scrollbar = 9,
     Title = 12,
     Pwd = 13,
+    ScrollbackMaxLines = 35,
+    Mode = 37,
 }
 
 /// `GhosttyTerminalScrollbar` — current viewport position in the full
@@ -147,6 +149,7 @@ pub enum GhosttyTerminalOption {
     ColorCursor = 13,
     /// `GhosttyColorRgb[256]*` — full 256-entry palette.
     ColorPalette = 14,
+    ScrollbackMaxLines = 28,
 }
 
 /// `GHOSTTY_RENDER_STATE_DATA_*` keys for `ghostty_render_state_get`.
@@ -236,6 +239,16 @@ pub type GhosttyCell = u64;
 /// (1 = ANSI, 0 = DEC private). Constructed via [`ghostty_mode`].
 pub type GhosttyMode = u16;
 
+/// Frozen-layout payload used with terminal mode get/set operations.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct GhosttyTerminalModeConfig {
+    pub mode: GhosttyMode,
+    pub value: bool,
+}
+
+const _: [(); 4] = [(); std::mem::size_of::<GhosttyTerminalModeConfig>()];
+
 /// Pack a mode value + ANSI flag into a [`GhosttyMode`]. Mirrors the
 /// inline `ghostty_mode_new` helper the C header ships.
 #[inline]
@@ -269,14 +282,6 @@ const GHOSTTY_DA_FEATURE_RECTANGULAR_EDITING: u16 = 28;
 const GHOSTTY_DA_FEATURE_CLIPBOARD: u16 = 52;
 const GHOSTTY_DA_DEVICE_TYPE_VT220: u16 = 1;
 
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
-pub struct GhosttyTerminalOptions {
-    pub cols: u16,
-    pub rows: u16,
-    pub max_scrollback: usize,
-}
-
 /// `GhosttyColorRgb` — R,G,B bytes per upstream `color.h`.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Default)]
@@ -291,13 +296,6 @@ pub struct GhosttyColorRgb {
 pub struct GhosttyString {
     pub ptr: *const u8,
     pub len: usize,
-}
-
-fn ghostty_string_from_bytes(bytes: &[u8]) -> GhosttyString {
-    GhosttyString {
-        ptr: bytes.as_ptr(),
-        len: bytes.len(),
-    }
 }
 
 #[repr(C)]
@@ -429,11 +427,15 @@ pub const ATTR_INVERSE: u8 = 1 << 4;
 // ── Raw FFI ────────────────────────────────────────────────────────────
 
 unsafe extern "C" {
+    // ABI manifest (`types.h`).
+    pub fn ghostty_type_json() -> *const c_char;
+
     // Terminal (`terminal.h`)
     pub fn ghostty_terminal_new(
         allocator: *const GhosttyAllocator,
         out_terminal: *mut GhosttyTerminal,
-        options: GhosttyTerminalOptions,
+        cols: u16,
+        rows: u16,
     ) -> GhosttyResult;
     pub fn ghostty_terminal_free(terminal: GhosttyTerminal);
     pub fn ghostty_terminal_resize(
@@ -464,14 +466,6 @@ unsafe extern "C" {
         terminal: GhosttyTerminal,
         key: GhosttyTerminalData,
         out: *mut c_void,
-    ) -> GhosttyResult;
-
-    /// Query whether a terminal mode is currently set. `out_value` is a
-    /// `bool` (1 byte). Returns `GHOSTTY_SUCCESS` on success.
-    pub fn ghostty_terminal_mode_get(
-        terminal: GhosttyTerminal,
-        mode: GhosttyMode,
-        out_value: *mut bool,
     ) -> GhosttyResult;
 
     // Render state (`render.h`)
@@ -683,23 +677,9 @@ struct VtInner {
     scratch_rows: u16,
     scratch: Vec<Cell>,
     last_cursor: Cursor,
-    osc_state: OscParseState,
-    osc_command: Vec<u8>,
-    osc7_buffer: Vec<u8>,
 }
 
 unsafe impl Send for VtInner {}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum OscParseState {
-    Ground,
-    Esc,
-    Command,
-    Ignore,
-    IgnoreEsc,
-    Osc7,
-    Osc7Esc,
-}
 
 fn default_device_attributes() -> GhosttyDeviceAttributes {
     let mut features = [0_u16; 64];
@@ -721,101 +701,6 @@ fn default_device_attributes() -> GhosttyDeviceAttributes {
         },
         tertiary: GhosttyDeviceAttributesTertiary { unit_id: 0 },
     }
-}
-
-fn ingest_osc7_cwd(inner: &mut VtInner, bytes: &[u8]) {
-    for &byte in bytes {
-        match inner.osc_state {
-            OscParseState::Ground => {
-                if byte == 0x1b {
-                    inner.osc_state = OscParseState::Esc;
-                }
-            }
-            OscParseState::Esc => {
-                if byte == b']' {
-                    inner.osc_command.clear();
-                    inner.osc_state = OscParseState::Command;
-                } else if byte != 0x1b {
-                    inner.osc_state = OscParseState::Ground;
-                }
-            }
-            OscParseState::Command => match byte {
-                b';' => {
-                    if inner.osc_command.as_slice() == b"7" {
-                        inner.osc7_buffer.clear();
-                        inner.osc_state = OscParseState::Osc7;
-                    } else {
-                        inner.osc_state = OscParseState::Ignore;
-                    }
-                }
-                0x07 => inner.osc_state = OscParseState::Ground,
-                0x1b => inner.osc_state = OscParseState::IgnoreEsc,
-                _ if inner.osc_command.len() < 16 => inner.osc_command.push(byte),
-                _ => inner.osc_state = OscParseState::Ignore,
-            },
-            OscParseState::Ignore => match byte {
-                0x07 => inner.osc_state = OscParseState::Ground,
-                0x1b => inner.osc_state = OscParseState::IgnoreEsc,
-                _ => {}
-            },
-            OscParseState::IgnoreEsc => {
-                inner.osc_state = OscParseState::Ground;
-                if byte == 0x1b {
-                    inner.osc_state = OscParseState::Esc;
-                } else if byte != b'\\' {
-                    // The ESC did not terminate the OSC. Resume ignoring
-                    // until the real BEL/ST terminator.
-                    inner.osc_state = OscParseState::Ignore;
-                }
-            }
-            OscParseState::Osc7 => match byte {
-                0x07 => finish_osc7_cwd(inner),
-                0x1b => inner.osc_state = OscParseState::Osc7Esc,
-                _ if inner.osc7_buffer.len() < 4096 => inner.osc7_buffer.push(byte),
-                _ => {
-                    inner.osc7_buffer.clear();
-                    inner.osc_state = OscParseState::Ignore;
-                }
-            },
-            OscParseState::Osc7Esc => {
-                if byte == b'\\' {
-                    finish_osc7_cwd(inner);
-                } else {
-                    if inner.osc7_buffer.len() + 2 <= 4096 {
-                        inner.osc7_buffer.push(0x1b);
-                        inner.osc7_buffer.push(byte);
-                        inner.osc_state = OscParseState::Osc7;
-                    } else {
-                        inner.osc7_buffer.clear();
-                        inner.osc_state = OscParseState::Ignore;
-                    }
-                }
-            }
-        }
-    }
-}
-
-fn finish_osc7_cwd(inner: &mut VtInner) {
-    if let Ok(url) = std::str::from_utf8(&inner.osc7_buffer)
-        && let Some(cwd) = parse_osc7_cwd(url)
-    {
-        let pwd = ghostty_string_from_bytes(cwd.as_bytes());
-        // SAFETY: `ghostty_terminal_set(PWD)` copies the string during
-        // the call; `cwd` stays alive until the call returns.
-        let rc = unsafe {
-            ghostty_terminal_set(
-                inner.terminal,
-                GhosttyTerminalOption::Pwd,
-                &pwd as *const _ as *const c_void,
-            )
-        };
-        if rc != 0 {
-            log::warn!("ghostty_terminal_set(Pwd) failed: rc={rc}");
-        }
-    }
-
-    inner.osc7_buffer.clear();
-    inner.osc_state = OscParseState::Ground;
 }
 
 fn parse_osc7_cwd(url: &str) -> Option<String> {
@@ -910,15 +795,23 @@ impl VtScreen {
         write_pty: Option<PtyWriteCallback>,
     ) -> anyhow::Result<Self> {
         let mut terminal: GhosttyTerminal = std::ptr::null_mut();
-        let options = GhosttyTerminalOptions {
-            cols,
-            rows,
-            max_scrollback: 10_000,
-        };
         // SAFETY: out param; allocator NULL = upstream default.
-        let rc = unsafe { ghostty_terminal_new(std::ptr::null(), &mut terminal, options) };
+        let rc = unsafe { ghostty_terminal_new(std::ptr::null(), &mut terminal, cols, rows) };
         if rc != 0 || terminal.is_null() {
             anyhow::bail!("ghostty_terminal_new failed: rc={rc}");
+        }
+
+        let max_scrollback_lines = 10_000_usize;
+        let rc = unsafe {
+            ghostty_terminal_set(
+                terminal,
+                GhosttyTerminalOption::ScrollbackMaxLines,
+                &max_scrollback_lines as *const _ as *const c_void,
+            )
+        };
+        if rc != 0 {
+            unsafe { ghostty_terminal_free(terminal) };
+            anyhow::bail!("ghostty_terminal_set(SCROLLBACK_MAX_LINES) failed: rc={rc}");
         }
 
         let mut callback_state = write_pty.map(|write_pty| {
@@ -1055,9 +948,6 @@ impl VtScreen {
                 scratch_rows: rows,
                 scratch: Vec::with_capacity(cols as usize * rows as usize),
                 last_cursor: Cursor::default(),
-                osc_state: OscParseState::Ground,
-                osc_command: Vec::with_capacity(8),
-                osc7_buffer: Vec::with_capacity(256),
             })),
         })
     }
@@ -1090,7 +980,6 @@ impl VtScreen {
     /// upstream: do not call from inside a registered callback.
     pub fn feed(&self, bytes: &[u8]) {
         let mut inner = self.inner.lock();
-        ingest_osc7_cwd(&mut inner, bytes);
         // SAFETY: terminal valid; bytes live for the call.
         unsafe { ghostty_terminal_vt_write(inner.terminal, bytes.as_ptr(), bytes.len()) };
         inner.generation = inner.generation.wrapping_add(1);
@@ -1511,7 +1400,15 @@ impl VtScreen {
         }
 
         let bytes = unsafe { std::slice::from_raw_parts(pwd.ptr, pwd.len) };
-        String::from_utf8(bytes.to_vec()).ok()
+        let pwd = std::str::from_utf8(bytes).ok()?;
+        if pwd.is_empty() {
+            return None;
+        }
+        if pwd.starts_with("file://") {
+            parse_osc7_cwd(pwd)
+        } else {
+            Some(pwd.to_string())
+        }
     }
 
     /// Returns `true` while the alternate screen buffer is active.
@@ -1590,10 +1487,16 @@ impl VtScreen {
         if inner.terminal.is_null() {
             return false;
         }
-        let mut on: bool = false;
-        // SAFETY: terminal valid; `on` is a 1-byte C `_Bool`.
-        let rc = unsafe { ghostty_terminal_mode_get(inner.terminal, mode, &mut on) };
-        rc == 0 && on
+        let mut config = GhosttyTerminalModeConfig { mode, value: false };
+        // SAFETY: terminal valid; `config` has the frozen C layout.
+        let rc = unsafe {
+            ghostty_terminal_get(
+                inner.terminal,
+                GhosttyTerminalData::Mode,
+                &mut config as *mut _ as *mut c_void,
+            )
+        };
+        rc == 0 && config.value
     }
 }
 
@@ -1898,6 +1801,77 @@ impl Drop for VtScreen {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::CStr;
+
+    #[test]
+    fn libghostty_vt_manifest_matches_handwritten_ffi() {
+        let manifest = unsafe {
+            let ptr = ghostty_type_json();
+            assert!(!ptr.is_null(), "ghostty_type_json returned null");
+            CStr::from_ptr(ptr).to_str().expect("manifest is utf-8")
+        };
+        let manifest: serde_json::Value =
+            serde_json::from_str(manifest).expect("manifest is valid json");
+        let types = &manifest["types"];
+
+        assert_eq!(manifest["schema"].as_u64(), Some(1));
+        assert_eq!(
+            types["GhosttyCell"]["size"].as_u64(),
+            Some(std::mem::size_of::<GhosttyCell>() as u64)
+        );
+        assert_eq!(
+            types["GhosttyStyle"]["size"].as_u64(),
+            Some(std::mem::size_of::<GhosttyStyle>() as u64)
+        );
+        assert_eq!(
+            types["GhosttyTerminalModeConfig"]["size"].as_u64(),
+            Some(std::mem::size_of::<GhosttyTerminalModeConfig>() as u64)
+        );
+        assert_eq!(
+            types["GhosttyTerminalModeConfig"]["fields"]["mode"]["offset"].as_u64(),
+            Some(0)
+        );
+        assert_eq!(
+            types["GhosttyTerminalModeConfig"]["fields"]["value"]["offset"].as_u64(),
+            Some(2)
+        );
+        assert_eq!(
+            types["GhosttyTerminalOption"]["values"]["SCROLLBACK_MAX_LINES"].as_i64(),
+            Some(GhosttyTerminalOption::ScrollbackMaxLines as i64)
+        );
+        assert_eq!(
+            types["GhosttyTerminalData"]["values"]["MODE"].as_i64(),
+            Some(GhosttyTerminalData::Mode as i64)
+        );
+    }
+
+    #[test]
+    fn vt_screen_configures_line_scrollback_limit() {
+        let screen = VtScreen::new(80, 24, None).expect("create vt screen");
+        let inner = screen.inner.lock();
+        let mut max_lines = 0_usize;
+        let rc = unsafe {
+            ghostty_terminal_get(
+                inner.terminal,
+                GhosttyTerminalData::ScrollbackMaxLines,
+                &mut max_lines as *mut _ as *mut c_void,
+            )
+        };
+
+        assert_eq!(rc, 0);
+        assert_eq!(max_lines, 10_000);
+    }
+
+    #[test]
+    fn vt_screen_queries_modes_through_terminal_data() {
+        let screen = VtScreen::new(80, 24, None).expect("create vt screen");
+
+        assert!(!screen.is_bracketed_paste());
+        screen.feed(b"\x1b[?2004h");
+        assert!(screen.is_bracketed_paste());
+        screen.feed(b"\x1b[?2004l");
+        assert!(!screen.is_bracketed_paste());
+    }
 
     #[test]
     fn vt_screen_reports_osc7_current_dir() {
@@ -1945,6 +1919,15 @@ mod tests {
             screen.current_dir().as_deref(),
             Some("/home/me/con terminal")
         );
+    }
+
+    #[test]
+    fn vt_screen_preserves_whitespace_in_bare_current_dir() {
+        let screen = VtScreen::new(80, 24, None).expect("create vt screen");
+
+        screen.feed(b"\x1b]9;9; /tmp/con cwd \x07");
+
+        assert_eq!(screen.current_dir().as_deref(), Some(" /tmp/con cwd "));
     }
 
     #[test]

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -82,6 +82,11 @@ const KITTY_IMAGE_STORAGE_LIMIT_BYTES: u64 = 10_000_000;
 const KITTY_PNG_MAX_INPUT_BYTES: usize = 16 * 1024 * 1024;
 const KITTY_PNG_MAX_DIMENSION: u32 = 10_000;
 const KITTY_PNG_DECODER_MAX_ALLOC_BYTES: u64 = 32 * 1024 * 1024;
+// A single tiny image can have an effectively unbounded number of explicit
+// placements upstream. Bound each render snapshot so hostile terminal output
+// cannot force either renderer to allocate and lay out millions of quads in
+// one frame. This is intentionally far above a dense visible terminal grid.
+const KITTY_PLACEMENT_SNAPSHOT_LIMIT: usize = 4_096;
 
 const GHOSTTY_MODS_SHIFT: u16 = 1 << 0;
 const GHOSTTY_MODS_CTRL: u16 = 1 << 1;
@@ -2689,7 +2694,16 @@ fn snapshot_kitty_placements(inner: &mut VtInner) -> Arc<[KittyPlacement]> {
 
     let mut images: HashMap<u32, Arc<KittyImage>> = HashMap::new();
     let mut placements = Vec::new();
+    let mut placement_count = 0_usize;
     while unsafe { ghostty_kitty_graphics_placement_next(inner.kitty_placement_iter) } {
+        if placement_count >= KITTY_PLACEMENT_SNAPSHOT_LIMIT {
+            log::debug!(
+                "truncating Kitty graphics snapshot at {KITTY_PLACEMENT_SNAPSHOT_LIMIT} placements"
+            );
+            break;
+        }
+        placement_count += 1;
+
         let mut image_id = 0_u32;
         let mut placement_id = 0_u32;
         let mut is_virtual = false;

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -2617,13 +2617,7 @@ fn ghostty_string_is_supported_text(value: GhosttyString) -> bool {
     } else {
         unsafe { std::slice::from_raw_parts(value.ptr, value.len) }
     };
-    bytes.eq_ignore_ascii_case(TEXT_PLAIN_MIME)
-        || bytes.eq_ignore_ascii_case(b"UTF8_STRING")
-        || bytes.eq_ignore_ascii_case(b"text")
-        || bytes
-            .iter()
-            .position(|byte| *byte == b';')
-            .is_some_and(|separator| bytes[..separator].eq_ignore_ascii_case(TEXT_PLAIN_MIME))
+    crate::clipboard_mime_is_text(bytes)
 }
 
 unsafe extern "C" fn vt_write_pty_callback(
@@ -3933,24 +3927,6 @@ mod tests {
             .expect_err("oversized paste must be rejected");
 
         assert!(err.to_string().contains("safety limit"));
-    }
-
-    #[test]
-    fn clipboard_text_mime_matching_is_exact_and_case_insensitive() {
-        let supported = |value: &[u8]| {
-            ghostty_string_is_supported_text(GhosttyString {
-                ptr: value.as_ptr(),
-                len: value.len(),
-            })
-        };
-
-        assert!(supported(b"text/plain"));
-        assert!(supported(b"TEXT/PLAIN"));
-        assert!(supported(b"text/plain;charset=utf-8"));
-        assert!(supported(b"UTF8_STRING"));
-        assert!(supported(b"text"));
-        assert!(!supported(b"text/plainEVIL"));
-        assert!(!supported(b"image/png"));
     }
 
     #[test]

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -83,6 +83,12 @@ const KITTY_PNG_MAX_INPUT_BYTES: usize = 16 * 1024 * 1024;
 const KITTY_PNG_MAX_DIMENSION: u32 = 10_000;
 const KITTY_PNG_DECODER_MAX_ALLOC_BYTES: u64 = 32 * 1024 * 1024;
 const TERMINAL_PASTE_LIMIT_BYTES: usize = 16 * 1024 * 1024;
+// libghostty may split one paste into framing and content callbacks. Collect
+// those callbacks before handing them to the bounded host queue so a queue
+// rejection cannot leave a partial bracketed paste in the child process.
+// Protocol framing should be tiny; the second input-sized allowance keeps a
+// malformed upstream expansion bounded without constraining valid text.
+const TERMINAL_PASTE_OUTPUT_LIMIT_BYTES: usize = TERMINAL_PASTE_LIMIT_BYTES * 2;
 // A single tiny image can have an effectively unbounded number of explicit
 // placements upstream. Bound each render snapshot so hostile terminal output
 // cannot force either renderer to allocate and lay out millions of quads in
@@ -1138,18 +1144,43 @@ struct VtPasteReader<'a> {
     served: bool,
 }
 
+enum PendingPasteWrite {
+    Buffer(Vec<u8>),
+    TooLarge,
+}
+
+impl PendingPasteWrite {
+    fn append(&mut self, bytes: &[u8]) {
+        let Self::Buffer(buffer) = self else {
+            return;
+        };
+        let Some(total) = buffer.len().checked_add(bytes.len()) else {
+            *self = Self::TooLarge;
+            return;
+        };
+        if total > TERMINAL_PASTE_OUTPUT_LIMIT_BYTES {
+            *self = Self::TooLarge;
+            return;
+        }
+        buffer.extend_from_slice(bytes);
+    }
+}
+
 struct VtCallbackState {
     write_pty: PtyWriteCallback,
+    /// Serializes host callback entry. `send_key` acquires this while it still
+    /// owns the VT mutex, then releases the VT mutex before invoking the host;
+    /// a parser reply therefore cannot overtake the already-encoded key.
+    write_order: Arc<Mutex<()>>,
     enquiry_response: Box<[u8]>,
     /// Last clipboard text the user explicitly chose to paste. Only a
     /// Kitty one-time paste grant can read this through the terminal
     /// clipboard effect; unsolicited OSC reads are denied.
     clipboard_text: Mutex<Option<Arc<str>>>,
-    /// WRITE_PTY is a void callback in libghostty's C ABI. Capture its first
-    /// host I/O failure so synchronous user operations such as paste can still
-    /// return an error instead of reporting bytes as written when they were
-    /// rejected by the host queue.
-    write_error: Mutex<Option<String>>,
+    /// Active only during `ghostty_terminal_paste`. The C callback cannot
+    /// return an I/O result, so buffer the complete logical paste and perform
+    /// one fallible host enqueue after libghostty returns.
+    pending_paste_write: Mutex<Option<PendingPasteWrite>>,
     rows: AtomicU16,
     cols: AtomicU16,
     cell_width: AtomicU32,
@@ -1477,9 +1508,10 @@ impl VtScreen {
         let mut callback_state = write_pty.map(|write_pty| {
             Box::new(VtCallbackState {
                 write_pty,
+                write_order: Arc::new(Mutex::new(())),
                 enquiry_response: b"con".to_vec().into_boxed_slice(),
                 clipboard_text: Mutex::new(None),
-                write_error: Mutex::new(None),
+                pending_paste_write: Mutex::new(None),
                 rows: AtomicU16::new(rows),
                 cols: AtomicU16::new(cols),
                 cell_width: AtomicU32::new(1),
@@ -1732,6 +1764,7 @@ impl VtScreen {
             anyhow::bail!("terminal key encoding requires a WRITE_PTY callback");
         };
         let write_pty = callback_state.write_pty.clone();
+        let write_order = callback_state.write_order.clone();
 
         let mut kitty_flags = 0_u8;
         let kitty_flags_rc = unsafe {
@@ -1811,13 +1844,16 @@ impl VtScreen {
             &inline[..len]
         };
 
-        // PTY writes may block. Keep the encoder and terminal mode snapshot
-        // serialized above, but release the VT mutex before entering host I/O
-        // so parser feeds and renderer snapshots cannot be stalled behind it.
-        drop(inner);
         if !bytes.is_empty() {
+            // Reserve the next host-write position before releasing the VT
+            // state. PTY feeds may then parse concurrently, but any generated
+            // reply waits behind this key instead of overtaking it. The real
+            // host callbacks enqueue into a non-blocking bounded queue.
+            let write_guard = write_order.lock();
+            drop(inner);
             write_pty(bytes)
                 .map_err(|err| anyhow::anyhow!("failed to write encoded key: {err}"))?;
+            drop(write_guard);
         }
 
         Ok(VtKeySend {
@@ -1850,11 +1886,15 @@ impl VtScreen {
         let Some(callback_state) = inner.callback_state.as_ref() else {
             anyhow::bail!("terminal paste requires a WRITE_PTY callback");
         };
-        // Every new paste intent invalidates both an older Kitty clipboard
-        // grant and an unrelated callback error. A fresh grant is minted only
-        // after this exact clipboard-origin paste emits a Kitty event.
+        // Every new paste intent invalidates an older Kitty clipboard grant.
+        // A fresh grant is minted only after this exact clipboard-origin paste
+        // emits a Kitty event and its complete output reaches the host queue.
         callback_state.clipboard_text.lock().take();
-        callback_state.write_error.lock().take();
+        let previous = callback_state
+            .pending_paste_write
+            .lock()
+            .replace(PendingPasteWrite::Buffer(Vec::new()));
+        debug_assert!(previous.is_none(), "paste writes must not nest");
 
         let mime = GhosttyString {
             ptr: TEXT_PLAIN_MIME.as_ptr(),
@@ -1881,11 +1921,26 @@ impl VtScreen {
         };
         let mut written = false;
         let rc = unsafe { ghostty_terminal_paste(inner.terminal, &paste, &mut written) };
-        if let Some(err) = callback_state.write_error.lock().take() {
-            anyhow::bail!("terminal paste failed to enqueue PTY bytes: {err}");
-        }
+        let pending_write = callback_state
+            .pending_paste_write
+            .lock()
+            .take()
+            .expect("paste write capture initialized");
         match rc {
             GHOSTTY_SUCCESS => {
+                let PendingPasteWrite::Buffer(output) = pending_write else {
+                    anyhow::bail!("terminal paste produced too much PTY output");
+                };
+                if !output.is_empty() {
+                    // The real host callback is a non-blocking bounded queue.
+                    // Keep the VT lock through this single enqueue so the
+                    // one-time Kitty grant is installed before a program can
+                    // react to the event and request its clipboard payload.
+                    let _write_guard = callback_state.write_order.lock();
+                    (callback_state.write_pty)(&output).map_err(|err| {
+                        anyhow::anyhow!("terminal paste failed to enqueue PTY bytes: {err}")
+                    })?;
+                }
                 if written && !reader.served && source == VtPasteSource::Clipboard {
                     // Ghostty does not call the MIME reader for a Kitty paste
                     // event. Retain the exact user-selected text for the
@@ -2583,16 +2638,20 @@ unsafe extern "C" fn vt_write_pty_callback(
 
     let state = unsafe { &*(userdata as *const VtCallbackState) };
     let bytes = unsafe { std::slice::from_raw_parts(data, len) };
-    if let Err(err) = (state.write_pty)(bytes) {
-        // The libghostty callback ABI cannot return an I/O error to the
-        // parser. Keep terminal-generated replies best-effort, while direct
-        // key encoding propagates the same callback error to its caller.
-        let message = err.to_string();
-        let mut write_error = state.write_error.lock();
-        if write_error.is_none() {
-            *write_error = Some(message.clone());
+    {
+        let mut pending = state.pending_paste_write.lock();
+        if let Some(pending) = pending.as_mut() {
+            pending.append(bytes);
+            return;
         }
-        log::debug!("vt WRITE_PTY callback failed: {message}");
+    }
+
+    let _write_guard = state.write_order.lock();
+    if let Err(err) = (state.write_pty)(bytes) {
+        // Asynchronous terminal replies are best-effort because libghostty's
+        // callback ABI has no error return. Keys and paste invoke the same
+        // host callback directly and propagate their enqueue failures.
+        log::debug!("vt WRITE_PTY callback failed: {err}");
     }
 }
 
@@ -3714,11 +3773,14 @@ mod tests {
     fn paste_applies_terminal_modes_and_requires_confirmation_for_command_injection() {
         let output = Arc::new(Mutex::new(Vec::new()));
         let output_for_callback = output.clone();
+        let callback_calls = Arc::new(Mutex::new(0_usize));
+        let callback_calls_for_callback = callback_calls.clone();
         let screen = VtScreen::new_with_write_pty(
             80,
             24,
             None,
             Some(Arc::new(move |bytes| {
+                *callback_calls_for_callback.lock() += 1;
                 output_for_callback.lock().extend_from_slice(bytes);
                 Ok(())
             })),
@@ -3752,6 +3814,7 @@ mod tests {
         assert_eq!(output.lock().as_slice(), b"echo first\recho second");
 
         output.lock().clear();
+        *callback_calls.lock() = 0;
         screen.feed(b"\x1b[?2004h");
         assert_eq!(
             screen
@@ -3760,6 +3823,11 @@ mod tests {
             VtPasteResult::Written
         );
         assert_eq!(output.lock().as_slice(), b"\x1b[200~first\nsecond\x1b[201~");
+        assert_eq!(
+            *callback_calls.lock(),
+            1,
+            "one logical paste must reach the bounded host queue atomically"
+        );
     }
 
     #[test]

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -28,6 +28,7 @@
 
 #![allow(non_camel_case_types, dead_code)]
 
+use std::collections::HashMap;
 use std::io::Cursor as IoCursor;
 use std::os::raw::{c_char, c_int, c_void};
 use std::sync::Arc;
@@ -62,6 +63,9 @@ pub type GhosttyRowIterator = *mut c_void;
 pub type GhosttyRowCells = *mut c_void;
 pub type GhosttyKeyEncoder = *mut c_void;
 pub type GhosttyKeyEvent = *mut c_void;
+pub type GhosttyKittyGraphics = *mut c_void;
+pub type GhosttyKittyGraphicsImage = *mut c_void;
+pub type GhosttyKittyGraphicsPlacementIterator = *mut c_void;
 pub type GhosttyAllocator = c_void;
 pub type GhosttyResult = c_int;
 
@@ -187,6 +191,52 @@ pub enum GhosttyTerminalOption {
 #[derive(Debug, Clone, Copy)]
 enum GhosttySysOption {
     DecodePng = 1,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+enum GhosttyKittyGraphicsData {
+    PlacementIterator = 1,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+enum GhosttyKittyGraphicsPlacementData {
+    ImageId = 1,
+    PlacementId = 2,
+    IsVirtual = 3,
+    XOffset = 4,
+    YOffset = 5,
+    Z = 12,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+enum GhosttyKittyGraphicsImageData {
+    Width = 3,
+    Height = 4,
+    Format = 5,
+    Compression = 6,
+    DataPtr = 7,
+    DataLen = 8,
+    Generation = 9,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GhosttyKittyImageFormat {
+    Rgb = 0,
+    Rgba = 1,
+    Png = 2,
+    GrayAlpha = 3,
+    Gray = 4,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GhosttyKittyImageCompression {
+    None = 0,
+    ZlibDeflate = 1,
 }
 
 /// `GHOSTTY_RENDER_STATE_DATA_*` keys for `ghostty_render_state_get`.
@@ -431,6 +481,23 @@ struct GhosttySysImage {
     data_len: usize,
 }
 
+#[repr(C)]
+#[derive(Default)]
+struct GhosttyKittyGraphicsPlacementRenderInfo {
+    size: usize,
+    pixel_width: u32,
+    pixel_height: u32,
+    grid_cols: u32,
+    grid_rows: u32,
+    viewport_col: i32,
+    viewport_row: i32,
+    viewport_visible: bool,
+    source_x: u32,
+    source_y: u32,
+    source_width: u32,
+    source_height: u32,
+}
+
 type GhosttySysDecodePngFn = unsafe extern "C" fn(
     userdata: *mut c_void,
     allocator: *const GhosttyAllocator,
@@ -446,6 +513,7 @@ const _: [(); 32] = [(); std::mem::size_of::<GhosttyClipboardContent>()];
 const _: [(); 56] = [(); std::mem::size_of::<GhosttyClipboardReadReply>()];
 const _: [(); 80] = [(); std::mem::size_of::<GhosttyClipboardRead>()];
 const _: [(); 24] = [(); std::mem::size_of::<GhosttySysImage>()];
+const _: [(); 56] = [(); std::mem::size_of::<GhosttyKittyGraphicsPlacementRenderInfo>()];
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -657,6 +725,53 @@ unsafe extern "C" {
     pub fn ghostty_key_event_set_composing(event: GhosttyKeyEvent, composing: bool);
     pub fn ghostty_key_event_set_utf8(event: GhosttyKeyEvent, utf8: *const c_char, len: usize);
     pub fn ghostty_key_event_set_unshifted_codepoint(event: GhosttyKeyEvent, codepoint: u32);
+
+    // Kitty graphics storage (`kitty_graphics.h`). Handles are borrowed from
+    // the terminal and remain valid only while its mutex is held.
+    fn ghostty_kitty_graphics_get(
+        graphics: GhosttyKittyGraphics,
+        data: GhosttyKittyGraphicsData,
+        out: *mut c_void,
+    ) -> GhosttyResult;
+    fn ghostty_kitty_graphics_image(
+        graphics: GhosttyKittyGraphics,
+        image_id: u32,
+    ) -> GhosttyKittyGraphicsImage;
+    fn ghostty_kitty_graphics_image_get(
+        image: GhosttyKittyGraphicsImage,
+        data: GhosttyKittyGraphicsImageData,
+        out: *mut c_void,
+    ) -> GhosttyResult;
+    fn ghostty_kitty_graphics_image_get_multi(
+        image: GhosttyKittyGraphicsImage,
+        count: usize,
+        keys: *const GhosttyKittyGraphicsImageData,
+        values: *mut *mut c_void,
+        out_written: *mut usize,
+    ) -> GhosttyResult;
+    fn ghostty_kitty_graphics_placement_iterator_new(
+        allocator: *const GhosttyAllocator,
+        out_iterator: *mut GhosttyKittyGraphicsPlacementIterator,
+    ) -> GhosttyResult;
+    fn ghostty_kitty_graphics_placement_iterator_free(
+        iterator: GhosttyKittyGraphicsPlacementIterator,
+    );
+    fn ghostty_kitty_graphics_placement_next(
+        iterator: GhosttyKittyGraphicsPlacementIterator,
+    ) -> bool;
+    fn ghostty_kitty_graphics_placement_get_multi(
+        iterator: GhosttyKittyGraphicsPlacementIterator,
+        count: usize,
+        keys: *const GhosttyKittyGraphicsPlacementData,
+        values: *mut *mut c_void,
+        out_written: *mut usize,
+    ) -> GhosttyResult;
+    fn ghostty_kitty_graphics_placement_render_info(
+        iterator: GhosttyKittyGraphicsPlacementIterator,
+        image: GhosttyKittyGraphicsImage,
+        terminal: GhosttyTerminal,
+        out_info: *mut GhosttyKittyGraphicsPlacementRenderInfo,
+    ) -> GhosttyResult;
 
     // Render state (`render.h`)
     pub fn ghostty_render_state_new(
@@ -910,11 +1025,40 @@ pub struct Cursor {
     pub visible: bool,
 }
 
+#[derive(Debug)]
+pub struct KittyImage {
+    pub id: u32,
+    pub generation: u64,
+    pub width: u32,
+    pub height: u32,
+    /// Straight-alpha RGBA8 pixels, normalized once when the upstream image
+    /// generation changes and shared by every placement and renderer frame.
+    pub rgba: Arc<[u8]>,
+}
+
+#[derive(Debug, Clone)]
+pub struct KittyPlacement {
+    pub image: Arc<KittyImage>,
+    pub placement_id: u32,
+    pub z: i32,
+    pub viewport_col: i32,
+    pub viewport_row: i32,
+    pub cell_x_offset: u32,
+    pub cell_y_offset: u32,
+    pub pixel_width: u32,
+    pub pixel_height: u32,
+    pub source_x: u32,
+    pub source_y: u32,
+    pub source_width: u32,
+    pub source_height: u32,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct ScreenSnapshot {
     pub cols: u16,
     pub rows: u16,
     pub cells: Vec<Cell>,
+    pub kitty_placements: Arc<[KittyPlacement]>,
     pub dirty_rows: Vec<u16>,
     pub cursor: Cursor,
     pub alternate_screen: bool,
@@ -1006,6 +1150,10 @@ struct VtInner {
     row_cells: GhosttyRowCells,
     key_encoder: GhosttyKeyEncoder,
     key_event: GhosttyKeyEvent,
+    kitty_placement_iter: GhosttyKittyGraphicsPlacementIterator,
+    kitty_image_cache: HashMap<u32, Arc<KittyImage>>,
+    kitty_placements: Arc<[KittyPlacement]>,
+    kitty_snapshot_generation: u64,
     callback_state: Option<Box<VtCallbackState>>,
     cols: u16,
     rows: u16,
@@ -1432,10 +1580,34 @@ impl VtScreen {
             );
         }
 
+        let mut kitty_placement_iter: GhosttyKittyGraphicsPlacementIterator = std::ptr::null_mut();
+        let rc = unsafe {
+            ghostty_kitty_graphics_placement_iterator_new(
+                std::ptr::null(),
+                &mut kitty_placement_iter,
+            )
+        };
+        if rc != GHOSTTY_SUCCESS || kitty_placement_iter.is_null() {
+            unsafe {
+                if !row_cells.is_null() {
+                    ghostty_render_state_row_cells_free(row_cells);
+                }
+                if !row_iter.is_null() {
+                    ghostty_render_state_row_iterator_free(row_iter);
+                }
+                if !render_state.is_null() {
+                    ghostty_render_state_free(render_state);
+                }
+                ghostty_terminal_free(terminal);
+            }
+            anyhow::bail!("ghostty_kitty_graphics_placement_iterator_new failed: rc={rc}");
+        }
+
         let mut key_encoder: GhosttyKeyEncoder = std::ptr::null_mut();
         let rc = unsafe { ghostty_key_encoder_new(std::ptr::null(), &mut key_encoder) };
         if rc != GHOSTTY_SUCCESS || key_encoder.is_null() {
             unsafe {
+                ghostty_kitty_graphics_placement_iterator_free(kitty_placement_iter);
                 if !row_cells.is_null() {
                     ghostty_render_state_row_cells_free(row_cells);
                 }
@@ -1455,6 +1627,7 @@ impl VtScreen {
         if rc != GHOSTTY_SUCCESS || key_event.is_null() {
             unsafe {
                 ghostty_key_encoder_free(key_encoder);
+                ghostty_kitty_graphics_placement_iterator_free(kitty_placement_iter);
                 if !row_cells.is_null() {
                     ghostty_render_state_row_cells_free(row_cells);
                 }
@@ -1481,6 +1654,10 @@ impl VtScreen {
                 row_cells,
                 key_encoder,
                 key_event,
+                kitty_placement_iter,
+                kitty_image_cache: HashMap::new(),
+                kitty_placements: Arc::from([]),
+                kitty_snapshot_generation: u64::MAX,
                 callback_state,
                 cols,
                 rows,
@@ -1760,6 +1937,7 @@ impl VtScreen {
                 cols: fallback_cols,
                 rows: fallback_rows,
                 cells: Vec::new(),
+                kitty_placements: Arc::from([]),
                 dirty_rows: Vec::new(),
                 cursor: Cursor::default(),
                 alternate_screen: false,
@@ -2000,6 +2178,7 @@ impl VtScreen {
         }
         dirty_rows.sort_unstable();
 
+        let kitty_placements = snapshot_kitty_placements(&mut inner);
         let clone_started = perf_trace_enabled().then(Instant::now);
         let cells = inner.scratch.clone();
         let clone_elapsed_ms =
@@ -2008,6 +2187,7 @@ impl VtScreen {
             cols,
             rows,
             cells,
+            kitty_placements,
             dirty_rows,
             cursor,
             alternate_screen,
@@ -2464,6 +2644,7 @@ fn empty_snapshot(cols: u16, rows: u16, generation: u64) -> ScreenSnapshot {
         cols,
         rows,
         cells: Vec::new(),
+        kitty_placements: Arc::from([]),
         dirty_rows: Vec::new(),
         cursor: Cursor::default(),
         alternate_screen: false,
@@ -2471,6 +2652,265 @@ fn empty_snapshot(cols: u16, rows: u16, generation: u64) -> ScreenSnapshot {
         title: None,
         generation,
     }
+}
+
+fn snapshot_kitty_placements(inner: &mut VtInner) -> Arc<[KittyPlacement]> {
+    if inner.kitty_snapshot_generation == inner.generation {
+        return inner.kitty_placements.clone();
+    }
+    inner.kitty_snapshot_generation = inner.generation;
+
+    let mut graphics: GhosttyKittyGraphics = std::ptr::null_mut();
+    let rc = unsafe {
+        ghostty_terminal_get(
+            inner.terminal,
+            GhosttyTerminalData::KittyGraphics,
+            &mut graphics as *mut _ as *mut c_void,
+        )
+    };
+    if rc != GHOSTTY_SUCCESS || graphics.is_null() || inner.kitty_placement_iter.is_null() {
+        inner.kitty_image_cache.clear();
+        inner.kitty_placements = Arc::from([]);
+        return inner.kitty_placements.clone();
+    }
+
+    let rc = unsafe {
+        ghostty_kitty_graphics_get(
+            graphics,
+            GhosttyKittyGraphicsData::PlacementIterator,
+            &mut inner.kitty_placement_iter as *mut _ as *mut c_void,
+        )
+    };
+    if rc != GHOSTTY_SUCCESS {
+        inner.kitty_image_cache.clear();
+        inner.kitty_placements = Arc::from([]);
+        return inner.kitty_placements.clone();
+    }
+
+    let mut images: HashMap<u32, Arc<KittyImage>> = HashMap::new();
+    let mut placements = Vec::new();
+    while unsafe { ghostty_kitty_graphics_placement_next(inner.kitty_placement_iter) } {
+        let mut image_id = 0_u32;
+        let mut placement_id = 0_u32;
+        let mut is_virtual = false;
+        let mut cell_x_offset = 0_u32;
+        let mut cell_y_offset = 0_u32;
+        let mut z = 0_i32;
+        let keys = [
+            GhosttyKittyGraphicsPlacementData::ImageId,
+            GhosttyKittyGraphicsPlacementData::PlacementId,
+            GhosttyKittyGraphicsPlacementData::IsVirtual,
+            GhosttyKittyGraphicsPlacementData::XOffset,
+            GhosttyKittyGraphicsPlacementData::YOffset,
+            GhosttyKittyGraphicsPlacementData::Z,
+        ];
+        let mut values = [
+            &mut image_id as *mut _ as *mut c_void,
+            &mut placement_id as *mut _ as *mut c_void,
+            &mut is_virtual as *mut _ as *mut c_void,
+            &mut cell_x_offset as *mut _ as *mut c_void,
+            &mut cell_y_offset as *mut _ as *mut c_void,
+            &mut z as *mut _ as *mut c_void,
+        ];
+        let rc = unsafe {
+            ghostty_kitty_graphics_placement_get_multi(
+                inner.kitty_placement_iter,
+                keys.len(),
+                keys.as_ptr(),
+                values.as_mut_ptr(),
+                std::ptr::null_mut(),
+            )
+        };
+        if rc != GHOSTTY_SUCCESS || is_virtual {
+            continue;
+        }
+
+        let image_handle = unsafe { ghostty_kitty_graphics_image(graphics, image_id) };
+        if image_handle.is_null() {
+            continue;
+        }
+        let mut info = GhosttyKittyGraphicsPlacementRenderInfo {
+            size: std::mem::size_of::<GhosttyKittyGraphicsPlacementRenderInfo>(),
+            ..GhosttyKittyGraphicsPlacementRenderInfo::default()
+        };
+        let rc = unsafe {
+            ghostty_kitty_graphics_placement_render_info(
+                inner.kitty_placement_iter,
+                image_handle,
+                inner.terminal,
+                &mut info,
+            )
+        };
+        if rc != GHOSTTY_SUCCESS
+            || !info.viewport_visible
+            || info.pixel_width == 0
+            || info.pixel_height == 0
+            || info.source_width == 0
+            || info.source_height == 0
+        {
+            continue;
+        }
+
+        let image = if let Some(image) = images.get(&image_id) {
+            image.clone()
+        } else {
+            let Some(image) = snapshot_kitty_image(
+                image_handle,
+                image_id,
+                inner.kitty_image_cache.get(&image_id),
+            ) else {
+                continue;
+            };
+            images.insert(image_id, image.clone());
+            image
+        };
+        placements.push(KittyPlacement {
+            image,
+            placement_id,
+            z,
+            viewport_col: info.viewport_col,
+            viewport_row: info.viewport_row,
+            cell_x_offset,
+            cell_y_offset,
+            pixel_width: info.pixel_width,
+            pixel_height: info.pixel_height,
+            source_x: info.source_x,
+            source_y: info.source_y,
+            source_width: info.source_width,
+            source_height: info.source_height,
+        });
+    }
+
+    // Draw lower z-index placements first. `sort_by_key` is stable, preserving
+    // libghostty's iterator order for equal z values where the C API exposes no
+    // additional ordering key.
+    placements.sort_by_key(|placement| placement.z);
+    inner.kitty_image_cache = images;
+    inner.kitty_placements = placements.into();
+    inner.kitty_placements.clone()
+}
+
+fn snapshot_kitty_image(
+    image: GhosttyKittyGraphicsImage,
+    image_id: u32,
+    cached: Option<&Arc<KittyImage>>,
+) -> Option<Arc<KittyImage>> {
+    let mut generation = 0_u64;
+    let rc = unsafe {
+        ghostty_kitty_graphics_image_get(
+            image,
+            GhosttyKittyGraphicsImageData::Generation,
+            &mut generation as *mut _ as *mut c_void,
+        )
+    };
+    if rc != GHOSTTY_SUCCESS || generation == 0 {
+        return None;
+    }
+    if let Some(cached) = cached.filter(|cached| cached.generation == generation) {
+        return Some(cached.clone());
+    }
+
+    let mut width = 0_u32;
+    let mut height = 0_u32;
+    let mut format_raw = GhosttyKittyImageFormat::Rgba as c_int;
+    let mut compression_raw = GhosttyKittyImageCompression::None as c_int;
+    let mut data_ptr: *const u8 = std::ptr::null();
+    let mut data_len = 0_usize;
+    let keys = [
+        GhosttyKittyGraphicsImageData::Width,
+        GhosttyKittyGraphicsImageData::Height,
+        GhosttyKittyGraphicsImageData::Format,
+        GhosttyKittyGraphicsImageData::Compression,
+        GhosttyKittyGraphicsImageData::DataPtr,
+        GhosttyKittyGraphicsImageData::DataLen,
+    ];
+    let mut values = [
+        &mut width as *mut _ as *mut c_void,
+        &mut height as *mut _ as *mut c_void,
+        &mut format_raw as *mut _ as *mut c_void,
+        &mut compression_raw as *mut _ as *mut c_void,
+        &mut data_ptr as *mut _ as *mut c_void,
+        &mut data_len as *mut _ as *mut c_void,
+    ];
+    let rc = unsafe {
+        ghostty_kitty_graphics_image_get_multi(
+            image,
+            keys.len(),
+            keys.as_ptr(),
+            values.as_mut_ptr(),
+            std::ptr::null_mut(),
+        )
+    };
+    if rc != GHOSTTY_SUCCESS
+        || width == 0
+        || height == 0
+        || data_ptr.is_null()
+        || compression_raw != GhosttyKittyImageCompression::None as c_int
+    {
+        return None;
+    }
+
+    // Read C enums through their integer representation so a future upstream
+    // format cannot create an invalid Rust enum discriminant before the ABI
+    // manifest check reports the drift.
+    let format = match format_raw {
+        value if value == GhosttyKittyImageFormat::Rgb as c_int => GhosttyKittyImageFormat::Rgb,
+        value if value == GhosttyKittyImageFormat::Rgba as c_int => GhosttyKittyImageFormat::Rgba,
+        value if value == GhosttyKittyImageFormat::GrayAlpha as c_int => {
+            GhosttyKittyImageFormat::GrayAlpha
+        }
+        value if value == GhosttyKittyImageFormat::Gray as c_int => GhosttyKittyImageFormat::Gray,
+        _ => return None,
+    };
+
+    let bytes_per_pixel = match format {
+        GhosttyKittyImageFormat::Rgb => 3,
+        GhosttyKittyImageFormat::Rgba => 4,
+        GhosttyKittyImageFormat::GrayAlpha => 2,
+        GhosttyKittyImageFormat::Gray => 1,
+        GhosttyKittyImageFormat::Png => return None,
+    };
+    let expected_len = usize::try_from(width)
+        .ok()?
+        .checked_mul(usize::try_from(height).ok()?)?
+        .checked_mul(bytes_per_pixel)?;
+    if data_len != expected_len || data_len > KITTY_IMAGE_STORAGE_LIMIT_BYTES as usize {
+        return None;
+    }
+    let source = unsafe { std::slice::from_raw_parts(data_ptr, data_len) };
+    let rgba: Arc<[u8]> = match format {
+        GhosttyKittyImageFormat::Rgba => Arc::from(source),
+        GhosttyKittyImageFormat::Rgb => {
+            let mut rgba = Vec::with_capacity(source.len() / 3 * 4);
+            for &[red, green, blue] in source.as_chunks::<3>().0 {
+                rgba.extend_from_slice(&[red, green, blue, 0xFF]);
+            }
+            rgba.into()
+        }
+        GhosttyKittyImageFormat::GrayAlpha => {
+            let mut rgba = Vec::with_capacity(source.len() / 2 * 4);
+            for &[gray, alpha] in source.as_chunks::<2>().0 {
+                rgba.extend_from_slice(&[gray, gray, gray, alpha]);
+            }
+            rgba.into()
+        }
+        GhosttyKittyImageFormat::Gray => {
+            let mut rgba = Vec::with_capacity(source.len() * 4);
+            for gray in source {
+                rgba.extend_from_slice(&[*gray, *gray, *gray, 0xFF]);
+            }
+            rgba.into()
+        }
+        GhosttyKittyImageFormat::Png => return None,
+    };
+
+    Some(Arc::new(KittyImage {
+        id: image_id,
+        generation,
+        width,
+        height,
+        rgba,
+    }))
 }
 
 fn read_scrollbar(terminal: GhosttyTerminal) -> Option<GhosttyScrollbar> {
@@ -2646,6 +3086,12 @@ impl Drop for VtScreen {
                 unsafe { ghostty_key_encoder_free(inner.key_encoder) };
                 inner.key_encoder = std::ptr::null_mut();
             }
+            if !inner.kitty_placement_iter.is_null() {
+                unsafe {
+                    ghostty_kitty_graphics_placement_iterator_free(inner.kitty_placement_iter)
+                };
+                inner.kitty_placement_iter = std::ptr::null_mut();
+            }
             if !inner.row_cells.is_null() {
                 unsafe { ghostty_render_state_row_cells_free(inner.row_cells) };
                 inner.row_cells = std::ptr::null_mut();
@@ -2751,6 +3197,11 @@ mod tests {
                 std::mem::size_of::<GhosttySysImage>(),
                 std::mem::align_of::<GhosttySysImage>(),
             ),
+            (
+                "GhosttyKittyGraphicsPlacementRenderInfo",
+                std::mem::size_of::<GhosttyKittyGraphicsPlacementRenderInfo>(),
+                std::mem::align_of::<GhosttyKittyGraphicsPlacementRenderInfo>(),
+            ),
         ] {
             assert_eq!(
                 types[name]["size"].as_u64(),
@@ -2825,6 +3276,79 @@ mod tests {
             types["GhosttySysOption"]["values"]["DECODE_PNG"].as_i64(),
             Some(GhosttySysOption::DecodePng as i64)
         );
+        assert_eq!(
+            types["GhosttyKittyGraphicsData"]["values"]["PLACEMENT_ITERATOR"].as_i64(),
+            Some(GhosttyKittyGraphicsData::PlacementIterator as i64)
+        );
+        for (name, value) in [
+            ("IMAGE_ID", GhosttyKittyGraphicsPlacementData::ImageId),
+            (
+                "PLACEMENT_ID",
+                GhosttyKittyGraphicsPlacementData::PlacementId,
+            ),
+            ("IS_VIRTUAL", GhosttyKittyGraphicsPlacementData::IsVirtual),
+            ("X_OFFSET", GhosttyKittyGraphicsPlacementData::XOffset),
+            ("Y_OFFSET", GhosttyKittyGraphicsPlacementData::YOffset),
+            ("Z", GhosttyKittyGraphicsPlacementData::Z),
+        ] {
+            assert_eq!(
+                types["GhosttyKittyGraphicsPlacementData"]["values"][name].as_i64(),
+                Some(value as i64),
+                "GhosttyKittyGraphicsPlacementData::{name}"
+            );
+        }
+        for (name, value) in [
+            ("WIDTH", GhosttyKittyGraphicsImageData::Width),
+            ("HEIGHT", GhosttyKittyGraphicsImageData::Height),
+            ("FORMAT", GhosttyKittyGraphicsImageData::Format),
+            ("COMPRESSION", GhosttyKittyGraphicsImageData::Compression),
+            ("DATA_PTR", GhosttyKittyGraphicsImageData::DataPtr),
+            ("DATA_LEN", GhosttyKittyGraphicsImageData::DataLen),
+            ("GENERATION", GhosttyKittyGraphicsImageData::Generation),
+        ] {
+            assert_eq!(
+                types["GhosttyKittyGraphicsImageData"]["values"][name].as_i64(),
+                Some(value as i64),
+                "GhosttyKittyGraphicsImageData::{name}"
+            );
+        }
+        for (name, value) in [
+            ("RGB", GhosttyKittyImageFormat::Rgb),
+            ("RGBA", GhosttyKittyImageFormat::Rgba),
+            ("PNG", GhosttyKittyImageFormat::Png),
+            ("GRAY_ALPHA", GhosttyKittyImageFormat::GrayAlpha),
+            ("GRAY", GhosttyKittyImageFormat::Gray),
+        ] {
+            assert_eq!(
+                types["GhosttyKittyImageFormat"]["values"][name].as_i64(),
+                Some(value as i64),
+                "GhosttyKittyImageFormat::{name}"
+            );
+        }
+        for (name, value) in [
+            ("NONE", GhosttyKittyImageCompression::None),
+            ("ZLIB_DEFLATE", GhosttyKittyImageCompression::ZlibDeflate),
+        ] {
+            assert_eq!(
+                types["GhosttyKittyImageCompression"]["values"][name].as_i64(),
+                Some(value as i64),
+                "GhosttyKittyImageCompression::{name}"
+            );
+        }
+        let render_info = &types["GhosttyKittyGraphicsPlacementRenderInfo"]["fields"];
+        for (name, offset) in [
+            ("size", 0),
+            ("pixel_width", 8),
+            ("viewport_visible", 32),
+            ("source_x", 36),
+            ("source_height", 48),
+        ] {
+            assert_eq!(
+                render_info[name]["offset"].as_u64(),
+                Some(offset),
+                "GhosttyKittyGraphicsPlacementRenderInfo::{name} offset"
+            );
+        }
         assert_eq!(
             types["GhosttyKittyKeyFlags"]["size"].as_u64(),
             Some(std::mem::size_of::<u8>() as u64)
@@ -2902,6 +3426,40 @@ mod tests {
         ] {
             assert_eq!(keys[name].as_i64(), Some(key as i64), "GhosttyKey::{key:?}");
         }
+    }
+
+    #[test]
+    fn kitty_graphics_snapshot_decodes_png_and_reuses_unchanged_pixels() {
+        let screen = VtScreen::new_with_write_pty(80, 24, None, Some(Arc::new(|_| Ok(()))))
+            .expect("create vt screen");
+        screen.resize(80, 24, 8, 16).expect("set cell size");
+        screen.feed(
+            b"\x1b_Ga=T,f=100,q=2;\
+              iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAA\
+              DUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg==\
+              \x1b\\",
+        );
+
+        let first = screen.snapshot();
+        assert_eq!(first.kitty_placements.len(), 1);
+        let placement = &first.kitty_placements[0];
+        assert_eq!((placement.image.width, placement.image.height), (1, 1));
+        assert_eq!(placement.image.rgba.as_ref(), &[0xFF, 0, 0, 0xFF]);
+        assert_eq!(
+            (
+                placement.source_x,
+                placement.source_y,
+                placement.source_width,
+                placement.source_height,
+            ),
+            (0, 0, 1, 1)
+        );
+
+        let pixels = placement.image.clone();
+        screen.bump_generation();
+        let second = screen.snapshot();
+        assert_eq!(second.kitty_placements.len(), 1);
+        assert!(Arc::ptr_eq(&pixels, &second.kitty_placements[0].image));
     }
 
     #[test]

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -28,6 +28,7 @@
 
 #![allow(non_camel_case_types, dead_code)]
 
+use std::io::Cursor as IoCursor;
 use std::os::raw::{c_char, c_int, c_void};
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -36,6 +37,7 @@ use std::time::Instant;
 
 use crate::stub::GhosttyScrollbar;
 
+use image::{ImageFormat, ImageReader, Limits};
 use parking_lot::Mutex;
 
 fn perf_trace_enabled() -> bool {
@@ -68,6 +70,15 @@ const GHOSTTY_OUT_OF_SPACE: GhosttyResult = -3;
 const GHOSTTY_IO_ERROR: GhosttyResult = -5;
 const GHOSTTY_REJECTED: GhosttyResult = -7;
 
+// Match libghostty's conservative embedded-library default. Keeping this
+// explicit makes the PNG decoder's output cap and the terminal's retained
+// image cap one contract instead of allowing a compressed payload to allocate
+// far more memory than the terminal can retain.
+const KITTY_IMAGE_STORAGE_LIMIT_BYTES: u64 = 10_000_000;
+const KITTY_PNG_MAX_INPUT_BYTES: usize = 16 * 1024 * 1024;
+const KITTY_PNG_MAX_DIMENSION: u32 = 10_000;
+const KITTY_PNG_DECODER_MAX_ALLOC_BYTES: u64 = 32 * 1024 * 1024;
+
 const GHOSTTY_MODS_SHIFT: u16 = 1 << 0;
 const GHOSTTY_MODS_CTRL: u16 = 1 << 1;
 const GHOSTTY_MODS_ALT: u16 = 1 << 2;
@@ -96,6 +107,8 @@ pub enum GhosttyTerminalData {
     Scrollbar = 9,
     Title = 12,
     Pwd = 13,
+    KittyImageStorageLimit = 26,
+    KittyGraphics = 30,
     ScrollbackMaxLines = 35,
     Mode = 37,
 }
@@ -164,8 +177,16 @@ pub enum GhosttyTerminalOption {
     ColorCursor = 13,
     /// `GhosttyColorRgb[256]*` — full 256-entry palette.
     ColorPalette = 14,
+    KittyImageStorageLimit = 15,
     ScrollbackMaxLines = 28,
     ClipboardRead = 38,
+}
+
+/// `GHOSTTY_SYS_OPT_*` keys for process-global optional services.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+enum GhosttySysOption {
+    DecodePng = 1,
 }
 
 /// `GHOSTTY_RENDER_STATE_DATA_*` keys for `ghostty_render_state_get`.
@@ -399,12 +420,32 @@ pub struct GhosttyClipboardRead {
         Option<unsafe extern "C" fn(*const GhosttyClipboardRead, *const GhosttyClipboardReadReply)>,
 }
 
+/// RGBA buffer returned by `GhosttySysDecodePngFn`. The pixel allocation is
+/// transferred to libghostty and must come from the allocator supplied to the
+/// callback, which is not necessarily Rust's global allocator on Windows.
+#[repr(C)]
+struct GhosttySysImage {
+    width: u32,
+    height: u32,
+    data: *mut u8,
+    data_len: usize,
+}
+
+type GhosttySysDecodePngFn = unsafe extern "C" fn(
+    userdata: *mut c_void,
+    allocator: *const GhosttyAllocator,
+    data: *const u8,
+    data_len: usize,
+    out: *mut GhosttySysImage,
+) -> bool;
+
 const _: [(); 16] = [(); std::mem::size_of::<GhosttyWriter>()];
 const _: [(); 16] = [(); std::mem::size_of::<GhosttyMimeReader>()];
 const _: [(); 56] = [(); std::mem::size_of::<GhosttyPaste>()];
 const _: [(); 32] = [(); std::mem::size_of::<GhosttyClipboardContent>()];
 const _: [(); 56] = [(); std::mem::size_of::<GhosttyClipboardReadReply>()];
 const _: [(); 80] = [(); std::mem::size_of::<GhosttyClipboardRead>()];
+const _: [(); 24] = [(); std::mem::size_of::<GhosttySysImage>()];
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -538,6 +579,10 @@ unsafe extern "C" {
     // ABI manifest (`types.h`).
     pub fn ghostty_type_json() -> *const c_char;
 
+    // Allocator + process-global optional services (`allocator.h`, `sys.h`).
+    fn ghostty_alloc(allocator: *const GhosttyAllocator, len: usize) -> *mut u8;
+    fn ghostty_sys_set(option: GhosttySysOption, value: *const c_void) -> GhosttyResult;
+
     // Terminal (`terminal.h`)
     pub fn ghostty_terminal_new(
         allocator: *const GhosttyAllocator,
@@ -662,6 +707,95 @@ unsafe extern "C" {
         key: GhosttyCellData,
         out: *mut c_void,
     ) -> GhosttyResult;
+}
+
+fn decode_png_rgba(data: &[u8]) -> anyhow::Result<(u32, u32, Vec<u8>)> {
+    if data.is_empty() || data.len() > KITTY_PNG_MAX_INPUT_BYTES {
+        anyhow::bail!("PNG input exceeds the Kitty image limit");
+    }
+
+    let mut reader = ImageReader::with_format(IoCursor::new(data), ImageFormat::Png);
+    let mut limits = Limits::default();
+    limits.max_image_width = Some(KITTY_PNG_MAX_DIMENSION);
+    limits.max_image_height = Some(KITTY_PNG_MAX_DIMENSION);
+    limits.max_alloc = Some(KITTY_PNG_DECODER_MAX_ALLOC_BYTES);
+    reader.limits(limits);
+    let decoded = reader.decode()?;
+    let width = decoded.width();
+    let height = decoded.height();
+    let rgba_len = usize::try_from(width)
+        .ok()
+        .and_then(|width| {
+            usize::try_from(height)
+                .ok()
+                .and_then(|height| width.checked_mul(height))
+        })
+        .and_then(|pixels| pixels.checked_mul(4))
+        .ok_or_else(|| anyhow::anyhow!("PNG dimensions overflow the host address space"))?;
+    if rgba_len > KITTY_IMAGE_STORAGE_LIMIT_BYTES as usize {
+        anyhow::bail!("decoded PNG exceeds the Kitty image storage limit");
+    }
+
+    let rgba = decoded.into_rgba8().into_raw();
+    if rgba.len() != rgba_len {
+        anyhow::bail!("PNG decoder returned an inconsistent pixel buffer");
+    }
+    Ok((width, height, rgba))
+}
+
+unsafe extern "C" fn decode_png_callback(
+    _userdata: *mut c_void,
+    allocator: *const GhosttyAllocator,
+    data: *const u8,
+    data_len: usize,
+    out: *mut GhosttySysImage,
+) -> bool {
+    if data.is_null() || out.is_null() {
+        return false;
+    }
+
+    // No Rust panic may cross the C ABI boundary. Malformed or over-limit
+    // terminal input is a normal protocol rejection, so all failures collapse
+    // to false and libghostty emits the protocol-level error response.
+    let decoded = std::panic::catch_unwind(|| {
+        let bytes = unsafe { std::slice::from_raw_parts(data, data_len) };
+        decode_png_rgba(bytes)
+    });
+    let Ok(Ok((width, height, rgba))) = decoded else {
+        return false;
+    };
+
+    let allocation = unsafe { ghostty_alloc(allocator, rgba.len()) };
+    if allocation.is_null() {
+        return false;
+    }
+    unsafe { std::ptr::copy_nonoverlapping(rgba.as_ptr(), allocation, rgba.len()) };
+    unsafe {
+        out.write(GhosttySysImage {
+            width,
+            height,
+            data: allocation,
+            data_len: rgba.len(),
+        });
+    }
+    true
+}
+
+fn install_ghostty_sys_services() -> anyhow::Result<()> {
+    static RESULT: OnceLock<GhosttyResult> = OnceLock::new();
+    let rc = *RESULT.get_or_init(|| {
+        let decoder: GhosttySysDecodePngFn = decode_png_callback;
+        unsafe {
+            ghostty_sys_set(
+                GhosttySysOption::DecodePng,
+                decoder as *const () as *const c_void,
+            )
+        }
+    });
+    if rc != GHOSTTY_SUCCESS {
+        anyhow::bail!("ghostty_sys_set(DECODE_PNG) failed: rc={rc}");
+    }
+    Ok(())
 }
 
 // ── Theme ──────────────────────────────────────────────────────────────
@@ -1143,6 +1277,8 @@ impl VtScreen {
         theme: Option<&ThemeColors>,
         write_pty: Option<PtyWriteCallback>,
     ) -> anyhow::Result<Self> {
+        install_ghostty_sys_services()?;
+
         let mut terminal: GhosttyTerminal = std::ptr::null_mut();
         // SAFETY: out param; allocator NULL = upstream default.
         let rc = unsafe { ghostty_terminal_new(std::ptr::null(), &mut terminal, cols, rows) };
@@ -1161,6 +1297,18 @@ impl VtScreen {
         if rc != 0 {
             unsafe { ghostty_terminal_free(terminal) };
             anyhow::bail!("ghostty_terminal_set(SCROLLBACK_MAX_LINES) failed: rc={rc}");
+        }
+
+        let rc = unsafe {
+            ghostty_terminal_set(
+                terminal,
+                GhosttyTerminalOption::KittyImageStorageLimit,
+                &KITTY_IMAGE_STORAGE_LIMIT_BYTES as *const _ as *const c_void,
+            )
+        };
+        if rc != 0 {
+            unsafe { ghostty_terminal_free(terminal) };
+            anyhow::bail!("ghostty_terminal_set(KITTY_IMAGE_STORAGE_LIMIT) failed: rc={rc}");
         }
 
         let mut callback_state = write_pty.map(|write_pty| {
@@ -2560,6 +2708,10 @@ mod tests {
             Some(GhosttyTerminalOption::ScrollbackMaxLines as i64)
         );
         assert_eq!(
+            types["GhosttyTerminalOption"]["values"]["KITTY_IMAGE_STORAGE_LIMIT"].as_i64(),
+            Some(GhosttyTerminalOption::KittyImageStorageLimit as i64)
+        );
+        assert_eq!(
             types["GhosttyTerminalOption"]["values"]["CLIPBOARD_READ"].as_i64(),
             Some(GhosttyTerminalOption::ClipboardRead as i64)
         );
@@ -2593,6 +2745,11 @@ mod tests {
                 "GhosttyClipboardRead",
                 std::mem::size_of::<GhosttyClipboardRead>(),
                 std::mem::align_of::<GhosttyClipboardRead>(),
+            ),
+            (
+                "GhosttySysImage",
+                std::mem::size_of::<GhosttySysImage>(),
+                std::mem::align_of::<GhosttySysImage>(),
             ),
         ] {
             assert_eq!(
@@ -2655,6 +2812,18 @@ mod tests {
         assert_eq!(
             types["GhosttyTerminalData"]["values"]["KITTY_KEYBOARD_FLAGS"].as_i64(),
             Some(GhosttyTerminalData::KittyKeyboardFlags as i64)
+        );
+        assert_eq!(
+            types["GhosttyTerminalData"]["values"]["KITTY_IMAGE_STORAGE_LIMIT"].as_i64(),
+            Some(GhosttyTerminalData::KittyImageStorageLimit as i64)
+        );
+        assert_eq!(
+            types["GhosttyTerminalData"]["values"]["KITTY_GRAPHICS"].as_i64(),
+            Some(GhosttyTerminalData::KittyGraphics as i64)
+        );
+        assert_eq!(
+            types["GhosttySysOption"]["values"]["DECODE_PNG"].as_i64(),
+            Some(GhosttySysOption::DecodePng as i64)
         );
         assert_eq!(
             types["GhosttyKittyKeyFlags"]["size"].as_u64(),

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -82,11 +82,16 @@ const KITTY_IMAGE_STORAGE_LIMIT_BYTES: u64 = 10_000_000;
 const KITTY_PNG_MAX_INPUT_BYTES: usize = 16 * 1024 * 1024;
 const KITTY_PNG_MAX_DIMENSION: u32 = 10_000;
 const KITTY_PNG_DECODER_MAX_ALLOC_BYTES: u64 = 32 * 1024 * 1024;
+const TERMINAL_PASTE_LIMIT_BYTES: usize = 16 * 1024 * 1024;
 // A single tiny image can have an effectively unbounded number of explicit
 // placements upstream. Bound each render snapshot so hostile terminal output
 // cannot force either renderer to allocate and lay out millions of quads in
 // one frame. This is intentionally far above a dense visible terminal grid.
 const KITTY_PLACEMENT_SNAPSHOT_LIMIT: usize = 4_096;
+// Rejected and virtual placements do not consume the render budget, but their
+// iterator entries still cost FFI calls. Keep a separate traversal ceiling so
+// invalid entries cannot turn one snapshot into unbounded parser work.
+const KITTY_PLACEMENT_SCAN_LIMIT: usize = KITTY_PLACEMENT_SNAPSHOT_LIMIT * 4;
 
 const GHOSTTY_MODS_SHIFT: u16 = 1 << 0;
 const GHOSTTY_MODS_CTRL: u16 = 1 << 1;
@@ -1139,7 +1144,12 @@ struct VtCallbackState {
     /// Last clipboard text the user explicitly chose to paste. Only a
     /// Kitty one-time paste grant can read this through the terminal
     /// clipboard effect; unsolicited OSC reads are denied.
-    clipboard_text: Option<Box<str>>,
+    clipboard_text: Mutex<Option<Arc<str>>>,
+    /// WRITE_PTY is a void callback in libghostty's C ABI. Capture its first
+    /// host I/O failure so synchronous user operations such as paste can still
+    /// return an error instead of reporting bytes as written when they were
+    /// rejected by the host queue.
+    write_error: Mutex<Option<String>>,
     rows: AtomicU16,
     cols: AtomicU16,
     cell_width: AtomicU32,
@@ -1468,7 +1478,8 @@ impl VtScreen {
             Box::new(VtCallbackState {
                 write_pty,
                 enquiry_response: b"con".to_vec().into_boxed_slice(),
-                clipboard_text: None,
+                clipboard_text: Mutex::new(None),
+                write_error: Mutex::new(None),
                 rows: AtomicU16::new(rows),
                 cols: AtomicU16::new(cols),
                 cell_width: AtomicU32::new(1),
@@ -1828,10 +1839,22 @@ impl VtScreen {
         source: VtPasteSource,
         allow_unsafe: bool,
     ) -> anyhow::Result<VtPasteResult> {
-        let mut inner = self.inner.lock();
-        if inner.callback_state.is_none() {
-            anyhow::bail!("terminal paste requires a WRITE_PTY callback");
+        if text.len() > TERMINAL_PASTE_LIMIT_BYTES {
+            anyhow::bail!(
+                "terminal paste exceeds the {} byte safety limit",
+                TERMINAL_PASTE_LIMIT_BYTES
+            );
         }
+
+        let inner = self.inner.lock();
+        let Some(callback_state) = inner.callback_state.as_ref() else {
+            anyhow::bail!("terminal paste requires a WRITE_PTY callback");
+        };
+        // Every new paste intent invalidates both an older Kitty clipboard
+        // grant and an unrelated callback error. A fresh grant is minted only
+        // after this exact clipboard-origin paste emits a Kitty event.
+        callback_state.clipboard_text.lock().take();
+        callback_state.write_error.lock().take();
 
         let mime = GhosttyString {
             ptr: TEXT_PLAIN_MIME.as_ptr(),
@@ -1858,17 +1881,16 @@ impl VtScreen {
         };
         let mut written = false;
         let rc = unsafe { ghostty_terminal_paste(inner.terminal, &paste, &mut written) };
+        if let Some(err) = callback_state.write_error.lock().take() {
+            anyhow::bail!("terminal paste failed to enqueue PTY bytes: {err}");
+        }
         match rc {
             GHOSTTY_SUCCESS => {
                 if written && !reader.served && source == VtPasteSource::Clipboard {
                     // Ghostty does not call the MIME reader for a Kitty paste
                     // event. Retain the exact user-selected text for the
                     // event's later one-time granted read.
-                    inner
-                        .callback_state
-                        .as_mut()
-                        .expect("callback state checked above")
-                        .clipboard_text = Some(text.into());
+                    *callback_state.clipboard_text.lock() = Some(Arc::from(text));
                 }
                 Ok(if written {
                     VtPasteResult::Written
@@ -2452,12 +2474,16 @@ unsafe extern "C" fn vt_clipboard_read_callback(
     };
     let mut contents_len = 0;
 
+    // Do not hold a Rust mutex across the foreign reply callback: libghostty
+    // may synchronously advance another effect while consuming this payload.
+    // Arc keeps the bytes stable for the callback without copying the paste.
+    let clipboard_text = state.clipboard_text.lock().clone();
     let listing_only = read.list && read.mimes_len == 0;
     if read.location != GhosttyClipboardLocation::Standard {
         result = GhosttyClipboardReadResult::Unsupported;
     } else if !listing_only && !read.granted {
         result = GhosttyClipboardReadResult::Denied;
-    } else if let Some(text) = state.clipboard_text.as_deref() {
+    } else if let Some(text) = clipboard_text.as_deref() {
         if read.list {
             available = GhosttyString {
                 ptr: TEXT_PLAIN_MIME.as_ptr(),
@@ -2507,6 +2533,12 @@ unsafe extern "C" fn vt_clipboard_read_callback(
         remember: false,
     };
     unsafe { reply(read, &reply_value) };
+    if contents_len > 0 {
+        // The reply callback consumes the borrowed content synchronously. Drop
+        // the host copy immediately so the one-time Ghostty password is backed
+        // by one-time data ownership as well.
+        state.clipboard_text.lock().take();
+    }
 }
 
 fn ghostty_string_eq(value: GhosttyString, expected: &[u8]) -> bool {
@@ -2555,7 +2587,12 @@ unsafe extern "C" fn vt_write_pty_callback(
         // The libghostty callback ABI cannot return an I/O error to the
         // parser. Keep terminal-generated replies best-effort, while direct
         // key encoding propagates the same callback error to its caller.
-        log::debug!("vt WRITE_PTY callback failed: {err}");
+        let message = err.to_string();
+        let mut write_error = state.write_error.lock();
+        if write_error.is_none() {
+            *write_error = Some(message.clone());
+        }
+        log::debug!("vt WRITE_PTY callback failed: {message}");
     }
 }
 
@@ -2663,7 +2700,6 @@ fn snapshot_kitty_placements(inner: &mut VtInner) -> Arc<[KittyPlacement]> {
     if inner.kitty_snapshot_generation == inner.generation {
         return inner.kitty_placements.clone();
     }
-    inner.kitty_snapshot_generation = inner.generation;
 
     let mut graphics: GhosttyKittyGraphics = std::ptr::null_mut();
     let rc = unsafe {
@@ -2673,9 +2709,14 @@ fn snapshot_kitty_placements(inner: &mut VtInner) -> Arc<[KittyPlacement]> {
             &mut graphics as *mut _ as *mut c_void,
         )
     };
-    if rc != GHOSTTY_SUCCESS || graphics.is_null() || inner.kitty_placement_iter.is_null() {
+    if rc != GHOSTTY_SUCCESS || inner.kitty_placement_iter.is_null() {
+        log::debug!("could not read Kitty graphics state for the current terminal generation");
+        return inner.kitty_placements.clone();
+    }
+    if graphics.is_null() {
         inner.kitty_image_cache.clear();
         inner.kitty_placements = Arc::from([]);
+        inner.kitty_snapshot_generation = inner.generation;
         return inner.kitty_placements.clone();
     }
 
@@ -2687,22 +2728,19 @@ fn snapshot_kitty_placements(inner: &mut VtInner) -> Arc<[KittyPlacement]> {
         )
     };
     if rc != GHOSTTY_SUCCESS {
-        inner.kitty_image_cache.clear();
-        inner.kitty_placements = Arc::from([]);
+        log::debug!("could not reset the Kitty placement iterator; retaining the prior snapshot");
         return inner.kitty_placements.clone();
     }
 
     let mut images: HashMap<u32, Arc<KittyImage>> = HashMap::new();
     let mut placements = Vec::new();
-    let mut placement_count = 0_usize;
+    let mut scanned = 0_usize;
     while unsafe { ghostty_kitty_graphics_placement_next(inner.kitty_placement_iter) } {
-        if placement_count >= KITTY_PLACEMENT_SNAPSHOT_LIMIT {
-            log::debug!(
-                "truncating Kitty graphics snapshot at {KITTY_PLACEMENT_SNAPSHOT_LIMIT} placements"
-            );
+        if scanned >= KITTY_PLACEMENT_SCAN_LIMIT {
+            log::debug!("stopping Kitty placement scan after {KITTY_PLACEMENT_SCAN_LIMIT} entries");
             break;
         }
-        placement_count += 1;
+        scanned += 1;
 
         let mut image_id = 0_u32;
         let mut placement_id = 0_u32;
@@ -2764,6 +2802,12 @@ fn snapshot_kitty_placements(inner: &mut VtInner) -> Arc<[KittyPlacement]> {
         {
             continue;
         }
+        if placements.len() >= KITTY_PLACEMENT_SNAPSHOT_LIMIT {
+            log::debug!(
+                "truncating Kitty graphics snapshot at {KITTY_PLACEMENT_SNAPSHOT_LIMIT} visible placements"
+            );
+            break;
+        }
 
         let image = if let Some(image) = images.get(&image_id) {
             image.clone()
@@ -2801,6 +2845,7 @@ fn snapshot_kitty_placements(inner: &mut VtInner) -> Arc<[KittyPlacement]> {
     placements.sort_by_key(|placement| placement.z);
     inner.kitty_image_cache = images;
     inner.kitty_placements = placements.into();
+    inner.kitty_snapshot_generation = inner.generation;
     inner.kitty_placements.clone()
 }
 
@@ -3773,6 +3818,18 @@ mod tests {
                 .any(|window| window == b"ZXZlbnQgc2VjcmV0"),
             "one-time paste grant did not expose cached text"
         );
+        assert!(
+            screen
+                .inner
+                .lock()
+                .callback_state
+                .as_ref()
+                .expect("callback state")
+                .clipboard_text
+                .lock()
+                .is_none(),
+            "host retained clipboard text after the granted read"
+        );
 
         output.lock().clear();
         screen.feed(&read);
@@ -3788,6 +3845,26 @@ mod tests {
                 .windows(b"ZXZlbnQgc2VjcmV0".len())
                 .any(|window| window == b"ZXZlbnQgc2VjcmV0")
         );
+    }
+
+    #[test]
+    fn terminal_paste_rejects_payloads_over_the_memory_limit() {
+        let screen = VtScreen::new_with_write_pty(
+            80,
+            24,
+            None,
+            Some(Arc::new(|_| {
+                panic!("oversized paste reached the PTY callback")
+            })),
+        )
+        .expect("create vt screen");
+        let oversized = "x".repeat(TERMINAL_PASTE_LIMIT_BYTES + 1);
+
+        let err = screen
+            .paste_text(&oversized, VtPasteSource::Clipboard, false)
+            .expect_err("oversized paste must be rejected");
+
+        assert!(err.to_string().contains("safety limit"));
     }
 
     #[test]

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -1089,7 +1089,14 @@ pub struct VtScreen {
     inner: Arc<Mutex<VtInner>>,
 }
 
-pub type PtyWriteCallback = Arc<dyn Fn(&[u8]) -> std::io::Result<()> + Send + Sync + 'static>;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PtyWritePriority {
+    UserInput,
+    TerminalControl,
+}
+
+pub type PtyWriteCallback =
+    Arc<dyn Fn(&[u8], PtyWritePriority) -> std::io::Result<()> + Send + Sync + 'static>;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VtKeyAction {
@@ -1177,6 +1184,10 @@ struct VtCallbackState {
     /// are one-time capabilities, but multiple outstanding grants read this
     /// shared current value. Unsolicited OSC reads remain denied.
     clipboard_text: Mutex<Option<Arc<str>>>,
+    /// A terminal-generated reply or release cannot be retried through the C
+    /// callback ABI. If its reserved queue capacity is exhausted, fail the
+    /// session explicitly rather than continuing with desynchronized state.
+    write_failed: Arc<AtomicBool>,
     /// Active only during `ghostty_terminal_paste`. The C callback cannot
     /// return an I/O result, so buffer the complete logical paste and perform
     /// one fallible host enqueue after libghostty returns.
@@ -1511,6 +1522,7 @@ impl VtScreen {
                 write_order: Arc::new(Mutex::new(())),
                 enquiry_response: b"con".to_vec().into_boxed_slice(),
                 clipboard_text: Mutex::new(None),
+                write_failed: Arc::new(AtomicBool::new(false)),
                 pending_paste_write: Mutex::new(None),
                 rows: AtomicU16::new(rows),
                 cols: AtomicU16::new(cols),
@@ -1743,6 +1755,52 @@ impl VtScreen {
         self.inner.lock().generation
     }
 
+    pub fn has_write_failure(&self) -> bool {
+        self.inner
+            .lock()
+            .callback_state
+            .as_ref()
+            .is_some_and(|state| state.write_failed.load(Ordering::Acquire))
+    }
+
+    /// Enqueue raw user input through the same ordering boundary as encoded
+    /// keys and parser replies.
+    pub fn write_input(&self, bytes: &[u8]) -> std::io::Result<()> {
+        self.write_bytes(bytes, PtyWritePriority::UserInput)
+    }
+
+    /// Enqueue a state-balancing host report, such as a key or mouse release,
+    /// using the queue capacity reserved for terminal control traffic.
+    pub fn write_control(&self, bytes: &[u8]) -> std::io::Result<()> {
+        self.write_bytes(bytes, PtyWritePriority::TerminalControl)
+    }
+
+    fn write_bytes(&self, bytes: &[u8], priority: PtyWritePriority) -> std::io::Result<()> {
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        let inner = self.inner.lock();
+        let Some(callback_state) = inner.callback_state.as_ref() else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotConnected,
+                "terminal input requires a WRITE_PTY callback",
+            ));
+        };
+        let write_pty = callback_state.write_pty.clone();
+        let write_failed = callback_state.write_failed.clone();
+        let write_order = callback_state.write_order.clone();
+        let write_guard = write_order.lock();
+        drop(inner);
+        let result = write_pty(bytes, priority);
+        if let Err(err) = &result
+            && priority == PtyWritePriority::TerminalControl
+        {
+            mark_control_write_failed(&write_failed, err);
+        }
+        drop(write_guard);
+        result
+    }
+
     /// Feed bytes from the PTY into the parser. Non-reentrant per
     /// upstream: do not call from inside a registered callback.
     pub fn feed(&self, bytes: &[u8]) {
@@ -1764,6 +1822,7 @@ impl VtScreen {
             anyhow::bail!("terminal key encoding requires a WRITE_PTY callback");
         };
         let write_pty = callback_state.write_pty.clone();
+        let write_failed = callback_state.write_failed.clone();
         let write_order = callback_state.write_order.clone();
 
         let mut kitty_flags = 0_u8;
@@ -1851,8 +1910,17 @@ impl VtScreen {
             // host callbacks enqueue into a non-blocking bounded queue.
             let write_guard = write_order.lock();
             drop(inner);
-            write_pty(bytes)
-                .map_err(|err| anyhow::anyhow!("failed to write encoded key: {err}"))?;
+            let priority = if event.action == VtKeyAction::Release {
+                PtyWritePriority::TerminalControl
+            } else {
+                PtyWritePriority::UserInput
+            };
+            if let Err(err) = write_pty(bytes, priority) {
+                if priority == PtyWritePriority::TerminalControl {
+                    mark_control_write_failed(&write_failed, &err);
+                }
+                return Err(anyhow::anyhow!("failed to write encoded key: {err}"));
+            }
             drop(write_guard);
         }
 
@@ -1933,9 +2001,9 @@ impl VtScreen {
                     // one-time Kitty grant is installed before a program can
                     // react to the event and request its clipboard payload.
                     let _write_guard = callback_state.write_order.lock();
-                    (callback_state.write_pty)(&output).map_err(|err| {
-                        anyhow::anyhow!("terminal paste failed to enqueue PTY bytes: {err}")
-                    })?;
+                    (callback_state.write_pty)(&output, PtyWritePriority::UserInput).map_err(
+                        |err| anyhow::anyhow!("terminal paste failed to enqueue PTY bytes: {err}"),
+                    )?;
                 }
                 if written && !reader.served && source == VtPasteSource::Clipboard {
                     // Ghostty does not call the MIME reader for a Kitty paste
@@ -2631,11 +2699,14 @@ unsafe extern "C" fn vt_write_pty_callback(
     }
 
     let _write_guard = state.write_order.lock();
-    if let Err(err) = (state.write_pty)(bytes) {
-        // Asynchronous terminal replies are best-effort because libghostty's
-        // callback ABI has no error return. Keys and paste invoke the same
-        // host callback directly and propagate their enqueue failures.
-        log::debug!("vt WRITE_PTY callback failed: {err}");
+    if let Err(err) = (state.write_pty)(bytes, PtyWritePriority::TerminalControl) {
+        mark_control_write_failed(&state.write_failed, &err);
+    }
+}
+
+fn mark_control_write_failed(write_failed: &AtomicBool, err: &std::io::Error) {
+    if !write_failed.swap(true, Ordering::AcqRel) {
+        log::error!("terminal control write failed; closing the desynchronized session: {err}");
     }
 }
 
@@ -3218,6 +3289,8 @@ impl Drop for VtScreen {
 mod tests {
     use super::*;
     use std::ffi::CStr;
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
 
     #[test]
     fn libghostty_vt_manifest_matches_handwritten_ffi() {
@@ -3532,7 +3605,7 @@ mod tests {
 
     #[test]
     fn kitty_graphics_snapshot_decodes_png_and_reuses_unchanged_pixels() {
-        let screen = VtScreen::new_with_write_pty(80, 24, None, Some(Arc::new(|_| Ok(()))))
+        let screen = VtScreen::new_with_write_pty(80, 24, None, Some(Arc::new(|_, _| Ok(()))))
             .expect("create vt screen");
         screen.resize(80, 24, 8, 16).expect("set cell size");
         screen.feed(
@@ -3572,7 +3645,7 @@ mod tests {
             80,
             24,
             None,
-            Some(Arc::new(move |bytes| {
+            Some(Arc::new(move |bytes, _| {
                 output_for_callback.lock().extend_from_slice(bytes);
                 Ok(())
             })),
@@ -3667,7 +3740,7 @@ mod tests {
             80,
             24,
             None,
-            Some(Arc::new(move |bytes| {
+            Some(Arc::new(move |bytes, _| {
                 output_for_callback.lock().extend_from_slice(bytes);
                 Ok(())
             })),
@@ -3702,7 +3775,7 @@ mod tests {
             80,
             24,
             None,
-            Some(Arc::new(|_| {
+            Some(Arc::new(|_, _| {
                 Err(std::io::Error::new(
                     std::io::ErrorKind::BrokenPipe,
                     "test PTY is closed",
@@ -3723,6 +3796,85 @@ mod tests {
             .send_key(&event)
             .expect_err("surface write must fail");
         assert!(err.to_string().contains("test PTY is closed"));
+    }
+
+    #[test]
+    fn raw_input_cannot_be_overtaken_by_a_terminal_reply() {
+        let gate = Arc::new((Mutex::new(false), parking_lot::Condvar::new()));
+        let callback_gate = gate.clone();
+        let (entered_tx, entered_rx) = mpsc::channel();
+        let writes = Arc::new(Mutex::new(Vec::new()));
+        let callback_writes = writes.clone();
+        let screen = Arc::new(
+            VtScreen::new_with_write_pty(
+                80,
+                24,
+                None,
+                Some(Arc::new(move |bytes, priority| {
+                    if bytes == b"user" {
+                        entered_tx.send(()).expect("signal raw input callback");
+                        let (open, ready) = &*callback_gate;
+                        let mut open = open.lock();
+                        while !*open {
+                            ready.wait(&mut open);
+                        }
+                    }
+                    callback_writes.lock().push((bytes.to_vec(), priority));
+                    Ok(())
+                })),
+            )
+            .expect("create vt screen"),
+        );
+
+        let input_screen = screen.clone();
+        let input =
+            std::thread::spawn(move || input_screen.write_input(b"user").expect("write raw input"));
+        entered_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("raw input callback must start");
+
+        let reply_screen = screen.clone();
+        let reply = std::thread::spawn(move || reply_screen.feed(b"\x1b[5n"));
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while screen.inner.try_lock().is_some() {
+            assert!(
+                Instant::now() < deadline,
+                "terminal reply did not reach the ordering gate"
+            );
+            std::thread::yield_now();
+        }
+
+        let (open, ready) = &*gate;
+        *open.lock() = true;
+        ready.notify_all();
+        input.join().expect("raw input thread");
+        reply.join().expect("terminal reply thread");
+
+        let writes = writes.lock();
+        assert_eq!(writes[0], (b"user".to_vec(), PtyWritePriority::UserInput));
+        assert_eq!(writes[1].1, PtyWritePriority::TerminalControl);
+        assert!(writes[1].0.starts_with(b"\x1b[0n"));
+    }
+
+    #[test]
+    fn failed_terminal_reply_marks_the_session_desynchronized() {
+        let screen = VtScreen::new_with_write_pty(
+            80,
+            24,
+            None,
+            Some(Arc::new(|_, priority| {
+                assert_eq!(priority, PtyWritePriority::TerminalControl);
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::WouldBlock,
+                    "reserved PTY capacity exhausted",
+                ))
+            })),
+        )
+        .expect("create vt screen");
+
+        screen.feed(b"\x1b[5n");
+
+        assert!(screen.has_write_failure());
     }
 
     #[test]
@@ -3763,7 +3915,7 @@ mod tests {
             80,
             24,
             None,
-            Some(Arc::new(move |bytes| {
+            Some(Arc::new(move |bytes, _| {
                 *callback_calls_for_callback.lock() += 1;
                 output_for_callback.lock().extend_from_slice(bytes);
                 Ok(())
@@ -3838,7 +3990,7 @@ mod tests {
                 80,
                 24,
                 None,
-                Some(Arc::new(move |bytes| {
+                Some(Arc::new(move |bytes, _| {
                     output_for_callback.lock().extend_from_slice(bytes);
                     Ok(())
                 })),
@@ -3919,7 +4071,7 @@ mod tests {
             80,
             24,
             None,
-            Some(Arc::new(|_| {
+            Some(Arc::new(|_, _| {
                 panic!("oversized paste reached the PTY callback")
             })),
         )

--- a/crates/con-ghostty/src/windows/backend.rs
+++ b/crates/con-ghostty/src/windows/backend.rs
@@ -15,6 +15,7 @@ use crate::stub::{
     CommandFinishedSignal, CommandRecord, GhosttyConfigPatch, GhosttyScrollbar,
     GhosttySplitDirection, GhosttySurfaceEvent, MouseButton, SurfaceSize, TerminalColors,
 };
+use crate::vt::{VtKeyEvent, VtKeySend};
 
 fn theme_from_colors(colors: &TerminalColors) -> ThemeColors {
     ThemeColors::from_ansi16(colors.foreground, colors.background, colors.palette)
@@ -225,6 +226,14 @@ impl WindowsGhosttyTerminal {
         if let Some(session) = self.inner.lock().as_ref() {
             session.write_input(text);
         }
+    }
+
+    pub fn send_key(&self, event: &VtKeyEvent<'_>) -> Result<VtKeySend, String> {
+        let guard = self.inner.lock();
+        let Some(session) = guard.as_ref() else {
+            return Ok(VtKeySend::default());
+        };
+        session.send_key(event).map_err(|err| err.to_string())
     }
 
     pub fn send_mouse_button(&self, _pressed: bool, _button: MouseButton, _mods: i32) -> bool {

--- a/crates/con-ghostty/src/windows/backend.rs
+++ b/crates/con-ghostty/src/windows/backend.rs
@@ -15,7 +15,7 @@ use crate::stub::{
     CommandFinishedSignal, CommandRecord, GhosttyConfigPatch, GhosttyScrollbar,
     GhosttySplitDirection, GhosttySurfaceEvent, MouseButton, SurfaceSize, TerminalColors,
 };
-use crate::vt::{VtKeyEvent, VtKeySend};
+use crate::vt::{VtKeyEvent, VtKeyOutcome};
 
 fn theme_from_colors(colors: &TerminalColors) -> ThemeColors {
     ThemeColors::from_ansi16(colors.foreground, colors.background, colors.palette)
@@ -232,10 +232,10 @@ impl WindowsGhosttyTerminal {
         }
     }
 
-    pub fn send_key(&self, event: &VtKeyEvent<'_>) -> Result<VtKeySend, String> {
+    pub fn send_key(&self, event: &VtKeyEvent<'_>) -> Result<VtKeyOutcome, String> {
         let guard = self.inner.lock();
         let Some(session) = guard.as_ref() else {
-            return Ok(VtKeySend::default());
+            return Ok(VtKeyOutcome::default());
         };
         session.send_key(event).map_err(|err| err.to_string())
     }
@@ -244,14 +244,14 @@ impl WindowsGhosttyTerminal {
         &self,
         text: &str,
         source: crate::vt::VtPasteSource,
-        allow_unsafe: bool,
+        confirm_unsafe_paste: bool,
     ) -> Result<crate::vt::VtPasteResult, String> {
         let guard = self.inner.lock();
         let Some(session) = guard.as_ref() else {
             return Ok(crate::vt::VtPasteResult::Empty);
         };
         session
-            .paste_text(text, source, allow_unsafe)
+            .paste_text(text, source, confirm_unsafe_paste)
             .map_err(|err| err.to_string())
     }
 

--- a/crates/con-ghostty/src/windows/backend.rs
+++ b/crates/con-ghostty/src/windows/backend.rs
@@ -216,15 +216,19 @@ impl WindowsGhosttyTerminal {
 
     pub fn write_to_pty(&self, data: &[u8]) {
         if let Some(session) = self.inner.lock().as_ref() {
-            if let Ok(s) = std::str::from_utf8(data) {
-                session.write_input(s);
+            if let Ok(s) = std::str::from_utf8(data)
+                && let Err(err) = session.write_input(s)
+            {
+                log::debug!("windows terminal input write failed: {err:#}");
             }
         }
     }
 
     pub fn send_text(&self, text: &str) {
-        if let Some(session) = self.inner.lock().as_ref() {
-            session.write_input(text);
+        if let Some(session) = self.inner.lock().as_ref()
+            && let Err(err) = session.write_input(text)
+        {
+            log::debug!("windows terminal text write failed: {err:#}");
         }
     }
 

--- a/crates/con-ghostty/src/windows/backend.rs
+++ b/crates/con-ghostty/src/windows/backend.rs
@@ -236,6 +236,21 @@ impl WindowsGhosttyTerminal {
         session.send_key(event).map_err(|err| err.to_string())
     }
 
+    pub fn paste_text(
+        &self,
+        text: &str,
+        source: crate::vt::VtPasteSource,
+        allow_unsafe: bool,
+    ) -> Result<crate::vt::VtPasteResult, String> {
+        let guard = self.inner.lock();
+        let Some(session) = guard.as_ref() else {
+            return Ok(crate::vt::VtPasteResult::Empty);
+        };
+        session
+            .paste_text(text, source, allow_unsafe)
+            .map_err(|err| err.to_string())
+    }
+
     pub fn send_mouse_button(&self, _pressed: bool, _button: MouseButton, _mods: i32) -> bool {
         false
     }

--- a/crates/con-ghostty/src/windows/conpty.rs
+++ b/crates/con-ghostty/src/windows/conpty.rs
@@ -47,6 +47,7 @@ use windows::Win32::System::Threading::{
 use windows::core::PWSTR;
 
 use crate::pty_write::{PtyWriteQueue, PtyWriteWorker};
+use crate::vt::PtyWritePriority;
 
 fn perf_trace_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
@@ -143,8 +144,11 @@ pub(crate) struct ConPtyWriter {
 }
 
 impl ConPtyWriter {
-    pub(crate) fn write_all(&self, bytes: &[u8]) -> io::Result<()> {
-        self.queue.enqueue(bytes)
+    pub(crate) fn write_all(&self, bytes: &[u8], priority: PtyWritePriority) -> io::Result<()> {
+        match priority {
+            PtyWritePriority::UserInput => self.queue.enqueue(bytes),
+            PtyWritePriority::TerminalControl => self.queue.enqueue_control(bytes),
+        }
     }
 }
 
@@ -206,7 +210,7 @@ pub struct ConPty {
     /// skips. See `close_hpcon_slot`.
     pcon: Arc<Mutex<Option<HPCON>>>,
     /// Host end of the pipe the child reads from.
-    input_writer: ConPtyWriter,
+    _input_writer: ConPtyWriter,
     /// Sole owner of the blocking pipe handle. Joined only after the child and
     /// pseudo-console have been terminated so a pending write cannot hang Drop.
     input_worker: PtyWriteWorker,
@@ -427,18 +431,13 @@ impl ConPty {
 
         Ok(Self {
             pcon,
-            input_writer,
+            _input_writer: input_writer,
             input_worker,
             process,
             _thread: thread,
             output_thread: Some(output_thread),
             exit_watcher,
         })
-    }
-
-    pub fn write(&self, bytes: &[u8]) -> io::Result<usize> {
-        self.input_writer.write_all(bytes)?;
-        Ok(bytes.len())
     }
 
     pub fn resize(&self, size: PtySize) -> Result<()> {

--- a/crates/con-ghostty/src/windows/conpty.rs
+++ b/crates/con-ghostty/src/windows/conpty.rs
@@ -101,6 +101,98 @@ impl Drop for OwnedHandle {
     }
 }
 
+struct PendingPseudoConsole(Option<HPCON>);
+
+impl PendingPseudoConsole {
+    fn new(handle: HPCON) -> Self {
+        Self(Some(handle))
+    }
+
+    fn handle(&self) -> HPCON {
+        self.0.expect("pending pseudo-console handle was taken")
+    }
+
+    fn take(&mut self) -> HPCON {
+        self.0
+            .take()
+            .expect("pending pseudo-console handle was already taken")
+    }
+}
+
+impl Drop for PendingPseudoConsole {
+    fn drop(&mut self) {
+        if let Some(handle) = self.0.take() {
+            // SAFETY: this guard exclusively owns the HPCON until a
+            // successfully-created ConPty takes it.
+            unsafe { ClosePseudoConsole(handle) }
+        }
+    }
+}
+
+/// Cloneable write-only view of the host side of ConPTY's input pipe.
+///
+/// libghostty-vt callbacks receive this instead of the full `ConPty` so
+/// terminal replies cannot re-enter `RenderSession` while the VT lock is
+/// held. The shared mutex also keeps user input and terminal-generated
+/// replies from interleaving within a pipe write.
+#[derive(Clone)]
+pub(crate) struct ConPtyWriter {
+    inner: Arc<Mutex<OwnedHandle>>,
+}
+
+impl ConPtyWriter {
+    pub(crate) fn write_all(&self, mut bytes: &[u8]) -> io::Result<()> {
+        let guard = self.inner.lock();
+        while !bytes.is_empty() {
+            let mut written = 0u32;
+            // SAFETY: the mutex guard keeps the pipe handle valid and
+            // exclusively borrowed for the duration of the write.
+            unsafe {
+                WriteFile(guard.as_handle(), Some(bytes), Some(&mut written), None)
+                    .map_err(|e| io::Error::other(e.message()))?;
+            }
+            if written == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "ConPTY input pipe accepted zero bytes",
+                ));
+            }
+            bytes = &bytes[written as usize..];
+        }
+        Ok(())
+    }
+}
+
+/// Pipe endpoints created before the child process starts.
+///
+/// This two-phase construction lets the VT capture a `ConPtyWriter` before
+/// the shell can emit its first query or output byte.
+pub(crate) struct PreparedConPty {
+    input_read: OwnedHandle,
+    input_writer: ConPtyWriter,
+    output_read: OwnedHandle,
+    output_write: OwnedHandle,
+}
+
+impl PreparedConPty {
+    pub(crate) fn writer(&self) -> ConPtyWriter {
+        self.input_writer.clone()
+    }
+
+    pub(crate) fn spawn<F>(
+        self,
+        command_line: &str,
+        cwd: Option<&Path>,
+        size: PtySize,
+        on_output: F,
+    ) -> Result<ConPty>
+    where
+        F: FnMut(&[u8]) + Send + 'static,
+    {
+        ConPty::spawn_prepared(self, command_line, cwd, size, on_output)
+    }
+}
+
 /// A live ConPTY session.
 pub struct ConPty {
     /// Pseudo-console handle, shared with the exit-watcher thread.
@@ -109,7 +201,7 @@ pub struct ConPty {
     /// skips. See `close_hpcon_slot`.
     pcon: Arc<Mutex<Option<HPCON>>>,
     /// Host end of the pipe the child reads from.
-    input_write: Arc<Mutex<OwnedHandle>>,
+    input_writer: ConPtyWriter,
     /// Process handle (kept so callers can `WaitForSingleObject` for exit).
     process: OwnedHandle,
     /// Child thread handle.
@@ -132,6 +224,19 @@ pub struct PtySize {
 }
 
 impl ConPty {
+    pub(crate) fn prepare() -> Result<PreparedConPty> {
+        let (input_read, input_write) = create_pipe().context("input pipe")?;
+        let (output_read, output_write) = create_pipe().context("output pipe")?;
+        Ok(PreparedConPty {
+            input_read,
+            input_writer: ConPtyWriter {
+                inner: Arc::new(Mutex::new(input_write)),
+            },
+            output_read,
+            output_write,
+        })
+    }
+
     /// Spawn a child shell, wire up ConPTY, and start a background reader
     /// that calls `on_output` for each chunk of bytes the shell writes.
     pub fn spawn<F>(
@@ -143,8 +248,25 @@ impl ConPty {
     where
         F: FnMut(&[u8]) + Send + 'static,
     {
-        let (input_read, input_write) = create_pipe().context("input pipe")?;
-        let (output_read, output_write) = create_pipe().context("output pipe")?;
+        Self::prepare()?.spawn(command_line, cwd, size, on_output)
+    }
+
+    fn spawn_prepared<F>(
+        prepared: PreparedConPty,
+        command_line: &str,
+        cwd: Option<&Path>,
+        size: PtySize,
+        on_output: F,
+    ) -> Result<Self>
+    where
+        F: FnMut(&[u8]) + Send + 'static,
+    {
+        let PreparedConPty {
+            input_read,
+            input_writer,
+            output_read,
+            output_write,
+        } = prepared;
 
         let coord = COORD {
             X: size.cols as i16,
@@ -157,6 +279,7 @@ impl ConPty {
             CreatePseudoConsole(coord, input_read.as_handle(), output_write.as_handle(), 0)
         }
         .context("CreatePseudoConsole failed")?;
+        let mut pending_pcon = PendingPseudoConsole::new(hpcon);
 
         // Per Microsoft docs, after CreatePseudoConsole the captured
         // child-side ends should be closed by the host so only the
@@ -164,9 +287,7 @@ impl ConPty {
         drop(input_read);
         drop(output_write);
 
-        let pcon = Arc::new(Mutex::new(Some(hpcon)));
-
-        let (startup_info, attribute_buffer) = build_startup_info(hpcon)?;
+        let (startup_info, attribute_buffer) = build_startup_info(pending_pcon.handle())?;
 
         let mut command_line_w: Vec<u16> = OsString::from(command_line)
             .encode_wide()
@@ -236,7 +357,7 @@ impl ConPty {
         let process = OwnedHandle::from_handle(process_info.hProcess);
         let thread = OwnedHandle::from_handle(process_info.hThread);
 
-        let input_write = Arc::new(Mutex::new(input_write));
+        let pcon = Arc::new(Mutex::new(Some(pending_pcon.take())));
         let output_thread = spawn_output_reader(output_read, on_output);
 
         // Duplicate the process handle so the watcher thread can wait
@@ -294,7 +415,7 @@ impl ConPty {
 
         Ok(Self {
             pcon,
-            input_write,
+            input_writer,
             process,
             _thread: thread,
             output_thread: Some(output_thread),
@@ -303,14 +424,8 @@ impl ConPty {
     }
 
     pub fn write(&self, bytes: &[u8]) -> io::Result<usize> {
-        let guard = self.input_write.lock();
-        let mut written = 0u32;
-        // SAFETY: guard handle is a valid pipe.
-        unsafe {
-            WriteFile(guard.as_handle(), Some(bytes), Some(&mut written), None)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e.message()))?;
-        }
-        Ok(written as usize)
+        self.input_writer.write_all(bytes)?;
+        Ok(bytes.len())
     }
 
     pub fn resize(&self, size: PtySize) -> Result<()> {

--- a/crates/con-ghostty/src/windows/conpty.rs
+++ b/crates/con-ghostty/src/windows/conpty.rs
@@ -46,6 +46,8 @@ use windows::Win32::System::Threading::{
 };
 use windows::core::PWSTR;
 
+use crate::pty_write::{PtyWriteQueue, PtyWriteWorker};
+
 fn perf_trace_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {
@@ -133,34 +135,36 @@ impl Drop for PendingPseudoConsole {
 ///
 /// libghostty-vt callbacks receive this instead of the full `ConPty` so
 /// terminal replies cannot re-enter `RenderSession` while the VT lock is
-/// held. The shared mutex also keeps user input and terminal-generated
-/// replies from interleaving within a pipe write.
+/// held. One bounded writer queue preserves ordering with user input without
+/// allowing a blocked child pipe to stall parser output or rendering.
 #[derive(Clone)]
 pub(crate) struct ConPtyWriter {
-    inner: Arc<Mutex<OwnedHandle>>,
+    queue: PtyWriteQueue,
 }
 
 impl ConPtyWriter {
-    pub(crate) fn write_all(&self, mut bytes: &[u8]) -> io::Result<()> {
-        let guard = self.inner.lock();
-        while !bytes.is_empty() {
-            let mut written = 0u32;
-            // SAFETY: the mutex guard keeps the pipe handle valid and
-            // exclusively borrowed for the duration of the write.
-            unsafe {
-                WriteFile(guard.as_handle(), Some(bytes), Some(&mut written), None)
-                    .map_err(|e| io::Error::other(e.message()))?;
-            }
-            if written == 0 {
-                return Err(io::Error::new(
-                    io::ErrorKind::WriteZero,
-                    "ConPTY input pipe accepted zero bytes",
-                ));
-            }
-            bytes = &bytes[written as usize..];
-        }
-        Ok(())
+    pub(crate) fn write_all(&self, bytes: &[u8]) -> io::Result<()> {
+        self.queue.enqueue(bytes)
     }
+}
+
+fn write_conpty_input(handle: &OwnedHandle, mut bytes: &[u8]) -> io::Result<()> {
+    while !bytes.is_empty() {
+        let mut written = 0u32;
+        // SAFETY: the dedicated writer thread exclusively owns this handle.
+        unsafe {
+            WriteFile(handle.as_handle(), Some(bytes), Some(&mut written), None)
+                .map_err(|e| io::Error::other(e.message()))?;
+        }
+        if written == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "ConPTY input pipe accepted zero bytes",
+            ));
+        }
+        bytes = &bytes[written as usize..];
+    }
+    Ok(())
 }
 
 /// Pipe endpoints created before the child process starts.
@@ -170,6 +174,7 @@ impl ConPtyWriter {
 pub(crate) struct PreparedConPty {
     input_read: OwnedHandle,
     input_writer: ConPtyWriter,
+    input_worker: PtyWriteWorker,
     output_read: OwnedHandle,
     output_write: OwnedHandle,
 }
@@ -202,6 +207,9 @@ pub struct ConPty {
     pcon: Arc<Mutex<Option<HPCON>>>,
     /// Host end of the pipe the child reads from.
     input_writer: ConPtyWriter,
+    /// Sole owner of the blocking pipe handle. Joined only after the child and
+    /// pseudo-console have been terminated so a pending write cannot hang Drop.
+    input_worker: PtyWriteWorker,
     /// Process handle (kept so callers can `WaitForSingleObject` for exit).
     process: OwnedHandle,
     /// Child thread handle.
@@ -227,11 +235,14 @@ impl ConPty {
     pub(crate) fn prepare() -> Result<PreparedConPty> {
         let (input_read, input_write) = create_pipe().context("input pipe")?;
         let (output_read, output_write) = create_pipe().context("output pipe")?;
+        let (input_queue, input_worker) = PtyWriteQueue::spawn("con-conpty-writer", move |bytes| {
+            write_conpty_input(&input_write, bytes)
+        })
+        .context("spawn ConPTY writer")?;
         Ok(PreparedConPty {
             input_read,
-            input_writer: ConPtyWriter {
-                inner: Arc::new(Mutex::new(input_write)),
-            },
+            input_writer: ConPtyWriter { queue: input_queue },
+            input_worker,
             output_read,
             output_write,
         })
@@ -264,6 +275,7 @@ impl ConPty {
         let PreparedConPty {
             input_read,
             input_writer,
+            input_worker,
             output_read,
             output_write,
         } = prepared;
@@ -416,6 +428,7 @@ impl ConPty {
         Ok(Self {
             pcon,
             input_writer,
+            input_worker,
             process,
             _thread: thread,
             output_thread: Some(output_thread),
@@ -492,6 +505,7 @@ impl Drop for ConPty {
         // Close the pseudo-console (idempotent with the watcher's
         // close via `close_hpcon_slot`).
         close_hpcon_slot(&self.pcon);
+        self.input_worker.shutdown();
 
         if let Some(handle) = self.output_thread.take() {
             let _ = handle.join();

--- a/crates/con-ghostty/src/windows/conpty.rs
+++ b/crates/con-ghostty/src/windows/conpty.rs
@@ -47,7 +47,7 @@ use windows::Win32::System::Threading::{
 use windows::core::PWSTR;
 
 use crate::pty_write::{PtyWriteQueue, PtyWriteWorker};
-use crate::vt::PtyWritePriority;
+use crate::vt::PtyWriteClass;
 
 fn perf_trace_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
@@ -144,10 +144,10 @@ pub(crate) struct ConPtyWriter {
 }
 
 impl ConPtyWriter {
-    pub(crate) fn write_all(&self, bytes: &[u8], priority: PtyWritePriority) -> io::Result<()> {
-        match priority {
-            PtyWritePriority::UserInput => self.queue.enqueue(bytes),
-            PtyWritePriority::TerminalControl => self.queue.enqueue_control(bytes),
+    pub(crate) fn write_all(&self, bytes: &[u8], class: PtyWriteClass) -> io::Result<()> {
+        match class {
+            PtyWriteClass::Regular => self.queue.enqueue(bytes),
+            PtyWriteClass::ReservedControl => self.queue.enqueue_with_reserved_capacity(bytes),
         }
     }
 }

--- a/crates/con-ghostty/src/windows/ghostty_vt_stub.c
+++ b/crates/con-ghostty/src/windows/ghostty_vt_stub.c
@@ -23,6 +23,9 @@ typedef void* GhosttyRowIterator;
 typedef void* GhosttyRowCells;
 typedef void* GhosttyKeyEncoder;
 typedef void* GhosttyKeyEvent;
+typedef void* GhosttyKittyGraphics;
+typedef void* GhosttyKittyGraphicsImage;
+typedef void* GhosttyKittyGraphicsPlacementIterator;
 typedef int   GhosttyResult;
 
 union GhosttyTerminalScrollViewportValue {
@@ -107,6 +110,74 @@ GhosttyResult ghostty_terminal_paste(
     (void)terminal; (void)paste;
     if (out_written) { *out_written = false; }
     return 0;
+}
+
+/* ── Kitty graphics ────────────────────────────────────────────── */
+
+GhosttyResult ghostty_kitty_graphics_get(
+    GhosttyKittyGraphics graphics, int data, void* out
+) {
+    (void)graphics; (void)data; (void)out;
+    return 1;
+}
+
+GhosttyKittyGraphicsImage ghostty_kitty_graphics_image(
+    GhosttyKittyGraphics graphics, uint32_t image_id
+) {
+    (void)graphics; (void)image_id;
+    return NULL;
+}
+
+GhosttyResult ghostty_kitty_graphics_image_get(
+    GhosttyKittyGraphicsImage image, int data, void* out
+) {
+    (void)image; (void)data; (void)out;
+    return 1;
+}
+
+GhosttyResult ghostty_kitty_graphics_image_get_multi(
+    GhosttyKittyGraphicsImage image, size_t count,
+    const int* keys, void** values, size_t* out_written
+) {
+    (void)image; (void)count; (void)keys; (void)values; (void)out_written;
+    return 1;
+}
+
+GhosttyResult ghostty_kitty_graphics_placement_iterator_new(
+    const void* allocator, GhosttyKittyGraphicsPlacementIterator* out_iterator
+) {
+    (void)allocator;
+    if (out_iterator) { *out_iterator = (void*)(uintptr_t)7; }
+    return 0;
+}
+
+void ghostty_kitty_graphics_placement_iterator_free(
+    GhosttyKittyGraphicsPlacementIterator iterator
+) {
+    (void)iterator;
+}
+
+bool ghostty_kitty_graphics_placement_next(
+    GhosttyKittyGraphicsPlacementIterator iterator
+) {
+    (void)iterator;
+    return false;
+}
+
+GhosttyResult ghostty_kitty_graphics_placement_get_multi(
+    GhosttyKittyGraphicsPlacementIterator iterator, size_t count,
+    const int* keys, void** values, size_t* out_written
+) {
+    (void)iterator; (void)count; (void)keys; (void)values; (void)out_written;
+    return 1;
+}
+
+GhosttyResult ghostty_kitty_graphics_placement_render_info(
+    GhosttyKittyGraphicsPlacementIterator iterator,
+    GhosttyKittyGraphicsImage image, GhosttyTerminal terminal, void* out_info
+) {
+    (void)iterator; (void)image; (void)terminal; (void)out_info;
+    return 1;
 }
 
 /* ── Key encoder ────────────────────────────────────────────────── */

--- a/crates/con-ghostty/src/windows/ghostty_vt_stub.c
+++ b/crates/con-ghostty/src/windows/ghostty_vt_stub.c
@@ -40,6 +40,18 @@ struct GhosttyTerminalScrollViewport {
  * than validating against invented metadata. */
 const char* ghostty_type_json(void) { return NULL; }
 
+/* ── Allocator and process-global services ─────────────────────── */
+
+uint8_t* ghostty_alloc(const void* allocator, size_t len) {
+    (void)allocator; (void)len;
+    return NULL;
+}
+
+GhosttyResult ghostty_sys_set(int option, const void* value) {
+    (void)option; (void)value;
+    return 0;
+}
+
 /* ── Terminal lifecycle ─────────────────────────────────────────── */
 
 GhosttyResult ghostty_terminal_new(

--- a/crates/con-ghostty/src/windows/ghostty_vt_stub.c
+++ b/crates/con-ghostty/src/windows/ghostty_vt_stub.c
@@ -21,6 +21,8 @@ typedef void* GhosttyTerminal;
 typedef void* GhosttyRenderState;
 typedef void* GhosttyRowIterator;
 typedef void* GhosttyRowCells;
+typedef void* GhosttyKeyEncoder;
+typedef void* GhosttyKeyEvent;
 typedef int   GhosttyResult;
 
 union GhosttyTerminalScrollViewportValue {
@@ -85,6 +87,68 @@ GhosttyResult ghostty_terminal_get(
 ) {
     (void)terminal; (void)key; (void)out;
     return 1;
+}
+
+/* ── Key encoder ────────────────────────────────────────────────── */
+
+GhosttyResult ghostty_key_encoder_new(
+    const void* allocator, GhosttyKeyEncoder* out_encoder
+) {
+    (void)allocator;
+    if (out_encoder) { *out_encoder = (void*)(uintptr_t)5; }
+    return 0;
+}
+
+void ghostty_key_encoder_free(GhosttyKeyEncoder encoder) { (void)encoder; }
+
+void ghostty_key_encoder_setopt_from_terminal(
+    GhosttyKeyEncoder encoder, GhosttyTerminal terminal
+) {
+    (void)encoder; (void)terminal;
+}
+
+GhosttyResult ghostty_key_encoder_encode(
+    GhosttyKeyEncoder encoder, GhosttyKeyEvent event,
+    char* out_buf, size_t out_buf_size, size_t* out_len
+) {
+    (void)encoder; (void)event; (void)out_buf; (void)out_buf_size;
+    if (out_len) { *out_len = 0; }
+    return 0;
+}
+
+GhosttyResult ghostty_key_event_new(
+    const void* allocator, GhosttyKeyEvent* out_event
+) {
+    (void)allocator;
+    if (out_event) { *out_event = (void*)(uintptr_t)6; }
+    return 0;
+}
+
+void ghostty_key_event_free(GhosttyKeyEvent event) { (void)event; }
+void ghostty_key_event_set_action(GhosttyKeyEvent event, int action) {
+    (void)event; (void)action;
+}
+void ghostty_key_event_set_key(GhosttyKeyEvent event, int key) {
+    (void)event; (void)key;
+}
+void ghostty_key_event_set_mods(GhosttyKeyEvent event, uint16_t mods) {
+    (void)event; (void)mods;
+}
+void ghostty_key_event_set_consumed_mods(GhosttyKeyEvent event, uint16_t mods) {
+    (void)event; (void)mods;
+}
+void ghostty_key_event_set_composing(GhosttyKeyEvent event, bool composing) {
+    (void)event; (void)composing;
+}
+void ghostty_key_event_set_utf8(
+    GhosttyKeyEvent event, const char* utf8, size_t len
+) {
+    (void)event; (void)utf8; (void)len;
+}
+void ghostty_key_event_set_unshifted_codepoint(
+    GhosttyKeyEvent event, uint32_t codepoint
+) {
+    (void)event; (void)codepoint;
 }
 
 /* ── Cell accessor ──────────────────────────────────────────────── */

--- a/crates/con-ghostty/src/windows/ghostty_vt_stub.c
+++ b/crates/con-ghostty/src/windows/ghostty_vt_stub.c
@@ -89,6 +89,14 @@ GhosttyResult ghostty_terminal_get(
     return 1;
 }
 
+GhosttyResult ghostty_terminal_paste(
+    GhosttyTerminal terminal, const void* paste, bool* out_written
+) {
+    (void)terminal; (void)paste;
+    if (out_written) { *out_written = false; }
+    return 0;
+}
+
 /* ── Key encoder ────────────────────────────────────────────────── */
 
 GhosttyResult ghostty_key_encoder_new(

--- a/crates/con-ghostty/src/windows/ghostty_vt_stub.c
+++ b/crates/con-ghostty/src/windows/ghostty_vt_stub.c
@@ -4,7 +4,7 @@
  * cargo build can link without a working Zig/libghostty-vt toolchain.
  *
  * Signatures mirror `include/ghostty/vt/{terminal,render,allocator}.h`
- * at GHOSTTY_REV `8867c37c55b578b9eb4cfaba41cb9023e557176d` — keep in
+ * at GHOSTTY_REV `5f5b988c5236facfe8d2439203d9ee9d5b636cf8` — keep in
  * sync with vt.rs on upstream bumps.
  *
  * All calls return empty / false / zero so downstream code degrades

--- a/crates/con-ghostty/src/windows/ghostty_vt_stub.c
+++ b/crates/con-ghostty/src/windows/ghostty_vt_stub.c
@@ -4,7 +4,7 @@
  * cargo build can link without a working Zig/libghostty-vt toolchain.
  *
  * Signatures mirror `include/ghostty/vt/{terminal,render,allocator}.h`
- * at GHOSTTY_REV `ca7516bea60190ee2e9a4f9182b61d318d107c6e` — keep in
+ * at GHOSTTY_REV `8867c37c55b578b9eb4cfaba41cb9023e557176d` — keep in
  * sync with vt.rs on upstream bumps.
  *
  * All calls return empty / false / zero so downstream code degrades
@@ -23,12 +23,6 @@ typedef void* GhosttyRowIterator;
 typedef void* GhosttyRowCells;
 typedef int   GhosttyResult;
 
-struct GhosttyTerminalOptions {
-    uint16_t cols;
-    uint16_t rows;
-    size_t   max_scrollback;
-};
-
 union GhosttyTerminalScrollViewportValue {
     intptr_t delta;
     uint64_t _padding[2];
@@ -39,14 +33,20 @@ struct GhosttyTerminalScrollViewport {
     union GhosttyTerminalScrollViewportValue value;
 };
 
+/* The stub has no real ABI manifest. Returning NULL keeps ordinary stub
+ * builds linkable while making manifest-aware tests fail explicitly rather
+ * than validating against invented metadata. */
+const char* ghostty_type_json(void) { return NULL; }
+
 /* ── Terminal lifecycle ─────────────────────────────────────────── */
 
 GhosttyResult ghostty_terminal_new(
     const void* allocator,
     GhosttyTerminal* out_terminal,
-    struct GhosttyTerminalOptions options
+    uint16_t cols,
+    uint16_t rows
 ) {
-    (void)allocator; (void)options;
+    (void)allocator; (void)cols; (void)rows;
     if (out_terminal) { *out_terminal = (void*)(uintptr_t)1; }
     return 0;
 }
@@ -73,20 +73,18 @@ void ghostty_terminal_scroll_viewport(
     (void)terminal; (void)behavior;
 }
 
-GhosttyResult ghostty_terminal_get(
-    GhosttyTerminal terminal, int key, void* out
+GhosttyResult ghostty_terminal_set(
+    GhosttyTerminal terminal, int option, const void* value
 ) {
-    (void)terminal; (void)key;
-    if (out) { *(uint8_t*)out = 0; }
+    (void)terminal; (void)option; (void)value;
     return 0;
 }
 
-GhosttyResult ghostty_terminal_mode_get(
-    GhosttyTerminal terminal, uint16_t mode, bool* out_value
+GhosttyResult ghostty_terminal_get(
+    GhosttyTerminal terminal, int key, void* out
 ) {
-    (void)terminal; (void)mode;
-    if (out_value) { *out_value = false; }
-    return 0;
+    (void)terminal; (void)key; (void)out;
+    return 1;
 }
 
 /* ── Cell accessor ──────────────────────────────────────────────── */

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -30,7 +30,7 @@ use crate::transcript::{TranscriptBuffer, snapshot_to_lines};
 use super::conpty::{ConPty, PtySize};
 use super::profile::{perf_trace_enabled, perf_trace_verbose};
 use super::render::{RenderOutcome, Renderer, RendererConfig, Selection, ThemeColors};
-use super::vt::{ScreenSnapshot, VtKeyEvent, VtKeySend, VtPasteResult, VtPasteSource, VtScreen};
+use super::vt::{ScreenSnapshot, VtKeyEvent, VtKeyOutcome, VtPasteResult, VtPasteSource, VtScreen};
 
 use super::render::CellMetrics;
 
@@ -173,23 +173,23 @@ impl RenderSession {
                 cols,
                 rows,
                 renderer_config.theme.as_ref(),
-                Some(Arc::new(move |bytes, priority| {
+                Some(Arc::new(move |bytes, class| {
                     if !accept_vt_replies_in_callback.load(Ordering::Acquire) {
                         return Ok(());
                     }
-                    vt_writer.write_all(bytes, priority)
+                    vt_writer.write_all(bytes, class)
                 })),
             )
             .context("VtScreen::new failed")?,
         );
         let metrics = renderer.metrics();
-        let cell_w = metrics.cell_width_px.max(1);
-        let cell_h = metrics.cell_height_px.max(1);
+        let cell_width_px = metrics.cell_width_px.max(1);
+        let cell_height_px = metrics.cell_height_px.max(1);
         // The renderer already owns an initial render target of the requested
         // size, so initialize only libghostty's pixel geometry here. Waiting
         // for the next size change leaves cell-based Kitty placements at 0px
         // indefinitely when the pane opens at its final dimensions.
-        vt.resize(cols, rows, cell_w, cell_h)
+        vt.resize(cols, rows, cell_width_px, cell_height_px)
             .context("initial VtScreen::resize failed")?;
         let transcript = Arc::new(Mutex::new(TranscriptBuffer::default()));
         if let Some(output) = initial_output
@@ -211,7 +211,8 @@ impl RenderSession {
         let shell = super::conpty::default_shell_command();
         let shell_cwd = resolve_shell_cwd(cwd);
         log::info!(
-            "RenderSession: spawning ConPTY shell={shell} cwd={shell_cwd:?} cell={cell_w}x{cell_h}"
+            "RenderSession: spawning ConPTY shell={shell} cwd={shell_cwd:?} \
+             cell={cell_width_px}x{cell_height_px}"
         );
         let conpty = prepared_conpty
             .spawn(
@@ -312,18 +313,19 @@ impl RenderSession {
         let config = self.config.lock();
         let (cols, rows) = renderer.grid_for_dimensions(&config);
         drop(config);
-        let cell_w = metrics.cell_width_px.max(1);
-        let cell_h = metrics.cell_height_px.max(1);
+        let cell_width_px = metrics.cell_width_px.max(1);
+        let cell_height_px = metrics.cell_height_px.max(1);
         drop(renderer);
 
         self.vt
-            .resize(cols, rows, cell_w, cell_h)
+            .resize(cols, rows, cell_width_px, cell_height_px)
             .context("VtScreen::resize failed")?;
         self.conpty
             .resize(PtySize { cols, rows })
             .context("ConPty::resize failed")?;
         log::debug!(
-            "RenderSession::resize -> {width_px}x{height_px} grid={cols}x{rows} cell={cell_w}x{cell_h}"
+            "RenderSession::resize -> {width_px}x{height_px} grid={cols}x{rows} \
+             cell={cell_width_px}x{cell_height_px}"
         );
         Ok(())
     }
@@ -404,7 +406,7 @@ impl RenderSession {
     }
 
     pub fn is_alive(&self) -> bool {
-        self.conpty.is_alive() && !self.vt.has_write_failure()
+        self.conpty.is_alive() && !self.vt.is_write_desynchronized()
     }
 
     pub fn is_decckm(&self) -> bool {
@@ -445,23 +447,23 @@ impl RenderSession {
             .context("failed to queue ConPTY input")
     }
 
-    pub fn send_key(&self, event: &VtKeyEvent<'_>) -> Result<VtKeySend> {
-        let sent = self.vt.send_key(event)?;
-        if sent.wrote {
+    pub fn send_key(&self, event: &VtKeyEvent<'_>) -> Result<VtKeyOutcome> {
+        let outcome = self.vt.send_key(event)?;
+        if outcome.output_accepted {
             self.scroll_viewport_to_bottom();
             self.request_low_latency_after_next_generation();
         }
-        Ok(sent)
+        Ok(outcome)
     }
 
     pub fn paste_text(
         &self,
         text: &str,
         source: VtPasteSource,
-        allow_unsafe: bool,
+        confirm_unsafe_paste: bool,
     ) -> Result<VtPasteResult> {
-        let result = self.vt.paste_text(text, source, allow_unsafe)?;
-        if result == VtPasteResult::Written {
+        let result = self.vt.paste_text(text, source, confirm_unsafe_paste)?;
+        if result == VtPasteResult::Accepted {
             self.scroll_viewport_to_bottom();
             self.request_low_latency_after_next_generation();
         }
@@ -709,10 +711,10 @@ impl RenderSession {
     }
 
     fn scroll_rows_for_delta(&self, delta_y_px: f32, alternate_screen: bool) -> isize {
-        let cell_h = self.metrics().cell_height_px.max(1) as f32;
+        let cell_height_px = self.metrics().cell_height_px.max(1) as f32;
         self.scroll_remainder
             .lock()
-            .rows_for_delta(delta_y_px, cell_h, alternate_screen)
+            .rows_for_delta(delta_y_px, cell_height_px, alternate_screen)
     }
 
     fn send_scroll_as_cursor_keys(&self, rows: isize) {

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -182,6 +182,15 @@ impl RenderSession {
             )
             .context("VtScreen::new failed")?,
         );
+        let metrics = renderer.metrics();
+        let cell_w = metrics.cell_width_px.max(1);
+        let cell_h = metrics.cell_height_px.max(1);
+        // The renderer already owns an initial render target of the requested
+        // size, so initialize only libghostty's pixel geometry here. Waiting
+        // for the next size change leaves cell-based Kitty placements at 0px
+        // indefinitely when the pane opens at its final dimensions.
+        vt.resize(cols, rows, cell_w, cell_h)
+            .context("initial VtScreen::resize failed")?;
         let transcript = Arc::new(Mutex::new(TranscriptBuffer::default()));
         if let Some(output) = initial_output
             .as_deref()
@@ -201,7 +210,9 @@ impl RenderSession {
         let wake_for_pty: Arc<dyn Fn() + Send + Sync> = Arc::new(wake);
         let shell = super::conpty::default_shell_command();
         let shell_cwd = resolve_shell_cwd(cwd);
-        log::info!("RenderSession: spawning ConPTY shell={shell} cwd={shell_cwd:?}");
+        log::info!(
+            "RenderSession: spawning ConPTY shell={shell} cwd={shell_cwd:?} cell={cell_w}x{cell_h}"
+        );
         let conpty = prepared_conpty
             .spawn(
                 &shell,

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -164,9 +164,25 @@ impl RenderSession {
         let (cols, rows) = renderer.grid_for_dimensions(&renderer_config);
         log::info!("RenderSession: grid {cols}x{rows}");
 
+        let prepared_conpty = ConPty::prepare().context("prepare ConPTY pipes failed")?;
+        let vt_writer = prepared_conpty.writer();
+        let accept_vt_replies = Arc::new(AtomicBool::new(false));
+        let accept_vt_replies_in_callback = accept_vt_replies.clone();
         let vt = Arc::new(
-            VtScreen::new(cols, rows, renderer_config.theme.as_ref())
-                .context("VtScreen::new failed")?,
+            VtScreen::new_with_write_pty(
+                cols,
+                rows,
+                renderer_config.theme.as_ref(),
+                Some(Arc::new(move |bytes| {
+                    if !accept_vt_replies_in_callback.load(Ordering::Acquire) {
+                        return;
+                    }
+                    if let Err(err) = vt_writer.write_all(bytes) {
+                        log::debug!("windows vt write_pty failed: {err}");
+                    }
+                })),
+            )
+            .context("VtScreen::new failed")?,
         );
         let transcript = Arc::new(Mutex::new(TranscriptBuffer::default()));
         if let Some(output) = initial_output
@@ -177,6 +193,10 @@ impl RenderSession {
             let text = String::from_utf8_lossy(output);
             transcript.lock().push(text.as_ref());
         }
+        // Replaying a restored transcript must not inject stale query
+        // responses into the new shell. Enable replies only after replay,
+        // while the child process still cannot have emitted output.
+        accept_vt_replies.store(true, Ordering::Release);
 
         let vt_for_pty = vt.clone();
         let transcript_for_pty = transcript.clone();
@@ -184,18 +204,19 @@ impl RenderSession {
         let shell = super::conpty::default_shell_command();
         let shell_cwd = resolve_shell_cwd(cwd);
         log::info!("RenderSession: spawning ConPTY shell={shell} cwd={shell_cwd:?}");
-        let conpty = ConPty::spawn(
-            &shell,
-            shell_cwd.as_deref(),
-            PtySize { cols, rows },
-            move |bytes| {
-                let text = String::from_utf8_lossy(bytes);
-                transcript_for_pty.lock().push(text.as_ref());
-                vt_for_pty.feed(bytes);
-                wake_for_pty();
-            },
-        )
-        .context("ConPty::spawn failed")?;
+        let conpty = prepared_conpty
+            .spawn(
+                &shell,
+                shell_cwd.as_deref(),
+                PtySize { cols, rows },
+                move |bytes| {
+                    let text = String::from_utf8_lossy(bytes);
+                    transcript_for_pty.lock().push(text.as_ref());
+                    vt_for_pty.feed(bytes);
+                    wake_for_pty();
+                },
+            )
+            .context("ConPty::spawn failed")?;
         let conpty = Arc::new(conpty);
 
         Ok(Self {

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -30,7 +30,7 @@ use crate::transcript::{TranscriptBuffer, snapshot_to_lines};
 use super::conpty::{ConPty, PtySize};
 use super::profile::{perf_trace_enabled, perf_trace_verbose};
 use super::render::{RenderOutcome, Renderer, RendererConfig, Selection, ThemeColors};
-use super::vt::{ScreenSnapshot, VtKeyEvent, VtKeySend, VtScreen};
+use super::vt::{ScreenSnapshot, VtKeyEvent, VtKeySend, VtPasteResult, VtPasteSource, VtScreen};
 
 use super::render::CellMetrics;
 
@@ -396,10 +396,6 @@ impl RenderSession {
         self.conpty.is_alive()
     }
 
-    pub fn is_bracketed_paste(&self) -> bool {
-        self.vt.is_bracketed_paste()
-    }
-
     pub fn is_decckm(&self) -> bool {
         self.vt.is_decckm()
     }
@@ -445,12 +441,18 @@ impl RenderSession {
         Ok(sent)
     }
 
-    /// Raw PTY write — no CR/LF normalization. Used for bracketed-paste
-    /// wrappers (ESC [200~ / ESC [201~) whose bytes mustn't be touched.
-    pub fn write_pty_raw(&self, data: &[u8]) {
-        self.scroll_viewport_to_bottom();
-        self.request_low_latency_after_next_generation();
-        let _ = self.conpty.write(data);
+    pub fn paste_text(
+        &self,
+        text: &str,
+        source: VtPasteSource,
+        allow_unsafe: bool,
+    ) -> Result<VtPasteResult> {
+        let result = self.vt.paste_text(text, source, allow_unsafe)?;
+        if result == VtPasteResult::Written {
+            self.scroll_viewport_to_bottom();
+            self.request_low_latency_after_next_generation();
+        }
+        Ok(result)
     }
 
     pub fn clear_screen_and_scrollback(&self) {

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -173,11 +173,11 @@ impl RenderSession {
                 cols,
                 rows,
                 renderer_config.theme.as_ref(),
-                Some(Arc::new(move |bytes| {
+                Some(Arc::new(move |bytes, priority| {
                     if !accept_vt_replies_in_callback.load(Ordering::Acquire) {
                         return Ok(());
                     }
-                    vt_writer.write_all(bytes)
+                    vt_writer.write_all(bytes, priority)
                 })),
             )
             .context("VtScreen::new failed")?,
@@ -404,7 +404,7 @@ impl RenderSession {
     }
 
     pub fn is_alive(&self) -> bool {
-        self.conpty.is_alive()
+        self.conpty.is_alive() && !self.vt.has_write_failure()
     }
 
     pub fn is_decckm(&self) -> bool {
@@ -432,7 +432,7 @@ impl RenderSession {
 
     /// Send UTF-8 text to the child shell. Handles the ConPTY Enter
     /// quirk (shell expects CR, not LF).
-    pub fn write_input(&self, text: &str) {
+    pub fn write_input(&self, text: &str) -> Result<()> {
         self.scroll_viewport_to_bottom();
         self.request_low_latency_after_next_generation();
         let bytes: std::borrow::Cow<[u8]> = if text.as_bytes().contains(&b'\n') {
@@ -440,7 +440,9 @@ impl RenderSession {
         } else {
             std::borrow::Cow::Borrowed(text.as_bytes())
         };
-        let _ = self.conpty.write(&bytes);
+        self.vt
+            .write_input(&bytes)
+            .context("failed to queue ConPTY input")
     }
 
     pub fn send_key(&self, event: &VtKeyEvent<'_>) -> Result<VtKeySend> {
@@ -584,7 +586,11 @@ impl RenderSession {
         pressed: bool,
     ) -> bool {
         let seq = sgr_button_sequence(base_button, col, row, mods, pressed);
-        self.conpty.write(seq.as_bytes()).is_ok()
+        if pressed {
+            self.vt.write_input(seq.as_bytes()).is_ok()
+        } else {
+            self.vt.write_control(seq.as_bytes()).is_ok()
+        }
     }
 
     /// Cancel any in-flight drag (used on focus loss).
@@ -613,7 +619,9 @@ impl RenderSession {
         let col = col.max(1);
         let row = row.max(1);
         let seq = format!("\x1b[<{button};{col};{row}M");
-        let _ = self.conpty.write(seq.as_bytes());
+        if let Err(err) = self.vt.write_input(seq.as_bytes()) {
+            log::debug!("windows terminal mouse wheel write failed: {err}");
+        }
     }
 
     /// Scroll the terminal viewport when the shell did not request
@@ -713,7 +721,10 @@ impl RenderSession {
         };
         self.request_low_latency_after_next_generation();
         for _ in 0..rows.unsigned_abs() {
-            let _ = self.conpty.write(seq.as_bytes());
+            if let Err(err) = self.vt.write_input(seq.as_bytes()) {
+                log::debug!("windows terminal alternate-scroll write failed: {err}");
+                break;
+            }
         }
     }
 

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -30,7 +30,7 @@ use crate::transcript::{TranscriptBuffer, snapshot_to_lines};
 use super::conpty::{ConPty, PtySize};
 use super::profile::{perf_trace_enabled, perf_trace_verbose};
 use super::render::{RenderOutcome, Renderer, RendererConfig, Selection, ThemeColors};
-use super::vt::{ScreenSnapshot, VtScreen};
+use super::vt::{ScreenSnapshot, VtKeyEvent, VtKeySend, VtScreen};
 
 use super::render::CellMetrics;
 
@@ -175,11 +175,9 @@ impl RenderSession {
                 renderer_config.theme.as_ref(),
                 Some(Arc::new(move |bytes| {
                     if !accept_vt_replies_in_callback.load(Ordering::Acquire) {
-                        return;
+                        return Ok(());
                     }
-                    if let Err(err) = vt_writer.write_all(bytes) {
-                        log::debug!("windows vt write_pty failed: {err}");
-                    }
+                    vt_writer.write_all(bytes)
                 })),
             )
             .context("VtScreen::new failed")?,
@@ -436,6 +434,15 @@ impl RenderSession {
             std::borrow::Cow::Borrowed(text.as_bytes())
         };
         let _ = self.conpty.write(&bytes);
+    }
+
+    pub fn send_key(&self, event: &VtKeyEvent<'_>) -> Result<VtKeySend> {
+        let sent = self.vt.send_key(event)?;
+        if sent.wrote {
+            self.scroll_viewport_to_bottom();
+            self.request_low_latency_after_next_generation();
+        }
+        Ok(sent)
     }
 
     /// Raw PTY write — no CR/LF normalization. Used for bracketed-paste

--- a/crates/con-ghostty/src/windows/render/atlas.rs
+++ b/crates/con-ghostty/src/windows/render/atlas.rs
@@ -1394,7 +1394,7 @@ mod tests {
     use super::{is_cjk_codepoint, is_wide_codepoint};
 
     #[test]
-    fn wide_codepoint_uses_unicode_width_instead_of_local_ranges() {
+    fn wide_codepoint_follows_unicode_width() {
         // These ranges were easy to miss in a hand-written East Asian
         // Width table. Keep the atlas decision delegated to
         // unicode-width so newly covered Unicode ranges do not regress
@@ -1402,7 +1402,6 @@ mod tests {
         for codepoint in [
             0x4E00,  // CJK Unified Ideograph
             0xA960,  // Hangul Jamo Extended-A
-            0xD7B0,  // Hangul Jamo Extended-B
             0x1B000, // Kana Supplement
             0x16FE0, // Tangut / ideographic marks
             0x1B170, // Nushu
@@ -1414,6 +1413,9 @@ mod tests {
         // Ambiguous-width punctuation should stay one cell unless the
         // terminal layer explicitly gains a CJK-ambiguous-width mode.
         assert!(!is_wide_codepoint(0x00B7));
+        // Hangul vowel and trailing jamo combine with a preceding consonant;
+        // unicode-width therefore assigns them zero columns rather than two.
+        assert!(!is_wide_codepoint(0xD7B0));
     }
 
     #[test]

--- a/crates/con-ghostty/src/windows/render/image_pipeline.rs
+++ b/crates/con-ghostty/src/windows/render/image_pipeline.rs
@@ -25,7 +25,7 @@ use super::pipeline::{
 use crate::vt::{KittyImage, KittyPlacement};
 
 const HLSL_SOURCE: &str = include_str!("image_shaders.hlsl");
-const INITIAL_IMAGE_CAPACITY: u32 = 64;
+const INITIAL_INSTANCE_CAPACITY: u32 = 64;
 const BELOW_BACKGROUND_LIMIT: i32 = i32::MIN / 2;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -125,11 +125,11 @@ impl ImagePipeline {
             rasterizer: create_no_cull_rasterizer(device)?,
             instance_buffer: create_dynamic_buffer(
                 device,
-                INITIAL_IMAGE_CAPACITY,
+                INITIAL_INSTANCE_CAPACITY,
                 std::mem::size_of::<ImageInstance>() as u32,
                 D3D11_BIND_VERTEX_BUFFER.0 as u32,
             )?,
-            instance_capacity: INITIAL_IMAGE_CAPACITY,
+            instance_capacity: INITIAL_INSTANCE_CAPACITY,
             globals_buffer: create_dynamic_buffer(
                 device,
                 1,
@@ -138,8 +138,8 @@ impl ImagePipeline {
             )?,
             textures: HashMap::new(),
             failed_uploads: HashSet::new(),
-            instances: Vec::with_capacity(INITIAL_IMAGE_CAPACITY as usize),
-            draws: Vec::with_capacity(INITIAL_IMAGE_CAPACITY as usize),
+            instances: Vec::with_capacity(INITIAL_INSTANCE_CAPACITY as usize),
+            draws: Vec::with_capacity(INITIAL_INSTANCE_CAPACITY as usize),
         })
     }
 
@@ -269,7 +269,7 @@ impl ImagePipeline {
         if needed <= self.instance_capacity {
             return Ok(());
         }
-        let capacity = (needed + needed / 2).max(INITIAL_IMAGE_CAPACITY);
+        let capacity = (needed + needed / 2).max(INITIAL_INSTANCE_CAPACITY);
         self.instance_buffer = create_dynamic_buffer(
             device,
             capacity,
@@ -283,8 +283,8 @@ impl ImagePipeline {
 
 fn image_instance(
     placement: &KittyPlacement,
-    cell_width: u32,
-    cell_height: u32,
+    cell_width_px: u32,
+    cell_height_px: u32,
 ) -> Option<ImageInstance> {
     let image = &placement.image;
     let source_right = placement.source_x.checked_add(placement.source_width)?;
@@ -301,8 +301,10 @@ fn image_instance(
         return None;
     }
 
-    let left = placement.viewport_col as f64 * cell_width as f64 + placement.cell_x_offset as f64;
-    let top = placement.viewport_row as f64 * cell_height as f64 + placement.cell_y_offset as f64;
+    let left =
+        placement.viewport_col as f64 * cell_width_px as f64 + placement.cell_x_offset as f64;
+    let top =
+        placement.viewport_row as f64 * cell_height_px as f64 + placement.cell_y_offset as f64;
     let right = left + placement.pixel_width as f64;
     let bottom = top + placement.pixel_height as f64;
     if ![left, top, right, bottom]
@@ -486,7 +488,7 @@ mod tests {
     use super::{image_instance, premultiplied_rgba};
 
     #[test]
-    fn texture_upload_premultiplies_translucent_rgb() {
+    fn premultiplied_rgba_premultiplies_translucent_rgb() {
         let rgba = [
             10, 20, 30, 255, // opaque prefix remains exact
             200, 100, 50, 128, // rounded half alpha

--- a/crates/con-ghostty/src/windows/render/image_pipeline.rs
+++ b/crates/con-ghostty/src/windows/render/image_pipeline.rs
@@ -1,0 +1,449 @@
+//! D3D11 Kitty image uploads and layered placement draws.
+
+use std::collections::{HashMap, HashSet};
+
+use anyhow::{Context, Result};
+use windows::Win32::Graphics::Direct3D::D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST;
+use windows::Win32::Graphics::Direct3D11::{
+    D3D11_BIND_CONSTANT_BUFFER, D3D11_BIND_SHADER_RESOURCE, D3D11_BIND_VERTEX_BUFFER,
+    D3D11_BUFFER_DESC, D3D11_COMPARISON_NEVER, D3D11_CPU_ACCESS_WRITE,
+    D3D11_FILTER_MIN_MAG_MIP_LINEAR, D3D11_INPUT_ELEMENT_DESC, D3D11_INPUT_PER_INSTANCE_DATA,
+    D3D11_MAP_WRITE_DISCARD, D3D11_MAPPED_SUBRESOURCE, D3D11_SAMPLER_DESC, D3D11_SUBRESOURCE_DATA,
+    D3D11_TEXTURE_ADDRESS_CLAMP, D3D11_TEXTURE2D_DESC, D3D11_USAGE_DYNAMIC, D3D11_USAGE_IMMUTABLE,
+    ID3D11Buffer, ID3D11Device, ID3D11DeviceContext, ID3D11InputLayout, ID3D11PixelShader,
+    ID3D11RasterizerState, ID3D11SamplerState, ID3D11ShaderResourceView, ID3D11VertexShader,
+};
+use windows::Win32::Graphics::Dxgi::Common::{
+    DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_FORMAT_R32G32B32A32_FLOAT, DXGI_SAMPLE_DESC,
+};
+
+use super::pipeline::{
+    blob_slice, compile_shader, create_no_cull_rasterizer, create_pixel_shader,
+    create_premultiplied_alpha_blend, create_vertex_shader,
+};
+use crate::vt::{KittyImage, KittyPlacement};
+
+const HLSL_SOURCE: &str = include_str!("image_shaders.hlsl");
+const INITIAL_IMAGE_CAPACITY: u32 = 64;
+const BELOW_BACKGROUND_LIMIT: i32 = i32::MIN / 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImageLayer {
+    BelowBackground,
+    BelowText,
+    AboveText,
+}
+
+impl ImageLayer {
+    fn contains(self, z: i32) -> bool {
+        match self {
+            Self::BelowBackground => z < BELOW_BACKGROUND_LIMIT,
+            Self::BelowText => (BELOW_BACKGROUND_LIMIT..0).contains(&z),
+            Self::AboveText => z >= 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct ImageKey {
+    id: u32,
+    generation: u64,
+}
+
+impl From<&KittyImage> for ImageKey {
+    fn from(image: &KittyImage) -> Self {
+        Self {
+            id: image.id,
+            generation: image.generation,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct ImageInstance {
+    destination: [f32; 4],
+    source: [f32; 4],
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct ImageGlobals {
+    inv_viewport: [f32; 2],
+    padding: [f32; 2],
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PreparedDraw {
+    key: ImageKey,
+    z: i32,
+}
+
+pub struct ImagePipeline {
+    vs: ID3D11VertexShader,
+    ps: ID3D11PixelShader,
+    input_layout: ID3D11InputLayout,
+    sampler: ID3D11SamplerState,
+    blend: windows::Win32::Graphics::Direct3D11::ID3D11BlendState,
+    rasterizer: ID3D11RasterizerState,
+    instance_buffer: ID3D11Buffer,
+    instance_capacity: u32,
+    globals_buffer: ID3D11Buffer,
+    textures: HashMap<ImageKey, ID3D11ShaderResourceView>,
+    failed_uploads: HashSet<ImageKey>,
+    instances: Vec<ImageInstance>,
+    draws: Vec<PreparedDraw>,
+}
+
+impl ImagePipeline {
+    pub fn new(device: &ID3D11Device) -> Result<Self> {
+        let vs_blob = compile_shader(HLSL_SOURCE, "vs_main", "vs_5_0")?;
+        let ps_blob = compile_shader(HLSL_SOURCE, "ps_main", "ps_5_0")?;
+        let vs = create_vertex_shader(device, &vs_blob)?;
+        let ps = create_pixel_shader(device, &ps_blob)?;
+
+        let destination = c"DESTINATION";
+        let source = c"SOURCE";
+        let layout = [
+            input_element(destination, DXGI_FORMAT_R32G32B32A32_FLOAT, 0),
+            input_element(source, DXGI_FORMAT_R32G32B32A32_FLOAT, 16),
+        ];
+        let mut input_layout = None;
+        unsafe { device.CreateInputLayout(&layout, blob_slice(&vs_blob), Some(&mut input_layout)) }
+            .context("CreateInputLayout(image) failed")?;
+
+        Ok(Self {
+            vs,
+            ps,
+            input_layout: input_layout.context("CreateInputLayout(image) produced no layout")?,
+            sampler: create_linear_sampler(device)?,
+            blend: create_premultiplied_alpha_blend(device)?,
+            rasterizer: create_no_cull_rasterizer(device)?,
+            instance_buffer: create_dynamic_buffer(
+                device,
+                INITIAL_IMAGE_CAPACITY,
+                std::mem::size_of::<ImageInstance>() as u32,
+                D3D11_BIND_VERTEX_BUFFER.0 as u32,
+            )?,
+            instance_capacity: INITIAL_IMAGE_CAPACITY,
+            globals_buffer: create_dynamic_buffer(
+                device,
+                1,
+                std::mem::size_of::<ImageGlobals>() as u32,
+                D3D11_BIND_CONSTANT_BUFFER.0 as u32,
+            )?,
+            textures: HashMap::new(),
+            failed_uploads: HashSet::new(),
+            instances: Vec::with_capacity(INITIAL_IMAGE_CAPACITY as usize),
+            draws: Vec::with_capacity(INITIAL_IMAGE_CAPACITY as usize),
+        })
+    }
+
+    pub fn prepare(
+        &mut self,
+        device: &ID3D11Device,
+        context: &ID3D11DeviceContext,
+        placements: &[KittyPlacement],
+        cell_size: [u32; 2],
+        viewport_size: [u32; 2],
+    ) -> Result<()> {
+        let active: HashSet<ImageKey> = placements
+            .iter()
+            .map(|placement| ImageKey::from(placement.image.as_ref()))
+            .collect();
+        self.textures.retain(|key, _| active.contains(key));
+        self.failed_uploads.retain(|key| active.contains(key));
+        self.instances.clear();
+        self.draws.clear();
+
+        for placement in placements {
+            let key = ImageKey::from(placement.image.as_ref());
+            if !self.textures.contains_key(&key) && !self.failed_uploads.contains(&key) {
+                match upload_texture(device, &placement.image) {
+                    Ok(texture) => {
+                        self.textures.insert(key, texture);
+                    }
+                    Err(error) => {
+                        log::warn!(
+                            "failed to upload Kitty image {} generation {}: {error:#}",
+                            key.id,
+                            key.generation
+                        );
+                        self.failed_uploads.insert(key);
+                    }
+                }
+            }
+            if !self.textures.contains_key(&key) {
+                continue;
+            }
+
+            let Some(instance) = image_instance(placement, cell_size[0], cell_size[1]) else {
+                log::warn!(
+                    "ignoring invalid Kitty image placement image={} placement={}",
+                    key.id,
+                    placement.placement_id
+                );
+                continue;
+            };
+            self.instances.push(instance);
+            self.draws.push(PreparedDraw {
+                key,
+                z: placement.z,
+            });
+        }
+
+        self.ensure_capacity(device, self.instances.len() as u32)?;
+        if !self.instances.is_empty() {
+            upload_slice(context, &self.instance_buffer, &self.instances)?;
+        }
+        let globals = ImageGlobals {
+            inv_viewport: [
+                2.0 / viewport_size[0].max(1) as f32,
+                -2.0 / viewport_size[1].max(1) as f32,
+            ],
+            padding: [0.0; 2],
+        };
+        upload_value(context, &self.globals_buffer, &globals)
+    }
+
+    pub fn draw_layer(&self, context: &ID3D11DeviceContext, layer: ImageLayer) {
+        if self.draws.is_empty() {
+            return;
+        }
+
+        unsafe {
+            context.IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+            context.IASetInputLayout(&self.input_layout);
+            context.RSSetState(&self.rasterizer);
+            let stride = std::mem::size_of::<ImageInstance>() as u32;
+            context.IASetVertexBuffers(
+                0,
+                1,
+                Some(&Some(self.instance_buffer.clone())),
+                Some(&stride),
+                Some(&0),
+            );
+            context.OMSetBlendState(&self.blend, None, u32::MAX);
+            context.VSSetShader(&self.vs, None);
+            context.PSSetShader(&self.ps, None);
+            context.VSSetConstantBuffers(0, Some(&[Some(self.globals_buffer.clone())]));
+            context.PSSetSamplers(0, Some(&[Some(self.sampler.clone())]));
+        }
+
+        let mut index = 0usize;
+        while index < self.draws.len() {
+            let draw = self.draws[index];
+            if !layer.contains(draw.z) {
+                index += 1;
+                continue;
+            }
+            let mut end = index + 1;
+            while end < self.draws.len()
+                && layer.contains(self.draws[end].z)
+                && self.draws[end].key == draw.key
+            {
+                end += 1;
+            }
+
+            let Some(texture) = self.textures.get(&draw.key) else {
+                index = end;
+                continue;
+            };
+            unsafe {
+                context.PSSetShaderResources(0, Some(&[Some(texture.clone())]));
+                context.DrawInstanced(6, (end - index) as u32, 0, index as u32);
+            }
+            index = end;
+        }
+
+        // Do not keep the last image alive through a context binding after its
+        // placement disappears and the cache prunes it on the next frame.
+        unsafe { context.PSSetShaderResources(0, Some(&[None])) };
+    }
+
+    fn ensure_capacity(&mut self, device: &ID3D11Device, needed: u32) -> Result<()> {
+        if needed <= self.instance_capacity {
+            return Ok(());
+        }
+        let capacity = (needed + needed / 2).max(INITIAL_IMAGE_CAPACITY);
+        self.instance_buffer = create_dynamic_buffer(
+            device,
+            capacity,
+            std::mem::size_of::<ImageInstance>() as u32,
+            D3D11_BIND_VERTEX_BUFFER.0 as u32,
+        )?;
+        self.instance_capacity = capacity;
+        Ok(())
+    }
+}
+
+fn image_instance(
+    placement: &KittyPlacement,
+    cell_width: u32,
+    cell_height: u32,
+) -> Option<ImageInstance> {
+    let image = &placement.image;
+    let source_right = placement.source_x.checked_add(placement.source_width)?;
+    let source_bottom = placement.source_y.checked_add(placement.source_height)?;
+    if placement.pixel_width == 0
+        || placement.pixel_height == 0
+        || placement.source_width == 0
+        || placement.source_height == 0
+        || source_right > image.width
+        || source_bottom > image.height
+        || image.width == 0
+        || image.height == 0
+    {
+        return None;
+    }
+
+    let left = placement.viewport_col as f64 * cell_width as f64 + placement.cell_x_offset as f64;
+    let top = placement.viewport_row as f64 * cell_height as f64 + placement.cell_y_offset as f64;
+    let right = left + placement.pixel_width as f64;
+    let bottom = top + placement.pixel_height as f64;
+    if ![left, top, right, bottom]
+        .iter()
+        .all(|value| value.is_finite())
+    {
+        return None;
+    }
+
+    Some(ImageInstance {
+        destination: [left as f32, top as f32, right as f32, bottom as f32],
+        source: [
+            placement.source_x as f32 / image.width as f32,
+            placement.source_y as f32 / image.height as f32,
+            source_right as f32 / image.width as f32,
+            source_bottom as f32 / image.height as f32,
+        ],
+    })
+}
+
+fn upload_texture(device: &ID3D11Device, image: &KittyImage) -> Result<ID3D11ShaderResourceView> {
+    let expected_len = (image.width as usize)
+        .checked_mul(image.height as usize)
+        .and_then(|pixels| pixels.checked_mul(4))
+        .context("Kitty image dimensions overflow")?;
+    if image.width == 0 || image.height == 0 || image.rgba.len() != expected_len {
+        anyhow::bail!(
+            "invalid RGBA dimensions {}x{} for {} bytes",
+            image.width,
+            image.height,
+            image.rgba.len()
+        );
+    }
+    let pitch = image
+        .width
+        .checked_mul(4)
+        .context("Kitty image row pitch overflow")?;
+    let desc = D3D11_TEXTURE2D_DESC {
+        Width: image.width,
+        Height: image.height,
+        MipLevels: 1,
+        ArraySize: 1,
+        Format: DXGI_FORMAT_R8G8B8A8_UNORM,
+        SampleDesc: DXGI_SAMPLE_DESC {
+            Count: 1,
+            Quality: 0,
+        },
+        Usage: D3D11_USAGE_IMMUTABLE,
+        BindFlags: D3D11_BIND_SHADER_RESOURCE.0 as u32,
+        CPUAccessFlags: 0,
+        MiscFlags: 0,
+    };
+    let initial = D3D11_SUBRESOURCE_DATA {
+        pSysMem: image.rgba.as_ptr().cast(),
+        SysMemPitch: pitch,
+        SysMemSlicePitch: 0,
+    };
+    let mut texture = None;
+    unsafe { device.CreateTexture2D(&desc, Some(&initial), Some(&mut texture)) }
+        .context("CreateTexture2D(Kitty image) failed")?;
+    let texture = texture.context("CreateTexture2D(Kitty image) produced no texture")?;
+    let mut view = None;
+    unsafe { device.CreateShaderResourceView(&texture, None, Some(&mut view)) }
+        .context("CreateShaderResourceView(Kitty image) failed")?;
+    view.context("CreateShaderResourceView(Kitty image) produced no view")
+}
+
+fn input_element(
+    name: &std::ffi::CStr,
+    format: windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT,
+    offset: u32,
+) -> D3D11_INPUT_ELEMENT_DESC {
+    D3D11_INPUT_ELEMENT_DESC {
+        SemanticName: windows::core::PCSTR(name.as_ptr().cast()),
+        SemanticIndex: 0,
+        Format: format,
+        InputSlot: 0,
+        AlignedByteOffset: offset,
+        InputSlotClass: D3D11_INPUT_PER_INSTANCE_DATA,
+        InstanceDataStepRate: 1,
+    }
+}
+
+fn create_linear_sampler(device: &ID3D11Device) -> Result<ID3D11SamplerState> {
+    let desc = D3D11_SAMPLER_DESC {
+        Filter: D3D11_FILTER_MIN_MAG_MIP_LINEAR,
+        AddressU: D3D11_TEXTURE_ADDRESS_CLAMP,
+        AddressV: D3D11_TEXTURE_ADDRESS_CLAMP,
+        AddressW: D3D11_TEXTURE_ADDRESS_CLAMP,
+        MipLODBias: 0.0,
+        MaxAnisotropy: 1,
+        ComparisonFunc: D3D11_COMPARISON_NEVER,
+        BorderColor: [0.0; 4],
+        MinLOD: 0.0,
+        MaxLOD: 0.0,
+    };
+    let mut sampler = None;
+    unsafe { device.CreateSamplerState(&desc, Some(&mut sampler)) }
+        .context("CreateSamplerState(image) failed")?;
+    sampler.context("CreateSamplerState(image) produced no sampler")
+}
+
+fn create_dynamic_buffer(
+    device: &ID3D11Device,
+    count: u32,
+    stride: u32,
+    bind_flags: u32,
+) -> Result<ID3D11Buffer> {
+    let byte_width = count
+        .checked_mul(stride)
+        .context("dynamic image buffer size overflow")?;
+    let desc = D3D11_BUFFER_DESC {
+        ByteWidth: (byte_width + 15) & !15,
+        Usage: D3D11_USAGE_DYNAMIC,
+        BindFlags: bind_flags,
+        CPUAccessFlags: D3D11_CPU_ACCESS_WRITE.0 as u32,
+        MiscFlags: 0,
+        StructureByteStride: 0,
+    };
+    let mut buffer = None;
+    unsafe { device.CreateBuffer(&desc, None, Some(&mut buffer)) }
+        .context("CreateBuffer(image dynamic) failed")?;
+    buffer.context("CreateBuffer(image dynamic) produced no buffer")
+}
+
+fn upload_slice<T: Copy>(
+    context: &ID3D11DeviceContext,
+    buffer: &ID3D11Buffer,
+    values: &[T],
+) -> Result<()> {
+    let mut mapped = D3D11_MAPPED_SUBRESOURCE::default();
+    unsafe {
+        context
+            .Map(buffer, 0, D3D11_MAP_WRITE_DISCARD, 0, Some(&mut mapped))
+            .context("Map(image instances) failed")?;
+        std::ptr::copy_nonoverlapping(values.as_ptr(), mapped.pData.cast::<T>(), values.len());
+        context.Unmap(buffer, 0);
+    }
+    Ok(())
+}
+
+fn upload_value<T: Copy>(
+    context: &ID3D11DeviceContext,
+    buffer: &ID3D11Buffer,
+    value: &T,
+) -> Result<()> {
+    upload_slice(context, buffer, std::slice::from_ref(value))
+}

--- a/crates/con-ghostty/src/windows/render/image_pipeline.rs
+++ b/crates/con-ghostty/src/windows/render/image_pipeline.rs
@@ -1,5 +1,6 @@
 //! D3D11 Kitty image uploads and layered placement draws.
 
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context, Result};
@@ -64,6 +65,7 @@ impl From<&KittyImage> for ImageKey {
 struct ImageInstance {
     destination: [f32; 4],
     source: [f32; 4],
+    source_clamp: [f32; 4],
 }
 
 #[repr(C)]
@@ -104,9 +106,11 @@ impl ImagePipeline {
 
         let destination = c"DESTINATION";
         let source = c"SOURCE";
+        let source_clamp = c"SOURCECLAMP";
         let layout = [
             input_element(destination, DXGI_FORMAT_R32G32B32A32_FLOAT, 0),
             input_element(source, DXGI_FORMAT_R32G32B32A32_FLOAT, 16),
+            input_element(source_clamp, DXGI_FORMAT_R32G32B32A32_FLOAT, 32),
         ];
         let mut input_layout = None;
         unsafe { device.CreateInputLayout(&layout, blob_slice(&vs_blob), Some(&mut input_layout)) }
@@ -316,7 +320,28 @@ fn image_instance(
             source_right as f32 / image.width as f32,
             source_bottom as f32 / image.height as f32,
         ],
+        source_clamp: [
+            (placement.source_x as f32 + 0.5) / image.width as f32,
+            (placement.source_y as f32 + 0.5) / image.height as f32,
+            (source_right as f32 - 0.5) / image.width as f32,
+            (source_bottom as f32 - 0.5) / image.height as f32,
+        ],
     })
+}
+
+fn premultiplied_rgba(rgba: &[u8]) -> Cow<'_, [u8]> {
+    let Some(first_translucent) = rgba.chunks_exact(4).position(|pixel| pixel[3] != u8::MAX) else {
+        return Cow::Borrowed(rgba);
+    };
+
+    let mut premultiplied = rgba.to_vec();
+    for pixel in premultiplied[first_translucent * 4..].chunks_exact_mut(4) {
+        let alpha = u16::from(pixel[3]);
+        for channel in &mut pixel[..3] {
+            *channel = ((u16::from(*channel) * alpha + 127) / 255) as u8;
+        }
+    }
+    Cow::Owned(premultiplied)
 }
 
 fn upload_texture(device: &ID3D11Device, image: &KittyImage) -> Result<ID3D11ShaderResourceView> {
@@ -336,6 +361,10 @@ fn upload_texture(device: &ID3D11Device, image: &KittyImage) -> Result<ID3D11Sha
         .width
         .checked_mul(4)
         .context("Kitty image row pitch overflow")?;
+    // Premultiply before the texture reaches LINEAR filtering. Multiplying in
+    // the pixel shader is too late: interpolation has already mixed RGB from
+    // transparent neighbours and produces dark fringes around scaled images.
+    let pixels = premultiplied_rgba(&image.rgba);
     let desc = D3D11_TEXTURE2D_DESC {
         Width: image.width,
         Height: image.height,
@@ -352,7 +381,7 @@ fn upload_texture(device: &ID3D11Device, image: &KittyImage) -> Result<ID3D11Sha
         MiscFlags: 0,
     };
     let initial = D3D11_SUBRESOURCE_DATA {
-        pSysMem: image.rgba.as_ptr().cast(),
+        pSysMem: pixels.as_ptr().cast(),
         SysMemPitch: pitch,
         SysMemSlicePitch: 0,
     };
@@ -446,4 +475,57 @@ fn upload_value<T: Copy>(
     value: &T,
 ) -> Result<()> {
     upload_slice(context, buffer, std::slice::from_ref(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::vt::{KittyImage, KittyPlacement};
+
+    use super::{image_instance, premultiplied_rgba};
+
+    #[test]
+    fn texture_upload_premultiplies_translucent_rgb() {
+        let rgba = [
+            10, 20, 30, 255, // opaque prefix remains exact
+            200, 100, 50, 128, // rounded half alpha
+            255, 128, 64, 0, // hidden RGB is eliminated
+        ];
+
+        assert_eq!(
+            premultiplied_rgba(&rgba).as_ref(),
+            &[10, 20, 30, 255, 100, 50, 25, 128, 0, 0, 0, 0]
+        );
+    }
+
+    #[test]
+    fn cropped_source_uvs_stay_inside_edge_texel_centres() {
+        let placement = KittyPlacement {
+            image: Arc::new(KittyImage {
+                id: 1,
+                generation: 2,
+                width: 4,
+                height: 4,
+                rgba: vec![0; 4 * 4 * 4].into(),
+            }),
+            placement_id: 3,
+            z: 0,
+            viewport_col: 2,
+            viewport_row: 1,
+            cell_x_offset: 3,
+            cell_y_offset: 4,
+            pixel_width: 20,
+            pixel_height: 10,
+            source_x: 1,
+            source_y: 1,
+            source_width: 2,
+            source_height: 1,
+        };
+
+        let instance = image_instance(&placement, 10, 20).expect("valid image placement");
+        assert_eq!(instance.destination, [23.0, 24.0, 43.0, 34.0]);
+        assert_eq!(instance.source, [0.25, 0.25, 0.75, 0.5]);
+        assert_eq!(instance.source_clamp, [0.375, 0.375, 0.625, 0.375]);
+    }
 }

--- a/crates/con-ghostty/src/windows/render/image_shaders.hlsl
+++ b/crates/con-ghostty/src/windows/render/image_shaders.hlsl
@@ -1,6 +1,6 @@
-// Kitty image placement pipeline. Source textures contain straight-alpha
-// RGBA8; the pixel shader premultiplies before source-over blending into the
-// renderer's premultiplied BGRA target.
+// Kitty image placement pipeline. Source textures are uploaded as
+// premultiplied RGBA8 so LINEAR filtering cannot mix hidden RGB from
+// transparent neighbours into visible edge pixels.
 
 cbuffer ImageGlobals : register(b0) {
     float2 invViewport;
@@ -10,11 +10,13 @@ cbuffer ImageGlobals : register(b0) {
 struct ImageInstance {
     float4 destination : DESTINATION; // left, top, right, bottom in pixels
     float4 source      : SOURCE;      // u0, v0, u1, v1
+    float4 sourceClamp : SOURCECLAMP; // first/last source texel centres
 };
 
 struct VSOut {
     float4 pos : SV_Position;
     float2 uv  : TEXCOORD0;
+    nointerpolation float4 sourceClamp : TEXCOORD1;
 };
 
 VSOut vs_main(uint vid : SV_VertexID, ImageInstance inst) {
@@ -34,6 +36,7 @@ VSOut vs_main(uint vid : SV_VertexID, ImageInstance inst) {
         corner.x == 0 ? inst.source.x : inst.source.z,
         corner.y == 0 ? inst.source.y : inst.source.w
     );
+    o.sourceClamp = inst.sourceClamp;
     return o;
 }
 
@@ -41,6 +44,6 @@ Texture2D<float4> image : register(t0);
 SamplerState imageSampler : register(s0);
 
 float4 ps_main(VSOut i) : SV_Target {
-    float4 color = image.Sample(imageSampler, i.uv);
-    return float4(color.rgb * color.a, color.a);
+    float2 uv = clamp(i.uv, i.sourceClamp.xy, i.sourceClamp.zw);
+    return image.Sample(imageSampler, uv);
 }

--- a/crates/con-ghostty/src/windows/render/image_shaders.hlsl
+++ b/crates/con-ghostty/src/windows/render/image_shaders.hlsl
@@ -1,0 +1,46 @@
+// Kitty image placement pipeline. Source textures contain straight-alpha
+// RGBA8; the pixel shader premultiplies before source-over blending into the
+// renderer's premultiplied BGRA target.
+
+cbuffer ImageGlobals : register(b0) {
+    float2 invViewport;
+    float2 _padding;
+};
+
+struct ImageInstance {
+    float4 destination : DESTINATION; // left, top, right, bottom in pixels
+    float4 source      : SOURCE;      // u0, v0, u1, v1
+};
+
+struct VSOut {
+    float4 pos : SV_Position;
+    float2 uv  : TEXCOORD0;
+};
+
+VSOut vs_main(uint vid : SV_VertexID, ImageInstance inst) {
+    const uint2 corners[6] = {
+        uint2(0, 0), uint2(1, 0), uint2(0, 1),
+        uint2(0, 1), uint2(1, 0), uint2(1, 1),
+    };
+    uint2 corner = corners[vid];
+    float2 px = float2(
+        corner.x == 0 ? inst.destination.x : inst.destination.z,
+        corner.y == 0 ? inst.destination.y : inst.destination.w
+    );
+
+    VSOut o;
+    o.pos = float4(px * invViewport + float2(-1.0, 1.0), 0.0, 1.0);
+    o.uv = float2(
+        corner.x == 0 ? inst.source.x : inst.source.z,
+        corner.y == 0 ? inst.source.y : inst.source.w
+    );
+    return o;
+}
+
+Texture2D<float4> image : register(t0);
+SamplerState imageSampler : register(s0);
+
+float4 ps_main(VSOut i) : SV_Target {
+    float4 color = image.Sample(imageSampler, i.uv);
+    return float4(color.rgb * color.a, color.a);
+}

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -19,12 +19,13 @@
 //! into its own DirectComposition tree — no child HWND on top of the
 //! app's modals, no z-order glitches on tab switch.
 //!
-//! One `DrawIndexedInstanced(6, cell_count)` per dirty frame. Grayscale
-//! coverage; bg/fg lerp in the pixel shader. See `shaders.hlsl` for the
-//! shader code and `pipeline.rs` for the D3D11 plumbing.
+//! Dirty frames use layered cell and RGBA image passes so Kitty placements
+//! can render below backgrounds, below text, or above text. See the HLSL
+//! sources and pipeline modules for the D3D11 plumbing.
 
 mod atlas;
 mod font_loader;
+mod image_pipeline;
 mod pipeline;
 
 use std::sync::Mutex;
@@ -51,6 +52,7 @@ use windows::Win32::Graphics::Dxgi::DXGI_ERROR_WAS_STILL_DRAWING;
 use super::profile::{perf_trace_enabled, perf_trace_verbose};
 use super::vt::{ATTR_INVERSE, ATTR_STRIKE, ATTR_UNDERLINE, Cell, ScreenSnapshot};
 use atlas::{GlyphCache, GlyphKey};
+use image_pipeline::{ImageLayer, ImagePipeline};
 use pipeline::{Globals, Instance, Pipeline, instance_for_cell};
 
 pub use super::vt::ThemeColors;
@@ -62,6 +64,8 @@ const ALTERNATE_SCREEN_BACKGROUND_OPACITY_FLOOR: f32 = 1.0;
 /// without reallocation; panes larger than that grow via
 /// `Pipeline::ensure_instance_capacity` in the hot path.
 const INITIAL_INSTANCE_CAPACITY: u32 = 16 * 1024;
+const RENDER_ATTR_DEFAULT_BG: u32 = 1 << 8;
+const RENDER_ATTR_CURSOR: u32 = 1 << 9;
 
 #[derive(Debug, Clone)]
 pub struct RendererConfig {
@@ -113,10 +117,12 @@ pub struct Renderer {
     _dwrite: IDWriteFactory,
 
     pipeline: std::sync::Mutex<Pipeline>,
+    image_pipeline: Mutex<ImagePipeline>,
     atlas: Mutex<GlyphCache>,
 
     instances: Mutex<Vec<Instance>>,
     has_full_frame: Mutex<bool>,
+    kitty_readback: Mutex<KittyReadbackState>,
     /// Generation fingerprint of the last frame we actually rendered.
     /// It includes VT generation, selection state, and snapshot/view
     /// geometry so resize catch-up frames are not mistaken for
@@ -268,6 +274,7 @@ impl Renderer {
         log::info!("Renderer: creating D3D11 pipeline (HLSL compile)");
         let pipeline =
             Pipeline::new(&device, INITIAL_INSTANCE_CAPACITY).context("Pipeline::new failed")?;
+        let image_pipeline = ImagePipeline::new(&device).context("ImagePipeline::new failed")?;
         log::info!("Renderer: pipeline ready");
 
         Ok(Self {
@@ -278,9 +285,11 @@ impl Renderer {
             staging_ring: Mutex::new(staging_ring),
             _dwrite: dwrite,
             pipeline: std::sync::Mutex::new(pipeline),
+            image_pipeline: Mutex::new(image_pipeline),
             atlas: Mutex::new(atlas),
             instances: Mutex::new(Vec::with_capacity(INITIAL_INSTANCE_CAPACITY as usize)),
             has_full_frame: Mutex::new(false),
+            kitty_readback: Mutex::new(KittyReadbackState::default()),
             last_generation: Mutex::new(u64::MAX),
             selection: Mutex::new(None),
             last_presented_at: Mutex::new(None),
@@ -543,9 +552,7 @@ impl Renderer {
                 self.context.ClearRenderTargetView(&self.rtv, &clear);
             }
 
-            if !snapshot.cells.is_empty() {
-                self.draw_cells(snapshot, config)?;
-            }
+            self.draw_terminal(snapshot, config)?;
             draw_ms = draw_started
                 .map(|started| started.elapsed().as_secs_f64() * 1000.0)
                 .unwrap_or(0.0);
@@ -561,8 +568,12 @@ impl Renderer {
                     .lock()
                     .expect("has_full_frame mutex poisoned checking partial readback");
             let readback_regions = self.readback_regions(snapshot, sel_hash, can_partial_readback);
-            submitted =
-                Some(ring.submit_copy_mailbox(&self.context, &self.rt_texture, &readback_regions));
+            submitted = Some(ring.submit_copy_mailbox(
+                &self.context,
+                &self.rt_texture,
+                &readback_regions,
+                !snapshot.kitty_placements.is_empty(),
+            ));
             submit_ms = submit_started
                 .map(|started| started.elapsed().as_secs_f64() * 1000.0)
                 .unwrap_or(0.0);
@@ -772,7 +783,16 @@ impl Renderer {
         sel_hash: u64,
         allow_partial: bool,
     ) -> Vec<ReadbackRegion> {
+        let force_full_for_images = {
+            let has_images = !snapshot.kitty_placements.is_empty();
+            let mut state = self
+                .kitty_readback
+                .lock()
+                .expect("kitty_readback mutex poisoned");
+            state.submitted(has_images)
+        };
         if !allow_partial
+            || force_full_for_images
             || sel_hash != 0
             || snapshot.dirty_rows.is_empty()
             || snapshot.dirty_rows.len() >= snapshot.rows as usize
@@ -836,6 +856,13 @@ impl Renderer {
 
     fn frame_from_readback(&self, mut readback: Readback) -> FrameBgra {
         if readback.regions.len() == 1 && readback.regions[0].is_full(self.height_px) {
+            if !readback.has_kitty_images {
+                let mut state = self
+                    .kitty_readback
+                    .lock()
+                    .expect("kitty_readback mutex poisoned in frame_from_readback()");
+                state.presented_without_images();
+            }
             *self
                 .has_full_frame
                 .lock()
@@ -883,11 +910,11 @@ impl Renderer {
         }
     }
 
-    fn draw_cells(&self, snapshot: &ScreenSnapshot, config: &RendererConfig) -> Result<()> {
+    fn draw_terminal(&self, snapshot: &ScreenSnapshot, config: &RendererConfig) -> Result<()> {
         let selection = *self
             .selection
             .lock()
-            .expect("selection mutex poisoned in draw_cells()");
+            .expect("selection mutex poisoned in draw_terminal()");
         // Sentinel alpha=0 in cell.bg means "default theme background"
         // (set by the VT layer); rewrite it to the configured opacity
         // so the shader composes the cell over Mica with the right
@@ -916,11 +943,11 @@ impl Renderer {
         let mut atlas = self
             .atlas
             .lock()
-            .expect("atlas mutex poisoned in draw_cells() glyph pass");
+            .expect("atlas mutex poisoned in draw_terminal() glyph pass");
         let mut instances = self
             .instances
             .lock()
-            .expect("instances mutex poisoned in draw_cells()");
+            .expect("instances mutex poisoned in draw_terminal()");
         instances.clear();
         instances.reserve(snapshot.cells.len().saturating_add(1));
         let cell_w_px = atlas.metrics().cell_width_px;
@@ -931,7 +958,6 @@ impl Renderer {
             None
         };
         let viewport_offset = snapshot.scrollbar.map_or(0, |scrollbar| scrollbar.offset);
-        let mut cursor_source: Option<Instance> = None;
         let mut has_wide_glyph = false;
 
         for (i, cell) in snapshot.cells.iter().enumerate() {
@@ -948,6 +974,17 @@ impl Renderer {
             };
 
             let is_cursor_cell = cursor_pos == Some((col, row));
+            let render_attrs = effective_attrs as u32
+                | if (cell.bg & 0xFF) == 0 {
+                    RENDER_ATTR_DEFAULT_BG
+                } else {
+                    0
+                }
+                | if is_cursor_cell {
+                    RENDER_ATTR_CURSOR
+                } else {
+                    0
+                };
 
             // The render target clear already paints the pane's default
             // background. Avoid emitting a bg-only instance for blank
@@ -967,11 +1004,8 @@ impl Renderer {
                     atlas_size: [0, 0],
                     fg: cell.fg,
                     bg: apply_opacity(cell.bg),
-                    attrs: effective_attrs as u32,
+                    attrs: render_attrs,
                 };
-                if is_cursor_cell {
-                    cursor_source = Some(instance);
-                }
                 instances.push(instance);
                 continue;
             }
@@ -1002,11 +1036,8 @@ impl Renderer {
                                 atlas_size: [0, 0],
                                 fg: cell.fg,
                                 bg: apply_opacity(cell.bg),
-                                attrs: effective_attrs as u32,
+                                attrs: render_attrs,
                             };
-                            if is_cursor_cell {
-                                cursor_source = Some(instance);
-                            }
                             instances.push(instance);
                             continue;
                         }
@@ -1020,15 +1051,11 @@ impl Renderer {
                 glyph,
                 cell.fg,
                 apply_opacity(cell.bg),
-                effective_attrs,
+                render_attrs,
             );
             has_wide_glyph |= glyph.w as u32 > cell_w_px;
-            if is_cursor_cell {
-                cursor_source = Some(instance);
-            }
             instances.push(instance);
         }
-        drop(atlas);
 
         // Sort so oversized PUA icons render LAST within the grid
         // pass. Their atlas slots are wider than a cell, so their
@@ -1039,32 +1066,42 @@ impl Renderer {
         // would otherwise paint on top. Stable partition keeps the
         // grid's row-major order within the narrow and wide groups
         // independently — bad ordering would show up as flicker.
-        if has_wide_glyph {
-            instances.sort_by_key(|inst| (inst.atlas_size[0] > cell_w_px) as u8);
-        }
-
-        // Push the cursor instance AFTER the sort so it always renders
-        // last — on top of any wide PUA glyph that might otherwise
-        // overdraw the cursor cell.
-        if let Some(src) = cursor_source {
-            // Force both alphas to 0xFF on the swapped cursor instance.
-            // `src.bg` may carry the opacity sentinel (see `apply_opacity`
-            // above — default-bg cells get alpha = opacity_byte so Mica
-            // shows through). Without this mask the cursor block itself
-            // would stay solid (it uses `src.fg`, which is always 0xFF)
-            // but the cursor's text glyph — which now draws with
-            // `fg = src.bg` — would render semi-transparent against
-            // the solid block. Cursor is meant to be a solid highlight,
-            // so both channels are pinned to opaque.
-            instances.push(Instance {
-                cell_pos: src.cell_pos,
-                atlas_pos: src.atlas_pos,
-                atlas_size: src.atlas_size,
-                fg: (src.bg & 0xFFFFFF00) | 0xFF,
-                bg: (src.fg & 0xFFFFFF00) | 0xFF,
-                attrs: src.attrs & !0x10,
+        if has_wide_glyph || cursor_pos.is_some() {
+            instances.sort_by_key(|instance| {
+                if instance.attrs & RENDER_ATTR_CURSOR != 0 {
+                    2
+                } else if instance.atlas_size[0] > cell_w_px {
+                    1
+                } else {
+                    0
+                }
             });
         }
+
+        let text_instance_count = instances.len() as u32;
+        let cursor_instance = instances
+            .iter()
+            .position(|instance| instance.attrs & RENDER_ATTR_CURSOR != 0)
+            .map(|index| index as u32);
+        // Background instances share the same GPU buffer but occupy a compact
+        // suffix. This avoids rasterizing every ordinary glyph cell through a
+        // discard-only background pass while retaining a single map/upload.
+        instances.reserve(text_instance_count as usize);
+        for index in 0..text_instance_count as usize {
+            let instance = instances[index];
+            if instance.attrs & RENDER_ATTR_CURSOR == 0
+                && (instance.attrs & RENDER_ATTR_DEFAULT_BG == 0
+                    || instance.attrs & ATTR_INVERSE as u32 != 0)
+            {
+                instances.push(instance);
+            }
+        }
+        let background_instance_count = instances.len() as u32 - text_instance_count;
+
+        let metrics = atlas.metrics();
+        let atlas_size = atlas.atlas_size() as f32;
+        let atlas_srv = atlas.atlas_srv().clone();
+        drop(atlas);
 
         let mut pipeline = self.pipeline.lock().expect("pipeline mutex poisoned");
         let needed = instances.len() as u32;
@@ -1085,12 +1122,6 @@ impl Renderer {
             .upload_instances(&self.context, &instances)
             .context("upload_instances failed")?;
 
-        let metrics = self.metrics();
-        let atlas_size = self
-            .atlas
-            .lock()
-            .expect("atlas mutex poisoned reading atlas_size")
-            .atlas_size() as f32;
         let inv_viewport = [
             2.0 / self.width_px.max(1) as f32,
             -2.0 / self.height_px.max(1) as f32,
@@ -1106,15 +1137,31 @@ impl Renderer {
             .upload_globals(&self.context, &globals)
             .context("upload_globals failed")?;
 
-        let instance_count = instances.len() as u32;
         drop(instances);
 
-        let atlas = self
-            .atlas
+        let mut image_pipeline = self
+            .image_pipeline
             .lock()
-            .expect("atlas mutex poisoned before bind_and_draw");
-        pipeline.bind_and_draw(&self.context, atlas.atlas_srv(), instance_count);
-        drop(atlas);
+            .expect("image_pipeline mutex poisoned");
+        image_pipeline.prepare(
+            &self.device,
+            &self.context,
+            &snapshot.kitty_placements,
+            [metrics.cell_width_px, metrics.cell_height_px],
+            [self.width_px, self.height_px],
+        )?;
+
+        image_pipeline.draw_layer(&self.context, ImageLayer::BelowBackground);
+        pipeline.draw_backgrounds(
+            &self.context,
+            text_instance_count,
+            background_instance_count,
+        );
+        image_pipeline.draw_layer(&self.context, ImageLayer::BelowText);
+        pipeline.draw_cursor(&self.context, cursor_instance);
+        pipeline.draw_text(&self.context, &atlas_srv, text_instance_count);
+        image_pipeline.draw_layer(&self.context, ImageLayer::AboveText);
+        drop(image_pipeline);
         drop(pipeline);
         Ok(())
     }
@@ -1279,6 +1326,33 @@ struct StagingSlot {
     /// flight.)
     seq: u64,
     regions: Vec<ReadbackRegion>,
+    has_kitty_images: bool,
+}
+
+#[derive(Debug, Default)]
+struct KittyReadbackState {
+    /// Image moves/removals can invalidate arbitrary rows. This stays set
+    /// until a no-image full frame is actually drained and presented, rather
+    /// than merely submitted into the lossy mailbox.
+    requires_full: bool,
+    latest_submit_has_images: bool,
+}
+
+impl KittyReadbackState {
+    fn submitted(&mut self, has_images: bool) -> bool {
+        self.latest_submit_has_images = has_images;
+        self.requires_full |= has_images;
+        self.requires_full
+    }
+
+    fn presented_without_images(&mut self) {
+        // A stale no-image readback may be drained while a newer image frame
+        // is already in flight. Only the latest submitted state may release
+        // the full-frame requirement.
+        if !self.latest_submit_has_images {
+            self.requires_full = false;
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1308,6 +1382,7 @@ impl ReadbackRegion {
 struct Readback {
     bytes: Vec<u8>,
     regions: Vec<ReadbackRegion>,
+    has_kitty_images: bool,
 }
 
 /// Two-slot staging ring. See `Renderer::render` for the state machine.
@@ -1335,6 +1410,7 @@ impl StagingRing {
                 in_flight: false,
                 seq: 0,
                 regions: vec![ReadbackRegion::full(height)],
+                has_kitty_images: false,
             });
         }
         Ok(Self {
@@ -1357,6 +1433,7 @@ impl StagingRing {
                 in_flight: false,
                 seq: 0,
                 regions: vec![ReadbackRegion::full(height)],
+                has_kitty_images: false,
             });
         }
         self.slots = new_slots;
@@ -1372,6 +1449,7 @@ impl StagingRing {
         ctx: &ID3D11DeviceContext,
         source: &ID3D11Texture2D,
         regions: &[ReadbackRegion],
+        has_kitty_images: bool,
     ) -> SubmittedCopy {
         let clean_idx = self
             .slots
@@ -1428,6 +1506,7 @@ impl StagingRing {
         slot.in_flight = true;
         slot.seq = self.next_seq;
         slot.regions = regions;
+        slot.has_kitty_images = has_kitty_images;
         self.next_seq = self.next_seq.wrapping_add(1);
         self.next_idx = (idx + 1) % self.slots.len();
         SubmittedCopy {
@@ -1503,6 +1582,7 @@ impl StagingRing {
         }
 
         let regions = slot.regions.clone();
+        let has_kitty_images = slot.has_kitty_images;
         let full = regions.len() == 1 && regions[0].is_full(self.height);
         let row_bytes = width * 4;
         let len = if full {
@@ -1544,6 +1624,7 @@ impl StagingRing {
         Ok(Some(Readback {
             bytes: out,
             regions,
+            has_kitty_images,
         }))
     }
 }
@@ -1652,4 +1733,31 @@ fn create_staging_texture(
     unsafe { device.CreateTexture2D(&desc, None, Some(&mut texture)) }
         .context("CreateTexture2D(staging) failed")?;
     texture.context("staging CreateTexture2D produced no texture")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::KittyReadbackState;
+
+    #[test]
+    fn kitty_image_removal_requires_a_presented_full_frame() {
+        let mut state = KittyReadbackState::default();
+        assert!(state.submitted(true));
+        assert!(state.submitted(false));
+        assert!(state.submitted(false));
+
+        state.presented_without_images();
+        assert!(!state.submitted(false));
+    }
+
+    #[test]
+    fn stale_no_image_readback_cannot_clear_a_newer_image_requirement() {
+        let mut state = KittyReadbackState::default();
+        assert!(state.submitted(true));
+        assert!(state.submitted(false));
+        assert!(state.submitted(true));
+
+        state.presented_without_images();
+        assert!(state.submitted(true));
+    }
 }

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -28,7 +28,7 @@ mod font_loader;
 mod image_pipeline;
 mod pipeline;
 
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
@@ -50,7 +50,7 @@ use windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT_B8G8R8A8_UNORM, DXGI_SA
 use windows::Win32::Graphics::Dxgi::DXGI_ERROR_WAS_STILL_DRAWING;
 
 use super::profile::{perf_trace_enabled, perf_trace_verbose};
-use super::vt::{ATTR_INVERSE, ATTR_STRIKE, ATTR_UNDERLINE, Cell, ScreenSnapshot};
+use super::vt::{ATTR_INVERSE, ATTR_STRIKE, ATTR_UNDERLINE, Cell, KittyPlacement, ScreenSnapshot};
 use atlas::{GlyphCache, GlyphKey};
 use image_pipeline::{ImageLayer, ImagePipeline};
 use pipeline::{Globals, Instance, Pipeline, instance_for_cell};
@@ -375,6 +375,10 @@ impl Renderer {
             .last_generation
             .lock()
             .expect("last_generation mutex poisoned in rebuild_atlas()") = u64::MAX;
+        *self
+            .has_full_frame
+            .lock()
+            .expect("has_full_frame mutex poisoned in rebuild_atlas()") = false;
         Ok(())
     }
 
@@ -552,7 +556,7 @@ impl Renderer {
                 self.context.ClearRenderTargetView(&self.rtv, &clear);
             }
 
-            self.draw_terminal(snapshot, config)?;
+            let cell_metrics = self.draw_terminal(snapshot, config)?;
             draw_ms = draw_started
                 .map(|started| started.elapsed().as_secs_f64() * 1000.0)
                 .unwrap_or(0.0);
@@ -562,17 +566,25 @@ impl Renderer {
             // so by the next prepaint the GPU will have run them all
             // and the staging texture will be ready to Map().
             let submit_started = perf_trace_enabled().then(Instant::now);
+            // Image damage is relative to the last frame handed to GPUI.
+            // Partial patches are safe only when no older mailbox slot can be
+            // presented first and change that baseline.
             let can_partial_readback = in_flight_before_submit == 0
                 && *self
                     .has_full_frame
                     .lock()
                     .expect("has_full_frame mutex poisoned checking partial readback");
-            let readback_regions = self.readback_regions(snapshot, sel_hash, can_partial_readback);
+            let kitty_visuals = KittyVisualState::from_placements(
+                &snapshot.kitty_placements,
+                [cell_metrics.cell_width_px, cell_metrics.cell_height_px],
+            );
+            let readback_regions =
+                self.readback_regions(snapshot, sel_hash, can_partial_readback, &kitty_visuals);
             submitted = Some(ring.submit_copy_mailbox(
                 &self.context,
                 &self.rt_texture,
                 &readback_regions,
-                !snapshot.kitty_placements.is_empty(),
+                kitty_visuals,
             ));
             submit_ms = submit_started
                 .map(|started| started.elapsed().as_secs_f64() * 1000.0)
@@ -782,17 +794,9 @@ impl Renderer {
         snapshot: &ScreenSnapshot,
         sel_hash: u64,
         allow_partial: bool,
+        kitty_visuals: &KittyVisualState,
     ) -> Vec<ReadbackRegion> {
-        let force_full_for_images = {
-            let has_images = !snapshot.kitty_placements.is_empty();
-            let mut state = self
-                .kitty_readback
-                .lock()
-                .expect("kitty_readback mutex poisoned");
-            state.submitted(has_images)
-        };
         if !allow_partial
-            || force_full_for_images
             || sel_hash != 0
             || snapshot.dirty_rows.is_empty()
             || snapshot.dirty_rows.len() >= snapshot.rows as usize
@@ -800,19 +804,16 @@ impl Renderer {
             return vec![ReadbackRegion::full(self.height_px)];
         }
 
-        let cell_h = self.metrics().cell_height_px.max(1);
-        let mut regions: Vec<ReadbackRegion> = Vec::new();
+        let cell_h = kitty_visuals.cell_size[1].max(1);
+        let mut regions = self
+            .kitty_readback
+            .lock()
+            .expect("kitty_readback mutex poisoned")
+            .damage_regions(kitty_visuals, self.height_px);
         for row in snapshot.dirty_rows.iter().copied() {
             let y = u32::from(row).saturating_mul(cell_h).min(self.height_px);
             let bottom = y.saturating_add(cell_h).min(self.height_px);
             if y >= bottom {
-                continue;
-            }
-            if let Some(last) = regions.last_mut()
-                && last.y.saturating_add(last.height) >= y
-            {
-                let merged_bottom = last.y.saturating_add(last.height).max(bottom);
-                last.height = merged_bottom.saturating_sub(last.y);
                 continue;
             }
             regions.push(ReadbackRegion {
@@ -820,6 +821,7 @@ impl Renderer {
                 height: bottom - y,
             });
         }
+        merge_readback_regions(&mut regions, self.height_px);
         if regions.is_empty() {
             vec![ReadbackRegion::full(self.height_px)]
         } else {
@@ -855,14 +857,11 @@ impl Renderer {
     }
 
     fn frame_from_readback(&self, mut readback: Readback) -> FrameBgra {
+        self.kitty_readback
+            .lock()
+            .expect("kitty_readback mutex poisoned in frame_from_readback()")
+            .presented(std::mem::take(&mut readback.kitty_visuals));
         if readback.regions.len() == 1 && readback.regions[0].is_full(self.height_px) {
-            if !readback.has_kitty_images {
-                let mut state = self
-                    .kitty_readback
-                    .lock()
-                    .expect("kitty_readback mutex poisoned in frame_from_readback()");
-                state.presented_without_images();
-            }
             *self
                 .has_full_frame
                 .lock()
@@ -910,7 +909,11 @@ impl Renderer {
         }
     }
 
-    fn draw_terminal(&self, snapshot: &ScreenSnapshot, config: &RendererConfig) -> Result<()> {
+    fn draw_terminal(
+        &self,
+        snapshot: &ScreenSnapshot,
+        config: &RendererConfig,
+    ) -> Result<CellMetrics> {
         let selection = *self
             .selection
             .lock()
@@ -1163,7 +1166,7 @@ impl Renderer {
         image_pipeline.draw_layer(&self.context, ImageLayer::AboveText);
         drop(image_pipeline);
         drop(pipeline);
-        Ok(())
+        Ok(metrics)
     }
 }
 
@@ -1326,31 +1329,150 @@ struct StagingSlot {
     /// flight.)
     seq: u64,
     regions: Vec<ReadbackRegion>,
-    has_kitty_images: bool,
+    kitty_visuals: KittyVisualState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct KittyVisual {
+    image_id: u32,
+    image_generation: u64,
+    image_size: [u32; 2],
+    z: i32,
+    viewport: [i32; 2],
+    cell_offset: [u32; 2],
+    pixel_size: [u32; 2],
+    source: [u32; 4],
+}
+
+impl From<&KittyPlacement> for KittyVisual {
+    fn from(placement: &KittyPlacement) -> Self {
+        Self {
+            image_id: placement.image.id,
+            image_generation: placement.image.generation,
+            image_size: [placement.image.width, placement.image.height],
+            z: placement.z,
+            viewport: [placement.viewport_col, placement.viewport_row],
+            cell_offset: [placement.cell_x_offset, placement.cell_y_offset],
+            pixel_size: [placement.pixel_width, placement.pixel_height],
+            source: [
+                placement.source_x,
+                placement.source_y,
+                placement.source_width,
+                placement.source_height,
+            ],
+        }
+    }
+}
+
+impl KittyVisual {
+    fn vertical_region(self, cell_height: u32, viewport_height: u32) -> Option<ReadbackRegion> {
+        let top = i64::from(self.viewport[1])
+            .saturating_mul(i64::from(cell_height))
+            .saturating_add(i64::from(self.cell_offset[1]));
+        let bottom = top.saturating_add(i64::from(self.pixel_size[1]));
+        let viewport_height = i64::from(viewport_height);
+        let top = top.clamp(0, viewport_height) as u32;
+        let bottom = bottom.clamp(0, viewport_height) as u32;
+        (top < bottom).then_some(ReadbackRegion {
+            y: top,
+            height: bottom - top,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct KittyVisualState {
+    cell_size: [u32; 2],
+    placements: Arc<[KittyVisual]>,
+}
+
+impl KittyVisualState {
+    fn from_placements(placements: &[KittyPlacement], cell_size: [u32; 2]) -> Self {
+        Self {
+            cell_size,
+            placements: placements
+                .iter()
+                .map(KittyVisual::from)
+                .collect::<Vec<_>>()
+                .into(),
+        }
+    }
 }
 
 #[derive(Debug, Default)]
 struct KittyReadbackState {
-    /// Image moves/removals can invalidate arbitrary rows. This stays set
-    /// until a no-image full frame is actually drained and presented, rather
-    /// than merely submitted into the lossy mailbox.
-    requires_full: bool,
-    latest_submit_has_images: bool,
+    /// Exact image state represented by the last readback handed to GPUI.
+    /// Submitted states are deliberately not authoritative: staging slots are
+    /// a lossy mailbox and may be replaced before presentation.
+    presented: KittyVisualState,
 }
 
 impl KittyReadbackState {
-    fn submitted(&mut self, has_images: bool) -> bool {
-        self.latest_submit_has_images = has_images;
-        self.requires_full |= has_images;
-        self.requires_full
+    fn damage_regions(
+        &self,
+        current: &KittyVisualState,
+        viewport_height: u32,
+    ) -> Vec<ReadbackRegion> {
+        let mut regions = Vec::new();
+        append_kitty_transition_regions(&self.presented, current, viewport_height, &mut regions);
+        regions
     }
 
-    fn presented_without_images(&mut self) {
-        // A stale no-image readback may be drained while a newer image frame
-        // is already in flight. Only the latest submitted state may release
-        // the full-frame requirement.
-        if !self.latest_submit_has_images {
-            self.requires_full = false;
+    fn presented(&mut self, visuals: KittyVisualState) {
+        self.presented = visuals;
+    }
+}
+
+fn append_kitty_transition_regions(
+    previous: &KittyVisualState,
+    current: &KittyVisualState,
+    viewport_height: u32,
+    regions: &mut Vec<ReadbackRegion>,
+) {
+    if previous == current {
+        return;
+    }
+
+    let (prefix, suffix) = if previous.cell_size == current.cell_size {
+        let prefix = previous
+            .placements
+            .iter()
+            .zip(current.placements.iter())
+            .take_while(|(left, right)| left == right)
+            .count();
+        let suffix_limit = previous
+            .placements
+            .len()
+            .min(current.placements.len())
+            .saturating_sub(prefix);
+        let suffix = previous
+            .placements
+            .iter()
+            .rev()
+            .zip(current.placements.iter().rev())
+            .take(suffix_limit)
+            .take_while(|(left, right)| left == right)
+            .count();
+        (prefix, suffix)
+    } else {
+        (0, 0)
+    };
+
+    let previous_end = previous.placements.len().saturating_sub(suffix);
+    let current_end = current.placements.len().saturating_sub(suffix);
+    regions.reserve(
+        previous_end
+            .saturating_sub(prefix)
+            .saturating_add(current_end.saturating_sub(prefix)),
+    );
+    for visual in &previous.placements[prefix..previous_end] {
+        if let Some(region) = visual.vertical_region(previous.cell_size[1], viewport_height) {
+            regions.push(region);
+        }
+    }
+    for visual in &current.placements[prefix..current_end] {
+        if let Some(region) = visual.vertical_region(current.cell_size[1], viewport_height) {
+            regions.push(region);
         }
     }
 }
@@ -1363,7 +1485,7 @@ struct SubmittedCopy {
     readback_rows: u32,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct ReadbackRegion {
     y: u32,
     height: u32,
@@ -1379,10 +1501,40 @@ impl ReadbackRegion {
     }
 }
 
+fn merge_readback_regions(regions: &mut Vec<ReadbackRegion>, viewport_height: u32) {
+    regions.sort_unstable_by_key(|region| region.y);
+    let mut write = 0usize;
+    for read in 0..regions.len() {
+        let y = regions[read].y.min(viewport_height);
+        let bottom = regions[read]
+            .y
+            .saturating_add(regions[read].height)
+            .min(viewport_height);
+        if y >= bottom {
+            continue;
+        }
+
+        if write > 0 {
+            let previous = &mut regions[write - 1];
+            let previous_bottom = previous.y.saturating_add(previous.height);
+            if previous_bottom >= y {
+                previous.height = previous_bottom.max(bottom) - previous.y;
+                continue;
+            }
+        }
+        regions[write] = ReadbackRegion {
+            y,
+            height: bottom - y,
+        };
+        write += 1;
+    }
+    regions.truncate(write);
+}
+
 struct Readback {
     bytes: Vec<u8>,
     regions: Vec<ReadbackRegion>,
-    has_kitty_images: bool,
+    kitty_visuals: KittyVisualState,
 }
 
 /// Two-slot staging ring. See `Renderer::render` for the state machine.
@@ -1410,7 +1562,7 @@ impl StagingRing {
                 in_flight: false,
                 seq: 0,
                 regions: vec![ReadbackRegion::full(height)],
-                has_kitty_images: false,
+                kitty_visuals: KittyVisualState::default(),
             });
         }
         Ok(Self {
@@ -1433,7 +1585,7 @@ impl StagingRing {
                 in_flight: false,
                 seq: 0,
                 regions: vec![ReadbackRegion::full(height)],
-                has_kitty_images: false,
+                kitty_visuals: KittyVisualState::default(),
             });
         }
         self.slots = new_slots;
@@ -1449,7 +1601,7 @@ impl StagingRing {
         ctx: &ID3D11DeviceContext,
         source: &ID3D11Texture2D,
         regions: &[ReadbackRegion],
-        has_kitty_images: bool,
+        kitty_visuals: KittyVisualState,
     ) -> SubmittedCopy {
         let clean_idx = self
             .slots
@@ -1506,7 +1658,7 @@ impl StagingRing {
         slot.in_flight = true;
         slot.seq = self.next_seq;
         slot.regions = regions;
-        slot.has_kitty_images = has_kitty_images;
+        slot.kitty_visuals = kitty_visuals;
         self.next_seq = self.next_seq.wrapping_add(1);
         self.next_idx = (idx + 1) % self.slots.len();
         SubmittedCopy {
@@ -1582,7 +1734,6 @@ impl StagingRing {
         }
 
         let regions = slot.regions.clone();
-        let has_kitty_images = slot.has_kitty_images;
         let full = regions.len() == 1 && regions[0].is_full(self.height);
         let row_bytes = width * 4;
         let len = if full {
@@ -1621,10 +1772,11 @@ impl StagingRing {
             ctx.Unmap(&slot.texture, 0);
         }
         slot.in_flight = false;
+        let kitty_visuals = std::mem::take(&mut slot.kitty_visuals);
         Ok(Some(Readback {
             bytes: out,
             regions,
-            has_kitty_images,
+            kitty_visuals,
         }))
     }
 }
@@ -1737,27 +1889,92 @@ fn create_staging_texture(
 
 #[cfg(test)]
 mod tests {
-    use super::KittyReadbackState;
+    use std::sync::Arc;
 
-    #[test]
-    fn kitty_image_removal_requires_a_presented_full_frame() {
-        let mut state = KittyReadbackState::default();
-        assert!(state.submitted(true));
-        assert!(state.submitted(false));
-        assert!(state.submitted(false));
+    use super::{
+        KittyReadbackState, KittyVisual, KittyVisualState, ReadbackRegion, merge_readback_regions,
+    };
 
-        state.presented_without_images();
-        assert!(!state.submitted(false));
+    const VIEWPORT_HEIGHT: u32 = 100;
+
+    fn visual(row: i32) -> KittyVisual {
+        KittyVisual {
+            image_id: 1,
+            image_generation: 2,
+            image_size: [8, 8],
+            z: 0,
+            viewport: [0, row],
+            cell_offset: [0, 0],
+            pixel_size: [8, 10],
+            source: [0, 0, 8, 8],
+        }
+    }
+
+    fn visual_state(placements: Vec<KittyVisual>) -> KittyVisualState {
+        KittyVisualState {
+            cell_size: [8, 10],
+            placements: Arc::from(placements),
+        }
+    }
+
+    fn damage(state: &KittyReadbackState, current: &KittyVisualState) -> Vec<ReadbackRegion> {
+        let mut regions = state.damage_regions(current, VIEWPORT_HEIGHT);
+        merge_readback_regions(&mut regions, VIEWPORT_HEIGHT);
+        regions
     }
 
     #[test]
-    fn stale_no_image_readback_cannot_clear_a_newer_image_requirement() {
-        let mut state = KittyReadbackState::default();
-        assert!(state.submitted(true));
-        assert!(state.submitted(false));
-        assert!(state.submitted(true));
+    fn unchanged_kitty_images_add_no_readback_damage() {
+        let current = visual_state(vec![visual(2)]);
+        let state = KittyReadbackState {
+            presented: current.clone(),
+        };
 
-        state.presented_without_images();
-        assert!(state.submitted(true));
+        assert!(damage(&state, &current).is_empty());
+    }
+
+    #[test]
+    fn moved_kitty_image_damages_old_and_new_rows() {
+        let previous = visual_state(vec![visual(1)]);
+        let current = visual_state(vec![visual(5)]);
+        let state = KittyReadbackState {
+            presented: previous,
+        };
+
+        assert_eq!(
+            damage(&state, &current),
+            vec![
+                ReadbackRegion { y: 10, height: 10 },
+                ReadbackRegion { y: 50, height: 10 },
+            ]
+        );
+    }
+
+    #[test]
+    fn inserted_kitty_image_preserves_common_prefix_and_suffix() {
+        let previous = visual_state(vec![visual(1), visual(7)]);
+        let current = visual_state(vec![visual(1), visual(4), visual(7)]);
+        let state = KittyReadbackState {
+            presented: previous,
+        };
+
+        assert_eq!(
+            damage(&state, &current),
+            vec![ReadbackRegion { y: 40, height: 10 }]
+        );
+    }
+
+    #[test]
+    fn removed_kitty_image_damages_its_previous_rows() {
+        let previous = visual_state(vec![visual(7)]);
+        let current = visual_state(Vec::new());
+        let state = KittyReadbackState {
+            presented: previous,
+        };
+
+        assert_eq!(
+            damage(&state, &current),
+            vec![ReadbackRegion { y: 70, height: 10 }]
+        );
     }
 }

--- a/crates/con-ghostty/src/windows/render/pipeline.rs
+++ b/crates/con-ghostty/src/windows/render/pipeline.rs
@@ -1,17 +1,8 @@
-//! D3D11 pipeline: HLSL compile, IA layout, buffers, draw state.
+//! D3D11 cell pipeline: HLSL compile, IA layout, buffers, and layered draws.
 //!
-//! Matches [`shaders.hlsl`] one-for-one:
-//!
-//! - vertex shader: `vs_main` — 6 vertices per quad, per-instance IA
-//!   inputs `CELLPOS`/`ATLAS`/`FGCOLOR`/`BGCOLOR`/`ATTRS`.
-//! - pixel shader: `ps_main` — samples the grayscale glyph atlas (t0)
-//!   through `samp` (s0), lerps bg→fg by coverage.
-//! - constant buffer at b0: `Globals { invViewport, cellSize,
-//!   gridCols, gridRows, _pad }`.
-//!
-//! One `DrawIndexedInstanced(6, cell_count, 0, 0, 0)` per frame. No
-//! separate background pass — the grayscale pattern composites bg and
-//! fg in the pixel shader.
+//! One uploaded instance buffer is replayed for cell backgrounds, the cursor,
+//! and glyphs. This leaves room for Kitty image draws between those passes
+//! without duplicating per-cell CPU work.
 
 use std::ffi::CString;
 
@@ -22,11 +13,14 @@ use windows::Win32::Graphics::Direct3D::Fxc::{
 use windows::Win32::Graphics::Direct3D::{D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST, ID3DBlob};
 use windows::Win32::Graphics::Direct3D11::{
     D3D11_BIND_CONSTANT_BUFFER, D3D11_BIND_INDEX_BUFFER, D3D11_BIND_VERTEX_BUFFER,
-    D3D11_BUFFER_DESC, D3D11_CPU_ACCESS_WRITE, D3D11_CULL_NONE, D3D11_FILL_SOLID,
-    D3D11_INPUT_ELEMENT_DESC, D3D11_INPUT_PER_INSTANCE_DATA, D3D11_MAP_WRITE_DISCARD,
-    D3D11_MAPPED_SUBRESOURCE, D3D11_RASTERIZER_DESC, D3D11_SUBRESOURCE_DATA, D3D11_USAGE_DYNAMIC,
-    D3D11_USAGE_IMMUTABLE, ID3D11Buffer, ID3D11Device, ID3D11DeviceContext, ID3D11InputLayout,
-    ID3D11PixelShader, ID3D11RasterizerState, ID3D11SamplerState, ID3D11VertexShader,
+    D3D11_BLEND_DESC, D3D11_BLEND_INV_SRC_ALPHA, D3D11_BLEND_ONE, D3D11_BLEND_OP_ADD,
+    D3D11_BUFFER_DESC, D3D11_COLOR_WRITE_ENABLE_ALL, D3D11_CPU_ACCESS_WRITE, D3D11_CULL_NONE,
+    D3D11_FILL_SOLID, D3D11_INPUT_ELEMENT_DESC, D3D11_INPUT_PER_INSTANCE_DATA,
+    D3D11_MAP_WRITE_DISCARD, D3D11_MAPPED_SUBRESOURCE, D3D11_RASTERIZER_DESC,
+    D3D11_RENDER_TARGET_BLEND_DESC, D3D11_SUBRESOURCE_DATA, D3D11_USAGE_DYNAMIC,
+    D3D11_USAGE_IMMUTABLE, ID3D11BlendState, ID3D11Buffer, ID3D11Device, ID3D11DeviceContext,
+    ID3D11InputLayout, ID3D11PixelShader, ID3D11RasterizerState, ID3D11SamplerState,
+    ID3D11VertexShader,
 };
 use windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT_R32_UINT, DXGI_FORMAT_R32G32_UINT};
 
@@ -69,10 +63,14 @@ pub struct Globals {
 }
 
 pub struct Pipeline {
-    pub vs: ID3D11VertexShader,
-    pub ps: ID3D11PixelShader,
+    text_vs: ID3D11VertexShader,
+    cell_vs: ID3D11VertexShader,
+    background_ps: ID3D11PixelShader,
+    cursor_ps: ID3D11PixelShader,
+    text_ps: ID3D11PixelShader,
     pub input_layout: ID3D11InputLayout,
     pub sampler: ID3D11SamplerState,
+    alpha_blend: ID3D11BlendState,
     /// Explicit no-cull rasterizer — guarantees both triangles of
     /// each cell-quad are rendered regardless of the winding we
     /// happen to produce. Cheaper than reasoning about
@@ -91,22 +89,17 @@ pub struct Pipeline {
 
 impl Pipeline {
     pub fn new(device: &ID3D11Device, initial_instance_capacity: u32) -> Result<Self> {
-        let vs_blob = compile_shader("vs_main", "vs_5_0")?;
-        let ps_blob = compile_shader("ps_main", "ps_5_0")?;
+        let text_vs_blob = compile_shader(HLSL_SOURCE, "vs_text", "vs_5_0")?;
+        let cell_vs_blob = compile_shader(HLSL_SOURCE, "vs_cell", "vs_5_0")?;
+        let background_ps_blob = compile_shader(HLSL_SOURCE, "ps_background", "ps_5_0")?;
+        let cursor_ps_blob = compile_shader(HLSL_SOURCE, "ps_cursor", "ps_5_0")?;
+        let text_ps_blob = compile_shader(HLSL_SOURCE, "ps_text", "ps_5_0")?;
 
-        let vs_bytes = blob_slice(&vs_blob);
-        let ps_bytes = blob_slice(&ps_blob);
-
-        // SAFETY: blob lifetimes exceed the Create* calls.
-        let mut vs: Option<ID3D11VertexShader> = None;
-        unsafe { device.CreateVertexShader(vs_bytes, None, Some(&mut vs)) }
-            .context("CreateVertexShader failed")?;
-        let vs = vs.context("CreateVertexShader produced no shader")?;
-
-        let mut ps: Option<ID3D11PixelShader> = None;
-        unsafe { device.CreatePixelShader(ps_bytes, None, Some(&mut ps)) }
-            .context("CreatePixelShader failed")?;
-        let ps = ps.context("CreatePixelShader produced no shader")?;
+        let text_vs = create_vertex_shader(device, &text_vs_blob)?;
+        let cell_vs = create_vertex_shader(device, &cell_vs_blob)?;
+        let background_ps = create_pixel_shader(device, &background_ps_blob)?;
+        let cursor_ps = create_pixel_shader(device, &cursor_ps_blob)?;
+        let text_ps = create_pixel_shader(device, &text_ps_blob)?;
 
         // Matches the `VSInstance` struct in shaders.hlsl. All per-instance.
         let cellpos = CString::new("CELLPOS").unwrap();
@@ -127,12 +120,15 @@ impl Pipeline {
 
         let mut input_layout: Option<ID3D11InputLayout> = None;
         // SAFETY: layout and vs_bytes live for the call.
-        unsafe { device.CreateInputLayout(&layout, vs_bytes, Some(&mut input_layout)) }
-            .context("CreateInputLayout failed")?;
+        unsafe {
+            device.CreateInputLayout(&layout, blob_slice(&text_vs_blob), Some(&mut input_layout))
+        }
+        .context("CreateInputLayout failed")?;
         let input_layout = input_layout.context("CreateInputLayout produced no layout")?;
 
         // Sampler: point clamp — pixel-accurate atlas reads.
         let sampler = create_point_sampler(device)?;
+        let alpha_blend = create_premultiplied_alpha_blend(device)?;
 
         // No-cull rasterizer: we compose each cell from two triangles
         // and don't want to worry about which winding happens to face
@@ -151,10 +147,14 @@ impl Pipeline {
         let globals_buffer = create_dynamic_cbuffer(device, std::mem::size_of::<Globals>() as u32)?;
 
         Ok(Self {
-            vs,
-            ps,
+            text_vs,
+            cell_vs,
+            background_ps,
+            cursor_ps,
+            text_ps,
             input_layout,
             sampler,
+            alpha_blend,
             rasterizer,
             index_buffer,
             instance_buffer,
@@ -229,47 +229,74 @@ impl Pipeline {
         Ok(())
     }
 
-    pub fn bind_and_draw(
-        &self,
-        context: &ID3D11DeviceContext,
-        atlas_srv: &windows::Win32::Graphics::Direct3D11::ID3D11ShaderResourceView,
-        instance_count: u32,
-    ) {
-        // SAFETY: all parameters are owned by self / caller for the
-        // duration of the draw call; D3D11 DeviceContext is single-threaded.
+    fn bind_common(&self, context: &ID3D11DeviceContext) {
         unsafe {
             context.IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
             context.IASetInputLayout(&self.input_layout);
             context.RSSetState(&self.rasterizer);
 
-            let stride: u32 = std::mem::size_of::<Instance>() as u32;
-            let offset: u32 = 0;
+            let stride = std::mem::size_of::<Instance>() as u32;
             context.IASetVertexBuffers(
                 0,
                 1,
                 Some(&Some(self.instance_buffer.clone())),
                 Some(&stride),
-                Some(&offset),
+                Some(&0),
             );
             context.IASetIndexBuffer(
                 &self.index_buffer,
                 windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT_R32_UINT,
                 0,
             );
-
-            context.VSSetShader(&self.vs, None);
-            context.PSSetShader(&self.ps, None);
-
             context.VSSetConstantBuffers(0, Some(&[Some(self.globals_buffer.clone())]));
-            // Also bind Globals to the PS — ps_main reads `cellSize` to
-            // size the underline / strikethrough band. Without this,
-            // the PS's b0 is uninitialized (cellSize.y == 0), so
-            // `pxUV = 1.0 / max(0, 1) = 1.0` and the band check matches
-            // every pixel → whole cell fills with fg for under/strike.
             context.PSSetConstantBuffers(0, Some(&[Some(self.globals_buffer.clone())]));
+        }
+    }
+
+    pub fn draw_backgrounds(
+        &self,
+        context: &ID3D11DeviceContext,
+        first_instance: u32,
+        instance_count: u32,
+    ) {
+        if instance_count == 0 {
+            return;
+        }
+        self.bind_common(context);
+        unsafe {
+            context.OMSetBlendState(None, None, u32::MAX);
+            context.VSSetShader(&self.cell_vs, None);
+            context.PSSetShader(&self.background_ps, None);
+            context.DrawIndexedInstanced(6, instance_count, 0, 0, first_instance);
+        }
+    }
+
+    pub fn draw_cursor(&self, context: &ID3D11DeviceContext, instance: Option<u32>) {
+        let Some(instance) = instance else {
+            return;
+        };
+        self.bind_common(context);
+        unsafe {
+            context.OMSetBlendState(None, None, u32::MAX);
+            context.VSSetShader(&self.cell_vs, None);
+            context.PSSetShader(&self.cursor_ps, None);
+            context.DrawIndexedInstanced(6, 1, 0, 0, instance);
+        }
+    }
+
+    pub fn draw_text(
+        &self,
+        context: &ID3D11DeviceContext,
+        atlas_srv: &windows::Win32::Graphics::Direct3D11::ID3D11ShaderResourceView,
+        instance_count: u32,
+    ) {
+        self.bind_common(context);
+        unsafe {
+            context.OMSetBlendState(&self.alpha_blend, None, u32::MAX);
+            context.VSSetShader(&self.text_vs, None);
+            context.PSSetShader(&self.text_ps, None);
             context.PSSetShaderResources(0, Some(&[Some(atlas_srv.clone())]));
             context.PSSetSamplers(0, Some(&[Some(self.sampler.clone())]));
-
             context.DrawIndexedInstanced(6, instance_count, 0, 0, 0);
         }
     }
@@ -277,8 +304,8 @@ impl Pipeline {
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
-fn compile_shader(entry: &str, target: &str) -> Result<ID3DBlob> {
-    let src_bytes = HLSL_SOURCE.as_bytes();
+pub(super) fn compile_shader(source: &str, entry: &str, target: &str) -> Result<ID3DBlob> {
+    let src_bytes = source.as_bytes();
     let entry_c = CString::new(entry).unwrap();
     let target_c = CString::new(target).unwrap();
 
@@ -323,13 +350,33 @@ fn compile_shader(entry: &str, target: &str) -> Result<ID3DBlob> {
     blob.context("D3DCompile produced no blob")
 }
 
-fn blob_slice(blob: &ID3DBlob) -> &[u8] {
+pub(super) fn blob_slice(blob: &ID3DBlob) -> &[u8] {
     // SAFETY: blob outlives the slice use at the call site.
     unsafe {
         let ptr = blob.GetBufferPointer() as *const u8;
         let len = blob.GetBufferSize();
         std::slice::from_raw_parts(ptr, len)
     }
+}
+
+pub(super) fn create_vertex_shader(
+    device: &ID3D11Device,
+    blob: &ID3DBlob,
+) -> Result<ID3D11VertexShader> {
+    let mut shader = None;
+    unsafe { device.CreateVertexShader(blob_slice(blob), None, Some(&mut shader)) }
+        .context("CreateVertexShader failed")?;
+    shader.context("CreateVertexShader produced no shader")
+}
+
+pub(super) fn create_pixel_shader(
+    device: &ID3D11Device,
+    blob: &ID3DBlob,
+) -> Result<ID3D11PixelShader> {
+    let mut shader = None;
+    unsafe { device.CreatePixelShader(blob_slice(blob), None, Some(&mut shader)) }
+        .context("CreatePixelShader failed")?;
+    shader.context("CreatePixelShader produced no shader")
 }
 
 fn instance_elem(
@@ -349,7 +396,7 @@ fn instance_elem(
     }
 }
 
-fn create_no_cull_rasterizer(device: &ID3D11Device) -> Result<ID3D11RasterizerState> {
+pub(super) fn create_no_cull_rasterizer(device: &ID3D11Device) -> Result<ID3D11RasterizerState> {
     let desc = D3D11_RASTERIZER_DESC {
         FillMode: D3D11_FILL_SOLID,
         CullMode: D3D11_CULL_NONE,
@@ -367,6 +414,25 @@ fn create_no_cull_rasterizer(device: &ID3D11Device) -> Result<ID3D11RasterizerSt
     unsafe { device.CreateRasterizerState(&desc, Some(&mut out)) }
         .context("CreateRasterizerState failed")?;
     out.context("CreateRasterizerState produced no state")
+}
+
+pub(super) fn create_premultiplied_alpha_blend(device: &ID3D11Device) -> Result<ID3D11BlendState> {
+    let target = D3D11_RENDER_TARGET_BLEND_DESC {
+        BlendEnable: true.into(),
+        SrcBlend: D3D11_BLEND_ONE,
+        DestBlend: D3D11_BLEND_INV_SRC_ALPHA,
+        BlendOp: D3D11_BLEND_OP_ADD,
+        SrcBlendAlpha: D3D11_BLEND_ONE,
+        DestBlendAlpha: D3D11_BLEND_INV_SRC_ALPHA,
+        BlendOpAlpha: D3D11_BLEND_OP_ADD,
+        RenderTargetWriteMask: D3D11_COLOR_WRITE_ENABLE_ALL.0 as u8,
+    };
+    let mut desc = D3D11_BLEND_DESC::default();
+    desc.RenderTarget[0] = target;
+    let mut state = None;
+    unsafe { device.CreateBlendState(&desc, Some(&mut state)) }
+        .context("CreateBlendState failed")?;
+    state.context("CreateBlendState produced no state")
 }
 
 fn create_point_sampler(device: &ID3D11Device) -> Result<ID3D11SamplerState> {
@@ -459,7 +525,7 @@ pub fn instance_for_cell(
     glyph: GlyphRect,
     fg: u32,
     bg: u32,
-    attrs: u8,
+    attrs: u32,
 ) -> Instance {
     Instance {
         cell_pos: [col as u32, row as u32],
@@ -467,6 +533,6 @@ pub fn instance_for_cell(
         atlas_size: [glyph.w as u32, glyph.h as u32],
         fg,
         bg,
-        attrs: attrs as u32,
+        attrs,
     }
 }

--- a/crates/con-ghostty/src/windows/render/shaders.hlsl
+++ b/crates/con-ghostty/src/windows/render/shaders.hlsl
@@ -1,69 +1,51 @@
-// Con Windows terminal renderer — HLSL.
+// Con Windows terminal cell renderer — HLSL.
 //
-// Single DrawIndexedInstanced(6, cells) per frame. Each cell is a quad
-// with per-instance inputs (IA layout, matching `VS_INSTANCE` in
-// pipeline.rs). VS computes the cell's screen-space position from its
-// grid coords; PS samples the DirectWrite grayscale glyph atlas (BGRA8,
-// same coverage in R,G,B) and composites fg over bg with one scalar
-// glyph coverage.
+// Kitty graphics can appear below cell backgrounds, between backgrounds
+// and text, or above text. Cell rendering is therefore split into three
+// passes over one instance buffer:
 //
-// Atlas contents: Direct2D draws a white brush through a grayscale text
-// render target onto an opaque-black background. Result RGB = glyph
-// coverage. We still defensively collapse sampled RGB to one scalar so
-// a driver / remote-display path cannot leak ClearType color fringe.
+//   ps_background  opaque/selected cell backgrounds
+//   ps_cursor      cursor block (text-layer decoration)
+//   ps_text        glyph coverage, underline, and strikethrough
+//
+// The background VS always emits one-cell quads. The text VS may widen a
+// quad to preserve oversized Nerd Font glyphs.
 
-// ── Constant buffer (per-frame) ────────────────────────────────────────
 cbuffer Globals : register(b0) {
-    // Pixel-to-NDC factors: 2.0/viewport_px per axis; also flips Y.
     float2 invViewport;
-    // Logical cell size in physical pixels.
     float2 cellSize;
-    // Grid dims — for cursor / debug overlays.
     uint   gridCols;
     uint   gridRows;
-    // Inverse of atlas texture dimensions (1/width, 1/height). Used
-    // to normalize the atlas UV (which we pass in pixel coords for
-    // simplicity) into the [0,1] range the D3D sampler expects.
     float2 invAtlasSize;
 };
 
-// ── Per-instance inputs ────────────────────────────────────────────────
 struct VSInstance {
-    // (col, row) of this cell in the grid.
     uint2  cellPos       : CELLPOS;
-    // (x, y) of this cell's glyph in atlas pixels.
     uint2  atlasPos      : ATLAS_POS;
-    // (w, h) of this cell's glyph in atlas pixels.
     uint2  atlasSize     : ATLAS_SIZE;
-    // Foreground RGBA8 (srgb).
     uint   fg            : FGCOLOR;
-    // Background RGBA8.
     uint   bg            : BGCOLOR;
-    // attrs: bit 0 = bold, 1 = italic, 2 = underline, 3 = strike,
-    // 4 = inverse. Unused low bits reserved.
+    // Low bits mirror Ghostty cell attrs. Con reserves:
+    //   bit 8 = default background
+    //   bit 9 = cursor cell
     uint   attrs         : ATTRS;
-};
-
-struct VSVertex {
-    // Built-in quad corner id (0..3). We use a 6-index strip, so vid %
-    // 4 maps to the corner: 0 = top-left, 1 = top-right, 2 = bot-left,
-    // 3 = bot-right.
-    uint   vid           : SV_VertexID;
 };
 
 struct VSOut {
     float4 pos           : SV_Position;
     float2 atlasUV       : TEXCOORD0;
-    // Cell-local UV, (0,0)=top-left .. (1,1)=bottom-right. Used by the
-    // PS to draw underline / strikethrough bands without needing to
-    // know the viewport.
     float2 cellUV        : TEXCOORD1;
     nointerpolation float4 fg : FGCOLOR;
     nointerpolation float4 bg : BGCOLOR;
     nointerpolation uint   attrs : ATTRS;
 };
 
-// ── Helpers ────────────────────────────────────────────────────────────
+static const uint ATTR_UNDERLINE  = 4u;
+static const uint ATTR_STRIKE     = 8u;
+static const uint ATTR_INVERSE    = 16u;
+static const uint ATTR_DEFAULT_BG = 256u;
+static const uint ATTR_CURSOR     = 512u;
+
 float4 unpackRGBA(uint v) {
     return float4(
         float((v >> 24) & 0xFF),
@@ -73,120 +55,114 @@ float4 unpackRGBA(uint v) {
     ) / 255.0;
 }
 
-// ── Atlas binding ──────────────────────────────────────────────────────
-Texture2D<float4> atlas : register(t0);
-SamplerState      samp  : register(s0);
-
-// ── VS ─────────────────────────────────────────────────────────────────
-VSOut vs_main(uint vid : SV_VertexID, VSInstance inst) {
-    // The index buffer is `[0, 1, 2, 2, 1, 3]` — two triangles making
-    // a quad. `SV_VertexID` is the VALUE from the index buffer (one of
-    // 0, 1, 2, 3 — never higher), not the position-in-strip. Four
-    // entries in the mapping, one per corner:
-    //   0 = top-left (0, 0)
-    //   1 = top-right (1, 0)
-    //   2 = bottom-left (0, 1)
-    //   3 = bottom-right (1, 1)
+uint2 quadCorner(uint vid) {
     const uint2 mapping[4] = {
         uint2(0, 0),
         uint2(1, 0),
         uint2(0, 1),
         uint2(1, 1),
     };
-    uint2 corner = mapping[vid % 4];
+    return mapping[vid % 4];
+}
 
-    // Wide-glyph handling: Nerd-Font PUA icons are authored with
-    // advance=1 cell but ink wider than that. The atlas allocates them
-    // in slots up to 2 cells wide; honoring `atlasSize.x` as the quad
-    // width lets those icons render at their natural size on screen.
-    // Empty cells (codepoint=0 or space) set atlasSize=(0,0), so the
-    // max keeps their quad exactly cellSize — no visual change for the
-    // common case.
-    float2 quadSize = float2(
-        max(cellSize.x, float(inst.atlasSize.x)),
-        cellSize.y
-    );
+VSOut vertexOut(uint vid, VSInstance inst, float2 quadSize) {
+    uint2 corner = quadCorner(vid);
     float2 px = float2(inst.cellPos) * cellSize + float2(corner) * quadSize;
 
     VSOut o;
-    o.pos = float4(px * invViewport + float2(-1.0,  1.0), 0.0, 1.0);
-    // NDC y is up; our logical y is down. invViewport.y is negative to flip.
-
-    float2 atlasTopLeft = float2(inst.atlasPos);
-    float2 atlasPixels  = float2(inst.atlasSize);
-    // Pixel coords for the glyph rect, then normalize by the atlas
-    // texture dims so the Sample() call gets UVs in [0,1].
-    o.atlasUV = (atlasTopLeft + atlasPixels * float2(corner)) * invAtlasSize;
-    o.cellUV  = float2(corner);
-
-    o.fg    = unpackRGBA(inst.fg);
-    o.bg    = unpackRGBA(inst.bg);
+    o.pos = float4(px * invViewport + float2(-1.0, 1.0), 0.0, 1.0);
+    o.atlasUV = (float2(inst.atlasPos) + float2(inst.atlasSize) * float2(corner))
+        * invAtlasSize;
+    o.cellUV = float2(corner);
+    o.fg = unpackRGBA(inst.fg);
+    o.bg = unpackRGBA(inst.bg);
     o.attrs = inst.attrs;
     return o;
 }
 
-// ── PS ─────────────────────────────────────────────────────────────────
-float4 ps_main(VSOut i) : SV_Target {
-    // atlasUV arrives already normalized (VS divides pixel coords by
-    // invAtlasSize). The atlas is grayscale, but collapse RGB anyway
-    // so any platform-level subpixel fallback becomes neutral coverage
-    // instead of colored fringe.
-    float3 coverage_rgb = atlas.Sample(samp, i.atlasUV).rgb;
-    float coverage = max(coverage_rgb.r, max(coverage_rgb.g, coverage_rgb.b));
+Texture2D<float4> atlas : register(t0);
+SamplerState      samp  : register(s0);
 
-    // Inverse handling: swap fg/bg when attr bit 4 is set (SGR 7 or
-    // a selected cell via the CPU-side XOR). After the swap the new
-    // `fg.a` inherits the original bg's alpha — which the CPU rewrites
-    // to `background_opacity` for default-bg cells so Mica can show
-    // through. For an inverse cell we don't want Mica behind the
-    // glyph: the whole point of inverse is a solid highlight, and
-    // translucent glyph pixels against a solid block would render
-    // text visibly semi-transparent. Pin both channels to 1.0 after
-    // swap so inverse / selection cells paint opaque.
-    float4 fg = i.fg;
-    float4 bg = i.bg;
-    if (i.attrs & 16u) {
+VSOut vs_text(uint vid : SV_VertexID, VSInstance inst) {
+    float2 quadSize = float2(
+        max(cellSize.x, float(inst.atlasSize.x)),
+        cellSize.y
+    );
+    return vertexOut(vid, inst, quadSize);
+}
+
+VSOut vs_cell(uint vid : SV_VertexID, VSInstance inst) {
+    return vertexOut(vid, inst, cellSize);
+}
+
+void effectiveColors(VSOut i, out float4 fg, out float4 bg) {
+    fg = i.fg;
+    bg = i.bg;
+    if (i.attrs & ATTR_INVERSE) {
         float4 tmp = fg;
         fg = bg;
         bg = tmp;
+        // Selection and inverse-video cells are solid highlights even when
+        // the terminal's default background is translucent.
         fg.a = 1.0;
         bg.a = 1.0;
     }
+}
 
-    // Underline / strikethrough: draw a 1-pixel-tall fg band inside
-    // the cell. Bands are in cell-local UV space:
-    //   underline: bottom ~10% of the cell (UV.y in [0.90, 0.97])
-    //   strike:    vertical middle (UV.y in [0.48, 0.55])
-    // The cellSize in px tells us how wide a pixel is in UV, which
-    // lets us build a crisp 1-px band without AA fringing.
+float4 premultiply(float4 color) {
+    return float4(color.rgb * color.a, color.a);
+}
+
+float4 ps_background(VSOut i) : SV_Target {
+    // The renderer clear already supplies the default background. Keeping
+    // these pixels untouched is also what lets below-background images show
+    // through empty/default cells, matching upstream Ghostty's cell-bg pass.
+    if ((i.attrs & ATTR_CURSOR) ||
+        ((i.attrs & ATTR_DEFAULT_BG) && !(i.attrs & ATTR_INVERSE))) {
+        discard;
+    }
+
+    float4 fg;
+    float4 bg;
+    effectiveColors(i, fg, bg);
+    return premultiply(bg);
+}
+
+float4 ps_cursor(VSOut i) : SV_Target {
+    if (!(i.attrs & ATTR_CURSOR)) {
+        discard;
+    }
+
+    float4 fg;
+    float4 bg;
+    effectiveColors(i, fg, bg);
+    // The cursor toggles the effective cell colors and stays opaque even
+    // when the effective foreground came from the translucent default bg.
+    fg.a = 1.0;
+    return premultiply(fg);
+}
+
+float4 ps_text(VSOut i) : SV_Target {
+    float3 coverageRgb = atlas.Sample(samp, i.atlasUV).rgb;
+    float coverage = max(coverageRgb.r, max(coverageRgb.g, coverageRgb.b));
+
     float pxUV = 1.0 / max(cellSize.y, 1.0);
-    float band_coverage = 0.0;
-    if (i.attrs & 4u) {
-        // Underline.
-        float center = 0.92;
-        if (abs(i.cellUV.y - center) < pxUV) {
-            band_coverage = 1.0;
-        }
+    float bandCoverage = 0.0;
+    if ((i.attrs & ATTR_UNDERLINE) && abs(i.cellUV.y - 0.92) < pxUV) {
+        bandCoverage = 1.0;
     }
-    if (i.attrs & 8u) {
-        // Strikethrough.
-        float center = 0.52;
-        if (abs(i.cellUV.y - center) < pxUV) {
-            band_coverage = 1.0;
-        }
+    if ((i.attrs & ATTR_STRIKE) && abs(i.cellUV.y - 0.52) < pxUV) {
+        bandCoverage = 1.0;
     }
 
-    // Scalar glyph coverage keeps text neutral during screenshots,
-    // scaling, transparency, and remote-display review. Decorations use
-    // the same scalar path so underline / strike bands stay clean.
-    float comp = max(coverage, band_coverage);
-    float3 rgb = lerp(bg.rgb, fg.rgb, comp);
-    // Output alpha follows the maximum coverage so glyph pixels stay
-    // opaque while the cell's background takes the bg.a (which the
-    // renderer drops to `background_opacity` for default-bg cells so
-    // Mica / DComp visuals beneath show through). GPUI's compositor
-    // expects premultiplied alpha — multiply the lerped RGB by the
-    // output alpha so translucent pixels don't look washed out.
-    float alpha = lerp(bg.a, fg.a, comp);
-    return float4(rgb * alpha, alpha);
+    float4 fg;
+    float4 bg;
+    effectiveColors(i, fg, bg);
+    float4 color = (i.attrs & ATTR_CURSOR) ? bg : fg;
+    if (i.attrs & ATTR_CURSOR) {
+        color.a = 1.0;
+    }
+
+    float alpha = color.a * max(coverage, bandCoverage);
+    return float4(color.rgb * alpha, alpha);
 }

--- a/docs/impl/windows-port.md
+++ b/docs/impl/windows-port.md
@@ -28,7 +28,7 @@ rustup default stable
 git clone https://github.com/nowledge-co/con-terminal.git
 cd con-terminal
 cargo wbuild -p con --release          # → target\release\con-app.exe
-cargo wtest  -p con-core -p con-cli -p con-agent -p con-terminal
+cargo wtest  -p con-core -p con-cli -p con-agent -p con-terminal -p con-ghostty
 ```
 
 Prerequisites:
@@ -36,7 +36,7 @@ Prerequisites:
 - **Visual Studio Build Tools 2022** with "Desktop development with
   C++" (for `link.exe` + Windows SDK).
 - **Git for Windows**.
-- **Zig 0.15.2 or newer** on PATH (for `libghostty-vt`); download from
+- **Zig 0.16.0 exactly** on PATH (for `libghostty-vt`); download from
   <https://ziglang.org/download/>. If the `zig` executable isn't on
   PATH, set `CON_ZIG_BIN` to its absolute path.
 
@@ -67,7 +67,7 @@ Common Windows pitfalls when the Zig step fails mid-build with
    path on Windows; if your machine disallows `C:\zc`, set
    `ZIG_GLOBAL_CACHE_DIR` explicitly to another short writable path.
 3. **Zig version mismatch** — the current pin is validated with Zig
-   0.15.2. If a newer Zig breaks upstream, either install the validated
+   0.16.0. If a newer Zig breaks upstream, either install the validated
    Zig version or bump `GHOSTTY_REV` in `build.rs` (requires macOS
    re-validation of the full libghostty build).
 
@@ -113,7 +113,7 @@ future Windows build will produce a valid executable filename.
 
 `con-ghostty` is a thin Rust wrapper over libghostty's C embedding API.
 libghostty is built from a pinned Ghostty revision via `zig build` and
-linked statically as `libghostty-fat.a`. Surface creation hands a NSView
+linked statically as the final `libghostty-internal.a` archive. Surface creation hands a NSView
 pointer to libghostty, which attaches a Metal `IOSurfaceLayer` and renders
 the terminal directly into it. PTY, VT parsing, and rendering are all
 inside libghostty.
@@ -469,13 +469,12 @@ polish, and distribution hardening rather than basic input/selection
 bring-up.
 
 Caveats:
-- You must have **Zig 0.15.2 exactly** on `PATH` for `cargo build` to
-  compile `libghostty-vt`. Do not use Zig 0.16.0 for this pinned
-  Ghostty revision; install 0.15.2 from
-  <https://ziglang.org/download/0.15.2/> or point `CON_ZIG_BIN` at an
-  explicit 0.15.2 binary. `cargo check` works without Zig
-  (compile-only, no link); set `CON_SKIP_GHOSTTY_VT=1` to skip the
-  build entirely.
+- You must have **Zig 0.16.0 exactly** on `PATH` for `cargo build` or
+  `cargo check` to compile `libghostty-vt`; install it from
+  <https://ziglang.org/download/0.16.0/> or point `CON_ZIG_BIN` at an
+  explicit 0.16.0 binary. `CON_SKIP_GHOSTTY_VT=1` remains a local
+  check-only escape hatch, but CI intentionally builds and links the real
+  library so removed symbols and calling-convention drift cannot hide.
 - The shell is `CON_SHELL` if set, else the configured Windows Terminal
   default profile command when `%LOCALAPPDATA%` settings are readable,
   else `pwsh.exe`/`powershell.exe` if on `PATH`, else `$env:COMSPEC`,

--- a/mise.toml
+++ b/mise.toml
@@ -12,4 +12,4 @@
 [tools]
 cmake = "latest"
 rust = "stable"
-zig = "0.15.2"
+zig = "0.16.0"


### PR DESCRIPTION
## Summary

- Pin Ghostty to `5f5b988c5236facfe8d2439203d9ee9d5b636cf8` and move the build toolchain to Zig 0.16.0.
- Migrate the macOS embedder and portable `libghostty-vt` integrations to the current C APIs, including action tags, clipboard callbacks, terminal construction, mode access, archive discovery, and OSC 7 handling.
- Add Kitty keyboard encoding and mediated clipboard paste support to the Windows and Linux terminal paths.
- Render static Kitty graphics on Windows through D3D11 and on Linux through GPUI, with bounded PNG decoding, image lifetime management, alpha-correct sampling, fractional-scale alignment, and image-aware damage tracking.
- Preserve PTY input order under backpressure, bound paste and image state, cancel blocked Linux PTY I/O during teardown, and retry Flatpak PTY resizes when the write queue is busy.
- Add ABI probes and transactional patch validation so incompatible Ghostty changes fail during the build instead of producing silent runtime corruption.

## Platform scope

macOS continues to use the full embedded libghostty renderer. Windows and Linux continue to use `libghostty-vt` with Con-owned PTY and rendering layers. This PR brings the portable paths closer to the macOS feature set without replacing those platform-specific backends.

This is not complete Kitty protocol coverage. It adds portable keyboard encoding, clipboard paste mediation, and static graphics. OSC 99 notifications, OSC 66 text sizing, Kitty drag and drop, graphics animation scheduling, and terminal snapshot restore remain separate work.

## Compatibility and security

- Existing user configuration remains compatible.
- Contributors and release builders now need Zig 0.16.0.
- Clipboard reads require explicit grants, unsafe multiline pastes retain confirmation, and MIME handling is consistent across platforms.
- PNG payloads, placements, paste queues, and PTY writes have bounded resource use.

## Validation

- [x] macOS `con-ghostty` test suite: 12 tests passed
- [x] macOS `cargo build -p con`
- [x] macOS development app launch with embedded Ghostty version `1.3.2-HEAD-+5f5b988c5`
- [x] Linux `con-ghostty` test suite against the real `libghostty-vt`: 35 tests passed in Docker
- [x] Linux `cargo check -p con` with warnings denied
- [x] Windows Rust cross-check with `CON_SKIP_GHOSTTY_VT=1`
- [ ] Windows runtime smoke test for Kitty keyboard input, clipboard paste, static PNG rendering, resize behavior, and ConPTY replies