### PR TITLE
fix(macOS): route SSH terminfo cache through con-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ con is still pre-release, so entries may group related beta work while the produ
 - Removed an unsupported Ghostty SSH terminfo helper invocation that could
   print a missing `Contents/MacOS/ghostty` error before SSH connections. SSH
   environment integration remains enabled. _(PR [#321](https://github.com/nowledge-co/con-terminal/pull/321) by [@wey-gu](https://github.com/wey-gu))_
+- Restored automatic SSH terminfo setup by routing Ghostty's existing shell
+  integration helper through the native `con-cli` implementation in the app
+  bundle. _(PR [#323](https://github.com/nowledge-co/con-terminal/pull/323) by [@wey-gu](https://github.com/wey-gu))_
 
 ### Added
 

--- a/docs/con-cli.md
+++ b/docs/con-cli.md
@@ -49,7 +49,9 @@ The host check exits `0` when an entry is present and `1` when it is absent,
 so shell integration can use it without parsing output. Cache entries are
 stored under Con's platform-specific user cache directory and are written
 atomically. `--expire-days N` filters entries older than `N` days for list and
-host checks.
+host checks. On macOS, the installed app bundle exposes this command through
+the compatibility entry point expected by Ghostty's shell integration, so SSH
+terminfo setup works without a separate Ghostty executable.
 
 ## Pane commands
 

--- a/scripts/macos/build-app.sh
+++ b/scripts/macos/build-app.sh
@@ -38,6 +38,10 @@ rsync -a "$binary_path" "$macos_dir/con"
 chmod 755 "$macos_dir/con"
 rsync -a "$cli_binary_path" "$macos_dir/con-cli"
 chmod 755 "$macos_dir/con-cli"
+# Ghostty's bundled shell integration invokes `$GHOSTTY_BIN_DIR/ghostty
+# +ssh-cache`. Con owns that protocol now, so keep the upstream integration
+# unchanged and provide a bundle-local compatibility entry point.
+ln -s con-cli "$macos_dir/ghostty"
 
 ghostty_resources_dir="$(find "$REPO_ROOT/target/$CON_RUST_TARGET/release/build" -path '*/out/ghostty-src/zig-out/share/ghostty' | head -n 1)"
 if [[ -z "$ghostty_resources_dir" || ! -d "$ghostty_resources_dir" ]]; then


### PR DESCRIPTION
## Summary

Wire the native `con-cli +ssh-cache` implementation into Con's macOS app bundle without modifying the embedded Ghostty shell-integration scripts.

The bundle already ships `con-cli`. This adds a bundle-local `ghostty` compatibility entry point as a symlink to that binary, so the upstream shell integration's existing:

```sh
$GHOSTTY_BIN_DIR/ghostty +ssh-cache ...
```

now executes Con's implementation for cache checks and updates.

## Why this shape

- keeps the upstream shell scripts untouched and reduces drift
- preserves all supported shells that use the same Ghostty integration
- avoids a second copied executable in the signed app bundle
- limits the behavior to the macOS bundle packaging path
- leaves Windows and Linux binaries and shell behavior unchanged

PR #322 provides the native cache data layer and CLI protocol. PR #321 removed the broken feature declaration while this compatibility path was not present.

## Validation

- `bash -n scripts/macos/build-app.sh`
- `git diff --check`

Related to #230
Related to #320
