### PR TITLE
linux: align launcher icon identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ con is still pre-release, so entries may group related beta work while the produ
   [#317](https://github.com/nowledge-co/con-terminal/pull/317) by
   [@wey-gu](https://github.com/wey-gu))_
 
+### Fixed
+
+**Linux**
+
+- Matched the installed launcher icon name to Con's desktop application id, so
+  launchers can resolve the correct icon and group windows consistently. Older
+  release archives remain compatible with the installer. _(PR
+  [#318](https://github.com/nowledge-co/con-terminal/pull/318) by
+  [@wey-gu](https://github.com/wey-gu))_
+
 ---
 
 ## `v0.1.0-beta.89` - 2026-08-30

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -249,7 +249,7 @@ pass "extracted"
 #     LICENSE
 #     README.md
 #     co.nowledge.con.desktop
-#     con.png
+#     co.nowledge.con.png
 staged_root=""
 for d in "$extract_dir"/*; do
   [ -d "$d" ] && [ -f "$d/con" ] && staged_root="$d" && break
@@ -330,8 +330,14 @@ elif [ -f "$staged_root/con.desktop" ]; then
   rm -f "${apps_dir}/${linux_app_id}.desktop"
 fi
 
-if [ -f "$staged_root/con.png" ]; then
+if [ -f "$staged_root/${linux_app_id}.png" ]; then
+  cp "$staged_root/${linux_app_id}.png" "${icons_dir}/${linux_app_id}.png"
+elif [ -f "$staged_root/con.png" ]; then
+  # Releases through beta.89 used the short icon name. Keep explicit-version
+  # installs working whether their desktop entry refers to `con` or the
+  # reverse-DNS application id used by current releases.
   cp "$staged_root/con.png" "${icons_dir}/con.png"
+  cp "$staged_root/con.png" "${icons_dir}/${linux_app_id}.png"
 fi
 
 # Refresh the desktop database so the new .desktop file is picked up

--- a/scripts/linux/release.sh
+++ b/scripts/linux/release.sh
@@ -178,7 +178,7 @@ GenericName=Terminal
 Comment=GPU-accelerated terminal emulator with a built-in AI agent harness
 TryExec=con
 Exec=/usr/local/bin/con %U
-Icon=con
+Icon=${linux_app_id}
 Terminal=false
 Categories=System;TerminalEmulator;Utility;
 Keywords=terminal;shell;command;cli;ai;agent;
@@ -194,7 +194,7 @@ EOF
 # first. Pull from the macOS app-icon set we already ship.
 icon_src="assets/Con-macOS-Dark-256x256@2x.png"
 if [[ -f "$icon_src" ]]; then
-  cp "$icon_src" "${stage_dir}/con.png"
+  cp "$icon_src" "${stage_dir}/${linux_app_id}.png"
 else
   echo "warning: ${icon_src} missing — Linux tarball ships without an app icon" >&2
 fi

--- a/scripts/release/verify-artifacts.sh
+++ b/scripts/release/verify-artifacts.sh
@@ -71,6 +71,8 @@ verify_linux() {
     || fail "$tarball_name does not contain con-cli"
   tar -tzf "$tarball" | grep -E "/co\\.nowledge\\.con\\.desktop$" >/dev/null \
     || fail "$tarball_name does not contain co.nowledge.con.desktop"
+  tar -tzf "$tarball" | grep -E "/co\\.nowledge\\.con\\.png$" >/dev/null \
+    || fail "$tarball_name does not contain co.nowledge.con.png"
 
   local tmp
   tmp="$(mktemp -d)"
@@ -89,7 +91,9 @@ verify_linux() {
   require_executable "$root/con"
   require_executable "$root/con-cli"
   require_file "$root/co.nowledge.con.desktop"
+  require_file "$root/co.nowledge.con.png"
   require_desktop_entry "$root/co.nowledge.con.desktop" "TryExec=con"
+  require_desktop_entry "$root/co.nowledge.con.desktop" "Icon=co.nowledge.con"
   verify_terminal_desktop_contract "$root/co.nowledge.con.desktop"
   "$root/con-cli" --help >/dev/null
   log "Linux artifact OK: $tarball_name"


### PR DESCRIPTION
## Summary

- package the Linux launcher icon as `co.nowledge.con.png`, matching the desktop entry's app identity
- install legacy `con.png` artifacts under both names so pinned older releases remain usable
- make release verification reject a tarball whose desktop entry and icon identity diverge

## Why

The Linux desktop entry uses the reverse-DNS app id for launcher grouping, but the tarball and installer still used the short `con.png` icon name. Some desktop environments can therefore fail to resolve Con's icon even though the application launches correctly. This closes that identity mismatch before the next Linux beta and advances #315 without claiming its real-hardware acceptance work is complete.

## Validation

- `bash -n scripts/linux/release.sh scripts/install.sh scripts/release/verify-artifacts.sh`
- `shellcheck -e SC2012,SC2059 scripts/linux/release.sh scripts/install.sh scripts/release/verify-artifacts.sh`
- synthetic beta.90 Linux artifact passes `verify-artifacts.sh linux`
- negative artifact with only legacy `con.png` is rejected by the release verifier
