### PR TITLE
docs: finalize beta 90 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
-## `v0.1.0-beta.90` - unreleased
+## `v0.1.0-beta.90` - 2026-08-30
 
 ### Added
 


### PR DESCRIPTION
Finalizes the beta.90 changelog date after verifying that every merged PR since beta.89 is represented with author credit.