### PR TITLE
fix(macOS): render IME preedit through Ghostty

### DIFF
--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -1899,20 +1899,22 @@ impl InputHandler for GhosttyInputHandler {
         window: &mut Window,
         cx: &mut App,
     ) {
-        if text.is_empty() {
-            return;
-        }
         let _ = self.view.update(cx, |view, cx| {
             let had_marked_text = view.ime_marked_text.take().is_some();
             if let Some(terminal) = &view.terminal {
-                if !had_marked_text && should_send_ime_insert_as_key_event(text) {
-                    send_ime_insert_as_key_events(terminal, text);
-                } else {
-                    // Use key event path (not ghostty_surface_text) to avoid
-                    // bracketed-paste wrapping and post-paste selection highlight.
-                    terminal.send_text_as_key_event(text);
+                if had_marked_text {
+                    terminal.set_preedit(None);
                 }
-                terminal.refresh();
+                if !text.is_empty() {
+                    if !had_marked_text && should_send_ime_insert_as_key_event(text) {
+                        send_ime_insert_as_key_events(terminal, text);
+                    } else {
+                        // Use key event path (not ghostty_surface_text) to avoid
+                        // bracketed-paste wrapping and post-paste selection highlight.
+                        terminal.send_text_as_key_event(text);
+                    }
+                    terminal.refresh();
+                }
             }
             cx.notify();
         });
@@ -1934,7 +1936,7 @@ impl InputHandler for GhosttyInputHandler {
                 Some(new_text.to_string())
             };
             if let Some(terminal) = &view.terminal {
-                terminal.refresh();
+                terminal.set_preedit(view.ime_marked_text.as_deref());
             }
             cx.notify();
         });
@@ -1945,7 +1947,7 @@ impl InputHandler for GhosttyInputHandler {
         let _ = self.view.update(cx, |view, cx| {
             view.ime_marked_text = None;
             if let Some(terminal) = &view.terminal {
-                terminal.refresh();
+                terminal.set_preedit(None);
             }
             cx.notify();
         });
@@ -2185,76 +2187,9 @@ impl Render for GhosttyView {
         let menu_focus = focus.clone();
         let right_click_consumed = self.right_click_consumed.clone();
         let ui_font = cx.theme().font_family.clone();
-        let mono_font = cx.theme().mono_font_family.clone();
-        let mono_font_size = cx.theme().mono_font_size;
         let entity = cx.entity().downgrade();
         let show_layout_fallback = self.show_layout_fallback();
         let terminal_find = self.terminal_find.clone();
-
-        // Preedit overlay: render IME composition text at the cursor position.
-        let preedit_overlay: Option<gpui::AnyElement> = self
-            .ime_marked_text
-            .as_deref()
-            .filter(|t| !t.is_empty())
-            .and_then(|preedit_text| {
-                let terminal = self.terminal.as_ref()?;
-                let bounds = self.last_bounds?;
-                let ime = terminal.ime_point();
-                let fg = self
-                    .app
-                    .foreground_rgb()
-                    .map(|rgb| {
-                        Rgba {
-                            r: rgb[0] as f32 / 255.0,
-                            g: rgb[1] as f32 / 255.0,
-                            b: rgb[2] as f32 / 255.0,
-                            a: 1.0,
-                        }
-                        .into()
-                    })
-                    .unwrap_or(cx.theme().foreground);
-                let bg = self
-                    .app
-                    .background_rgb()
-                    .map(|rgb| {
-                        // Force opaque so the overlay covers ghostty's real cursor.
-                        Rgba {
-                            r: rgb[0] as f32 / 255.0,
-                            g: rgb[1] as f32 / 255.0,
-                            b: rgb[2] as f32 / 255.0,
-                            a: 1.0,
-                        }
-                        .into()
-                    })
-                    .unwrap_or(cx.theme().background);
-                let left = px(ime.x as f32)
-                    .min(bounds.size.width - px(1.0))
-                    .max(px(0.0));
-                // ime_point y is the bottom of the cursor cell (candidate anchor).
-                // Subtract cell height to align the overlay with the cursor row.
-                let cell_height = if ime.height > 0.0 {
-                    ime.height as f32
-                } else {
-                    f32::from(mono_font_size)
-                };
-                let top = px(ime.y as f32 - cell_height)
-                    .min(bounds.size.height - mono_font_size)
-                    .max(px(0.0));
-                let text = preedit_text.to_string();
-                Some(
-                    div()
-                        .absolute()
-                        .left(left)
-                        .top(top)
-                        .bg(bg)
-                        .text_color(fg)
-                        .font_family(mono_font.clone())
-                        .text_size(mono_font_size)
-                        .underline()
-                        .child(text)
-                        .into_any_element(),
-                )
-            });
 
         let layout_fallback_bg = self
             .app
@@ -2537,7 +2472,6 @@ impl Render for GhosttyView {
                 )
                 .size_full(),
             )
-            .children(preedit_overlay)
             .children(self.render_terminal_scrollbar(cx))
             .children(terminal_find)
             .context_menu(move |menu, window, cx| {

--- a/crates/con-ghostty/src/ffi.rs
+++ b/crates/con-ghostty/src/ffi.rs
@@ -650,6 +650,7 @@ unsafe extern "C" {
     // Surface input
     pub fn ghostty_surface_key(surface: ghostty_surface_t, key: ghostty_input_key_s) -> bool;
     pub fn ghostty_surface_text(surface: ghostty_surface_t, text: *const c_char, len: usize);
+    pub fn ghostty_surface_preedit(surface: ghostty_surface_t, text: *const c_char, len: usize);
     pub fn ghostty_surface_ime_point(
         surface: ghostty_surface_t,
         x: *mut c_double,

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -566,15 +566,6 @@ impl GhosttyApp {
             .map(|colors| colors.background)
     }
 
-    /// Current configured terminal foreground color.
-    pub fn foreground_rgb(&self) -> Option<[u8; 3]> {
-        self.appearance
-            .lock()
-            .colors
-            .as_ref()
-            .map(|colors| colors.foreground)
-    }
-
     /// Current configured terminal background opacity. This lets the macOS
     /// embedding layer keep short-lived AppKit backing mattes visually aligned
     /// with Ghostty's own transparent terminal background.
@@ -934,6 +925,14 @@ impl GhosttyTerminal {
         }
         // If text contains NUL bytes, we silently drop it — this matches
         // terminal semantics where NUL in text input is meaningless.
+    }
+
+    pub fn set_preedit(&self, text: Option<&str>) {
+        let text = text.filter(|text| !text.is_empty());
+        let (ptr, len) = text.map_or((std::ptr::null(), 0), |text| {
+            (text.as_ptr().cast(), text.len())
+        });
+        unsafe { ffi::ghostty_surface_preedit(self.surface, ptr, len) }
     }
 
     pub fn ime_point(&self) -> ImePoint {

--- a/postmortem/2026-08-31-macos-ime-preedit-cursor.md
+++ b/postmortem/2026-08-31-macos-ime-preedit-cursor.md
@@ -1,0 +1,33 @@
+# macOS IME preedit retained the terminal cursor
+
+## What happened
+
+While composing text with a macOS IME, Con displayed the marked text inline
+but left the terminal cursor visible at its leading edge. Committed text and
+the candidate window otherwise behaved normally.
+
+## Root cause
+
+Con stored GPUI's marked text and rendered it as a separate GPUI overlay above
+the embedded Ghostty surface. The overlay never set libghostty's preedit state,
+so Ghostty continued to render the normal terminal cursor.
+
+The overlay also treated `ghostty_surface_ime_point` as the marked text's
+origin. That API returns a candidate-window anchor at the horizontal midpoint
+of the cursor cell, which left the cursor partially uncovered.
+
+## Fix applied
+
+Con now forwards marked text through `ghostty_surface_preedit`, which was
+already available in the pinned Ghostty revision. The native renderer owns
+preedit text, underlining, cell width, clipping, and cursor suppression. Con
+clears native preedit state before sending committed text and when GPUI
+unmarks the composition. The redundant GPUI overlay and its color helper were
+removed.
+
+## What we learned
+
+- Marked text and the terminal grid must have one rendering owner.
+- An IME candidate-window anchor is not a text-layout origin.
+- Embedded Ghostty integrations should expose existing surface APIs before
+  recreating renderer behavior in the host UI.


### PR DESCRIPTION
## Summary

- Forward macOS marked text to `ghostty_surface_preedit`.
- Let Ghostty render preedit text, underline it, and suppress the normal terminal cursor.
- Clear native preedit state before commit or cancellation and remove the GPUI overlay.

## Why

Con rendered marked text in GPUI while Ghostty continued to draw the terminal cursor. The overlay also used Ghostty's candidate-window anchor as its text origin, which left the cursor visible at the leading edge.

The pinned Ghostty revision already provides a native preedit API. Using it keeps cursor visibility, terminal cell width, clipping, and IME rendering in one renderer.

## Testing

- `CON_ZIG_BIN="$(mise which zig)" cargo check -p con`
- `CON_ZIG_BIN="$(mise which zig)" cargo test --workspace`
- Built `dist/macos/dev/arm64/con Dev.app`
- Manual Chinese IME visual check pending

## Screenshots

Both screenshots show the same Chinese IME composition state.

### Before

The terminal cursor remains visible at the leading edge of the preedit text.
<img width="530" height="143" alt="con Beta 2026-08-31 17 00 01" src="https://github.com/user-attachments/assets/b6a1068b-7c0e-4d46-ac48-336792fdcbc4" />

### After

Ghostty renders the preedit text without the extra leading cursor.
<img width="568" height="146" alt="con Dev 2026-08-31 16 59 28" src="https://github.com/user-attachments/assets/1bc64ea6-b715-46ed-8501-b24152ec4219" />
