### PR TITLE
fix(macos): integrate terminal scrollback scrollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ con is still pre-release, so entries may group related beta work while the produ
   terminal's layout or transparency behavior. _(PR
   [#309](https://github.com/nowledge-co/con-terminal/pull/309) by
   [@wey-gu](https://github.com/wey-gu))_
+- Clicking a scrollback scrollbar now also focuses its pane, so the next
+  keyboard input goes to the pane the user is working with. _(PR
+  [#310](https://github.com/nowledge-co/con-terminal/pull/310) by
+  [@wey-gu](https://github.com/wey-gu))_
 
 **Branding**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ### Changed
 
+**macOS**
+
+- Added a subtle overlay scrollbar for terminal scrollback. It appears only
+  when a pane has history beyond the visible screen, without changing the
+  terminal's layout or transparency behavior. _(PR
+  [#309](https://github.com/nowledge-co/con-terminal/pull/309) by
+  [@wey-gu](https://github.com/wey-gu))_
+
 **Branding**
 
 - Updated the company name shown in Con's About window, license, and Flatpak

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -201,6 +201,8 @@ pub struct GhosttyView {
     #[cfg(target_os = "macos")]
     scrollbar_drag: Option<ScrollbarDrag>,
     #[cfg(target_os = "macos")]
+    last_scrollbar: Option<GhosttyScrollbar>,
+    #[cfg(target_os = "macos")]
     native_transition_underlay_visible: Cell<bool>,
     #[cfg(target_os = "macos")]
     native_transition_underlay_owner_id: u64,
@@ -268,6 +270,8 @@ impl GhosttyView {
             last_mouse_position: None,
             #[cfg(target_os = "macos")]
             scrollbar_drag: None,
+            #[cfg(target_os = "macos")]
+            last_scrollbar: None,
             #[cfg(target_os = "macos")]
             native_transition_underlay_visible: Cell::new(false),
             #[cfg(target_os = "macos")]
@@ -398,8 +402,10 @@ impl GhosttyView {
                 .on_mouse_up_out(
                     gpui::MouseButton::Left,
                     cx.listener(|this, _event: &MouseUpEvent, _window, cx| {
-                        this.scrollbar_drag = None;
-                        cx.stop_propagation();
+                        if this.scrollbar_drag.take().is_some() {
+                            cx.stop_propagation();
+                            cx.notify();
+                        }
                     }),
                 )
                 .child(
@@ -529,6 +535,15 @@ impl GhosttyView {
         }
 
         let _ = terminal.take_needs_render();
+
+        #[cfg(target_os = "macos")]
+        {
+            let scrollbar = terminal.scrollbar();
+            if scrollbar != self.last_scrollbar {
+                self.last_scrollbar = scrollbar;
+                changed = true;
+            }
+        }
 
         if !terminal.is_alive() && !self.process_exit_emitted {
             self.process_exit_emitted = true;
@@ -2429,6 +2444,7 @@ impl Render for GhosttyView {
                 {
                     this.drag_scrollbar(event.position);
                     cx.stop_propagation();
+                    cx.notify();
                     return;
                 }
                 this.last_mouse_position = Some(event.position);

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -60,6 +60,14 @@ const NS_VIEW_LAYER_CONTENTS_REDRAW_DURING_VIEW_RESIZE: isize = 2;
 #[cfg(target_os = "macos")]
 const NATIVE_SEAM_OVERDRAW_PT: f64 = 2.0;
 #[cfg(target_os = "macos")]
+const SCROLLBAR_INSET_PX: f32 = 6.0;
+#[cfg(target_os = "macos")]
+const SCROLLBAR_HIT_WIDTH_PX: f32 = 14.0;
+#[cfg(target_os = "macos")]
+const SCROLLBAR_THUMB_WIDTH_PX: f32 = 4.0;
+#[cfg(target_os = "macos")]
+const SCROLLBAR_MIN_THUMB_PX: f32 = 28.0;
+#[cfg(target_os = "macos")]
 static NATIVE_TRANSITION_UNDERLAY_ASSOCIATION_KEY: u8 = 0;
 #[cfg(target_os = "macos")]
 static NATIVE_TRANSITION_UNDERLAY_OWNERS_ASSOCIATION_KEY: u8 = 0;
@@ -261,6 +269,53 @@ impl GhosttyView {
             pending_terminal_find: None,
             restore_terminal_focus: false,
         }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn render_terminal_scrollbar(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
+        let terminal = self.terminal.as_ref()?;
+        let scrollbar = terminal.scrollbar()?;
+        if scrollbar.total <= scrollbar.len || scrollbar.len == 0 {
+            return None;
+        }
+
+        let bounds = self.last_bounds?;
+        let track_height = (bounds.size.height.as_f32() - SCROLLBAR_INSET_PX * 2.0).max(0.0);
+        if track_height <= 0.0 {
+            return None;
+        }
+
+        let thumb_height = ((scrollbar.len as f32 / scrollbar.total as f32) * track_height)
+            .clamp(SCROLLBAR_MIN_THUMB_PX.min(track_height), track_height);
+        let max_offset = scrollbar.total.saturating_sub(scrollbar.len).max(1);
+        let travel = (track_height - thumb_height).max(0.0);
+        let thumb_top = if travel == 0.0 {
+            0.0
+        } else {
+            (scrollbar.offset.min(max_offset) as f32 / max_offset as f32) * travel
+        };
+        let foreground = cx.theme().foreground;
+
+        Some(
+            div()
+                .absolute()
+                .top(px(SCROLLBAR_INSET_PX))
+                .right(px(0.0))
+                .bottom(px(SCROLLBAR_INSET_PX))
+                .w(px(SCROLLBAR_HIT_WIDTH_PX))
+                .child(
+                    div()
+                        .absolute()
+                        .top(px(thumb_top))
+                        .right(px((SCROLLBAR_HIT_WIDTH_PX - SCROLLBAR_THUMB_WIDTH_PX) / 2.0))
+                        .w(px(SCROLLBAR_THUMB_WIDTH_PX))
+                        .h(px(thumb_height))
+                        .rounded(px(SCROLLBAR_THUMB_WIDTH_PX / 2.0))
+                        .bg(foreground.opacity(0.2))
+                        .hover(|style| style.bg(foreground.opacity(0.38))),
+                )
+                .into_any_element(),
+        )
     }
 
     pub(crate) fn show_terminal_find(
@@ -2356,6 +2411,7 @@ impl Render for GhosttyView {
                 .size_full(),
             )
             .children(preedit_overlay)
+            .children(self.render_terminal_scrollbar(cx))
             .children(terminal_find)
             .context_menu(move |menu, window, cx| {
                 // An empty PopupMenu renders nothing (ContextMenu checks

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -22,6 +22,8 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
+#[cfg(target_os = "macos")]
+use con_ghostty::GhosttyScrollbar;
 use con_ghostty::ffi;
 use con_ghostty::{
     GhosttyApp, GhosttySplitDirection, GhosttySurfaceEvent, GhosttyTerminal, MouseButton,
@@ -136,6 +138,12 @@ struct PendingTerminalFind {
     selected: Option<Option<usize>>,
 }
 
+#[cfg(target_os = "macos")]
+#[derive(Debug, Clone, Copy)]
+struct ScrollbarDrag {
+    grab_offset: f32,
+}
+
 /// GPUI view wrapping a ghostty terminal surface.
 pub struct GhosttyView {
     app: Arc<GhosttyApp>,
@@ -190,6 +198,8 @@ pub struct GhosttyView {
     /// mouse-move event when the pointer is stationary.
     #[cfg(target_os = "macos")]
     last_mouse_position: Option<Point<Pixels>>,
+    #[cfg(target_os = "macos")]
+    scrollbar_drag: Option<ScrollbarDrag>,
     #[cfg(target_os = "macos")]
     native_transition_underlay_visible: Cell<bool>,
     #[cfg(target_os = "macos")]
@@ -257,6 +267,8 @@ impl GhosttyView {
             #[cfg(target_os = "macos")]
             last_mouse_position: None,
             #[cfg(target_os = "macos")]
+            scrollbar_drag: None,
+            #[cfg(target_os = "macos")]
             native_transition_underlay_visible: Cell::new(false),
             #[cfg(target_os = "macos")]
             native_transition_underlay_owner_id: NEXT_NATIVE_TRANSITION_OWNER_ID
@@ -272,7 +284,7 @@ impl GhosttyView {
     }
 
     #[cfg(target_os = "macos")]
-    fn render_terminal_scrollbar(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
+    fn scrollbar_metrics(&self) -> Option<(GhosttyScrollbar, f32, f32, f32)> {
         let terminal = self.terminal.as_ref()?;
         let scrollbar = terminal.scrollbar()?;
         if scrollbar.total <= scrollbar.len || scrollbar.len == 0 {
@@ -294,6 +306,77 @@ impl GhosttyView {
         } else {
             (scrollbar.offset.min(max_offset) as f32 / max_offset as f32) * travel
         };
+        Some((scrollbar, track_height, thumb_height, thumb_top))
+    }
+
+    #[cfg(target_os = "macos")]
+    fn scroll_to_row(&self, row: u64) {
+        let Some(terminal) = self.terminal.as_ref() else {
+            return;
+        };
+        let _ = terminal.perform_binding_action(&format!("scroll_to_row:{row}"));
+        terminal.refresh();
+    }
+
+    #[cfg(target_os = "macos")]
+    fn scroll_page(&self, upward: bool) {
+        let Some(terminal) = self.terminal.as_ref() else {
+            return;
+        };
+        let action = if upward {
+            "scroll_page_up"
+        } else {
+            "scroll_page_down"
+        };
+        let _ = terminal.perform_binding_action(action);
+        terminal.refresh();
+    }
+
+    #[cfg(target_os = "macos")]
+    fn start_scrollbar_interaction(
+        &mut self,
+        position: Point<Pixels>,
+        window: &mut Window,
+    ) -> bool {
+        let Some((_scrollbar, _, thumb_height, thumb_top)) = self.scrollbar_metrics() else {
+            return false;
+        };
+        let (_, local_y) = self.view_local_pos(position);
+        let track_y = (local_y as f32 - SCROLLBAR_INSET_PX).clamp(0.0, f32::MAX);
+        if (thumb_top..=thumb_top + thumb_height).contains(&track_y) {
+            self.scrollbar_drag = Some(ScrollbarDrag {
+                grab_offset: track_y - thumb_top,
+            });
+        } else {
+            self.scroll_page(track_y < thumb_top);
+        }
+        window.prevent_default();
+        true
+    }
+
+    #[cfg(target_os = "macos")]
+    fn drag_scrollbar(&mut self, position: Point<Pixels>) {
+        let Some(drag) = self.scrollbar_drag else {
+            return;
+        };
+        let Some((scrollbar, track_height, thumb_height, _)) = self.scrollbar_metrics() else {
+            self.scrollbar_drag = None;
+            return;
+        };
+        let (_, local_y) = self.view_local_pos(position);
+        let travel = (track_height - thumb_height).max(0.0);
+        if travel == 0.0 {
+            return;
+        }
+        let thumb_top = (local_y as f32 - SCROLLBAR_INSET_PX - drag.grab_offset).clamp(0.0, travel);
+        let max_offset = scrollbar.total.saturating_sub(scrollbar.len);
+        let row = ((thumb_top / travel) * max_offset as f32).round() as u64;
+        self.scroll_to_row(row.min(max_offset));
+    }
+
+    #[cfg(target_os = "macos")]
+    fn render_terminal_scrollbar(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
+        let (_scrollbar, _track_height, thumb_height, thumb_top) = self.scrollbar_metrics()?;
         let foreground = cx.theme().foreground;
 
         Some(
@@ -303,8 +386,26 @@ impl GhosttyView {
                 .right(px(0.0))
                 .bottom(px(SCROLLBAR_INSET_PX))
                 .w(px(SCROLLBAR_HIT_WIDTH_PX))
+                .cursor_pointer()
+                .on_mouse_down(
+                    gpui::MouseButton::Left,
+                    cx.listener(move |this, event: &MouseDownEvent, window, cx| {
+                        if this.start_scrollbar_interaction(event.position, window) {
+                            cx.stop_propagation();
+                            cx.notify();
+                        }
+                    }),
+                )
+                .on_mouse_up_out(
+                    gpui::MouseButton::Left,
+                    cx.listener(|this, _event: &MouseUpEvent, _window, cx| {
+                        this.scrollbar_drag = None;
+                        cx.stop_propagation();
+                    }),
+                )
                 .child(
                     div()
+                        .id("terminal-scrollbar-thumb")
                         .absolute()
                         .top(px(thumb_top))
                         .right(px((SCROLLBAR_HIT_WIDTH_PX - SCROLLBAR_THUMB_WIDTH_PX) / 2.0))
@@ -2275,6 +2376,7 @@ impl Render for GhosttyView {
             .on_mouse_up(
                 gpui::MouseButton::Left,
                 cx.listener(|this, event: &MouseUpEvent, _window, cx| {
+                    this.scrollbar_drag = None;
                     this.last_mouse_position = Some(event.position);
                     let mods = gpui_mods_to_ghostty(&event.modifiers);
                     if this.finish_mouse_sequence(MouseButton::Left, event.position, Some(mods))
@@ -2287,6 +2389,7 @@ impl Render for GhosttyView {
             .on_mouse_up_out(
                 gpui::MouseButton::Left,
                 cx.listener(|this, event: &MouseUpEvent, _window, cx| {
+                    this.scrollbar_drag = None;
                     if !this.left_mouse_sequence.is_active() {
                         return;
                     }
@@ -2322,6 +2425,13 @@ impl Render for GhosttyView {
                 }),
             )
             .on_mouse_move(cx.listener(|this, event: &MouseMoveEvent, _window, cx| {
+                if event.pressed_button == Some(gpui::MouseButton::Left)
+                    && this.scrollbar_drag.is_some()
+                {
+                    this.drag_scrollbar(event.position);
+                    cx.stop_propagation();
+                    return;
+                }
                 this.last_mouse_position = Some(event.position);
                 let mods = gpui_mods_to_ghostty(&event.modifiers);
                 if event.pressed_button.is_none() {

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -394,6 +394,8 @@ impl GhosttyView {
                     gpui::MouseButton::Left,
                     cx.listener(move |this, event: &MouseDownEvent, window, cx| {
                         if this.start_scrollbar_interaction(event.position, window) {
+                            window.focus(&this.focus_handle, cx);
+                            cx.emit(GhosttyFocusChanged);
                             cx.stop_propagation();
                             cx.notify();
                         }

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -386,7 +386,6 @@ impl GhosttyView {
                 .right(px(0.0))
                 .bottom(px(SCROLLBAR_INSET_PX))
                 .w(px(SCROLLBAR_HIT_WIDTH_PX))
-                .cursor_pointer()
                 .on_mouse_down(
                     gpui::MouseButton::Left,
                     cx.listener(move |this, event: &MouseDownEvent, window, cx| {


### PR DESCRIPTION
Integrates the merged scrollbar work from PR #309 into main and fixes focus handoff when clicking an inactive pane scrollbar.

Refs #309.

The scrollbar remains macOS-only and does not alter the Linux or Windows renderers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> macOS-only input and scrollback plumbing in the hot terminal view path; wrong focus or event propagation could affect pane focus or mouse selection, but scope is gated to overlay scrollbar handling.
> 
> **Overview**
> On **macOS**, `GhosttyView` now draws a **GPUI overlay scrollbar** for shell scrollback when Ghostty reports history beyond the visible screen. The thumb size and position follow `terminal.scrollbar()` metrics; dragging maps to `scroll_to_row`, and clicks on the track page up/down via Ghostty binding actions.
> 
> Scrollbar interaction is wired through dedicated hit targets on the right edge (with inset and min thumb sizing), including drag state that clears on mouse up and during left-button release paths so it does not fight terminal selection. **Clicking the scrollbar focuses the pane** and emits focus changed, addressing inactive-pane scrollbar clicks.
> 
> Repaints when scrollbar state changes are driven by comparing `last_scrollbar` in `drain_surface_state`. Linux and Windows render paths are unchanged (`#[cfg(target_os = "macos")]`). The changelog documents the overlay scrollbar under macOS **Changed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a825cf66aa988efe810c7b01a8c9420ea9bc32bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->