### PR TITLE
fix(release): make appcast publication and finalization reliable

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -139,10 +139,10 @@ jobs:
               "repos/${GH_REPO}/actions/workflows/${wf}/runs?head_sha=${HEAD_SHA}&event=push&per_page=20")
 
             total_count=$(jq -r '.total_count' <<<"$runs_json")
-            latest=$(jq -r --arg sha "$HEAD_SHA" '\
-              [.workflow_runs[] | select(.head_sha == $sha)]\
-              | sort_by(.updated_at) | last // {}\
-              | [.status // "missing", .conclusion // "", .id // ""]\
+            latest=$(jq -r --arg sha "$HEAD_SHA" '
+              [.workflow_runs[] | select(.head_sha == $sha)]
+              | sort_by(.updated_at) | last // {}
+              | [.status // "missing", .conclusion // "", .id // ""]
               | @tsv' <<<"$runs_json")
             read -r latest_status latest_conclusion latest_id <<<"$latest"
 

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -223,7 +223,10 @@ jobs:
   update-appcast:
     name: Update Sparkle appcast (linux-x86_64)
     concurrency:
-      group: con-gh-pages-publish
+      # Each platform owns a different appcast file. Do not put these jobs
+      # in one GitHub concurrency group: it has only one pending slot, so a
+      # later platform completion silently cancels an earlier appcast job.
+      group: con-gh-pages-publish-linux
       cancel-in-progress: false
     # Run on macOS because Sparkle's `sign_update` tool ships only in
     # the macOS Sparkle distribution. Identical pattern to
@@ -392,5 +395,15 @@ jobs:
             exit 0
           fi
           git commit -m "Update Linux appcast for $GITHUB_REF_NAME"
-          git pull --rebase origin gh-pages 2>/dev/null || true
-          git push origin gh-pages
+          for attempt in 1 2 3 4 5; do
+            git fetch origin gh-pages
+            if git rebase origin/gh-pages && git push origin gh-pages; then
+              exit 0
+            fi
+            git rebase --abort 2>/dev/null || true
+            if [[ "$attempt" -eq 5 ]]; then
+              echo "::error::Unable to push Linux appcast after $attempt attempts"
+              exit 1
+            fi
+            sleep $((attempt * 2))
+          done

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -218,7 +218,10 @@ jobs:
   update-appcast:
     name: Update Sparkle appcast
     concurrency:
-      group: con-gh-pages-publish
+      # Keep macOS retries independent from the other platform jobs. The
+      # push below rebases against the shared branch when another platform
+      # publishes first.
+      group: con-gh-pages-publish-macos
       cancel-in-progress: false
     runs-on: macos-15
     needs: publish
@@ -364,9 +367,18 @@ jobs:
             exit 0
           fi
           git commit -m "Update appcast for $GITHUB_REF_NAME"
-          # Pull-rebase to handle concurrent pushes gracefully
-          git pull --rebase origin gh-pages 2>/dev/null || true
-          git push origin gh-pages
+          for attempt in 1 2 3 4 5; do
+            git fetch origin gh-pages
+            if git rebase origin/gh-pages && git push origin gh-pages; then
+              exit 0
+            fi
+            git rebase --abort 2>/dev/null || true
+            if [[ "$attempt" -eq 5 ]]; then
+              echo "::error::Unable to push macOS appcast after $attempt attempts"
+              exit 1
+            fi
+            sleep $((attempt * 2))
+          done
 
   update-homebrew:
     name: Update Homebrew cask

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -397,7 +397,9 @@ jobs:
   update-appcast:
     name: Update Sparkle appcast (windows-x86_64)
     concurrency:
-      group: con-gh-pages-publish
+      # Keep Windows appcast publication independent from Linux/macOS. The
+      # three jobs update different appcast files and rebase before pushing.
+      group: con-gh-pages-publish-windows
       cancel-in-progress: false
     # Run on macOS because Sparkle's `sign_update` tool ships only in
     # the macOS Sparkle distribution. The signing key is the same
@@ -551,5 +553,15 @@ jobs:
             exit 0
           fi
           git commit -m "Update Windows appcast for $GITHUB_REF_NAME"
-          git pull --rebase origin gh-pages 2>/dev/null || true
-          git push origin gh-pages
+          for attempt in 1 2 3 4 5; do
+            git fetch origin gh-pages
+            if git rebase origin/gh-pages && git push origin gh-pages; then
+              exit 0
+            fi
+            git rebase --abort 2>/dev/null || true
+            if [[ "$attempt" -eq 5 ]]; then
+              echo "::error::Unable to push Windows appcast after $attempt attempts"
+              exit 1
+            fi
+            sleep $((attempt * 2))
+          done


### PR DESCRIPTION
## Summary

- Fix the release finalizer jq program so successful platform runs can be evaluated.
- Prevent Linux, macOS, and Windows appcast jobs from replacing each other in GitHub Actions pending concurrency slots.
- Retry gh-pages fetch/rebase/push instead of ignoring rebase failures.

## Recovery

This repairs the release path exposed by `v0.1.0-beta.87`; it does not create or move any tags. After merge, rerun the affected `.87` workflow/finalization and verify all release assets, appcasts, installers, and final Release state.

## Validation

- `git diff --check`
- Ruby YAML parse for all four release workflows
- Executable local jq expression test

Closes the release reliability regression observed on `v0.1.0-beta.87`.