### PR TITLE
docs(changelog): mark beta 86 released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
-## `v0.1.0-beta.86` - unreleased
+## `v0.1.0-beta.87` - unreleased
+
+---
+
+## `v0.1.0-beta.86` - 2026-08-27
 
 ### Added
 


### PR DESCRIPTION
Mark beta.86 with its publication date and leave a clean beta.87 unreleased section so the website does not describe a shipped release as unreleased.