### PR TITLE
fix: handle terminal mouse releases outside pane bounds

### DIFF
--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -177,7 +177,9 @@ pub struct GhosttyView {
     native_transition_underlay_visible: Cell<bool>,
     #[cfg(target_os = "macos")]
     native_transition_underlay_owner_id: u64,
-    /// Whether the current right-button press was consumed by libghostty.
+    left_mouse_pressed: bool,
+    right_mouse_pressed: bool,
+    /// Whether the most recent right-button press was consumed by libghostty.
     right_click_consumed: Rc<Cell<bool>>,
     ime_marked_text: Option<String>,
 }
@@ -241,6 +243,8 @@ impl GhosttyView {
             #[cfg(target_os = "macos")]
             native_transition_underlay_owner_id: NEXT_NATIVE_TRANSITION_OWNER_ID
                 .fetch_add(1, Ordering::Relaxed),
+            left_mouse_pressed: false,
+            right_mouse_pressed: false,
             right_click_consumed: Rc::new(Cell::new(false)),
             ime_marked_text: None,
         }
@@ -414,6 +418,16 @@ impl GhosttyView {
         self.terminal.as_ref().and_then(|t| t.selection_text())
     }
 
+    pub fn release_mouse_selection(&mut self, cx: &mut Context<Self>) {
+        let Some(position) = self.last_mouse_position else {
+            return;
+        };
+        if self.finish_mouse_sequence(MouseButton::Left, position, 0) {
+            self.drain_surface_state(true, cx);
+            cx.notify();
+        }
+    }
+
     #[cfg(target_os = "macos")]
     fn detach_host_view(&mut self) {
         if let Some(underlay_view) = self.native_underlay_view {
@@ -540,6 +554,7 @@ impl GhosttyView {
     }
 
     pub fn shutdown_surface(&mut self, _window: Option<&mut Window>, _cx: &mut App) {
+        self.finish_active_mouse_sequences();
         self.native_view_visible.set(false);
 
         if let Some(ref terminal) = self.terminal {
@@ -566,6 +581,9 @@ impl GhosttyView {
     }
 
     pub fn set_surface_focus_state(&mut self, focused: bool) {
+        if !focused {
+            self.finish_active_mouse_sequences();
+        }
         let changed = self.surface_focused.replace(focused) != focused;
         if !changed {
             return;
@@ -1353,6 +1371,57 @@ impl GhosttyView {
         }
     }
 
+    fn begin_mouse_sequence(
+        &mut self,
+        button: MouseButton,
+        position: Point<Pixels>,
+        mods: i32,
+    ) -> Option<bool> {
+        self.last_mouse_position = Some(position);
+        self.finish_active_mouse_sequences();
+        let terminal = self.terminal.as_ref()?;
+        let (x, y) = self.view_local_pos(position);
+        terminal.send_mouse_pos(x, y, mods);
+        let consumed = terminal.send_mouse_button(true, button, mods);
+        match button {
+            MouseButton::Left => self.left_mouse_pressed = true,
+            MouseButton::Right => self.right_mouse_pressed = true,
+            MouseButton::Middle => {}
+        }
+        Some(consumed)
+    }
+
+    fn finish_mouse_sequence(
+        &mut self,
+        button: MouseButton,
+        position: Point<Pixels>,
+        mods: i32,
+    ) -> bool {
+        let pressed = match button {
+            MouseButton::Left => std::mem::take(&mut self.left_mouse_pressed),
+            MouseButton::Right => std::mem::take(&mut self.right_mouse_pressed),
+            MouseButton::Middle => false,
+        };
+        if !pressed {
+            return false;
+        }
+
+        let Some(terminal) = self.terminal.as_ref() else {
+            return false;
+        };
+        let (x, y) = self.view_local_pos(position);
+        terminal.send_mouse_pos(x, y, mods);
+        terminal.send_mouse_button(false, button, mods);
+        true
+    }
+
+    fn finish_active_mouse_sequences(&mut self) {
+        if let Some(position) = self.last_mouse_position {
+            self.finish_mouse_sequence(MouseButton::Left, position, 0);
+            self.finish_mouse_sequence(MouseButton::Right, position, 0);
+        }
+    }
+
     #[cfg(target_os = "macos")]
     fn refresh_mouse_modifiers(&self, modifiers: &Modifiers) {
         let (Some(terminal), Some(position)) = (self.terminal.as_ref(), self.last_mouse_position)
@@ -1793,6 +1862,7 @@ fn gpui_key_to_keycode(key: &str) -> Option<(u32, u32)> {
 
 impl Drop for GhosttyView {
     fn drop(&mut self) {
+        self.finish_active_mouse_sequences();
         #[cfg(target_os = "macos")]
         {
             // The AppKit backing observer stores Ghostty's raw surface pointer.
@@ -1988,16 +2058,13 @@ impl Render for GhosttyView {
                     let right_click_consumed = right_click_consumed.clone();
                     move |this, event: &MouseDownEvent, window, cx| {
                         window.focus(&context_focus, cx);
-                        this.last_mouse_position = Some(event.position);
                         // Reset first so a click without a terminal can't
                         // carry a stale consumed state into the menu gate.
                         right_click_consumed.set(false);
-                        if let Some(ref terminal) = this.terminal {
-                            let (x, y) = this.view_local_pos(event.position);
-                            let mods = gpui_mods_to_ghostty(&event.modifiers);
-                            terminal.send_mouse_pos(x, y, mods);
-                            let consumed =
-                                terminal.send_mouse_button(true, MouseButton::Right, mods);
+                        let mods = gpui_mods_to_ghostty(&event.modifiers);
+                        if let Some(consumed) =
+                            this.begin_mouse_sequence(MouseButton::Right, event.position, mods)
+                        {
                             right_click_consumed.set(consumed);
                         }
                         cx.emit(GhosttyFocusChanged);
@@ -2009,13 +2076,8 @@ impl Render for GhosttyView {
                 gpui::MouseButton::Left,
                 cx.listener(move |this, event: &MouseDownEvent, window, cx| {
                     window.focus(&focus, cx);
-                    this.last_mouse_position = Some(event.position);
-                    if let Some(ref terminal) = this.terminal {
-                        let (x, y) = this.view_local_pos(event.position);
-                        let mods = gpui_mods_to_ghostty(&event.modifiers);
-                        terminal.send_mouse_pos(x, y, mods);
-                        terminal.send_mouse_button(true, MouseButton::Left, mods);
-                    }
+                    let mods = gpui_mods_to_ghostty(&event.modifiers);
+                    this.begin_mouse_sequence(MouseButton::Left, event.position, mods);
                     cx.emit(GhosttyFocusChanged);
                     cx.notify();
                 }),
@@ -2024,59 +2086,65 @@ impl Render for GhosttyView {
                 gpui::MouseButton::Left,
                 cx.listener(|this, event: &MouseUpEvent, _window, cx| {
                     this.last_mouse_position = Some(event.position);
-                    if let Some(ref terminal) = this.terminal {
-                        let (x, y) = this.view_local_pos(event.position);
-                        let mods = gpui_mods_to_ghostty(&event.modifiers);
-                        terminal.send_mouse_pos(x, y, mods);
-                        terminal.send_mouse_button(false, MouseButton::Left, mods);
+                    let mods = gpui_mods_to_ghostty(&event.modifiers);
+                    if this.finish_mouse_sequence(MouseButton::Left, event.position, mods)
+                        && this.drain_surface_state(true, cx)
+                    {
+                        cx.notify();
                     }
-                    let changed = this.drain_surface_state(true, cx);
-                    if changed {
+                }),
+            )
+            .on_mouse_up_out(
+                gpui::MouseButton::Left,
+                cx.listener(|this, event: &MouseUpEvent, _window, cx| {
+                    if !this.left_mouse_pressed {
+                        return;
+                    }
+                    this.last_mouse_position = Some(event.position);
+                    let mods = gpui_mods_to_ghostty(&event.modifiers);
+                    if this.finish_mouse_sequence(MouseButton::Left, event.position, mods)
+                        && this.drain_surface_state(true, cx)
+                    {
                         cx.notify();
                     }
                 }),
             )
             .on_mouse_up(
                 gpui::MouseButton::Right,
-                cx.listener({
-                    let right_click_consumed = right_click_consumed.clone();
-                    move |this, event: &MouseUpEvent, _window, _cx| {
-                        this.last_mouse_position = Some(event.position);
-                        if right_click_consumed.get() {
-                            if let Some(ref terminal) = this.terminal {
-                                let (x, y) = this.view_local_pos(event.position);
-                                let mods = gpui_mods_to_ghostty(&event.modifiers);
-                                terminal.send_mouse_pos(x, y, mods);
-                                terminal.send_mouse_button(false, MouseButton::Right, mods);
-                            }
-                            right_click_consumed.set(false);
-                        }
+                cx.listener(|this, event: &MouseUpEvent, _window, _cx| {
+                    if !this.right_mouse_pressed {
+                        return;
                     }
+                    this.last_mouse_position = Some(event.position);
+                    let mods = gpui_mods_to_ghostty(&event.modifiers);
+                    this.finish_mouse_sequence(MouseButton::Right, event.position, mods);
                 }),
             )
             .on_mouse_up_out(
                 gpui::MouseButton::Right,
-                cx.listener({
-                    let right_click_consumed = right_click_consumed.clone();
-                    move |this, event: &MouseUpEvent, _window, _cx| {
-                        this.last_mouse_position = Some(event.position);
-                        if right_click_consumed.get() {
-                            if let Some(ref terminal) = this.terminal {
-                                let (x, y) = this.view_local_pos(event.position);
-                                let mods = gpui_mods_to_ghostty(&event.modifiers);
-                                terminal.send_mouse_pos(x, y, mods);
-                                terminal.send_mouse_button(false, MouseButton::Right, mods);
-                            }
-                            right_click_consumed.set(false);
-                        }
+                cx.listener(|this, event: &MouseUpEvent, _window, _cx| {
+                    if !this.right_mouse_pressed {
+                        return;
                     }
+                    this.last_mouse_position = Some(event.position);
+                    let mods = gpui_mods_to_ghostty(&event.modifiers);
+                    this.finish_mouse_sequence(MouseButton::Right, event.position, mods);
                 }),
             )
-            .on_mouse_move(cx.listener(|this, event: &MouseMoveEvent, _window, _cx| {
+            .on_mouse_move(cx.listener(|this, event: &MouseMoveEvent, _window, cx| {
                 this.last_mouse_position = Some(event.position);
+                let mods = gpui_mods_to_ghostty(&event.modifiers);
+                if event.pressed_button.is_none() {
+                    let released_left =
+                        this.finish_mouse_sequence(MouseButton::Left, event.position, mods);
+                    this.finish_mouse_sequence(MouseButton::Right, event.position, mods);
+                    if released_left && this.drain_surface_state(true, cx) {
+                        cx.notify();
+                    }
+                }
                 if let Some(ref terminal) = this.terminal {
                     let (x, y) = this.view_local_pos(event.position);
-                    terminal.send_mouse_pos(x, y, gpui_mods_to_ghostty(&event.modifiers));
+                    terminal.send_mouse_pos(x, y, mods);
                 }
             }))
             .on_modifiers_changed(cx.listener(

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -30,6 +30,7 @@ use gpui::{prelude::FluentBuilder as _, *};
 use gpui_component::ActiveTheme;
 use gpui_component::menu::ContextMenuExt;
 
+use crate::mouse_sequence::MouseButtonSequence;
 use crate::terminal_paste::{
     TerminalPastePayload, payload_from_clipboard, payload_from_external_paths,
 };
@@ -177,8 +178,8 @@ pub struct GhosttyView {
     native_transition_underlay_visible: Cell<bool>,
     #[cfg(target_os = "macos")]
     native_transition_underlay_owner_id: u64,
-    left_mouse_pressed: bool,
-    right_mouse_pressed: bool,
+    left_mouse_sequence: MouseButtonSequence<i32>,
+    right_mouse_sequence: MouseButtonSequence<i32>,
     /// Whether the most recent right-button press was consumed by libghostty.
     right_click_consumed: Rc<Cell<bool>>,
     ime_marked_text: Option<String>,
@@ -243,8 +244,8 @@ impl GhosttyView {
             #[cfg(target_os = "macos")]
             native_transition_underlay_owner_id: NEXT_NATIVE_TRANSITION_OWNER_ID
                 .fetch_add(1, Ordering::Relaxed),
-            left_mouse_pressed: false,
-            right_mouse_pressed: false,
+            left_mouse_sequence: MouseButtonSequence::default(),
+            right_mouse_sequence: MouseButtonSequence::default(),
             right_click_consumed: Rc::new(Cell::new(false)),
             ime_marked_text: None,
         }
@@ -422,7 +423,7 @@ impl GhosttyView {
         let Some(position) = self.last_mouse_position else {
             return;
         };
-        if self.finish_mouse_sequence(MouseButton::Left, position, 0) {
+        if self.finish_mouse_sequence(MouseButton::Left, position, None) {
             self.drain_surface_state(true, cx);
             cx.notify();
         }
@@ -1378,14 +1379,14 @@ impl GhosttyView {
         mods: i32,
     ) -> Option<bool> {
         self.last_mouse_position = Some(position);
-        self.finish_active_mouse_sequences();
+        self.finish_mouse_sequence(button, position, None);
         let terminal = self.terminal.as_ref()?;
         let (x, y) = self.view_local_pos(position);
         terminal.send_mouse_pos(x, y, mods);
         let consumed = terminal.send_mouse_button(true, button, mods);
         match button {
-            MouseButton::Left => self.left_mouse_pressed = true,
-            MouseButton::Right => self.right_mouse_pressed = true,
+            MouseButton::Left => self.left_mouse_sequence.press_sent(mods),
+            MouseButton::Right => self.right_mouse_sequence.press_sent(mods),
             MouseButton::Middle => {}
         }
         Some(consumed)
@@ -1395,16 +1396,17 @@ impl GhosttyView {
         &mut self,
         button: MouseButton,
         position: Point<Pixels>,
-        mods: i32,
+        mods: Option<i32>,
     ) -> bool {
-        let pressed = match button {
-            MouseButton::Left => std::mem::take(&mut self.left_mouse_pressed),
-            MouseButton::Right => std::mem::take(&mut self.right_mouse_pressed),
-            MouseButton::Middle => false,
+        let press_modifiers = match button {
+            MouseButton::Left => self.left_mouse_sequence.finish(),
+            MouseButton::Right => self.right_mouse_sequence.finish(),
+            MouseButton::Middle => None,
         };
-        if !pressed {
+        let Some(press_modifiers) = press_modifiers else {
             return false;
-        }
+        };
+        let mods = mods.unwrap_or(press_modifiers);
 
         let Some(terminal) = self.terminal.as_ref() else {
             return false;
@@ -1417,8 +1419,8 @@ impl GhosttyView {
 
     fn finish_active_mouse_sequences(&mut self) {
         if let Some(position) = self.last_mouse_position {
-            self.finish_mouse_sequence(MouseButton::Left, position, 0);
-            self.finish_mouse_sequence(MouseButton::Right, position, 0);
+            self.finish_mouse_sequence(MouseButton::Left, position, None);
+            self.finish_mouse_sequence(MouseButton::Right, position, None);
         }
     }
 
@@ -2087,7 +2089,7 @@ impl Render for GhosttyView {
                 cx.listener(|this, event: &MouseUpEvent, _window, cx| {
                     this.last_mouse_position = Some(event.position);
                     let mods = gpui_mods_to_ghostty(&event.modifiers);
-                    if this.finish_mouse_sequence(MouseButton::Left, event.position, mods)
+                    if this.finish_mouse_sequence(MouseButton::Left, event.position, Some(mods))
                         && this.drain_surface_state(true, cx)
                     {
                         cx.notify();
@@ -2097,12 +2099,12 @@ impl Render for GhosttyView {
             .on_mouse_up_out(
                 gpui::MouseButton::Left,
                 cx.listener(|this, event: &MouseUpEvent, _window, cx| {
-                    if !this.left_mouse_pressed {
+                    if !this.left_mouse_sequence.is_active() {
                         return;
                     }
                     this.last_mouse_position = Some(event.position);
                     let mods = gpui_mods_to_ghostty(&event.modifiers);
-                    if this.finish_mouse_sequence(MouseButton::Left, event.position, mods)
+                    if this.finish_mouse_sequence(MouseButton::Left, event.position, Some(mods))
                         && this.drain_surface_state(true, cx)
                     {
                         cx.notify();
@@ -2112,23 +2114,23 @@ impl Render for GhosttyView {
             .on_mouse_up(
                 gpui::MouseButton::Right,
                 cx.listener(|this, event: &MouseUpEvent, _window, _cx| {
-                    if !this.right_mouse_pressed {
+                    if !this.right_mouse_sequence.is_active() {
                         return;
                     }
                     this.last_mouse_position = Some(event.position);
                     let mods = gpui_mods_to_ghostty(&event.modifiers);
-                    this.finish_mouse_sequence(MouseButton::Right, event.position, mods);
+                    this.finish_mouse_sequence(MouseButton::Right, event.position, Some(mods));
                 }),
             )
             .on_mouse_up_out(
                 gpui::MouseButton::Right,
                 cx.listener(|this, event: &MouseUpEvent, _window, _cx| {
-                    if !this.right_mouse_pressed {
+                    if !this.right_mouse_sequence.is_active() {
                         return;
                     }
                     this.last_mouse_position = Some(event.position);
                     let mods = gpui_mods_to_ghostty(&event.modifiers);
-                    this.finish_mouse_sequence(MouseButton::Right, event.position, mods);
+                    this.finish_mouse_sequence(MouseButton::Right, event.position, Some(mods));
                 }),
             )
             .on_mouse_move(cx.listener(|this, event: &MouseMoveEvent, _window, cx| {
@@ -2136,8 +2138,8 @@ impl Render for GhosttyView {
                 let mods = gpui_mods_to_ghostty(&event.modifiers);
                 if event.pressed_button.is_none() {
                     let released_left =
-                        this.finish_mouse_sequence(MouseButton::Left, event.position, mods);
-                    this.finish_mouse_sequence(MouseButton::Right, event.position, mods);
+                        this.finish_mouse_sequence(MouseButton::Left, event.position, Some(mods));
+                    this.finish_mouse_sequence(MouseButton::Right, event.position, Some(mods));
                     if released_left && this.drain_surface_state(true, cx) {
                         cx.notify();
                     }

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -32,6 +32,7 @@ use gpui_component::{ActiveTheme, Sizable as _};
 use image::{Frame, RgbaImage};
 use smallvec::SmallVec;
 
+use crate::mouse_sequence::MouseButtonSequence;
 use crate::terminal_ime::{TerminalImeInputHandler, TerminalImeView};
 use crate::terminal_links::{self, TerminalLink};
 use crate::terminal_paste::{
@@ -140,10 +141,7 @@ pub struct GhosttyView {
     /// terminal app (an SGR report emitted). The context-menu builder
     /// suppresses con's menu only when this is true.
     terminal_mouse_right_consumed: Option<bool>,
-    terminal_mouse_right_pressed: bool,
-    /// Shift state at the right-button press, reused for the matching
-    /// release so a modifier change in between doesn't break pairing.
-    terminal_mouse_right_shift: bool,
+    terminal_right_mouse_sequence: MouseButtonSequence<bool>,
     keys_awaiting_release: HashMap<String, crate::terminal_keys::TrackedVtKey>,
     pending_unsafe_paste: Option<(String, VtPasteSource)>,
 }
@@ -229,8 +227,7 @@ impl GhosttyView {
             selection: None,
             drag_anchor: None,
             terminal_mouse_right_consumed: None,
-            terminal_mouse_right_pressed: false,
-            terminal_mouse_right_shift: false,
+            terminal_right_mouse_sequence: MouseButtonSequence::default(),
             keys_awaiting_release: HashMap::new(),
             pending_unsafe_paste: None,
         }
@@ -346,8 +343,7 @@ impl GhosttyView {
         self.selection = None;
         self.drag_anchor = None;
         self.terminal_mouse_right_consumed = None;
-        self.terminal_mouse_right_pressed = false;
-        self.terminal_mouse_right_shift = false;
+        self.terminal_right_mouse_sequence = MouseButtonSequence::default();
         self.keys_awaiting_release.clear();
         self.pending_unsafe_paste = None;
     }
@@ -672,7 +668,7 @@ impl GhosttyView {
 
     fn clear_hovered_link(&mut self) -> bool {
         let changed = self.hovered_link.take().is_some();
-        if self.drag_anchor.is_none() && !self.terminal_mouse_right_pressed {
+        if self.drag_anchor.is_none() && !self.terminal_right_mouse_sequence.is_active() {
             self.last_mouse_position = None;
         }
         changed
@@ -725,11 +721,9 @@ impl GhosttyView {
     }
 
     fn finish_right_mouse_sequence(&mut self, pos: Point<Pixels>) -> bool {
-        let pressed = std::mem::take(&mut self.terminal_mouse_right_pressed);
-        let shift = std::mem::take(&mut self.terminal_mouse_right_shift);
-        if !pressed {
+        let Some(shift) = self.terminal_right_mouse_sequence.finish() else {
             return false;
-        }
+        };
 
         if let Some(terminal) = self.terminal()
             && let Some((col, row)) = self.clamped_cell_from_event_position(pos)
@@ -739,16 +733,21 @@ impl GhosttyView {
         true
     }
 
-    fn cancel_pointer_interactions(&mut self) {
+    fn cancel_left_pointer_interactions(&mut self, position: Point<Pixels>) {
         self.mouse_down_link = None;
         self.suppress_link_mouse_up = false;
+        self.finish_selection(position);
+    }
+
+    fn cancel_pointer_interactions(&mut self) {
         let Some(position) = self.last_mouse_position else {
+            self.mouse_down_link = None;
+            self.suppress_link_mouse_up = false;
             self.drag_anchor = None;
-            self.terminal_mouse_right_pressed = false;
-            self.terminal_mouse_right_shift = false;
+            self.terminal_right_mouse_sequence.finish();
             return;
         };
-        self.finish_selection(position);
+        self.cancel_left_pointer_interactions(position);
         self.finish_right_mouse_sequence(position);
     }
 
@@ -1717,9 +1716,7 @@ impl Render for GhosttyView {
                     window.focus(&context_focus, cx);
                     let _ = this.ensure_session(cx);
                     this.last_mouse_position = Some(event.position);
-                    this.cancel_pointer_interactions();
-                    this.mouse_down_link = None;
-                    this.suppress_link_mouse_up = false;
+                    this.finish_right_mouse_sequence(event.position);
                     let _ = this.update_hovered_link(&event.modifiers);
                     // SGR button 2 = right; unconsumed when tracking is off.
                     // Record the press shift state so the matching release
@@ -1734,9 +1731,10 @@ impl Render for GhosttyView {
                     } else {
                         None
                     };
-                    this.terminal_mouse_right_pressed =
-                        this.terminal_mouse_right_consumed == Some(true);
-                    this.terminal_mouse_right_shift = shift_at_press;
+                    if this.terminal_mouse_right_consumed == Some(true) {
+                        this.terminal_right_mouse_sequence
+                            .press_sent(shift_at_press);
+                    }
                     cx.emit(GhosttyFocusChanged);
                     cx.notify();
                 }),
@@ -1747,9 +1745,7 @@ impl Render for GhosttyView {
                     window.focus(&focus, cx);
                     let _ = this.ensure_session(cx);
                     this.last_mouse_position = Some(event.position);
-                    this.cancel_pointer_interactions();
-                    this.mouse_down_link = None;
-                    this.suppress_link_mouse_up = false;
+                    this.cancel_left_pointer_interactions(event.position);
                     let _ = this.update_hovered_link(&event.modifiers);
                     if terminal_links::should_open_link(&event.modifiers)
                         && let Some(link) = this.link_at_position(event.position)
@@ -1770,31 +1766,40 @@ impl Render for GhosttyView {
             .on_mouse_move(cx.listener(|this, event: &MouseMoveEvent, _window, cx| {
                 this.last_mouse_position = Some(event.position);
                 if this.suppress_link_mouse_up {
-                    let mut changed = this.update_hovered_link(&event.modifiers);
-                    if event.pressed_button != Some(MouseButton::Left) {
+                    if event.pressed_button == Some(MouseButton::Left) {
+                        let mut changed = this.update_hovered_link(&event.modifiers);
+                        if let Some(down_link) = this.mouse_down_link.as_ref() {
+                            let still_on_same_link =
+                                this.link_at_position(event.position).as_ref() == Some(down_link);
+                            if !still_on_same_link {
+                                this.mouse_down_link = None;
+                                changed = true;
+                            }
+                        }
+                        cx.stop_propagation();
+                        if changed {
+                            cx.notify();
+                        }
+                        return;
+                    }
+                    if event.pressed_button.is_none() {
+                        let mut changed = this.update_hovered_link(&event.modifiers);
                         changed |= this.mouse_down_link.take().is_some();
                         this.suppress_link_mouse_up = false;
-                    } else if let Some(down_link) = this.mouse_down_link.as_ref() {
-                        let still_on_same_link =
-                            this.link_at_position(event.position).as_ref() == Some(down_link);
-                        if !still_on_same_link {
-                            this.mouse_down_link = None;
-                            changed = true;
+                        cx.stop_propagation();
+                        if changed {
+                            cx.notify();
                         }
                     }
-                    cx.stop_propagation();
-                    if changed {
-                        cx.notify();
-                    }
-                    return;
                 }
                 let mut changed = this.update_hovered_link(&event.modifiers);
                 if event.pressed_button == Some(MouseButton::Left) {
                     changed |= this.update_selection_drag(event.position);
-                } else if this.drag_anchor.is_some() {
+                } else if event.pressed_button.is_none() && this.drag_anchor.is_some() {
                     changed |= this.finish_selection(event.position);
                 }
-                if event.pressed_button.is_none() && this.terminal_mouse_right_pressed {
+                if event.pressed_button.is_none() && this.terminal_right_mouse_sequence.is_active()
+                {
                     changed |= this.finish_right_mouse_sequence(event.position);
                 }
                 if changed {
@@ -1854,7 +1859,7 @@ impl Render for GhosttyView {
             .on_mouse_up_out(
                 MouseButton::Right,
                 cx.listener(|this, event: &MouseUpEvent, _window, cx| {
-                    if !this.terminal_mouse_right_pressed {
+                    if !this.terminal_right_mouse_sequence.is_active() {
                         return;
                     }
                     this.last_mouse_position = Some(event.position);

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -140,6 +140,7 @@ pub struct GhosttyView {
     /// terminal app (an SGR report emitted). The context-menu builder
     /// suppresses con's menu only when this is true.
     terminal_mouse_right_consumed: Option<bool>,
+    terminal_mouse_right_pressed: bool,
     /// Shift state at the right-button press, reused for the matching
     /// release so a modifier change in between doesn't break pairing.
     terminal_mouse_right_shift: bool,
@@ -228,6 +229,7 @@ impl GhosttyView {
             selection: None,
             drag_anchor: None,
             terminal_mouse_right_consumed: None,
+            terminal_mouse_right_pressed: false,
             terminal_mouse_right_shift: false,
             keys_awaiting_release: HashMap::new(),
             pending_unsafe_paste: None,
@@ -281,6 +283,15 @@ impl GhosttyView {
         extract_selection_text(self.snapshot.as_ref()?, self.selection?)
     }
 
+    pub fn release_mouse_selection(&mut self, cx: &mut Context<Self>) {
+        let Some(position) = self.last_mouse_position else {
+            return;
+        };
+        if self.finish_selection(position) {
+            cx.notify();
+        }
+    }
+
     fn clear_selection(&mut self) -> bool {
         let changed = self.selection.take().is_some() || self.drag_anchor.take().is_some();
         changed
@@ -306,6 +317,7 @@ impl GhosttyView {
 
     pub fn shutdown_surface(&mut self, mut window: Option<&mut Window>, cx: &mut App) {
         self.release_tracked_keys();
+        self.cancel_pointer_interactions();
         if let Some(terminal) = &self.terminal {
             terminal.request_close();
         }
@@ -334,6 +346,7 @@ impl GhosttyView {
         self.selection = None;
         self.drag_anchor = None;
         self.terminal_mouse_right_consumed = None;
+        self.terminal_mouse_right_pressed = false;
         self.terminal_mouse_right_shift = false;
         self.keys_awaiting_release.clear();
         self.pending_unsafe_paste = None;
@@ -342,6 +355,7 @@ impl GhosttyView {
     pub fn set_surface_focus_state(&mut self, focused: bool) {
         if !focused {
             self.release_tracked_keys();
+            self.cancel_pointer_interactions();
         }
         if let Some(terminal) = &self.terminal {
             terminal.set_focus(focused);
@@ -658,7 +672,9 @@ impl GhosttyView {
 
     fn clear_hovered_link(&mut self) -> bool {
         let changed = self.hovered_link.take().is_some();
-        self.last_mouse_position = None;
+        if self.drag_anchor.is_none() && !self.terminal_mouse_right_pressed {
+            self.last_mouse_position = None;
+        }
         changed
     }
 
@@ -706,6 +722,34 @@ impl GhosttyView {
         }
         self.selection = Some(next);
         true
+    }
+
+    fn finish_right_mouse_sequence(&mut self, pos: Point<Pixels>) -> bool {
+        let pressed = std::mem::take(&mut self.terminal_mouse_right_pressed);
+        let shift = std::mem::take(&mut self.terminal_mouse_right_shift);
+        if !pressed {
+            return false;
+        }
+
+        if let Some(terminal) = self.terminal()
+            && let Some((col, row)) = self.clamped_cell_from_event_position(pos)
+        {
+            terminal.mouse_release(2, col, row, shift);
+        }
+        true
+    }
+
+    fn cancel_pointer_interactions(&mut self) {
+        self.mouse_down_link = None;
+        self.suppress_link_mouse_up = false;
+        let Some(position) = self.last_mouse_position else {
+            self.drag_anchor = None;
+            self.terminal_mouse_right_pressed = false;
+            self.terminal_mouse_right_shift = false;
+            return;
+        };
+        self.finish_selection(position);
+        self.finish_right_mouse_sequence(position);
     }
 
     fn selection_point_from_event_position(&self, pos: Point<Pixels>) -> Option<(u16, u64)> {
@@ -1673,6 +1717,7 @@ impl Render for GhosttyView {
                     window.focus(&context_focus, cx);
                     let _ = this.ensure_session(cx);
                     this.last_mouse_position = Some(event.position);
+                    this.cancel_pointer_interactions();
                     this.mouse_down_link = None;
                     this.suppress_link_mouse_up = false;
                     let _ = this.update_hovered_link(&event.modifiers);
@@ -1689,6 +1734,8 @@ impl Render for GhosttyView {
                     } else {
                         None
                     };
+                    this.terminal_mouse_right_pressed =
+                        this.terminal_mouse_right_consumed == Some(true);
                     this.terminal_mouse_right_shift = shift_at_press;
                     cx.emit(GhosttyFocusChanged);
                     cx.notify();
@@ -1700,6 +1747,7 @@ impl Render for GhosttyView {
                     window.focus(&focus, cx);
                     let _ = this.ensure_session(cx);
                     this.last_mouse_position = Some(event.position);
+                    this.cancel_pointer_interactions();
                     this.mouse_down_link = None;
                     this.suppress_link_mouse_up = false;
                     let _ = this.update_hovered_link(&event.modifiers);
@@ -1746,6 +1794,9 @@ impl Render for GhosttyView {
                 } else if this.drag_anchor.is_some() {
                     changed |= this.finish_selection(event.position);
                 }
+                if event.pressed_button.is_none() && this.terminal_mouse_right_pressed {
+                    changed |= this.finish_right_mouse_sequence(event.position);
+                }
                 if changed {
                     cx.notify();
                 }
@@ -1775,26 +1826,40 @@ impl Render for GhosttyView {
                     }
                 }),
             )
+            .on_mouse_up_out(
+                MouseButton::Left,
+                cx.listener(|this, event: &MouseUpEvent, _window, cx| {
+                    if this.drag_anchor.is_none() && !this.suppress_link_mouse_up {
+                        return;
+                    }
+                    this.last_mouse_position = Some(event.position);
+                    this.mouse_down_link = None;
+                    this.suppress_link_mouse_up = false;
+                    let mut changed = this.finish_selection(event.position);
+                    changed |= this.update_hovered_link(&event.modifiers);
+                    if changed {
+                        cx.notify();
+                    }
+                }),
+            )
             .on_mouse_up(
                 MouseButton::Right,
-                cx.listener(|this, event: &MouseUpEvent, _window, _cx| {
+                cx.listener(|this, event: &MouseUpEvent, _window, cx| {
                     this.last_mouse_position = Some(event.position);
-                    // Only release when the press was consumed by the app, so
-                    // plain right-clicks (menu path) never emit a stray release.
-                    if this.terminal_mouse_right_consumed == Some(true) {
-                        if let Some(terminal) = this.terminal() {
-                            if let Some((col, row)) =
-                                this.clamped_cell_from_event_position(event.position)
-                            {
-                                terminal.mouse_release(
-                                    2,
-                                    col,
-                                    row,
-                                    this.terminal_mouse_right_shift,
-                                );
-                            }
-                        }
-                        this.terminal_mouse_right_consumed = None;
+                    if this.finish_right_mouse_sequence(event.position) {
+                        cx.notify();
+                    }
+                }),
+            )
+            .on_mouse_up_out(
+                MouseButton::Right,
+                cx.listener(|this, event: &MouseUpEvent, _window, cx| {
+                    if !this.terminal_mouse_right_pressed {
+                        return;
+                    }
+                    this.last_mouse_position = Some(event.position);
+                    if this.finish_right_mouse_sequence(event.position) {
+                        cx.notify();
                     }
                 }),
             )
@@ -1860,6 +1925,7 @@ impl Render for GhosttyView {
 impl Drop for GhosttyView {
     fn drop(&mut self) {
         self.release_tracked_keys();
+        self.cancel_pointer_interactions();
         if let Some(terminal) = &self.terminal {
             terminal.request_close();
         }

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -64,6 +64,7 @@ mod input_bar;
 mod keycaps;
 mod model_registry;
 mod motion;
+mod mouse_sequence;
 mod pane_tree;
 mod settings_panel;
 mod sidebar;

--- a/crates/con-app/src/mouse_sequence.rs
+++ b/crates/con-app/src/mouse_sequence.rs
@@ -1,0 +1,52 @@
+pub(crate) struct MouseButtonSequence<M> {
+    press_modifiers: Option<M>,
+}
+
+impl<M> Default for MouseButtonSequence<M> {
+    fn default() -> Self {
+        Self {
+            press_modifiers: None,
+        }
+    }
+}
+
+impl<M> MouseButtonSequence<M> {
+    pub(crate) fn is_active(&self) -> bool {
+        self.press_modifiers.is_some()
+    }
+
+    #[cfg(target_os = "windows")]
+    pub(crate) fn press_modifiers(&self) -> Option<&M> {
+        self.press_modifiers.as_ref()
+    }
+
+    pub(crate) fn press_sent(&mut self, modifiers: M) {
+        debug_assert!(self.press_modifiers.is_none());
+        self.press_modifiers = Some(modifiers);
+    }
+
+    pub(crate) fn finish(&mut self) -> Option<M> {
+        self.press_modifiers.take()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MouseButtonSequence;
+
+    #[test]
+    fn button_sequences_finish_independently_and_once() {
+        let mut left = MouseButtonSequence::default();
+        let mut right = MouseButtonSequence::default();
+
+        left.press_sent(1);
+        right.press_sent(2);
+
+        assert_eq!(left.finish(), Some(1));
+        assert!(!left.is_active());
+        assert!(right.is_active());
+        assert_eq!(left.finish(), None);
+        assert_eq!(right.finish(), Some(2));
+        assert_eq!(right.finish(), None);
+    }
+}

--- a/crates/con-app/src/stub_view.rs
+++ b/crates/con-app/src/stub_view.rs
@@ -94,6 +94,8 @@ impl GhosttyView {
         None
     }
 
+    pub fn release_mouse_selection(&mut self, _cx: &mut Context<Self>) {}
+
     pub fn shutdown_surface(&mut self, _window: Option<&mut Window>, _cx: &mut App) {}
 
     pub fn set_surface_focus_state(&mut self, _focused: bool) {}

--- a/crates/con-app/src/terminal_pane.rs
+++ b/crates/con-app/src/terminal_pane.rs
@@ -178,10 +178,9 @@ impl TerminalPane {
         self.entity.read(cx).selection_text()
     }
 
-    pub fn release_mouse_selection(&self, cx: &App) {
-        if let Some(terminal) = self.entity.read(cx).terminal() {
-            terminal.send_mouse_button(false, con_ghostty::MouseButton::Left, 0);
-        }
+    pub fn release_mouse_selection(&self, cx: &mut App) {
+        self.entity
+            .update(cx, |view, cx| view.release_mouse_selection(cx));
     }
 
     pub fn entity_id(&self) -> EntityId {

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -302,8 +302,26 @@ impl GhosttyView {
         self.terminal.as_ref().and_then(|t| t.selection_text())
     }
 
+    pub fn release_mouse_selection(&mut self, cx: &mut Context<Self>) {
+        let Some(position) = self.last_mouse_position else {
+            return;
+        };
+        if self.finish_terminal_mouse_sequence(
+            0,
+            position,
+            MouseEventMods {
+                shift: self.terminal_mouse_sequence_shift,
+                alt: false,
+                control: false,
+            },
+        ) {
+            cx.notify();
+        }
+    }
+
     pub fn shutdown_surface(&mut self, _window: Option<&mut Window>, _cx: &mut App) {
         self.release_tracked_keys();
+        self.cancel_pointer_interactions();
         if let Some(terminal) = &self.terminal {
             terminal.request_close();
         }
@@ -336,6 +354,7 @@ impl GhosttyView {
     pub fn set_surface_focus_state(&mut self, focused: bool) {
         if !focused {
             self.release_tracked_keys();
+            self.cancel_pointer_interactions();
         }
         if let Some(terminal) = &self.terminal {
             terminal.set_focus(focused);
@@ -865,7 +884,9 @@ impl GhosttyView {
 
     fn clear_hovered_link(&mut self) -> bool {
         let changed = self.hovered_link.take().is_some();
-        self.last_mouse_position = None;
+        if !self.terminal_mouse_sequence_active {
+            self.last_mouse_position = None;
+        }
         changed
     }
 
@@ -956,6 +977,57 @@ impl GhosttyView {
                 }
             }
         }
+    }
+
+    fn finish_terminal_mouse_sequence(
+        &mut self,
+        button: u8,
+        pos: Point<Pixels>,
+        mods: MouseEventMods,
+    ) -> bool {
+        if !self.terminal_mouse_sequence_active
+            || self.terminal_mouse_sequence_button != Some(button)
+        {
+            return false;
+        }
+
+        self.terminal_mouse_sequence_active = false;
+        self.terminal_mouse_sequence_button = None;
+        self.forward_mouse_up(button, pos, mods, true);
+        if button == 0 {
+            self.terminal_mouse_sequence_shift = false;
+        } else if button == 2 {
+            self.terminal_mouse_right_shift = false;
+        }
+        true
+    }
+
+    fn cancel_pointer_interactions(&mut self) {
+        self.scrollbar_drag = None;
+        self.mouse_down_link = None;
+        self.suppress_link_mouse_up = false;
+        if let (Some(position), Some(button)) = (
+            self.last_mouse_position,
+            self.terminal_mouse_sequence_button,
+        ) {
+            self.finish_terminal_mouse_sequence(
+                button,
+                position,
+                MouseEventMods {
+                    shift: if button == 2 {
+                        self.terminal_mouse_right_shift
+                    } else {
+                        self.terminal_mouse_sequence_shift
+                    },
+                    alt: false,
+                    control: false,
+                },
+            );
+        }
+        self.terminal_mouse_sequence_active = false;
+        self.terminal_mouse_sequence_button = None;
+        self.terminal_mouse_sequence_shift = false;
+        self.terminal_mouse_right_shift = false;
     }
 
     fn forward_scroll(&self, pos: Point<Pixels>, delta: ScrollDelta, mods: MouseEventMods) -> bool {
@@ -1743,6 +1815,7 @@ impl Render for GhosttyView {
                 cx.listener(move |this, event: &MouseDownEvent, window, cx| {
                     window.focus(&context_focus, cx);
                     this.last_mouse_position = Some(event.position);
+                    this.cancel_pointer_interactions();
                     this.mouse_down_link = None;
                     this.suppress_link_mouse_up = false;
                     let _ = this.update_hovered_link(&event.modifiers);
@@ -1767,8 +1840,7 @@ impl Render for GhosttyView {
                 cx.listener(move |this, event: &MouseDownEvent, window, cx| {
                     window.focus(&focus, cx);
                     this.last_mouse_position = Some(event.position);
-                    this.terminal_mouse_sequence_active = false;
-                    this.terminal_mouse_sequence_button = None;
+                    this.cancel_pointer_interactions();
                     this.mouse_down_link = None;
                     this.suppress_link_mouse_up = false;
                     let _ = this.update_hovered_link(&event.modifiers);
@@ -1792,7 +1864,7 @@ impl Render for GhosttyView {
                     let tracking_active = this.terminal_mouse_tracking_active_at(event.position);
                     let consumed = this.forward_mouse_down(0, event.position, mods);
                     if consumed
-                        || (!tracking_active
+                        || ((!tracking_active || mods.shift)
                             && this.terminal().is_some()
                             && this.cell_from_event_position(event.position).is_some())
                     {
@@ -1869,29 +1941,18 @@ impl Render for GhosttyView {
                     );
                     cx.notify();
                 } else if event.pressed_button.is_none() && this.terminal_mouse_sequence_active {
-                    let button = this.terminal_mouse_sequence_button.unwrap_or(0);
-                    let release_mods = mouse_mods_from(&event.modifiers);
-                    let release_mods = if button == 2 {
-                        MouseEventMods {
-                            shift: this.terminal_mouse_right_shift,
+                    if let Some(button) = this.terminal_mouse_sequence_button {
+                        let release_mods = mouse_mods_from(&event.modifiers);
+                        let release_mods = MouseEventMods {
+                            shift: if button == 2 {
+                                this.terminal_mouse_right_shift
+                            } else {
+                                this.terminal_mouse_sequence_shift
+                            },
                             ..release_mods
-                        }
-                    } else if button == 0 {
-                        MouseEventMods {
-                            shift: this.terminal_mouse_sequence_shift,
-                            ..release_mods
-                        }
-                    } else {
-                        release_mods
-                    };
-                    this.forward_mouse_up(button, event.position, release_mods, true);
-                    if button == 2 {
-                        this.terminal_mouse_right_shift = false;
-                    } else if button == 0 {
-                        this.terminal_mouse_sequence_shift = false;
+                        };
+                        this.finish_terminal_mouse_sequence(button, event.position, release_mods);
                     }
-                    this.terminal_mouse_sequence_active = false;
-                    this.terminal_mouse_sequence_button = None;
                     cx.notify();
                 } else if hover_changed {
                     cx.notify();
@@ -1906,7 +1967,6 @@ impl Render for GhosttyView {
                         cx.notify();
                         return;
                     }
-                    let had_terminal_mouse_sequence = this.terminal_mouse_sequence_active;
                     if this.suppress_link_mouse_up {
                         let down_link = this.mouse_down_link.take();
                         this.suppress_link_mouse_up = false;
@@ -1921,21 +1981,40 @@ impl Render for GhosttyView {
                         cx.notify();
                         return;
                     }
-                    if had_terminal_mouse_sequence {
-                        let button = this.terminal_mouse_sequence_button.unwrap_or(0);
-                        this.forward_mouse_up(
-                            button,
-                            event.position,
-                            MouseEventMods {
-                                shift: this.terminal_mouse_sequence_shift,
-                                ..mouse_mods_from(&event.modifiers)
-                            },
-                            true,
-                        );
+                    this.finish_terminal_mouse_sequence(
+                        0,
+                        event.position,
+                        MouseEventMods {
+                            shift: this.terminal_mouse_sequence_shift,
+                            ..mouse_mods_from(&event.modifiers)
+                        },
+                    );
+                    let _ = this.update_hovered_link(&event.modifiers);
+                    cx.notify();
+                }),
+            )
+            .on_mouse_up_out(
+                MouseButton::Left,
+                cx.listener(|this, event: &MouseUpEvent, _window, cx| {
+                    let owns_sequence = this.scrollbar_drag.is_some()
+                        || this.suppress_link_mouse_up
+                        || (this.terminal_mouse_sequence_active
+                            && this.terminal_mouse_sequence_button == Some(0));
+                    if !owns_sequence {
+                        return;
                     }
-                    this.terminal_mouse_sequence_active = false;
-                    this.terminal_mouse_sequence_shift = false;
-                    this.terminal_mouse_sequence_button = None;
+                    this.last_mouse_position = Some(event.position);
+                    this.scrollbar_drag = None;
+                    this.mouse_down_link = None;
+                    this.suppress_link_mouse_up = false;
+                    this.finish_terminal_mouse_sequence(
+                        0,
+                        event.position,
+                        MouseEventMods {
+                            shift: this.terminal_mouse_sequence_shift,
+                            ..mouse_mods_from(&event.modifiers)
+                        },
+                    );
                     let _ = this.update_hovered_link(&event.modifiers);
                     cx.notify();
                 }),
@@ -1944,21 +2023,35 @@ impl Render for GhosttyView {
                 MouseButton::Right,
                 cx.listener(|this, event: &MouseUpEvent, _window, cx| {
                     this.last_mouse_position = Some(event.position);
-                    if this.terminal_mouse_sequence_active {
-                        let button = this.terminal_mouse_sequence_button.unwrap_or(2);
-                        this.forward_mouse_up(
-                            button,
-                            event.position,
-                            MouseEventMods {
-                                shift: this.terminal_mouse_right_shift,
-                                ..mouse_mods_from(&event.modifiers)
-                            },
-                            true,
-                        );
-                        this.terminal_mouse_sequence_active = false;
-                        this.terminal_mouse_sequence_button = None;
+                    this.finish_terminal_mouse_sequence(
+                        2,
+                        event.position,
+                        MouseEventMods {
+                            shift: this.terminal_mouse_right_shift,
+                            ..mouse_mods_from(&event.modifiers)
+                        },
+                    );
+                    let _ = this.update_hovered_link(&event.modifiers);
+                    cx.notify();
+                }),
+            )
+            .on_mouse_up_out(
+                MouseButton::Right,
+                cx.listener(|this, event: &MouseUpEvent, _window, cx| {
+                    if !this.terminal_mouse_sequence_active
+                        || this.terminal_mouse_sequence_button != Some(2)
+                    {
+                        return;
                     }
-                    this.terminal_mouse_right_shift = false;
+                    this.last_mouse_position = Some(event.position);
+                    this.finish_terminal_mouse_sequence(
+                        2,
+                        event.position,
+                        MouseEventMods {
+                            shift: this.terminal_mouse_right_shift,
+                            ..mouse_mods_from(&event.modifiers)
+                        },
+                    );
                     let _ = this.update_hovered_link(&event.modifiers);
                     cx.notify();
                 }),
@@ -2093,6 +2186,7 @@ impl Render for GhosttyView {
 impl Drop for GhosttyView {
     fn drop(&mut self) {
         self.release_tracked_keys();
+        self.cancel_pointer_interactions();
         if let Some(terminal) = &self.terminal {
             terminal.request_close();
         }

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -53,6 +53,7 @@ use gpui_component::{ActiveTheme, Sizable as _};
 use image::{Frame, RgbaImage};
 use smallvec::SmallVec;
 
+use crate::mouse_sequence::MouseButtonSequence;
 use crate::terminal_ime::{TerminalImeInputHandler, TerminalImeView};
 use crate::terminal_links::{self, TerminalLink};
 use crate::terminal_paste::{
@@ -154,17 +155,12 @@ pub struct GhosttyView {
     /// `Window::drop_image` to evict sprite-atlas tiles.
     images_to_drop: Vec<Arc<RenderImage>>,
     scrollbar_drag: Option<ScrollbarDrag>,
-    terminal_mouse_sequence_active: bool,
-    terminal_mouse_sequence_shift: bool,
-    /// SGR button index of the in-flight terminal mouse sequence, so the
-    /// release/move-release report uses the same button as the press.
-    terminal_mouse_sequence_button: Option<u8>,
+    terminal_left_mouse_sequence: MouseButtonSequence<bool>,
+    terminal_right_mouse_sequence: MouseButtonSequence<bool>,
     /// Whether the most recent right-button press was consumed by the
     /// terminal app (an SGR report emitted). The context-menu builder
     /// suppresses con's menu only when this is true.
     terminal_mouse_right_consumed: Option<bool>,
-    /// Shift state at the right-button press, reused for its release.
-    terminal_mouse_right_shift: bool,
     mouse_down_link: Option<TerminalLink>,
     suppress_link_mouse_up: bool,
     hovered_link: Option<TerminalLink>,
@@ -248,11 +244,9 @@ impl GhosttyView {
             scrollbar_cache: None,
             images_to_drop: Vec::new(),
             scrollbar_drag: None,
-            terminal_mouse_sequence_active: false,
-            terminal_mouse_sequence_shift: false,
-            terminal_mouse_sequence_button: None,
+            terminal_left_mouse_sequence: MouseButtonSequence::default(),
+            terminal_right_mouse_sequence: MouseButtonSequence::default(),
             terminal_mouse_right_consumed: None,
-            terminal_mouse_right_shift: false,
             mouse_down_link: None,
             suppress_link_mouse_up: false,
             hovered_link: None,
@@ -310,7 +304,7 @@ impl GhosttyView {
             0,
             position,
             MouseEventMods {
-                shift: self.terminal_mouse_sequence_shift,
+                shift: false,
                 alt: false,
                 control: false,
             },
@@ -335,9 +329,8 @@ impl GhosttyView {
         self.cached_frame_size = None;
         self.scrollbar_cache = None;
         self.scrollbar_drag = None;
-        self.terminal_mouse_sequence_active = false;
-        self.terminal_mouse_sequence_shift = false;
-        self.terminal_mouse_sequence_button = None;
+        self.terminal_left_mouse_sequence = MouseButtonSequence::default();
+        self.terminal_right_mouse_sequence = MouseButtonSequence::default();
         self.terminal_mouse_right_consumed = None;
         self.ime_marked_text = None;
         self.ime_selected_range = None;
@@ -884,7 +877,9 @@ impl GhosttyView {
 
     fn clear_hovered_link(&mut self) -> bool {
         let changed = self.hovered_link.take().is_some();
-        if !self.terminal_mouse_sequence_active {
+        if !self.terminal_left_mouse_sequence.is_active()
+            && !self.terminal_right_mouse_sequence.is_active()
+        {
             self.last_mouse_position = None;
         }
         changed
@@ -983,51 +978,40 @@ impl GhosttyView {
         &mut self,
         button: u8,
         pos: Point<Pixels>,
-        mods: MouseEventMods,
+        mut mods: MouseEventMods,
     ) -> bool {
-        if !self.terminal_mouse_sequence_active
-            || self.terminal_mouse_sequence_button != Some(button)
-        {
+        let press_shift = match button {
+            0 => self.terminal_left_mouse_sequence.finish(),
+            2 => self.terminal_right_mouse_sequence.finish(),
+            _ => None,
+        };
+        let Some(press_shift) = press_shift else {
             return false;
-        }
+        };
 
-        self.terminal_mouse_sequence_active = false;
-        self.terminal_mouse_sequence_button = None;
+        mods.shift = press_shift;
         self.forward_mouse_up(button, pos, mods, true);
-        if button == 0 {
-            self.terminal_mouse_sequence_shift = false;
-        } else if button == 2 {
-            self.terminal_mouse_right_shift = false;
-        }
         true
     }
 
-    fn cancel_pointer_interactions(&mut self) {
+    fn cancel_left_pointer_interactions(&mut self, position: Point<Pixels>) {
         self.scrollbar_drag = None;
         self.mouse_down_link = None;
         self.suppress_link_mouse_up = false;
-        if let (Some(position), Some(button)) = (
-            self.last_mouse_position,
-            self.terminal_mouse_sequence_button,
-        ) {
-            self.finish_terminal_mouse_sequence(
-                button,
-                position,
-                MouseEventMods {
-                    shift: if button == 2 {
-                        self.terminal_mouse_right_shift
-                    } else {
-                        self.terminal_mouse_sequence_shift
-                    },
-                    alt: false,
-                    control: false,
-                },
-            );
+        self.finish_terminal_mouse_sequence(0, position, MouseEventMods::default());
+    }
+
+    fn cancel_pointer_interactions(&mut self) {
+        if let Some(position) = self.last_mouse_position {
+            self.cancel_left_pointer_interactions(position);
+            self.finish_terminal_mouse_sequence(2, position, MouseEventMods::default());
+        } else {
+            self.scrollbar_drag = None;
+            self.mouse_down_link = None;
+            self.suppress_link_mouse_up = false;
+            self.terminal_left_mouse_sequence.finish();
+            self.terminal_right_mouse_sequence.finish();
         }
-        self.terminal_mouse_sequence_active = false;
-        self.terminal_mouse_sequence_button = None;
-        self.terminal_mouse_sequence_shift = false;
-        self.terminal_mouse_right_shift = false;
     }
 
     fn forward_scroll(&self, pos: Point<Pixels>, delta: ScrollDelta, mods: MouseEventMods) -> bool {
@@ -1815,9 +1799,11 @@ impl Render for GhosttyView {
                 cx.listener(move |this, event: &MouseDownEvent, window, cx| {
                     window.focus(&context_focus, cx);
                     this.last_mouse_position = Some(event.position);
-                    this.cancel_pointer_interactions();
-                    this.mouse_down_link = None;
-                    this.suppress_link_mouse_up = false;
+                    this.finish_terminal_mouse_sequence(
+                        2,
+                        event.position,
+                        MouseEventMods::default(),
+                    );
                     let _ = this.update_hovered_link(&event.modifiers);
                     // SGR button 2 = right; unconsumed when tracking is off.
                     let consumed = this.forward_mouse_down(
@@ -1826,10 +1812,9 @@ impl Render for GhosttyView {
                         mouse_mods_from(&event.modifiers),
                     );
                     this.terminal_mouse_right_consumed = Some(consumed);
-                    this.terminal_mouse_right_shift = event.modifiers.shift;
-                    this.terminal_mouse_sequence_active = consumed;
                     if consumed {
-                        this.terminal_mouse_sequence_button = Some(2);
+                        this.terminal_right_mouse_sequence
+                            .press_sent(event.modifiers.shift);
                     }
                     cx.emit(GhosttyFocusChanged);
                     cx.notify();
@@ -1840,9 +1825,7 @@ impl Render for GhosttyView {
                 cx.listener(move |this, event: &MouseDownEvent, window, cx| {
                     window.focus(&focus, cx);
                     this.last_mouse_position = Some(event.position);
-                    this.cancel_pointer_interactions();
-                    this.mouse_down_link = None;
-                    this.suppress_link_mouse_up = false;
+                    this.cancel_left_pointer_interactions(event.position);
                     let _ = this.update_hovered_link(&event.modifiers);
                     if terminal_links::should_open_link(&event.modifiers)
                         && let Some(link) = this.link_at_position(event.position)
@@ -1868,9 +1851,8 @@ impl Render for GhosttyView {
                             && this.terminal().is_some()
                             && this.cell_from_event_position(event.position).is_some())
                     {
-                        this.terminal_mouse_sequence_active = true;
-                        this.terminal_mouse_sequence_shift = event.modifiers.shift;
-                        this.terminal_mouse_sequence_button = Some(0);
+                        this.terminal_left_mouse_sequence
+                            .press_sent(event.modifiers.shift);
                     }
                     cx.emit(GhosttyFocusChanged);
                     cx.notify();
@@ -1879,43 +1861,54 @@ impl Render for GhosttyView {
             .on_mouse_move(cx.listener(|this, event: &MouseMoveEvent, _window, cx| {
                 this.last_mouse_position = Some(event.position);
                 if this.scrollbar_drag.is_some() {
-                    if event.pressed_button != Some(MouseButton::Left) {
-                        this.scrollbar_drag = None;
-                        this.update_hovered_link(&event.modifiers);
+                    if event.pressed_button == Some(MouseButton::Left) {
+                        this.drag_scrollbar(event.position);
                         cx.notify();
                         return;
                     }
-                    this.drag_scrollbar(event.position);
-                    cx.notify();
-                    return;
-                }
-                if this.suppress_link_mouse_up {
-                    let mut changed = this.update_hovered_link(&event.modifiers);
-                    if event.pressed_button != Some(MouseButton::Left) {
-                        changed |= this.mouse_down_link.take().is_some();
-                        this.suppress_link_mouse_up = false;
-                    } else if let Some(down_link) = this.mouse_down_link.as_ref() {
-                        let still_on_same_link =
-                            this.link_at_position(event.position).as_ref() == Some(down_link);
-                        if !still_on_same_link {
-                            this.mouse_down_link = None;
-                            changed = true;
-                        }
-                    }
-                    cx.stop_propagation();
-                    if changed {
+                    if event.pressed_button.is_none() {
+                        this.scrollbar_drag = None;
+                        this.update_hovered_link(&event.modifiers);
                         cx.notify();
                     }
-                    return;
+                }
+                if this.suppress_link_mouse_up {
+                    if event.pressed_button == Some(MouseButton::Left) {
+                        let mut changed = this.update_hovered_link(&event.modifiers);
+                        if let Some(down_link) = this.mouse_down_link.as_ref() {
+                            let still_on_same_link =
+                                this.link_at_position(event.position).as_ref() == Some(down_link);
+                            if !still_on_same_link {
+                                this.mouse_down_link = None;
+                                changed = true;
+                            }
+                        }
+                        cx.stop_propagation();
+                        if changed {
+                            cx.notify();
+                        }
+                        return;
+                    }
+                    if event.pressed_button.is_none() {
+                        let mut changed = this.update_hovered_link(&event.modifiers);
+                        changed |= this.mouse_down_link.take().is_some();
+                        this.suppress_link_mouse_up = false;
+                        cx.stop_propagation();
+                        if changed {
+                            cx.notify();
+                        }
+                    }
                 }
                 let hover_changed = this.update_hovered_link(&event.modifiers);
                 if event.pressed_button == Some(MouseButton::Left) {
-                    if this.terminal_mouse_sequence_active {
+                    if let Some(shift) =
+                        this.terminal_left_mouse_sequence.press_modifiers().copied()
+                    {
                         this.forward_mouse_drag(
                             0,
                             event.position,
                             MouseEventMods {
-                                shift: this.terminal_mouse_sequence_shift,
+                                shift,
                                 ..mouse_mods_from(&event.modifiers)
                             },
                             true,
@@ -1925,7 +1918,10 @@ impl Render for GhosttyView {
                         cx.notify();
                     }
                 } else if event.pressed_button == Some(MouseButton::Right)
-                    && this.terminal_mouse_sequence_active
+                    && let Some(shift) = this
+                        .terminal_right_mouse_sequence
+                        .press_modifiers()
+                        .copied()
                 {
                     // Right button is held and the sequence is active: keep
                     // reporting motion (button 2 + 32) instead of treating
@@ -1934,25 +1930,19 @@ impl Render for GhosttyView {
                         2,
                         event.position,
                         MouseEventMods {
-                            shift: this.terminal_mouse_right_shift,
+                            shift,
                             ..mouse_mods_from(&event.modifiers)
                         },
                         true,
                     );
                     cx.notify();
-                } else if event.pressed_button.is_none() && this.terminal_mouse_sequence_active {
-                    if let Some(button) = this.terminal_mouse_sequence_button {
-                        let release_mods = mouse_mods_from(&event.modifiers);
-                        let release_mods = MouseEventMods {
-                            shift: if button == 2 {
-                                this.terminal_mouse_right_shift
-                            } else {
-                                this.terminal_mouse_sequence_shift
-                            },
-                            ..release_mods
-                        };
-                        this.finish_terminal_mouse_sequence(button, event.position, release_mods);
-                    }
+                } else if event.pressed_button.is_none()
+                    && (this.terminal_left_mouse_sequence.is_active()
+                        || this.terminal_right_mouse_sequence.is_active())
+                {
+                    let release_mods = mouse_mods_from(&event.modifiers);
+                    this.finish_terminal_mouse_sequence(0, event.position, release_mods);
+                    this.finish_terminal_mouse_sequence(2, event.position, release_mods);
                     cx.notify();
                 } else if hover_changed {
                     cx.notify();
@@ -1984,10 +1974,7 @@ impl Render for GhosttyView {
                     this.finish_terminal_mouse_sequence(
                         0,
                         event.position,
-                        MouseEventMods {
-                            shift: this.terminal_mouse_sequence_shift,
-                            ..mouse_mods_from(&event.modifiers)
-                        },
+                        mouse_mods_from(&event.modifiers),
                     );
                     let _ = this.update_hovered_link(&event.modifiers);
                     cx.notify();
@@ -1998,8 +1985,7 @@ impl Render for GhosttyView {
                 cx.listener(|this, event: &MouseUpEvent, _window, cx| {
                     let owns_sequence = this.scrollbar_drag.is_some()
                         || this.suppress_link_mouse_up
-                        || (this.terminal_mouse_sequence_active
-                            && this.terminal_mouse_sequence_button == Some(0));
+                        || this.terminal_left_mouse_sequence.is_active();
                     if !owns_sequence {
                         return;
                     }
@@ -2010,10 +1996,7 @@ impl Render for GhosttyView {
                     this.finish_terminal_mouse_sequence(
                         0,
                         event.position,
-                        MouseEventMods {
-                            shift: this.terminal_mouse_sequence_shift,
-                            ..mouse_mods_from(&event.modifiers)
-                        },
+                        mouse_mods_from(&event.modifiers),
                     );
                     let _ = this.update_hovered_link(&event.modifiers);
                     cx.notify();
@@ -2026,10 +2009,7 @@ impl Render for GhosttyView {
                     this.finish_terminal_mouse_sequence(
                         2,
                         event.position,
-                        MouseEventMods {
-                            shift: this.terminal_mouse_right_shift,
-                            ..mouse_mods_from(&event.modifiers)
-                        },
+                        mouse_mods_from(&event.modifiers),
                     );
                     let _ = this.update_hovered_link(&event.modifiers);
                     cx.notify();
@@ -2038,19 +2018,14 @@ impl Render for GhosttyView {
             .on_mouse_up_out(
                 MouseButton::Right,
                 cx.listener(|this, event: &MouseUpEvent, _window, cx| {
-                    if !this.terminal_mouse_sequence_active
-                        || this.terminal_mouse_sequence_button != Some(2)
-                    {
+                    if !this.terminal_right_mouse_sequence.is_active() {
                         return;
                     }
                     this.last_mouse_position = Some(event.position);
                     this.finish_terminal_mouse_sequence(
                         2,
                         event.position,
-                        MouseEventMods {
-                            shift: this.terminal_mouse_right_shift,
-                            ..mouse_mods_from(&event.modifiers)
-                        },
+                        mouse_mods_from(&event.modifiers),
                     );
                     let _ = this.update_hovered_link(&event.modifiers);
                     cx.notify();
@@ -2065,14 +2040,14 @@ impl Render for GhosttyView {
                     mouse_mods_from(&event.modifiers),
                 );
                 if scrolled_viewport
-                    && this.terminal_mouse_sequence_active
-                    && this.terminal_mouse_sequence_button == Some(0)
+                    && let Some(shift) =
+                        this.terminal_left_mouse_sequence.press_modifiers().copied()
                 {
                     this.forward_mouse_drag(
                         0,
                         event.position,
                         MouseEventMods {
-                            shift: this.terminal_mouse_sequence_shift,
+                            shift,
                             ..mouse_mods_from(&event.modifiers)
                         },
                         true,

--- a/crates/con-app/src/workspace/chrome_actions.rs
+++ b/crates/con-app/src/workspace/chrome_actions.rs
@@ -558,7 +558,7 @@ impl ConWorkspace {
         self.prompt_for_workspace_layout_path(window, cx, true);
     }
 
-    pub(super) fn release_active_terminal_mouse_selection(&self, cx: &App) {
+    pub(super) fn release_active_terminal_mouse_selection(&self, cx: &mut App) {
         if self.active_tab >= self.tabs.len() {
             return;
         }

--- a/postmortem/2026-08-27-terminal-mouse-release-outside-view.md
+++ b/postmortem/2026-08-27-terminal-mouse-release-outside-view.md
@@ -1,0 +1,31 @@
+# Terminal selection remained active after releasing over the sidebar
+
+## What happened
+
+Dragging a selection from a terminal into the sidebar and releasing the mouse
+left Ghostty's selection gesture active. Moving the pointer back over the
+terminal continued the old drag, and the next click cleared the selection.
+
+## Root cause
+
+GPUI's `on_mouse_up` handler only runs while the pointer is inside the
+element's hitbox. The macOS terminal sent Ghostty a button press but did not
+track ownership of that gesture, so a release over another element was never
+forwarded. Right-button handling also used Ghostty's consumed result as the
+pairing condition even though a non-consumed press still updates Ghostty's
+mouse state.
+
+## Fix applied
+
+Each terminal view now records the mouse sequences it starts and handles both
+inside and outside releases. Release and cancellation paths clear ownership
+before forwarding one matching release, so unrelated panes cannot receive a
+stray event. Windows and Linux keep their existing move-based recovery while
+also closing supported gestures at the real outside-release position.
+
+## What we learned
+
+Mouse gesture ownership belongs to the view that sent the press, not to the
+element under the pointer at release time. A terminal's consumed result is a
+host UI decision, such as whether to show a context menu; it is not proof that
+the terminal did or did not begin internal button state.

--- a/postmortem/2026-08-27-terminal-mouse-release-outside-view.md
+++ b/postmortem/2026-08-27-terminal-mouse-release-outside-view.md
@@ -20,8 +20,12 @@ mouse state.
 Each terminal view now records the mouse sequences it starts and handles both
 inside and outside releases. Release and cancellation paths clear ownership
 before forwarding one matching release, so unrelated panes cannot receive a
-stray event. Windows and Linux keep their existing move-based recovery while
-also closing supported gestures at the real outside-release position.
+stray event. Left and right buttons keep independent ownership, so restarting
+one does not end the other's active gesture. Synthetic releases retain the
+press modifiers. Windows and Linux keep their existing move-based recovery
+while also closing supported gestures at the real outside-release position.
+Windows also owns Shift-bypassed local selection while terminal mouse tracking
+is active.
 
 ## What we learned
 


### PR DESCRIPTION
## Summary

Dragging a terminal selection into the sidebar can release the mouse outside the terminal hitbox. GPUI only runs `on_mouse_up` for the hovered element, so Ghostty can retain the press state and continue the old selection when the pointer returns.

- Track mouse sequence ownership in the terminal view and handle releases both inside and outside the pane.
- Pair each release with a sent press instead of the consumed return value, and keep left and right button sequences independent.
- Route focus loss, view teardown, and pane chrome cancellation through the same guarded release path while preserving press modifiers.
- Add regression coverage for independent, exactly-once sequence completion and document the root cause.

## Testing

- `CON_ZIG_BIN="$(mise which zig)" cargo test -p con` (322 tests passed)
- Linux Docker: `CON_SKIP_GHOSTTY_VT=1 cargo check -p con`
- `CON_ZIG_BIN="$(mise which zig)" just channel=dev macos-bundle`