### PR TITLE
fix(agent): avoid false completion after semantic prompt loss

### DIFF
--- a/crates/con-agent/src/tools.rs
+++ b/crates/con-agent/src/tools.rs
@@ -96,6 +96,47 @@ pub struct TerminalExecRequest {
 pub struct TerminalExecResponse {
     pub output: String,
     pub exit_code: Option<i32>,
+    status: TerminalExecStatus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TerminalExecStatus {
+    Completed,
+    Unconfirmed,
+}
+
+impl TerminalExecResponse {
+    const UNCONFIRMED_MESSAGE: &'static str = "Shell command completion could not be confirmed; the command may still be running. Do not issue another command to this pane until its state is verified.";
+
+    pub fn completed(output: String, exit_code: Option<i32>) -> Self {
+        Self {
+            output,
+            exit_code,
+            status: TerminalExecStatus::Completed,
+        }
+    }
+
+    pub fn unconfirmed(output: String) -> Self {
+        Self {
+            output,
+            exit_code: None,
+            status: TerminalExecStatus::Unconfirmed,
+        }
+    }
+
+    pub fn completion_error(&self) -> Option<&'static str> {
+        (self.status == TerminalExecStatus::Unconfirmed).then_some(Self::UNCONFIRMED_MESSAGE)
+    }
+
+    pub fn completion_error_with_output(&self) -> Option<String> {
+        self.completion_error().map(|message| {
+            if self.output.is_empty() {
+                message.to_string()
+            } else {
+                format!("{message}\nRecent output:\n{}", self.output)
+            }
+        })
+    }
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
@@ -238,6 +279,10 @@ impl Tool for TerminalExecTool {
                     )
                 })
         })?;
+
+        if let Some(error) = response.completion_error_with_output() {
+            return Err(ToolError::CommandFailed(error));
+        }
 
         Ok(ShellExecOutput {
             stdout: response.output,
@@ -4954,13 +4999,16 @@ impl Tool for BatchExecTool {
                 .into_iter()
                 .map(|(pane_index, pane_id, rx)| {
                     match rx.recv_timeout(std::time::Duration::from_secs(60)) {
-                        Ok(resp) => BatchResult {
-                            pane_index,
-                            pane_id,
-                            output: resp.output,
-                            exit_code: resp.exit_code,
-                            error: None,
-                        },
+                        Ok(resp) => {
+                            let error = resp.completion_error().map(str::to_string);
+                            BatchResult {
+                                pane_index,
+                                pane_id,
+                                output: resp.output,
+                                exit_code: resp.exit_code,
+                                error,
+                            }
+                        }
                         Err(_) => BatchResult {
                             pane_index,
                             pane_id,
@@ -5948,6 +5996,13 @@ async fn ensure_remote_tmux_workspace_impl(
             })
     })?;
 
+    if let Some(error) = tmux_bootstrap.completion_error_with_output() {
+        return Err(ToolError::CommandFailed(format!(
+            "Failed to confirm tmux session preparation for `{}` on host `{}`.\n{}",
+            session_name, ensure.host, error
+        )));
+    }
+
     if tmux_bootstrap.exit_code.is_some_and(|code| code != 0) {
         return Err(ToolError::CommandFailed(format!(
             "Failed to prepare tmux session `{}` on host `{}`.\n{}",
@@ -6448,17 +6503,20 @@ impl Tool for RemoteExecTool {
                 .map(
                     |(host, pane_index, pane_id, created, match_source, bootstrap_output, rx)| {
                         match rx.recv_timeout(std::time::Duration::from_secs(60)) {
-                            Ok(resp) => RemoteExecHostResult {
-                                host,
-                                pane_index,
-                                pane_id,
-                                created,
-                                match_source,
-                                bootstrap_output,
-                                output: resp.output,
-                                exit_code: resp.exit_code,
-                                error: None,
-                            },
+                            Ok(resp) => {
+                                let error = resp.completion_error().map(str::to_string);
+                                RemoteExecHostResult {
+                                    host,
+                                    pane_index,
+                                    pane_id,
+                                    created,
+                                    match_source,
+                                    bootstrap_output,
+                                    output: resp.output,
+                                    exit_code: resp.exit_code,
+                                    error,
+                                }
+                            }
                             Err(_) => RemoteExecHostResult {
                                 host,
                                 pane_index,
@@ -6778,8 +6836,8 @@ impl Tool for CreatePaneTool {
 #[cfg(test)]
 mod tests {
     use super::{
-        AgentCliNativeAttachmentState, ResolveWorkTargetResult, TmuxTargetKindFilter,
-        WorkTargetControlPath, WorkTargetIntent, agent_cli_native_attachment,
+        AgentCliNativeAttachmentState, ResolveWorkTargetResult, TerminalExecResponse,
+        TmuxTargetKindFilter, WorkTargetControlPath, WorkTargetIntent, agent_cli_native_attachment,
         build_local_cwd_command_prefix, canonical_agent_cli_name, decode_key_escapes,
         expand_home_prefix, is_tmux_agent_cli_command, is_tmux_shell_command, pane_matches_cwd,
         resolve_work_target_candidates, split_at_standalone_esc,
@@ -6797,6 +6855,19 @@ mod tests {
         PaneSelector, preferred_tmux_shell_session, shell_quote_fragment, tmux_creation_target,
     };
     use crossbeam_channel::unbounded;
+
+    #[test]
+    fn terminal_exec_response_distinguishes_unconfirmed_completion() {
+        let completed = TerminalExecResponse::completed("done".to_string(), Some(0));
+        let response = TerminalExecResponse::unconfirmed("$ ".to_string());
+
+        assert_eq!(completed.completion_error(), None);
+        let error = response
+            .completion_error_with_output()
+            .expect("completion error");
+        assert!(error.contains("may still be running"));
+        assert!(error.contains("$ "));
+    }
 
     #[test]
     fn decode_standard_escapes() {

--- a/crates/con-app/src/workspace/control_agent_tools.rs
+++ b/crates/con-app/src/workspace/control_agent_tools.rs
@@ -1,8 +1,10 @@
 use super::*;
 
 const AGENT_CLI_DETECT_LOOKBACK_LINES: usize = 80;
+const PROMPT_STABLE_POLLS: u32 = 2;
+const VISIBLE_EXEC_POLL_COUNT: usize = 30;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SemanticPromptState {
     Unknown,
     Waiting,
@@ -42,6 +44,66 @@ impl SemanticPromptTracker {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum VisibleExecDecision {
+    Waiting,
+    Complete,
+    Unconfirmed,
+}
+
+struct VisibleExecTracker {
+    semantic_prompt: SemanticPromptTracker,
+    last_prompt_snapshot: String,
+    stable_prompt_polls: u32,
+}
+
+impl VisibleExecTracker {
+    fn new(cursor_at_prompt: bool) -> Self {
+        Self {
+            semantic_prompt: SemanticPromptTracker::new(cursor_at_prompt),
+            last_prompt_snapshot: String::new(),
+            stable_prompt_polls: 0,
+        }
+    }
+
+    fn observe(
+        &mut self,
+        cursor_at_prompt: bool,
+        output_advanced: bool,
+        output: &str,
+        prompt_like: bool,
+    ) -> VisibleExecDecision {
+        let semantic_state = self
+            .semantic_prompt
+            .observe(cursor_at_prompt, output_advanced);
+        if semantic_state == SemanticPromptState::AtPrompt {
+            return VisibleExecDecision::Complete;
+        }
+        if !output_advanced || !prompt_like || output.is_empty() {
+            self.last_prompt_snapshot.clear();
+            self.stable_prompt_polls = 0;
+            return VisibleExecDecision::Waiting;
+        }
+
+        if output == self.last_prompt_snapshot {
+            self.stable_prompt_polls += 1;
+        } else {
+            self.last_prompt_snapshot.clear();
+            self.last_prompt_snapshot.push_str(output);
+            self.stable_prompt_polls = 0;
+        }
+        if self.stable_prompt_polls < PROMPT_STABLE_POLLS {
+            return VisibleExecDecision::Waiting;
+        }
+
+        match semantic_state {
+            SemanticPromptState::Unknown => VisibleExecDecision::Complete,
+            SemanticPromptState::Waiting => VisibleExecDecision::Unconfirmed,
+            SemanticPromptState::AtPrompt => VisibleExecDecision::Complete,
+        }
+    }
+}
+
 impl ConWorkspace {
     /// Handle a visible terminal execution request from the agent.
     ///
@@ -57,10 +119,9 @@ impl ConWorkspace {
         let resolved = match self.resolve_pane_target_for_tab(tab_idx, req.target) {
             Ok(target) => target,
             Err(err) => {
-                let _ = req.response_tx.send(TerminalExecResponse {
-                    output: err,
-                    exit_code: Some(1),
-                });
+                let _ = req
+                    .response_tx
+                    .send(TerminalExecResponse::completed(err, Some(1)));
                 return;
             }
         };
@@ -69,10 +130,10 @@ impl ConWorkspace {
 
         // Safety: refuse to execute on a dead PTY.
         if !pane.is_alive(cx) {
-            let _ = req.response_tx.send(TerminalExecResponse {
-                output: "Pane PTY process has exited — cannot execute command.".to_string(),
-                exit_code: Some(1),
-            });
+            let _ = req.response_tx.send(TerminalExecResponse::completed(
+                "Pane PTY process has exited — cannot execute command.".to_string(),
+                Some(1),
+            ));
             return;
         }
 
@@ -160,10 +221,9 @@ impl ConWorkspace {
                 notes,
                 suggestion,
             );
-            let _ = req.response_tx.send(TerminalExecResponse {
-                output,
-                exit_code: Some(2),
-            });
+            let _ = req
+                .response_tx
+                .send(TerminalExecResponse::completed(output, Some(2)));
             return;
         }
 
@@ -177,7 +237,7 @@ impl ConWorkspace {
 
         let _ = pane.take_command_finished(cx);
         let initial_prompt_state = pane.prompt_state(cx);
-        let mut semantic_prompt = SemanticPromptTracker::new(initial_prompt_state.cursor_at_prompt);
+        let mut visible_exec = VisibleExecTracker::new(initial_prompt_state.cursor_at_prompt);
 
         // Write the command to the PTY — user sees it execute in real time
         let cmd_with_newline = format!("{}\n", req.command);
@@ -203,22 +263,21 @@ impl ConWorkspace {
                     output: String,
                     exit_code: Option<i32>,
                 },
-                Waiting,
-                Observe {
+                Unconfirmed {
                     output: String,
-                    prompt_like: bool,
                 },
+                Waiting,
             }
 
-            const PROMPT_STABLE_POLLS: u32 = 2;
-            let mut last_prompt_snapshot = String::new();
-            let mut stable_prompt_polls = 0u32;
+            let mut observed_generation = None;
+            let mut observed_output = String::new();
+            let mut observed_prompt_like = false;
 
             cx.background_executor()
                 .timer(std::time::Duration::from_millis(500))
                 .await;
 
-            for _ in 0..29 {
+            for poll_index in 0..VISIBLE_EXEC_POLL_COUNT {
                 let poll = _this
                     .update(cx, |_ws, cx| {
                         if let Some((exit_code, _duration)) =
@@ -231,42 +290,61 @@ impl ConWorkspace {
                         }
 
                         let prompt_state = pane_for_fallback.prompt_state(cx);
-                        match semantic_prompt.observe(
+                        if observed_generation != Some(prompt_state.output_generation) {
+                            let observation = pane_for_fallback.observation_frame(50, cx);
+                            observed_output = observation
+                                .recent_output
+                                .iter()
+                                .map(|line| line.trim_end())
+                                .collect::<Vec<_>>()
+                                .join("\n");
+                            observed_prompt_like = observation.screen_hints.iter().any(|hint| {
+                                matches!(
+                                    hint.kind,
+                                    con_agent::context::PaneObservationHintKind::PromptLikeInput
+                                )
+                            });
+                            observed_generation = Some(prompt_state.output_generation);
+                        }
+                        let decision = visible_exec.observe(
                             prompt_state.cursor_at_prompt,
                             prompt_state.output_generation
                                 != initial_prompt_state.output_generation,
-                        ) {
-                            SemanticPromptState::Waiting => {
-                                return VisibleExecPoll::Waiting;
-                            }
-                            SemanticPromptState::AtPrompt => {
+                            &observed_output,
+                            observed_prompt_like,
+                        );
+
+                        match decision {
+                            VisibleExecDecision::Waiting => VisibleExecPoll::Waiting,
+                            VisibleExecDecision::Complete => {
+                                if let Some((exit_code, _duration)) =
+                                    pane_for_fallback.take_command_finished(cx)
+                                {
+                                    return VisibleExecPoll::Finished {
+                                        output: pane_for_fallback.recent_lines(50, cx).join("\n"),
+                                        exit_code,
+                                    };
+                                }
                                 let lines = pane_for_fallback.recent_lines(50, cx);
                                 pane_for_fallback.recover_shell_prompt_state(cx);
-                                return VisibleExecPoll::Finished {
+                                VisibleExecPoll::Finished {
                                     output: lines.join("\n"),
                                     exit_code: None,
-                                };
+                                }
                             }
-                            SemanticPromptState::Unknown => {}
-                        }
-
-                        let observation = pane_for_fallback.observation_frame(50, cx);
-                        let output = observation
-                            .recent_output
-                            .iter()
-                            .map(|line| line.trim_end())
-                            .collect::<Vec<_>>()
-                            .join("\n");
-                        let prompt_like = observation.screen_hints.iter().any(|hint| {
-                            matches!(
-                                hint.kind,
-                                con_agent::context::PaneObservationHintKind::PromptLikeInput
-                            )
-                        });
-
-                        VisibleExecPoll::Observe {
-                            output,
-                            prompt_like,
+                            VisibleExecDecision::Unconfirmed => {
+                                if let Some((exit_code, _duration)) =
+                                    pane_for_fallback.take_command_finished(cx)
+                                {
+                                    return VisibleExecPoll::Finished {
+                                        output: pane_for_fallback.recent_lines(50, cx).join("\n"),
+                                        exit_code,
+                                    };
+                                }
+                                VisibleExecPoll::Unconfirmed {
+                                    output: pane_for_fallback.recent_lines(50, cx).join("\n"),
+                                }
+                            }
                         }
                     })
                     .ok();
@@ -274,56 +352,42 @@ impl ConWorkspace {
                 match poll {
                     Some(VisibleExecPoll::Finished { output, exit_code }) => {
                         let _ = fallback_response_tx
-                            .try_send(TerminalExecResponse { output, exit_code });
+                            .try_send(TerminalExecResponse::completed(output, exit_code));
                         return;
                     }
-                    Some(VisibleExecPoll::Observe {
-                        output,
-                        prompt_like,
-                    }) if prompt_like => {
-                        if !output.is_empty() && output == last_prompt_snapshot {
-                            stable_prompt_polls += 1;
-                        } else {
-                            last_prompt_snapshot = output;
-                            stable_prompt_polls = 0;
-                        }
-
-                        if stable_prompt_polls >= PROMPT_STABLE_POLLS {
-                            let output = _this
-                                .update(cx, |_ws, cx| {
-                                    pane_for_fallback.recover_shell_prompt_state(cx);
-                                    pane_for_fallback.recent_lines(50, cx).join("\n")
-                                })
-                                .unwrap_or_else(|_| last_prompt_snapshot.clone());
-                            let _ = fallback_response_tx.try_send(TerminalExecResponse {
-                                output,
-                                exit_code: None,
-                            });
-                            return;
-                        }
-                    }
-                    Some(VisibleExecPoll::Observe { output, .. }) => {
-                        last_prompt_snapshot = output;
-                        stable_prompt_polls = 0;
+                    Some(VisibleExecPoll::Unconfirmed { output }) => {
+                        let _ = fallback_response_tx
+                            .try_send(TerminalExecResponse::unconfirmed(output));
+                        return;
                     }
                     Some(VisibleExecPoll::Waiting) => {}
                     None => return,
                 }
 
-                cx.background_executor()
-                    .timer(std::time::Duration::from_millis(500))
-                    .await;
+                if poll_index + 1 < VISIBLE_EXEC_POLL_COUNT {
+                    cx.background_executor()
+                        .timer(std::time::Duration::from_millis(500))
+                        .await;
+                }
             }
 
-            let output = _this
+            let response = _this
                 .update(cx, |_ws, cx| {
-                    pane_for_fallback.recent_lines(50, cx).join("\n")
+                    if let Some((exit_code, _duration)) =
+                        pane_for_fallback.take_command_finished(cx)
+                    {
+                        TerminalExecResponse::completed(
+                            pane_for_fallback.recent_lines(50, cx).join("\n"),
+                            exit_code,
+                        )
+                    } else {
+                        TerminalExecResponse::unconfirmed(
+                            pane_for_fallback.recent_lines(50, cx).join("\n"),
+                        )
+                    }
                 })
-                .unwrap_or_default();
-            let _ = fallback_response_tx.try_send(TerminalExecResponse {
-                output,
-                exit_code: None,
-            });
+                .unwrap_or_else(|_| TerminalExecResponse::unconfirmed(String::new()));
+            let _ = fallback_response_tx.try_send(response);
         })
         .detach();
     }
@@ -1156,7 +1220,9 @@ impl ConWorkspace {
 
 #[cfg(test)]
 mod tests {
-    use super::{SemanticPromptState, SemanticPromptTracker};
+    use super::{
+        SemanticPromptState, SemanticPromptTracker, VisibleExecDecision, VisibleExecTracker,
+    };
 
     #[test]
     fn semantic_prompt_remains_authoritative_after_being_observed() {
@@ -1176,5 +1242,72 @@ mod tests {
         assert_eq!(prompt.observe(true, false), SemanticPromptState::Waiting);
         assert_eq!(prompt.observe(true, true), SemanticPromptState::Waiting);
         assert_eq!(prompt.observe(true, true), SemanticPromptState::AtPrompt);
+    }
+
+    #[test]
+    fn stable_plain_prompt_after_semantic_marker_loss_is_unconfirmed() {
+        let mut exec = VisibleExecTracker::new(true);
+
+        assert_eq!(
+            exec.observe(false, true, "$ ", true),
+            VisibleExecDecision::Waiting
+        );
+        assert_eq!(
+            exec.observe(false, true, "$ ", true),
+            VisibleExecDecision::Waiting
+        );
+        assert_eq!(
+            exec.observe(false, true, "$ ", true),
+            VisibleExecDecision::Unconfirmed
+        );
+    }
+
+    #[test]
+    fn stable_prompt_without_semantic_markers_uses_fallback() {
+        let mut exec = VisibleExecTracker::new(false);
+
+        assert_eq!(
+            exec.observe(false, true, "$ ", true),
+            VisibleExecDecision::Waiting
+        );
+        assert_eq!(
+            exec.observe(false, true, "$ ", true),
+            VisibleExecDecision::Waiting
+        );
+        assert_eq!(
+            exec.observe(false, true, "$ ", true),
+            VisibleExecDecision::Complete
+        );
+    }
+
+    #[test]
+    fn semantic_prompt_return_completes_visible_exec() {
+        let mut exec = VisibleExecTracker::new(true);
+
+        assert_eq!(
+            exec.observe(false, true, "running", false),
+            VisibleExecDecision::Waiting
+        );
+        assert_eq!(
+            exec.observe(true, true, "$ ", true),
+            VisibleExecDecision::Complete
+        );
+    }
+
+    #[test]
+    fn stale_initial_prompt_cannot_end_visible_exec() {
+        let mut semantic_exec = VisibleExecTracker::new(true);
+        let mut fallback_exec = VisibleExecTracker::new(false);
+
+        for _ in 0..3 {
+            assert_eq!(
+                semantic_exec.observe(true, false, "$ ", true),
+                VisibleExecDecision::Waiting
+            );
+            assert_eq!(
+                fallback_exec.observe(false, false, "$ ", true),
+                VisibleExecDecision::Waiting
+            );
+        }
     }
 }

--- a/crates/con-app/src/workspace/control_surfaces.rs
+++ b/crates/con-app/src/workspace/control_surfaces.rs
@@ -1158,6 +1158,9 @@ impl ConWorkspace {
     pub(super) fn terminal_exec_response_to_control_result(
         response: TerminalExecResponse,
     ) -> ControlResult {
+        if let Some(error) = response.completion_error_with_output() {
+            return Err(ControlError::internal(error));
+        }
         Ok(json!({
             "output": response.output,
             "exit_code": response.exit_code,

--- a/postmortem/2026-09-01-semantic-prompt-degradation.md
+++ b/postmortem/2026-09-01-semantic-prompt-degradation.md
@@ -1,0 +1,38 @@
+# Semantic prompt loss delayed visible commands
+
+## What happened
+
+After Con began using Ghostty's semantic prompt state for visible command
+completion, a shell that removed its OSC 133 hooks during a command could draw
+an ordinary prompt without emitting another completion or prompt marker. Con
+kept waiting for semantic confirmation until its polling deadline.
+
+## Root cause
+
+The per-command tracker remembered that semantic prompt state had been
+observed, but represented every later `cursor_at_prompt = false` sample as the
+same waiting state. It could not distinguish a running command from a finished
+command whose shell integration had disappeared, so it also suppressed the
+existing no-integration heuristic without reporting that completion had become
+unprovable.
+
+## Fix applied
+
+Stable prompt-like output now remains advisory after semantic markers have
+been observed. Instead of claiming completion or waiting for the full polling
+deadline, Con returns an explicit unconfirmed result and preserves the recent
+output. Agent, batch, remote, and control-plane callers treat that result as an
+error and do not receive it as shell-ready. Poll exhaustion is handled the same
+way. Authoritative command-finished events still take priority, normal semantic
+prompt returns still complete, and panes that never exposed semantic markers
+retain the existing fallback.
+
+Con does not recover shell state from an unconfirmed result and does not append
+sentinels or wrappers to the user's command.
+
+## What we learned
+
+- A sticky capability signal also needs an explicit degraded outcome.
+- Prompt-shaped text cannot prove that an interactive shell is ready.
+- When completion is unprovable, returning uncertainty is safer than either
+  reporting success or silently waiting until a deadline.


### PR DESCRIPTION
## Context

Follow-up to #328. Once semantic prompt state had been observed, a shell could remove its OSC 133 hooks during a command and redraw an ordinary prompt without emitting another semantic marker. Con could no longer prove whether the command had finished.

## Summary

- Return an explicit unconfirmed result when semantic prompt markers disappear and only stable prompt-like text remains.
- Keep `COMMAND_FINISHED` events and semantic prompt returns authoritative.
- Preserve the existing heuristic fallback for shells that never expose semantic markers.
- Propagate unconfirmed results through terminal, batch, remote, tmux bootstrap, and control-plane callers without marking the pane shell-ready.
- Cache screen observations by output generation and check every poll through the deadline.

Prompt-shaped text alone cannot distinguish a ready shell from a command that is still running after printing similar text.

## Testing

- `cargo test --workspace`
- `cargo test -p con workspace::control_agent_tools::tests`
- `cargo test -p con-agent terminal_exec_response_distinguishes_unconfirmed_completion`
- Targeted `rustfmt --check`
- `git diff --check`