### PR TITLE
fix(macOS): stop invoking the missing Ghostty SSH helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## `v0.1.0-beta.91` - unreleased
+
+### Fixed
+
+**macOS**
+
+- Removed an unsupported Ghostty SSH terminfo helper invocation that could
+  print a missing `Contents/MacOS/ghostty` error before SSH connections. SSH
+  environment integration remains enabled. _(PR [#321](https://github.com/nowledge-co/con-terminal/pull/321) by [@wey-gu](https://github.com/wey-gu))_
+
+---
+
 ## `v0.1.0-beta.90` - 2026-08-30
 
 ### Added

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -26,7 +26,9 @@ use parking_lot::Mutex;
 use crate::ffi;
 
 const DEFAULT_GHOSTTY_FONT_FAMILY: &str = "Ioskeley Mono";
-const CON_SHELL_INTEGRATION_FEATURES: &str = "no-cursor,ssh-env,ssh-terminfo";
+// Con does not ship Ghostty's `+ssh-cache` CLI helper. Do not advertise
+// `ssh-terminfo` until Con has an equivalent cache implementation.
+const CON_SHELL_INTEGRATION_FEATURES: &str = "no-cursor,ssh-env";
 
 fn sanitize_font_family_for_ghostty(font_family: &str) -> &str {
     let trimmed = font_family.trim();
@@ -159,8 +161,9 @@ impl GhosttyConfigPatch {
         // Disable ghostty shell-integration cursor override so con's
         // cursor-style setting is respected. Ghostty's integration
         // unconditionally forces a bar cursor at prompts otherwise.
-        // Enable ssh-env and ssh-terminfo so Ghostty's shell integration
-        // auto-installs xterm-ghostty terminfo on remote SSH hosts.
+        // Keep ssh-env compatibility. ssh-terminfo is intentionally omitted:
+        // Ghostty's shell integration would invoke a missing
+        // `ghostty +ssh-cache` helper from Con's app bundle.
         s.push_str("shell-integration-features = ");
         s.push_str(CON_SHELL_INTEGRATION_FEATURES);
         s.push('\n');
@@ -1922,7 +1925,8 @@ mod tests {
     fn ghostty_config_always_includes_con_shell_integration_features() {
         let config = GhosttyConfigPatch::default().to_config_string();
 
-        assert!(config.contains("shell-integration-features = no-cursor,ssh-env,ssh-terminfo"));
+        assert!(config.contains("shell-integration-features = no-cursor,ssh-env\n"));
+        assert!(!config.contains("ssh-terminfo"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Con's macOS shell integration advertised Ghostty's `ssh-terminfo` feature, but Con does not ship the Ghostty executable that feature invokes. An SSH connection could therefore print:

```text
no such file or directory: .../Contents/MacOS/ghostty
```

This PR removes the unsupported feature from Con's generated libghostty configuration while preserving `no-cursor` and `ssh-env`.

## Scope

- macOS only: changes the full libghostty configuration patch.
- Windows and Linux use their existing `libghostty-vt` paths and are unchanged.
- This intentionally removes the broken helper invocation only; native Con SSH terminfo caching is a follow-up PR.

## Validation

- `rustfmt --edition 2024 --check crates/con-ghostty/src/terminal.rs`
- `CON_ZIG_BIN=/opt/homebrew/bin/zig cargo test -p con-ghostty`

Addresses #320
Related to #230
