### PR TITLE
docs: date beta 91 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
-## `v0.1.0-beta.91` - unreleased
+## `v0.1.0-beta.91` - 2026-08-31
 
 ### Fixed
 


### PR DESCRIPTION
Mark the already-complete `v0.1.0-beta.91` changelog section with its release date.

The section covers merged PRs #321, #322, and #323, with contributor attribution preserved. This is the final release-notes change before tagging beta 91 after `v0.1.0-beta.90`.
