### PR TITLE
Fix input mode baseline and shortcut tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ con is still pre-release, so entries may group related beta work while the produ
   [#306](https://github.com/nowledge-co/con-terminal/pull/306) by
   [@wey-gu](https://github.com/wey-gu))_
 
+### Fixed
+
+**Input Bar**
+
+- Restored the UI typeface for natural-language Agent input and aligned its
+  baseline with Smart and Shell modes. The mode control now also shows the
+  configured shortcut for switching modes with the same keycaps used elsewhere
+  in Con. _(PR
+  [#307](https://github.com/nowledge-co/con-terminal/pull/307) by
+  [@wey-gu](https://github.com/wey-gu))_
+
 ---
 
 ## `v0.1.0-beta.88` - 2026-08-28

--- a/crates/con-app/src/input_bar.rs
+++ b/crates/con-app/src/input_bar.rs
@@ -1303,7 +1303,27 @@ impl Render for InputBar {
             )
             .tooltip({
                 let mode_label = self.mode.tooltip().to_string();
-                move |window, cx| Tooltip::new(mode_label.clone()).build(window, cx)
+                move |window, cx| {
+                    let stroke =
+                        crate::keycaps::first_action_keystroke(&crate::CycleInputMode, window);
+                    let mode_label = mode_label.clone();
+                    Tooltip::element(move |_, cx| {
+                        let theme = cx.theme();
+                        let mut content = div().flex().items_center().gap(px(7.0)).child(
+                            div()
+                                .text_size(px(12.0))
+                                .line_height(px(16.0))
+                                .text_color(theme.popover_foreground)
+                                .child(format!("{} · switch mode", mode_label)),
+                        );
+                        if let Some(stroke) = stroke.as_ref() {
+                            content =
+                                content.child(crate::keycaps::keycaps_for_stroke(stroke, theme));
+                        }
+                        content
+                    })
+                    .build(window, cx)
+                }
             })
             .child(
                 svg()
@@ -1426,8 +1446,13 @@ impl Render for InputBar {
                     }),
             );
 
-        // Keep all terminal-adjacent inputs in the mono family for consistency.
-        let input_font = theme.mono_font_family.clone();
+        // Shell input is terminal chrome; natural-language agent input uses
+        // the UI font so its prose reads like the agent panel.
+        let input_font = if self.mode == InputMode::Agent {
+            theme.font_family.clone()
+        } else {
+            theme.mono_font_family.clone()
+        };
         let input_text_size = match self.mode {
             InputMode::Agent => mono_px(theme, 14.0),
             _ => mono_px(theme, 13.0),
@@ -1436,10 +1461,9 @@ impl Render for InputBar {
             InputMode::Agent => rems(1.15),
             _ => rems(1.25),
         };
-        let input_vertical_offset = match self.mode {
-            InputMode::Agent => px(-4.0),
-            _ => px(0.0),
-        };
+        // All modes share the same centered row. Agent mode used to apply a
+        // negative offset, which made its placeholder visibly sit too high.
+        let input_vertical_offset = px(0.0);
         let show_inline_suggestion = self.mode != InputMode::Agent
             && input_cursor == input_value.len()
             && !input_value.is_empty()


### PR DESCRIPTION
## Summary
- restore the UI font for natural-language Agent input
- align Agent mode vertically with Smart and Shell modes
- show the configured Cycle Input Mode shortcut using shared keycaps

## Verification
- `git diff --check`
- `rustfmt --edition 2024 --check crates/con-app/src/input_bar.rs`
- `CON_ZIG_BIN=/opt/homebrew/bin/zig cargo check -p con`

Fixes the bottom input bar polish issue reported on 2026-08-29.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized input bar rendering and tooltip UI only; no changes to submission, routing, or keyboard handling beyond displaying the existing shortcut.
> 
> **Overview**
> Polishes the bottom **input bar** so Agent mode matches the rest of the UI and the mode control is easier to discover.
> 
> **Agent input** again uses the **UI font** (`theme.font_family`) instead of the mono stack used for Smart/Shell, and the extra negative vertical offset for Agent is removed so placeholders and text line up with Smart and Shell in the same row.
> 
> The **mode toggle** tooltip is richer: it shows the current mode with “switch mode” copy and renders the user’s **Cycle Input Mode** binding via the shared `keycaps` helpers (`first_action_keystroke` / `keycaps_for_stroke`), consistent with shortcuts elsewhere in Con.
> 
> **CHANGELOG** adds a Fixed → Input Bar entry for beta.89.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5381908182b155e9d980682f4724190153f627de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->