### PR TITLE
docs: prepare beta 92 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## `v0.1.0-beta.92` - 2026-08-31
+
+### Fixed
+
+**macOS**
+
+- Improved IME composition rendering by keeping marked text, cursor
+  suppression, underlining, and cell layout in the terminal renderer. _(PR
+  [#326](https://github.com/nowledge-co/con-terminal/pull/326) by
+  [@yyhhyyyyyy](https://github.com/yyhhyyyyyy))_
+
+---
+
 ## `v0.1.0-beta.91` - 2026-08-31
 
 ### Fixed


### PR DESCRIPTION
## Summary\n- document the macOS IME preedit fix in beta.92\n- credit PR #326 and @yyhhyyyyyy\n\nRelease notes only; no runtime behavior changes.