### PR TITLE
ci(release): make finalization reliable and document release operations

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -46,10 +46,10 @@ name: Finalize release
 #   tag name (e.g. `v0.1.0-beta.35`). We use it to derive the tag,
 #   and we use `head_sha` to correlate runs across the three sibling
 #   workflows.
-# - `gh release edit --draft=false` is idempotent for an already-
-#   published release, so concurrent finalize runs (which can fire
-#   roughly simultaneously when the slowest two platforms finish
-#   close together) are safe.
+# - Every completion event gets its own finalizer run. Do not collapse
+#   these events into one concurrency group: GitHub keeps only one
+#   pending run per group, so a later platform completion can otherwise
+#   cancel the event that would have promoted the release.
 
 on:
   workflow_run:
@@ -64,13 +64,12 @@ permissions:
   contents: write
   actions: read
 
-# Serialize finalize attempts per-tag so two near-simultaneous
-# triggering completions don't both call `gh release edit` at the
-# same instant. Cheap insurance — the operation is idempotent, but
-# this also avoids two concurrent runs racing to compute the
-# "all green?" result with a stale cache.
+# Keep each workflow_run completion independent. GitHub concurrency has
+# one running slot and one pending slot per group; sharing a tag or
+# repository-wide group silently drops completion events. The source
+# run ID is unique, so all three completion events get a chance to run.
 concurrency:
-  group: con-gh-pages-publish
+  group: release-finalize-${{ github.event.workflow_run.id }}
   cancel-in-progress: false
 
 jobs:
@@ -110,8 +109,9 @@ jobs:
           HEAD_SHA: ${{ steps.ctx.outputs.sha }}
         # Strategy: for each of the three release workflow files,
         # query its workflow_runs filtered by head_sha and event=push.
-        # If at least one of those runs has conclusion=success, that
-        # platform is "done". If all three are done, we promote.
+        # The newest matching run must be completed successfully. A
+        # previous success is not enough: a later retry may have failed.
+        # If all three latest runs are successful, we promote.
         # Otherwise we exit cleanly — the next sibling's completion
         # will trigger another finalize attempt.
         #
@@ -138,15 +138,17 @@ jobs:
             runs_json=$(gh api \
               "repos/${GH_REPO}/actions/workflows/${wf}/runs?head_sha=${HEAD_SHA}&event=push&per_page=20")
 
-            success_count=$(jq -r \
-              '[.workflow_runs[] | select(.conclusion == "success")] | length' \
-              <<<"$runs_json")
-
             total_count=$(jq -r '.total_count' <<<"$runs_json")
+            latest=$(jq -r --arg sha "$HEAD_SHA" '\
+              [.workflow_runs[] | select(.head_sha == $sha)]\
+              | sort_by(.updated_at) | last // {}\
+              | [.status // "missing", .conclusion // "", .id // ""]\
+              | @tsv' <<<"$runs_json")
+            read -r latest_status latest_conclusion latest_id <<<"$latest"
 
-            echo "${wf}: head_sha=${HEAD_SHA} total=${total_count} success=${success_count}"
+            echo "${wf}: head_sha=${HEAD_SHA} total=${total_count} latest_run=${latest_id} status=${latest_status} conclusion=${latest_conclusion}"
 
-            if [[ "$success_count" -lt 1 ]]; then
+            if [[ "$latest_status" != "completed" || "$latest_conclusion" != "success" ]]; then
               all_done=0
             fi
           done

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: release
+description: Run and verify Con beta, dev, and stable releases without publishing incomplete artifacts.
+---
+
+# Con Release
+
+Use this skill when preparing a release, pushing a release tag, checking a
+release workflow, or recovering a failed publication. The release workflow is
+the source of truth; do not treat a green build on one platform as a release.
+
+## Release contract
+
+- Release from `main` only.
+- Prepare `CHANGELOG.md` before tagging. The top section must be the next
+  unreleased beta and every PR-derived item must credit its GitHub author.
+- Push exactly one immutable tag. Use `v0.1.0-beta.N` for beta, `v0.1.0-dev.N`
+  for dev, and the project stable tag when stable is explicitly approved.
+- A tag push starts the macOS, Linux, Windows, and Flatpak workflows. Platform
+  jobs create or update one GitHub draft release and upload their own assets.
+- A release is public only after all required platform assets and release-gate
+  checks pass. Installers and updaters must never consume a draft.
+- Never delete and recreate a tag to repair a release. Fix the workflow or
+  rerun the affected workflow against the same commit.
+
+## Before tagging
+
+Run these checks from a clean checkout:
+
+```bash
+git fetch origin main --tags
+git switch main
+git pull --ff-only origin main
+git status --short
+git tag --sort=-v:refname | rg '^v[0-9]+\\.[0-9]+\\.[0-9]+-(beta|dev)\\.' | head
+gh release list --limit 5
+```
+
+Confirm the next version is greater than the latest released version, the
+changelog heading matches it, and `git status --short` is empty. Run the
+release-relevant test suite before tagging; platform packaging tests belong in
+the release workflows and must not be replaced by a local cross-build.
+
+## Publish
+
+Create an annotated tag at the verified `main` commit and push only that tag:
+
+```bash
+git tag -a v0.1.0-beta.N origin/main -m "Release v0.1.0-beta.N"
+git push origin refs/tags/v0.1.0-beta.N
+```
+
+Track the four tag-triggered workflows:
+
+```bash
+gh run list --limit 20 --json workflowName,status,conclusion,headBranch,headSha,url \\
+  --jq '.[] | select(.headBranch == "v0.1.0-beta.N")'
+```
+
+Do not publish a draft manually while a required platform is still running or
+failed. The finalizer checks the newest matching run for each required
+platform, then validates assets, checksums, appcasts, and public installer
+scripts before promoting the draft.
+
+## Verify the public result
+
+After the finalizer succeeds, verify the public contract:
+
+```bash
+gh release view v0.1.0-beta.N --json isDraft,isPrerelease,publishedAt,assets,url
+```
+
+For a beta, expect `isDraft: false` and the repository's beta-channel release
+semantics. Confirm the expected macOS arm64/x86_64 DMGs and ZIPs, Linux
+tarball, Windows ZIP, and checksum files are present. Check the beta appcasts
+and the public installer endpoints if they are part of the release:
+
+```bash
+curl -fsSL https://con-releases.nowledge.co/install.sh >/dev/null
+curl -fsSL https://con-releases.nowledge.co/install.ps1 >/dev/null
+```
+
+## Recovery
+
+- If a platform workflow is cancelled, rerun that exact workflow run; do not
+  push a second tag.
+- If all platform workflows succeeded but the release remains draft, inspect
+  the latest `Finalize release` run. Rerun only the finalizer after confirming
+  the release gate inputs are complete.
+- If an asset is missing, rerun the platform that owns it and verify its
+  checksum before promotion.
+- If the release is already public, later finalizer runs are harmless and must
+  not change its prerelease/channel semantics.
+- Record a workflow or release incident in `postmortem/` when the failure
+  exposes a new invariant or requires manual recovery.
+
+## Common mistakes
+
+- Do not tag from a stale local `main`.
+- Do not use `--force` on release tags.
+- Do not mark beta releases as prereleases unless the channel policy changes;
+  current installers use the public latest beta semantics.
+- Do not assume a draft URL or an uploaded asset means the release is public.
+- Do not use a repository-wide GitHub Actions concurrency group for finalizer
+  events; each source completion must remain observable.


### PR DESCRIPTION
## Summary

- Prevent release finalizer completion events from being dropped by a shared GitHub Actions concurrency group.
- Make the release gate evaluate the newest matching platform run, so a failed retry cannot be hidden by an older success.
- Add `skills/release/SKILL.md` with the repeatable beta/dev/stable release procedure and recovery checks.

## Why

Beta.86 had all platform artifacts available, but Linux, Windows, and Flatpak runs were initially cancelled and the finalizer's shared pending slot left the release as a draft. The release had to be recovered manually. Each `workflow_run` completion now has an independent concurrency key, so the final platform completion remains observable.

## Validation

- `git diff --check`
- YAML parse via Ruby
- Existing release workflow behavior reviewed against beta.86 runs

This PR does not change platform build jobs or artifact contents.
