### PR TITLE
chore(brand): update legal entity to Nowledge Labs, Inc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
-## `v0.1.0-beta.88` - unreleased
+## `v0.1.0-beta.89` - unreleased
+
+### Changed
+
+**Branding**
+
+- Updated the company name shown in Con's About window, license, and Flatpak
+  metadata to **Nowledge Labs, Inc.** Apple signing and notarization settings
+  are unchanged. _(PR
+  [#306](https://github.com/nowledge-co/con-terminal/pull/306) by
+  [@wey-gu](https://github.com/wey-gu))_
+
+---
+
+## `v0.1.0-beta.88` - 2026-08-28
 
 ### Added
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Nowledge Labs
+Copyright (c) 2026 Nowledge Labs, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -1356,7 +1356,7 @@ impl Render for AboutView {
                         div()
                             .text_size(px(12.0))
                             .text_color(muted_text)
-                            .child("Copyright © 2026 Nowledge Labs, LLC"),
+                            .child("Copyright © 2026 Nowledge Labs, Inc."),
                     ),
             )
     }

--- a/packaging/flatpak/aetherpak-publish.yaml
+++ b/packaging/flatpak/aetherpak-publish.yaml
@@ -25,7 +25,7 @@ branding:
   logo_url: "https://con.nowledge.co/assets/icon_con_192.png"
   favicon_url: "https://con.nowledge.co/assets/icon_con_192.png"
   accent_color: "#ffc798"
-  footer_text: "&copy; 2026 Nowledge Labs"
+  footer_text: "&copy; 2026 Nowledge Labs, Inc."
   index_template: "packaging/flatpak/index-template.html"
 
 apps:

--- a/packaging/flatpak/aetherpak.yaml
+++ b/packaging/flatpak/aetherpak.yaml
@@ -20,7 +20,7 @@ branding:
   logo_url: "https://con.nowledge.co/assets/icon_con_192.png"
   favicon_url: "https://con.nowledge.co/assets/icon_con_192.png"
   accent_color: "#ffc798"
-  footer_text: "&copy; 2026 Nowledge Labs"
+  footer_text: "&copy; 2026 Nowledge Labs, Inc."
   index_template: "packaging/flatpak/index-template.html"
 
 apps:

--- a/packaging/flatpak/co.nowledge.con.metainfo.xml
+++ b/packaging/flatpak/co.nowledge.con.metainfo.xml
@@ -22,7 +22,7 @@
   <url type="homepage">https://con.nowledge.co/</url>
   <url type="bugtracker">https://github.com/nowledge-co/con-terminal/issues</url>
   <developer id="co.nowledge">
-    <name>Nowledge Labs</name>
+    <name>Nowledge Labs, Inc.</name>
   </developer>
   <provides>
     <binary>con</binary>

--- a/packaging/flatpak/index-template.html
+++ b/packaging/flatpak/index-template.html
@@ -576,7 +576,7 @@
     <footer>
       <div class="wrap">
         <div>
-          <span>{{if .FooterText}}{{.FooterText}}{{else}}&copy; 2026 Nowledge Labs{{end}}</span>
+          <span>{{if .FooterText}}{{.FooterText}}{{else}}&copy; 2026 Nowledge Labs, Inc.{{end}}</span>
           <span class="tagline">&mdash; we build the knowledge layer.</span>
         </div>
         <div class="links">


### PR DESCRIPTION
## Summary

- Update the public legal entity name from Nowledge Labs, LLC / Nowledge Labs to Nowledge Labs, Inc.
- Refresh the About window, MIT copyright notice, and Flatpak developer/footer metadata.
- Leave Apple signing identities, certificates, Team ID, bundle IDs, notarization, and Sparkle signing configuration unchanged.

## Validation

- `git diff --check`
- `xmllint --noout packaging/flatpak/co.nowledge.con.metainfo.xml`
- Parsed both AetherPak YAML files with Ruby Psych
- Confirmed no signing-adjacent files changed

`cargo fmt --all -- --check` currently reports pre-existing formatting drift in PR #305 files (`keycaps.rs` and `settings_panel.rs`); this PR does not modify those sections.