### PR TITLE
Fix precise macOS shell scrolling speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ## `v0.1.0-beta.89` - unreleased
 
+### Fixed
+
+**macOS**
+
+- Refined trackpad scrolling in shell scrollback by preserving precise input
+  deltas instead of applying an extra host-side speed multiplier. This keeps
+  slow, fine-grained scrolling from feeling unexpectedly fast while leaving
+  terminal applications' own scroll handling unchanged. _(PR
+  [#308](https://github.com/nowledge-co/con-terminal/pull/308) by
+  [@wey-gu](https://github.com/wey-gu))_
+
 ### Changed
 
 **Branding**

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -2293,11 +2293,11 @@ impl Render for GhosttyView {
                     let delta = match event.delta {
                         ScrollDelta::Lines(d) => (f64::from(d.x), f64::from(d.y)),
                         ScrollDelta::Pixels(d) => {
-                            // Match Ghostty's AppKit host: precise trackpad
-                            // deltas are sent as-is with a subjective 2x
-                            // multiplier and the ScrollMods precision bit.
-                            // Ghostty core then accumulates sub-row remainders.
-                            (f64::from(d.x) * 2.0, f64::from(d.y) * 2.0)
+                            // Preserve precise trackpad deltas. Ghostty owns
+                            // the precision/discrete multiplier and its
+                            // sub-row remainder, so the host must not apply a
+                            // second, device-independent scale factor here.
+                            (f64::from(d.x), f64::from(d.y))
                         }
                     };
                     terminal.send_mouse_scroll(


### PR DESCRIPTION
## Summary
- preserve macOS precise scroll deltas when forwarding them to libghostty
- remove the host-side 2x multiplier that made trackpad scrolling feel too fast
- leave TUI, alternate-screen, discrete wheel, and Windows/Linux paths unchanged

## Verification
- `git diff --check`
- `CON_ZIG_BIN=/opt/homebrew/bin/zig cargo check -p con`

This is intentionally a small, reversible tuning change for shell scrollback UX.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavioral tweak in macOS scroll forwarding with no auth, data, or API surface changes; easily reversible UX tuning.
> 
> **Overview**
> **Fixes macOS trackpad scrolling feeling too fast in shell scrollback** by stopping the GPUI host from doubling precise (`ScrollDelta::Pixels`) wheel deltas before they reach libghostty.
> 
> The embedded `GhosttyView` scroll handler now forwards pixel deltas unchanged while still marking them with the precision scroll modifier; **line-based wheel events and non-macOS paths are untouched**, so TUIs and discrete mice behave as before. The unreleased changelog documents the UX fix under macOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65a24d49653b0581a9e1477ea38c95dcddd7bb81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->