### PR TITLE
feat(terminal): use semantic prompt state for visible exec

### DIFF
--- a/crates/con-app/src/terminal_pane.rs
+++ b/crates/con-app/src/terminal_pane.rs
@@ -1,7 +1,7 @@
 //! TerminalPane — Ghostty-backed terminal pane wrapper.
 
 use con_agent::context::{PaneObservationFrame, PaneObservationSupport, derive_screen_hints};
-use con_ghostty::TerminalColors;
+use con_ghostty::{TerminalColors, TerminalPromptState};
 use con_terminal::TerminalTheme;
 use gpui::*;
 
@@ -28,6 +28,14 @@ impl TerminalPane {
 
     pub fn is_alive(&self, cx: &App) -> bool {
         self.entity.read(cx).is_alive()
+    }
+
+    pub fn prompt_state(&self, cx: &App) -> TerminalPromptState {
+        self.entity
+            .read(cx)
+            .terminal()
+            .map(|terminal| terminal.prompt_state())
+            .unwrap_or_default()
     }
 
     pub fn surface_ready(&self, cx: &App) -> bool {

--- a/crates/con-app/src/workspace/control_agent_tools.rs
+++ b/crates/con-app/src/workspace/control_agent_tools.rs
@@ -2,12 +2,52 @@ use super::*;
 
 const AGENT_CLI_DETECT_LOOKBACK_LINES: usize = 80;
 
+#[derive(Debug, PartialEq, Eq)]
+enum SemanticPromptState {
+    Unknown,
+    Waiting,
+    AtPrompt,
+}
+
+struct SemanticPromptTracker {
+    observed: bool,
+    left_prompt: bool,
+    pending_prompt: bool,
+}
+
+impl SemanticPromptTracker {
+    fn new(observed: bool) -> Self {
+        Self {
+            observed,
+            left_prompt: false,
+            pending_prompt: false,
+        }
+    }
+
+    fn observe(&mut self, cursor_at_prompt: bool, output_advanced: bool) -> SemanticPromptState {
+        self.observed |= cursor_at_prompt;
+        if !self.observed {
+            return SemanticPromptState::Unknown;
+        }
+        if !cursor_at_prompt || !output_advanced {
+            self.left_prompt |= !cursor_at_prompt;
+            self.pending_prompt = false;
+            return SemanticPromptState::Waiting;
+        }
+        if self.left_prompt || std::mem::replace(&mut self.pending_prompt, true) {
+            SemanticPromptState::AtPrompt
+        } else {
+            SemanticPromptState::Waiting
+        }
+    }
+}
+
 impl ConWorkspace {
     /// Handle a visible terminal execution request from the agent.
     ///
     /// Writes the command to the focused PTY so the user sees it execute.
-    /// Uses Ghostty's COMMAND_FINISHED signal when available, with a bounded
-    /// recent-output fallback when shell integration is unavailable.
+    /// Uses Ghostty's completion and semantic prompt state when available,
+    /// with a bounded recent-output fallback otherwise.
     pub(super) fn handle_terminal_exec_request_for_tab(
         &mut self,
         tab_idx: usize,
@@ -135,6 +175,10 @@ impl ConWorkspace {
             );
         }
 
+        let _ = pane.take_command_finished(cx);
+        let initial_prompt_state = pane.prompt_state(cx);
+        let mut semantic_prompt = SemanticPromptTracker::new(initial_prompt_state.cursor_at_prompt);
+
         // Write the command to the PTY — user sees it execute in real time
         let cmd_with_newline = format!("{}\n", req.command);
         pane.write(cmd_with_newline.as_bytes(), cx);
@@ -159,6 +203,7 @@ impl ConWorkspace {
                     output: String,
                     exit_code: Option<i32>,
                 },
+                Waiting,
                 Observe {
                     output: String,
                     prompt_like: bool,
@@ -183,6 +228,26 @@ impl ConWorkspace {
                                 output: pane_for_fallback.recent_lines(50, cx).join("\n"),
                                 exit_code,
                             };
+                        }
+
+                        let prompt_state = pane_for_fallback.prompt_state(cx);
+                        match semantic_prompt.observe(
+                            prompt_state.cursor_at_prompt,
+                            prompt_state.output_generation
+                                != initial_prompt_state.output_generation,
+                        ) {
+                            SemanticPromptState::Waiting => {
+                                return VisibleExecPoll::Waiting;
+                            }
+                            SemanticPromptState::AtPrompt => {
+                                let lines = pane_for_fallback.recent_lines(50, cx);
+                                pane_for_fallback.recover_shell_prompt_state(cx);
+                                return VisibleExecPoll::Finished {
+                                    output: lines.join("\n"),
+                                    exit_code: None,
+                                };
+                            }
+                            SemanticPromptState::Unknown => {}
                         }
 
                         let observation = pane_for_fallback.observation_frame(50, cx);
@@ -241,6 +306,7 @@ impl ConWorkspace {
                         last_prompt_snapshot = output;
                         stable_prompt_polls = 0;
                     }
+                    Some(VisibleExecPoll::Waiting) => {}
                     None => return,
                 }
 
@@ -1085,5 +1151,30 @@ impl ConWorkspace {
         };
 
         let _ = req.response_tx.send(response);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SemanticPromptState, SemanticPromptTracker};
+
+    #[test]
+    fn semantic_prompt_remains_authoritative_after_being_observed() {
+        let mut prompt = SemanticPromptTracker::new(false);
+
+        assert_eq!(prompt.observe(false, true), SemanticPromptState::Unknown);
+        assert_eq!(prompt.observe(true, true), SemanticPromptState::Waiting);
+        assert_eq!(prompt.observe(true, true), SemanticPromptState::AtPrompt);
+        assert_eq!(prompt.observe(false, true), SemanticPromptState::Waiting);
+        assert_eq!(prompt.observe(true, true), SemanticPromptState::AtPrompt);
+    }
+
+    #[test]
+    fn semantic_prompt_requires_output_after_dispatch() {
+        let mut prompt = SemanticPromptTracker::new(true);
+
+        assert_eq!(prompt.observe(true, false), SemanticPromptState::Waiting);
+        assert_eq!(prompt.observe(true, true), SemanticPromptState::Waiting);
+        assert_eq!(prompt.observe(true, true), SemanticPromptState::AtPrompt);
     }
 }

--- a/crates/con-ghostty/src/lib.rs
+++ b/crates/con-ghostty/src/lib.rs
@@ -16,6 +16,12 @@
 // Suppress warnings from objc 0.2's `sel_impl!` and `class!` macros.
 #![allow(unexpected_cfgs)]
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TerminalPromptState {
+    pub cursor_at_prompt: bool,
+    pub output_generation: u64,
+}
+
 pub fn restored_terminal_output_text(lines: &[String]) -> Option<String> {
     if lines.is_empty() {
         return None;

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -444,6 +444,14 @@ impl LinuxGhosttyTerminal {
             .is_some_and(LinuxPtySession::is_alive)
     }
 
+    pub fn prompt_state(&self) -> crate::TerminalPromptState {
+        self.inner
+            .lock()
+            .as_ref()
+            .map(LinuxPtySession::prompt_state)
+            .unwrap_or_default()
+    }
+
     pub fn is_busy(&self) -> bool {
         false
     }

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -317,8 +317,10 @@ impl SessionShared {
         }
     }
 
-    fn push_output(&self, chunk: &str) {
-        self.transcript.lock().push(chunk);
+    fn push_output(&self, chunk: &[u8]) {
+        let text = String::from_utf8_lossy(chunk);
+        self.transcript.lock().push(text.as_ref());
+        self.screen.feed(chunk);
         self.needs_render.store(true, Ordering::Release);
         self.wake();
     }
@@ -515,6 +517,10 @@ impl LinuxPtySession {
     pub fn is_alive(&self) -> bool {
         self.poll_child_status();
         self.shared.alive.load(Ordering::Acquire) && !self.shared.screen.is_write_desynchronized()
+    }
+
+    pub fn prompt_state(&self) -> crate::TerminalPromptState {
+        self.shared.screen.prompt_state()
     }
 
     pub fn take_command_finished(&self) -> Option<CommandFinishedSignal> {
@@ -1112,9 +1118,7 @@ fn spawn_bridge_reader_thread(
                             shared.mark_exited(None, started_at.elapsed());
                             break;
                         }
-                        shared.screen.feed(&payload);
-                        let chunk = String::from_utf8_lossy(&payload);
-                        shared.push_output(chunk.as_ref());
+                        shared.push_output(&payload);
                     }
                     0x02 => {
                         let mut code_bytes = [0u8; 4];
@@ -1163,9 +1167,7 @@ fn spawn_reader_thread(
                         break;
                     }
                     Ok(read) => {
-                        shared.screen.feed(&buffer[..read]);
-                        let chunk = String::from_utf8_lossy(&buffer[..read]);
-                        shared.push_output(chunk.as_ref());
+                        shared.push_output(&buffer[..read]);
                     }
                     Err(err)
                         if matches!(err.kind(), ErrorKind::Interrupted | ErrorKind::WouldBlock) =>

--- a/crates/con-ghostty/src/stub.rs
+++ b/crates/con-ghostty/src/stub.rs
@@ -236,6 +236,9 @@ impl GhosttyTerminal {
     pub fn is_alive(&self) -> bool {
         false
     }
+    pub fn prompt_state(&self) -> crate::TerminalPromptState {
+        crate::TerminalPromptState::default()
+    }
     pub fn is_busy(&self) -> bool {
         false
     }

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -1059,6 +1059,10 @@ impl GhosttyTerminal {
         !unsafe { ffi::ghostty_surface_process_exited(self.surface) }
     }
 
+    pub fn prompt_state(&self) -> crate::TerminalPromptState {
+        crate::TerminalPromptState::default()
+    }
+
     /// Take the command-finished signal (if any). Consuming — returns None on second call.
     /// Used by terminal_exec to detect command completion with exit code.
     pub fn take_command_finished(&self) -> Option<CommandFinishedSignal> {

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -131,6 +131,7 @@ pub enum GhosttyTerminalData {
     KittyGraphics = 30,
     ScrollbackMaxLines = 35,
     Mode = 37,
+    CursorAtPrompt = 39,
 }
 
 /// `GhosttyTerminalScrollbar` — current viewport position in the full
@@ -1220,6 +1221,7 @@ struct VtInner {
     scratch_rows: u16,
     scratch: Vec<Cell>,
     last_cursor: Cursor,
+    output_generation: u64,
 }
 
 unsafe impl Send for VtInner {}
@@ -1727,6 +1729,7 @@ impl VtScreen {
                 scratch_rows: rows,
                 scratch: Vec::with_capacity(cols as usize * rows as usize),
                 last_cursor: Cursor::default(),
+                output_generation: 0,
             })),
         })
     }
@@ -1807,6 +1810,7 @@ impl VtScreen {
         let mut inner = self.inner.lock();
         // SAFETY: terminal valid; bytes live for the call.
         unsafe { ghostty_terminal_vt_write(inner.terminal, bytes.as_ptr(), bytes.len()) };
+        inner.output_generation = inner.output_generation.wrapping_add(1);
         inner.generation = inner.generation.wrapping_add(1);
     }
 
@@ -2469,6 +2473,25 @@ impl VtScreen {
             )
         };
         rc == 0 && screen == GhosttyTerminalScreen::Alternate
+    }
+
+    pub fn prompt_state(&self) -> crate::TerminalPromptState {
+        let inner = self.inner.lock();
+        if inner.terminal.is_null() {
+            return crate::TerminalPromptState::default();
+        }
+        let mut at_prompt = false;
+        let rc = unsafe {
+            ghostty_terminal_get(
+                inner.terminal,
+                GhosttyTerminalData::CursorAtPrompt,
+                &mut at_prompt as *mut _ as *mut c_void,
+            )
+        };
+        crate::TerminalPromptState {
+            cursor_at_prompt: rc == GHOSTTY_SUCCESS && at_prompt,
+            output_generation: inner.output_generation,
+        }
     }
 
     /// Scroll the visible viewport by terminal rows. Negative is up;
@@ -3436,6 +3459,10 @@ mod tests {
             Some(GhosttyTerminalData::Mode as i64)
         );
         assert_eq!(
+            types["GhosttyTerminalData"]["values"]["CURSOR_AT_PROMPT"].as_i64(),
+            Some(GhosttyTerminalData::CursorAtPrompt as i64)
+        );
+        assert_eq!(
             types["GhosttyTerminalData"]["values"]["KITTY_KEYBOARD_FLAGS"].as_i64(),
             Some(GhosttyTerminalData::KittyKeyboardFlags as i64)
         );
@@ -3928,6 +3955,47 @@ mod tests {
         assert!(screen.is_bracketed_paste());
         screen.feed(b"\x1b[?2004l");
         assert!(!screen.is_bracketed_paste());
+    }
+
+    #[test]
+    fn vt_screen_queries_semantic_prompt_state() {
+        let screen = VtScreen::new(80, 24, None).expect("create vt screen");
+
+        assert_eq!(screen.prompt_state(), crate::TerminalPromptState::default());
+        screen.feed(b"\x1b]133;A\x07$ \x1b]133;B\x07");
+        assert_eq!(
+            screen.prompt_state(),
+            crate::TerminalPromptState {
+                cursor_at_prompt: true,
+                output_generation: 1,
+            }
+        );
+
+        screen.feed(b"echo test\r\n\x1b]133;C\x07");
+        assert_eq!(
+            screen.prompt_state(),
+            crate::TerminalPromptState {
+                cursor_at_prompt: false,
+                output_generation: 2,
+            }
+        );
+        screen.feed(b"\x1b]133;D;0\x07\x1b]133;A\x07");
+        assert_eq!(
+            screen.prompt_state(),
+            crate::TerminalPromptState {
+                cursor_at_prompt: true,
+                output_generation: 3,
+            }
+        );
+
+        screen.feed(b"\x1b[?1049h");
+        assert_eq!(
+            screen.prompt_state(),
+            crate::TerminalPromptState {
+                cursor_at_prompt: false,
+                output_generation: 4,
+            }
+        );
     }
 
     #[test]

--- a/crates/con-ghostty/src/windows/backend.rs
+++ b/crates/con-ghostty/src/windows/backend.rs
@@ -279,6 +279,13 @@ impl WindowsGhosttyTerminal {
             None => true,
         }
     }
+    pub fn prompt_state(&self) -> crate::TerminalPromptState {
+        self.inner
+            .lock()
+            .as_ref()
+            .map(|session| session.vt().prompt_state())
+            .unwrap_or_default()
+    }
     pub fn is_busy(&self) -> bool {
         false
     }


### PR DESCRIPTION
## Summary

- Bind Ghostty’s `CURSOR_AT_PROMPT` terminal data for the Windows and Linux VT backends.
- Prefer OSC 133 semantic prompt state when determining whether a visible terminal command has returned to the prompt.
- Keep `COMMAND_FINISHED` as the highest-priority completion signal, preserving exit code and duration.
- Retain the existing text and output-stability heuristic when shell integration is unavailable.
- Track prompt state and output generation atomically to avoid stale-prompt and background-output races.
- Ensure Linux transcript output is published before its corresponding semantic terminal state.

macOS behavior remains unchanged because the embedded surface API does not expose this terminal-data query.

## Testing

- `cargo test --workspace`
- Linux `con-ghostty` cross-target check
- Windows Rust-path `con-ghostty` cross-target check
- Ghostty `CURSOR_AT_PROMPT` upstream VT test
- Local macOS application bundle build and smoke test