### PR TITLE
feat(terminal): support portable Ghostty effects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,6 +1272,7 @@ name = "con"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ashpd",
  "cc",
  "chrono",
  "cocoa 0.26.0",

--- a/crates/con-app/Cargo.toml
+++ b/crates/con-app/Cargo.toml
@@ -81,6 +81,7 @@ windows = { version = "0.61", features = [
     "Win32_System_Kernel",             # EXCEPTION_POINTERS definition
     "Win32_System_Pipes",              # WaitNamedPipeW
     "Win32_Graphics_Dwm",              # DwmSetWindowAttribute — Mica/Acrylic backdrop
+    "Win32_UI_WindowsAndMessaging",     # FlashWindowEx for terminal notifications
 ] }
 # Used only by the Windows `GhosttyView` to wrap D3D11-readback BGRA into
 # a GPUI `RenderImage` (GPUI's `RenderImage::new` takes a
@@ -92,6 +93,7 @@ smallvec = "1"
 raw-window-handle = "0.6"
 unicode-width.workspace = true
 x11rb = "0.13.2"
+ashpd = { version = "0.13", default-features = false, features = ["async-io", "notification"] }
 # Linux wraps shared libghostty-vt Kitty RGBA snapshots in GPUI
 # `RenderImage`s, whose constructor exposes these concrete crate types.
 image = { version = "0.25", default-features = false }

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -116,6 +116,8 @@ fn perf_trace_enabled() -> bool {
 #[allow(dead_code)]
 pub struct GhosttyTitleChanged(pub Option<String>);
 
+pub struct GhosttyBell;
+
 /// Emitted when the terminal process exits.
 pub struct GhosttyProcessExited;
 
@@ -126,6 +128,7 @@ pub struct GhosttySplitRequested(pub GhosttySplitDirection);
 pub struct GhosttyCwdChanged(pub Option<String>);
 
 impl EventEmitter<GhosttyTitleChanged> for GhosttyView {}
+impl EventEmitter<GhosttyBell> for GhosttyView {}
 impl EventEmitter<GhosttyProcessExited> for GhosttyView {}
 impl EventEmitter<GhosttyFocusChanged> for GhosttyView {}
 impl EventEmitter<GhosttySplitRequested> for GhosttyView {}
@@ -492,6 +495,12 @@ impl GhosttyView {
 
         let started = perf_trace_enabled().then(Instant::now);
         let mut changed = false;
+
+        if terminal.take_bell() {
+            changed = true;
+            cx.emit(GhosttyBell);
+        }
+
         for event in terminal.take_pending_events() {
             changed = true;
             match event {

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -27,6 +27,7 @@ use con_ghostty::GhosttyScrollbar;
 use con_ghostty::ffi;
 use con_ghostty::{
     GhosttyApp, GhosttySplitDirection, GhosttySurfaceEvent, GhosttyTerminal, MouseButton,
+    TerminalProgress,
 };
 use gpui::{prelude::FluentBuilder as _, *};
 use gpui_component::ActiveTheme;
@@ -126,6 +127,7 @@ pub struct GhosttyFocusChanged;
 /// Emitted when Ghostty requests a new split from this surface.
 pub struct GhosttySplitRequested(pub GhosttySplitDirection);
 pub struct GhosttyCwdChanged(pub Option<String>);
+pub struct GhosttyProgressChanged;
 
 impl EventEmitter<GhosttyTitleChanged> for GhosttyView {}
 impl EventEmitter<GhosttyBell> for GhosttyView {}
@@ -133,6 +135,7 @@ impl EventEmitter<GhosttyProcessExited> for GhosttyView {}
 impl EventEmitter<GhosttyFocusChanged> for GhosttyView {}
 impl EventEmitter<GhosttySplitRequested> for GhosttyView {}
 impl EventEmitter<GhosttyCwdChanged> for GhosttyView {}
+impl EventEmitter<GhosttyProgressChanged> for GhosttyView {}
 
 #[derive(Default)]
 struct PendingTerminalFind {
@@ -177,6 +180,7 @@ pub struct GhosttyView {
     scale_factor: f32,
     last_title: Option<String>,
     last_cwd: Option<String>,
+    last_progress: Option<TerminalProgress>,
     /// Data queued for the PTY before the surface was created.
     /// Flushed once in `ensure_initialized()` after the terminal exists.
     pending_write: Option<Vec<u8>>,
@@ -262,6 +266,7 @@ impl GhosttyView {
             scale_factor: 1.0,
             last_title: None,
             last_cwd: cwd,
+            last_progress: None,
             pending_write: None,
             restored_screen_text,
             native_view_visible: Cell::new(true),
@@ -576,6 +581,13 @@ impl GhosttyView {
             cx.emit(GhosttyCwdChanged(cwd));
         }
 
+        let progress = terminal.progress();
+        if progress != self.last_progress {
+            self.last_progress = progress;
+            changed = true;
+            cx.emit(GhosttyProgressChanged);
+        }
+
         #[cfg(target_os = "macos")]
         if sync_native_scroll {
             self.sync_native_scroll_view();
@@ -676,6 +688,10 @@ impl GhosttyView {
             .as_ref()
             .and_then(|t| t.current_dir())
             .or_else(|| self.initial_cwd.clone())
+    }
+
+    pub fn progress(&self) -> Option<TerminalProgress> {
+        self.last_progress
     }
 
     pub fn is_alive(&self) -> bool {
@@ -851,6 +867,7 @@ impl GhosttyView {
         self.awaiting_first_layout_visibility = false;
         self.last_bounds = None;
         self.last_title = None;
+        self.last_progress = None;
         self.pending_write = None;
         self.restored_screen_text = None;
         self.next_surface_init_retry_at = None;

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -88,12 +88,14 @@ actions!(ghostty, [ConsumeTab, ConsumeTabPrev]);
 
 #[allow(dead_code)]
 pub struct GhosttyTitleChanged(pub Option<String>);
+pub struct GhosttyBell;
 pub struct GhosttyProcessExited;
 pub struct GhosttyFocusChanged;
 pub struct GhosttySplitRequested(pub GhosttySplitDirection);
 pub struct GhosttyCwdChanged(pub Option<String>);
 
 impl EventEmitter<GhosttyTitleChanged> for GhosttyView {}
+impl EventEmitter<GhosttyBell> for GhosttyView {}
 impl EventEmitter<GhosttyProcessExited> for GhosttyView {}
 impl EventEmitter<GhosttyFocusChanged> for GhosttyView {}
 impl EventEmitter<GhosttySplitRequested> for GhosttyView {}
@@ -407,6 +409,11 @@ impl GhosttyView {
             changed |= self.refresh_snapshot();
         }
 
+        if terminal.take_bell() {
+            changed = true;
+            cx.emit(GhosttyBell);
+        }
+
         let title = terminal.title();
         if title != self.last_title {
             self.last_title = title.clone();
@@ -447,6 +454,11 @@ impl GhosttyView {
             // wake signal we explicitly want to react to.
             if terminal.take_needs_render() {
                 changed |= self.refresh_snapshot();
+            }
+
+            if terminal.take_bell() {
+                changed = true;
+                cx.emit(GhosttyBell);
             }
 
             let title = terminal.title();

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 
 use con_ghostty::vt::{VtKeyAction, VtKeyEvent, VtKeyModifiers, VtPasteResult, VtPasteSource};
 use con_ghostty::{
-    ATTR_BOLD, ATTR_INVERSE, ATTR_ITALIC, ATTR_STRIKE, ATTR_UNDERLINE, GhosttyApp,
-    GhosttySplitDirection, GhosttyTerminal, KittyImage, KittyPlacement, ScreenSnapshot,
+    ATTR_BOLD, ATTR_INVERSE, ATTR_ITALIC, ATTR_STRIKE, ATTR_UNDERLINE, DesktopNotification,
+    GhosttyApp, GhosttySplitDirection, GhosttyTerminal, KittyImage, KittyPlacement, ScreenSnapshot,
     SurfaceSize, TerminalProgress, VtCell, VtCursor,
 };
 use futures::StreamExt;
@@ -94,6 +94,7 @@ pub struct GhosttyFocusChanged;
 pub struct GhosttySplitRequested(pub GhosttySplitDirection);
 pub struct GhosttyCwdChanged(pub Option<String>);
 pub struct GhosttyProgressChanged;
+pub struct GhosttyDesktopNotification(pub DesktopNotification);
 
 impl EventEmitter<GhosttyTitleChanged> for GhosttyView {}
 impl EventEmitter<GhosttyBell> for GhosttyView {}
@@ -102,6 +103,7 @@ impl EventEmitter<GhosttyFocusChanged> for GhosttyView {}
 impl EventEmitter<GhosttySplitRequested> for GhosttyView {}
 impl EventEmitter<GhosttyCwdChanged> for GhosttyView {}
 impl EventEmitter<GhosttyProgressChanged> for GhosttyView {}
+impl EventEmitter<GhosttyDesktopNotification> for GhosttyView {}
 
 pub struct GhosttyView {
     app: Arc<GhosttyApp>,
@@ -426,6 +428,11 @@ impl GhosttyView {
             cx.write_to_clipboard(ClipboardItem::new_string(text));
         }
 
+        if let Some(notification) = terminal.take_desktop_notification() {
+            changed = true;
+            cx.emit(GhosttyDesktopNotification(notification));
+        }
+
         let title = terminal.title();
         if title != self.last_title {
             self.last_title = title.clone();
@@ -478,6 +485,11 @@ impl GhosttyView {
             if terminal.take_bell() {
                 changed = true;
                 cx.emit(GhosttyBell);
+            }
+
+            if let Some(notification) = terminal.take_desktop_notification() {
+                changed = true;
+                cx.emit(GhosttyDesktopNotification(notification));
             }
 
             let title = terminal.title();

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -21,7 +21,7 @@ use con_ghostty::vt::{VtKeyAction, VtKeyEvent, VtKeyModifiers, VtPasteResult, Vt
 use con_ghostty::{
     ATTR_BOLD, ATTR_INVERSE, ATTR_ITALIC, ATTR_STRIKE, ATTR_UNDERLINE, GhosttyApp,
     GhosttySplitDirection, GhosttyTerminal, KittyImage, KittyPlacement, ScreenSnapshot,
-    SurfaceSize, VtCell, VtCursor,
+    SurfaceSize, TerminalProgress, VtCell, VtCursor,
 };
 use futures::StreamExt;
 use futures::channel::mpsc::unbounded;
@@ -93,6 +93,7 @@ pub struct GhosttyProcessExited;
 pub struct GhosttyFocusChanged;
 pub struct GhosttySplitRequested(pub GhosttySplitDirection);
 pub struct GhosttyCwdChanged(pub Option<String>);
+pub struct GhosttyProgressChanged;
 
 impl EventEmitter<GhosttyTitleChanged> for GhosttyView {}
 impl EventEmitter<GhosttyBell> for GhosttyView {}
@@ -100,6 +101,7 @@ impl EventEmitter<GhosttyProcessExited> for GhosttyView {}
 impl EventEmitter<GhosttyFocusChanged> for GhosttyView {}
 impl EventEmitter<GhosttySplitRequested> for GhosttyView {}
 impl EventEmitter<GhosttyCwdChanged> for GhosttyView {}
+impl EventEmitter<GhosttyProgressChanged> for GhosttyView {}
 
 pub struct GhosttyView {
     app: Arc<GhosttyApp>,
@@ -114,6 +116,7 @@ pub struct GhosttyView {
     process_exit_emitted: bool,
     last_title: Option<String>,
     last_cwd: Option<String>,
+    last_progress: Option<TerminalProgress>,
     pending_write: Option<Vec<u8>>,
     snapshot: Option<ScreenSnapshot>,
     row_cache: Vec<CachedTerminalRow>,
@@ -212,6 +215,7 @@ impl GhosttyView {
             process_exit_emitted: false,
             last_title: None,
             last_cwd: None,
+            last_progress: None,
             pending_write: None,
             snapshot: None,
             row_cache: Vec::new(),
@@ -275,6 +279,10 @@ impl GhosttyView {
                     .as_ref()
                     .map(|cwd| cwd.to_string_lossy().into_owned())
             })
+    }
+
+    pub fn progress(&self) -> Option<TerminalProgress> {
+        self.last_progress
     }
 
     pub fn is_alive(&self) -> bool {
@@ -428,6 +436,13 @@ impl GhosttyView {
             cx.emit(GhosttyCwdChanged(cwd));
         }
 
+        let progress = terminal.progress();
+        if progress != self.last_progress {
+            self.last_progress = progress;
+            changed = true;
+            cx.emit(GhosttyProgressChanged);
+        }
+
         if self.initialized && !terminal.is_alive() && !self.process_exit_emitted {
             self.process_exit_emitted = true;
             changed = true;
@@ -473,6 +488,13 @@ impl GhosttyView {
                 self.last_cwd = cwd.clone();
                 changed = true;
                 cx.emit(GhosttyCwdChanged(cwd));
+            }
+
+            let progress = terminal.progress();
+            if progress != self.last_progress {
+                self.last_progress = progress;
+                changed = true;
+                cx.emit(GhosttyProgressChanged);
             }
 
             if self.initialized && !terminal.is_alive() && !self.process_exit_emitted {

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -422,6 +422,10 @@ impl GhosttyView {
             cx.emit(GhosttyBell);
         }
 
+        if let Some(text) = terminal.take_clipboard_write() {
+            cx.write_to_clipboard(ClipboardItem::new_string(text));
+        }
+
         let title = terminal.title();
         if title != self.last_title {
             self.last_title = title.clone();

--- a/crates/con-app/src/pane_tree.rs
+++ b/crates/con-app/src/pane_tree.rs
@@ -343,8 +343,12 @@ impl PaneTree {
     /// Like `focused_terminal` but returns `None` if no terminal exists
     /// (e.g. the tab contains only editor panes).
     pub fn try_focused_terminal(&self) -> Option<&TerminalPane> {
-        Self::find_terminal(&self.root, self.focused_pane_id)
+        self.focused_pane_terminal()
             .or_else(|| Self::try_first_terminal(&self.root))
+    }
+
+    pub fn focused_pane_terminal(&self) -> Option<&TerminalPane> {
+        Self::find_terminal(&self.root, self.focused_pane_id)
     }
 
     /// Get all terminals in the tree
@@ -938,7 +942,8 @@ impl PaneTree {
     }
 
     pub fn focused_terminal_entity_id(&self) -> Option<EntityId> {
-        Self::find_terminal(&self.root, self.focused_pane_id).map(|terminal| terminal.entity_id())
+        self.focused_pane_terminal()
+            .map(|terminal| terminal.entity_id())
     }
 
     /// Find the pane ID for a given terminal by entity ID

--- a/crates/con-app/src/settings_panel.rs
+++ b/crates/con-app/src/settings_panel.rs
@@ -3261,6 +3261,25 @@ impl SettingsPanel {
                     theme,
                 ))),
         )
+        .child(
+            div()
+                .flex()
+                .flex_col()
+                .gap(px(8.0))
+                .child(group_label("Security", &theme))
+                .child(card(theme, card_opacity).child(toggle_row(
+                    "Clipboard Writes",
+                    "Allow terminal programs to copy plain text to the system clipboard.",
+                    Switch::new("clipboard-write-toggle")
+                        .checked(self.config.terminal.clipboard_write)
+                        .small()
+                        .on_click(cx.listener(|this, checked: &bool, _, cx| {
+                            this.config.terminal.clipboard_write = *checked;
+                            cx.notify();
+                        })),
+                    theme,
+                ))),
+        )
         // Skills paths
         .child(
             div()

--- a/crates/con-app/src/sidebar.rs
+++ b/crates/con-app/src/sidebar.rs
@@ -16,11 +16,12 @@
 
 use crate::activity_bar::ActivitySlot;
 use crate::motion::MotionValue;
+use con_ghostty::TerminalProgress;
 use gpui::{
     AnyElement, App, Bounds, Context, Div, Entity, EventEmitter, FontWeight, Hsla,
     InteractiveElement, IntoElement, MouseButton, MouseDownEvent, ParentElement, Pixels, Point,
     Render, SharedString, Size, Stateful, StatefulInteractiveElement, Styled, WeakEntity, Window,
-    div, point, prelude::*, px, svg,
+    div, point, prelude::*, px, relative, svg,
 };
 use gpui_component::{
     ActiveTheme, ElementExt, InteractiveElementExt, Sizable,
@@ -71,6 +72,7 @@ pub struct SessionEntry {
     pub subtitle: Option<String>,
     pub is_ssh: bool,
     pub needs_attention: bool,
+    pub progress: Option<TerminalProgress>,
     pub icon: &'static str,
     pub has_user_label: bool,
     /// How many panes the tab contains (split count). Surfaced in
@@ -1091,6 +1093,9 @@ impl SessionSidebar {
                         .bg(theme.primary),
                 );
             }
+            if let Some(progress) = session.progress {
+                pill = pill.child(tab_progress_indicator(theme, progress, is_active, 4.0));
+            }
             if is_active {
                 let dot_color = if let Some(color) = session.color {
                     crate::tab_colors::tab_accent_color_hsla(color, cx)
@@ -1441,6 +1446,7 @@ impl SessionSidebar {
                 subtitle: self.sessions[i].subtitle.clone(),
                 is_ssh: self.sessions[i].is_ssh,
                 needs_attention: self.sessions[i].needs_attention,
+                progress: self.sessions[i].progress,
                 icon: self.sessions[i].icon,
                 has_user_label: self.sessions[i].has_user_label,
                 pane_count: self.sessions[i].pane_count,
@@ -1682,7 +1688,7 @@ impl SessionSidebar {
             );
         }
 
-        let row = div()
+        let mut row = div()
             .id(SharedString::from(format!("panel-tab-{i}")))
             .group(row_group.clone())
             .relative()
@@ -1813,6 +1819,9 @@ impl SessionSidebar {
                     .child(rename_btn)
                     .child(close_btn),
             );
+        if let Some(progress) = session.progress {
+            row = row.child(tab_progress_indicator(theme, progress, is_active, 8.0));
+        }
         row.into_any_element()
     }
 }
@@ -1929,6 +1938,38 @@ fn rail_drop_indicator(theme: &gpui_component::Theme, above: bool) -> Div {
         bar.top(px(-2.0))
     } else {
         bar.bottom(px(-2.0))
+    }
+}
+
+fn tab_progress_indicator(
+    theme: &gpui_component::Theme,
+    progress: TerminalProgress,
+    is_active: bool,
+    inset: f32,
+) -> Div {
+    let (color, percent) = match progress {
+        TerminalProgress::Running(percent) => (theme.progress_bar, percent),
+        TerminalProgress::Error(percent) => (theme.danger, percent),
+        TerminalProgress::Indeterminate => (theme.progress_bar, None),
+        TerminalProgress::Paused(percent) => (theme.warning, percent),
+    };
+    let indicator = div()
+        .absolute()
+        .left(px(inset))
+        .right(px(inset))
+        .bottom(px(1.0))
+        .h(px(2.0));
+    if let Some(percent) = percent {
+        indicator
+            .bg(color.opacity(if is_active { 0.16 } else { 0.10 }))
+            .child(
+                div()
+                    .h_full()
+                    .w(relative(f32::from(percent) / 100.0))
+                    .bg(color.opacity(if is_active { 0.82 } else { 0.58 })),
+            )
+    } else {
+        indicator.bg(color.opacity(if is_active { 0.62 } else { 0.42 }))
     }
 }
 

--- a/crates/con-app/src/stub_view.rs
+++ b/crates/con-app/src/stub_view.rs
@@ -13,7 +13,7 @@
 
 use std::sync::Arc;
 
-use con_ghostty::{GhosttyApp, GhosttySplitDirection, GhosttyTerminal};
+use con_ghostty::{GhosttyApp, GhosttySplitDirection, GhosttyTerminal, TerminalProgress};
 use gpui::*;
 use gpui_component::ActiveTheme;
 
@@ -26,6 +26,7 @@ pub struct GhosttyProcessExited;
 pub struct GhosttyFocusChanged;
 pub struct GhosttySplitRequested(pub GhosttySplitDirection);
 pub struct GhosttyCwdChanged(pub Option<String>);
+pub struct GhosttyProgressChanged;
 
 impl EventEmitter<GhosttyTitleChanged> for GhosttyView {}
 impl EventEmitter<GhosttyBell> for GhosttyView {}
@@ -33,6 +34,7 @@ impl EventEmitter<GhosttyProcessExited> for GhosttyView {}
 impl EventEmitter<GhosttyFocusChanged> for GhosttyView {}
 impl EventEmitter<GhosttySplitRequested> for GhosttyView {}
 impl EventEmitter<GhosttyCwdChanged> for GhosttyView {}
+impl EventEmitter<GhosttyProgressChanged> for GhosttyView {}
 
 /// Placeholder terminal view. Holds the shared `GhosttyApp` handle so the
 /// field shape matches the macOS view, but never creates a real surface.
@@ -81,6 +83,10 @@ impl GhosttyView {
 
     pub fn current_dir(&self) -> Option<String> {
         self.initial_cwd.clone()
+    }
+
+    pub fn progress(&self) -> Option<TerminalProgress> {
+        None
     }
 
     pub fn is_alive(&self) -> bool {

--- a/crates/con-app/src/stub_view.rs
+++ b/crates/con-app/src/stub_view.rs
@@ -21,12 +21,14 @@ actions!(ghostty, [ConsumeTab, ConsumeTabPrev]);
 
 #[allow(dead_code)]
 pub struct GhosttyTitleChanged(pub Option<String>);
+pub struct GhosttyBell;
 pub struct GhosttyProcessExited;
 pub struct GhosttyFocusChanged;
 pub struct GhosttySplitRequested(pub GhosttySplitDirection);
 pub struct GhosttyCwdChanged(pub Option<String>);
 
 impl EventEmitter<GhosttyTitleChanged> for GhosttyView {}
+impl EventEmitter<GhosttyBell> for GhosttyView {}
 impl EventEmitter<GhosttyProcessExited> for GhosttyView {}
 impl EventEmitter<GhosttyFocusChanged> for GhosttyView {}
 impl EventEmitter<GhosttySplitRequested> for GhosttyView {}

--- a/crates/con-app/src/terminal_pane.rs
+++ b/crates/con-app/src/terminal_pane.rs
@@ -348,6 +348,8 @@ pub fn subscribe_terminal_pane(
         ConWorkspace::on_terminal_title_changed,
     )
     .detach();
+    cx.subscribe_in(&pane.entity, window, ConWorkspace::on_terminal_bell)
+        .detach();
     cx.subscribe_in(&pane.entity, window, ConWorkspace::on_terminal_cwd_changed)
         .detach();
     cx.subscribe_in(

--- a/crates/con-app/src/terminal_pane.rs
+++ b/crates/con-app/src/terminal_pane.rs
@@ -129,6 +129,13 @@ impl TerminalPane {
         }
     }
 
+    pub fn set_clipboard_write_enabled(&self, enabled: bool, cx: &App) -> Result<(), String> {
+        if let Some(terminal) = self.entity.read(cx).terminal() {
+            terminal.set_clipboard_write_enabled(enabled)?;
+        }
+        Ok(())
+    }
+
     pub fn notify(&self, cx: &mut App) {
         self.entity.update(cx, |_, cx| cx.notify());
     }

--- a/crates/con-app/src/terminal_pane.rs
+++ b/crates/con-app/src/terminal_pane.rs
@@ -1,7 +1,7 @@
 //! TerminalPane — Ghostty-backed terminal pane wrapper.
 
 use con_agent::context::{PaneObservationFrame, PaneObservationSupport, derive_screen_hints};
-use con_ghostty::TerminalColors;
+use con_ghostty::{TerminalColors, TerminalProgress};
 use con_terminal::TerminalTheme;
 use gpui::*;
 
@@ -24,6 +24,10 @@ impl TerminalPane {
 
     pub fn current_dir(&self, cx: &App) -> Option<String> {
         self.entity.read(cx).current_dir()
+    }
+
+    pub fn progress(&self, cx: &App) -> Option<TerminalProgress> {
+        self.entity.read(cx).progress()
     }
 
     pub fn is_alive(&self, cx: &App) -> bool {
@@ -352,6 +356,12 @@ pub fn subscribe_terminal_pane(
         .detach();
     cx.subscribe_in(&pane.entity, window, ConWorkspace::on_terminal_cwd_changed)
         .detach();
+    cx.subscribe_in(
+        &pane.entity,
+        window,
+        ConWorkspace::on_terminal_progress_changed,
+    )
+    .detach();
     cx.subscribe_in(
         &pane.entity,
         window,

--- a/crates/con-app/src/terminal_pane.rs
+++ b/crates/con-app/src/terminal_pane.rs
@@ -361,6 +361,13 @@ pub fn subscribe_terminal_pane(
     .detach();
     cx.subscribe_in(&pane.entity, window, ConWorkspace::on_terminal_bell)
         .detach();
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    cx.subscribe_in(
+        &pane.entity,
+        window,
+        ConWorkspace::on_terminal_desktop_notification,
+    )
+    .detach();
     cx.subscribe_in(&pane.entity, window, ConWorkspace::on_terminal_cwd_changed)
         .detach();
     cx.subscribe_in(

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -42,6 +42,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
+use con_ghostty::TerminalProgress;
 use con_ghostty::vt::{VtKeyAction, VtKeyEvent, VtKeyModifiers, VtPasteResult, VtPasteSource};
 use con_ghostty::{GhosttyApp, GhosttyScrollbar, GhosttySplitDirection, GhosttyTerminal};
 use futures::StreamExt;
@@ -103,6 +104,7 @@ pub struct GhosttyProcessExited;
 pub struct GhosttyFocusChanged;
 pub struct GhosttySplitRequested(pub GhosttySplitDirection);
 pub struct GhosttyCwdChanged(pub Option<String>);
+pub struct GhosttyProgressChanged;
 
 impl EventEmitter<GhosttyTitleChanged> for GhosttyView {}
 impl EventEmitter<GhosttyBell> for GhosttyView {}
@@ -110,6 +112,7 @@ impl EventEmitter<GhosttyProcessExited> for GhosttyView {}
 impl EventEmitter<GhosttyFocusChanged> for GhosttyView {}
 impl EventEmitter<GhosttySplitRequested> for GhosttyView {}
 impl EventEmitter<GhosttyCwdChanged> for GhosttyView {}
+impl EventEmitter<GhosttyProgressChanged> for GhosttyView {}
 
 pub struct GhosttyView {
     app: Arc<GhosttyApp>,
@@ -127,6 +130,7 @@ pub struct GhosttyView {
     process_exit_emitted: bool,
     last_title: Option<String>,
     last_cwd: Option<String>,
+    last_progress: Option<TerminalProgress>,
     /// Pane bounds in logical window pixels, captured during prepaint.
     pane_bounds: Option<Bounds<Pixels>>,
     scale_factor: f32,
@@ -235,6 +239,7 @@ impl GhosttyView {
             process_exit_emitted: false,
             last_title: None,
             last_cwd: None,
+            last_progress: None,
             pane_bounds: None,
             scale_factor: 1.0,
             ime_marked_text: None,
@@ -285,6 +290,10 @@ impl GhosttyView {
             .as_ref()
             .and_then(|t| t.current_dir())
             .or_else(|| self.initial_cwd.clone())
+    }
+
+    pub fn progress(&self) -> Option<TerminalProgress> {
+        self.last_progress
     }
 
     pub fn is_alive(&self) -> bool {
@@ -440,6 +449,13 @@ impl GhosttyView {
             self.last_cwd = cwd.clone();
             changed = true;
             cx.emit(GhosttyCwdChanged(cwd));
+        }
+
+        let progress = terminal.progress();
+        if progress != self.last_progress {
+            self.last_progress = progress;
+            changed = true;
+            cx.emit(GhosttyProgressChanged);
         }
 
         // Portable effects reuse the existing output wake and are drained

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -417,8 +417,8 @@ impl GhosttyView {
         self.poll_terminal_state(cx)
     }
 
-    pub fn pump_deferred_work(&mut self, cx: &mut Context<Self>) -> bool {
-        self.poll_terminal_state(cx)
+    pub fn pump_deferred_work(&mut self, _cx: &mut Context<Self>) -> bool {
+        false
     }
 
     fn poll_terminal_state(&mut self, cx: &mut Context<Self>) -> bool {
@@ -435,6 +435,10 @@ impl GhosttyView {
         if terminal.take_bell() {
             changed = true;
             cx.emit(GhosttyBell);
+        }
+
+        if let Some(text) = terminal.take_clipboard_write() {
+            cx.write_to_clipboard(ClipboardItem::new_string(text));
         }
 
         let title = terminal.title();
@@ -502,7 +506,16 @@ impl GhosttyView {
 
         let cwd = self.initial_cwd.as_deref().map(std::path::PathBuf::from);
         let initial_output = restored_terminal_output(self.restored_screen_text.as_deref());
-        match RenderSession::new(width_px, height_px, dpi, config, cwd, initial_output, wake) {
+        match RenderSession::new(
+            width_px,
+            height_px,
+            dpi,
+            config,
+            cwd,
+            initial_output,
+            self.app.clipboard_write_enabled(),
+            wake,
+        ) {
             Ok(session) => {
                 if let Some(terminal) = &self.terminal {
                     terminal.attach(session);

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -98,12 +98,14 @@ actions!(ghostty, [ConsumeTab, ConsumeTabPrev]);
 
 #[allow(dead_code)]
 pub struct GhosttyTitleChanged(pub Option<String>);
+pub struct GhosttyBell;
 pub struct GhosttyProcessExited;
 pub struct GhosttyFocusChanged;
 pub struct GhosttySplitRequested(pub GhosttySplitDirection);
 pub struct GhosttyCwdChanged(pub Option<String>);
 
 impl EventEmitter<GhosttyTitleChanged> for GhosttyView {}
+impl EventEmitter<GhosttyBell> for GhosttyView {}
 impl EventEmitter<GhosttyProcessExited> for GhosttyView {}
 impl EventEmitter<GhosttyFocusChanged> for GhosttyView {}
 impl EventEmitter<GhosttySplitRequested> for GhosttyView {}
@@ -420,6 +422,11 @@ impl GhosttyView {
         };
 
         let mut changed = false;
+
+        if terminal.take_bell() {
+            changed = true;
+            cx.emit(GhosttyBell);
+        }
 
         let title = terminal.title();
         if title != self.last_title {

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -123,6 +123,7 @@ pub struct GhosttyView {
     init_failed: bool,
     /// Emit `GhosttyProcessExited` exactly once on shell death.
     process_exit_emitted: bool,
+    last_title: Option<String>,
     last_cwd: Option<String>,
     /// Pane bounds in logical window pixels, captured during prepaint.
     pane_bounds: Option<Bounds<Pixels>>,
@@ -230,6 +231,7 @@ impl GhosttyView {
             initialized: false,
             init_failed: false,
             process_exit_emitted: false,
+            last_title: None,
             last_cwd: None,
             pane_bounds: None,
             scale_factor: 1.0,
@@ -419,6 +421,13 @@ impl GhosttyView {
 
         let mut changed = false;
 
+        let title = terminal.title();
+        if title != self.last_title {
+            self.last_title = title.clone();
+            changed = true;
+            cx.emit(GhosttyTitleChanged(title));
+        }
+
         let cwd = terminal.current_dir();
         if cwd != self.last_cwd {
             self.last_cwd = cwd.clone();
@@ -426,9 +435,9 @@ impl GhosttyView {
             cx.emit(GhosttyCwdChanged(cwd));
         }
 
-        // No action-callback channel on Windows (cf. macOS's
-        // `wake_generation`). Poll `is_alive` so workspace's
-        // `on_terminal_process_exited` runs when the child shell exits.
+        // Portable effects reuse the existing output wake and are drained
+        // above. Process exit has no corresponding VT effect, so poll it to
+        // ensure workspace's `on_terminal_process_exited` still runs.
         if !self.process_exit_emitted && !terminal.is_alive() {
             self.process_exit_emitted = true;
             changed = true;
@@ -477,6 +486,7 @@ impl GhosttyView {
                 }
                 self.restored_screen_text = None;
                 self.initialized = true;
+                self.last_title = self.terminal.as_ref().and_then(|t| t.title());
                 self.last_cwd = self.terminal.as_ref().and_then(|t| t.current_dir());
                 self.last_physical_size = Some((width_px, height_px));
                 self.last_scale_factor = dpi as f32 / 96.0;

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -42,8 +42,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
-use con_ghostty::TerminalProgress;
 use con_ghostty::vt::{VtKeyAction, VtKeyEvent, VtKeyModifiers, VtPasteResult, VtPasteSource};
+use con_ghostty::{DesktopNotification, TerminalProgress};
 use con_ghostty::{GhosttyApp, GhosttyScrollbar, GhosttySplitDirection, GhosttyTerminal};
 use futures::StreamExt;
 use futures::channel::mpsc::{UnboundedSender, unbounded};
@@ -105,6 +105,7 @@ pub struct GhosttyFocusChanged;
 pub struct GhosttySplitRequested(pub GhosttySplitDirection);
 pub struct GhosttyCwdChanged(pub Option<String>);
 pub struct GhosttyProgressChanged;
+pub struct GhosttyDesktopNotification(pub DesktopNotification);
 
 impl EventEmitter<GhosttyTitleChanged> for GhosttyView {}
 impl EventEmitter<GhosttyBell> for GhosttyView {}
@@ -113,6 +114,7 @@ impl EventEmitter<GhosttyFocusChanged> for GhosttyView {}
 impl EventEmitter<GhosttySplitRequested> for GhosttyView {}
 impl EventEmitter<GhosttyCwdChanged> for GhosttyView {}
 impl EventEmitter<GhosttyProgressChanged> for GhosttyView {}
+impl EventEmitter<GhosttyDesktopNotification> for GhosttyView {}
 
 pub struct GhosttyView {
     app: Arc<GhosttyApp>,
@@ -441,6 +443,11 @@ impl GhosttyView {
             cx.write_to_clipboard(ClipboardItem::new_string(text));
         }
 
+        if let Some(notification) = terminal.take_desktop_notification() {
+            changed = true;
+            cx.emit(GhosttyDesktopNotification(notification));
+        }
+
         let title = terminal.title();
         if title != self.last_title {
             self.last_title = title.clone();
@@ -514,6 +521,7 @@ impl GhosttyView {
             cwd,
             initial_output,
             self.app.clipboard_write_enabled(),
+            self.app.desktop_notification_policy(),
             wake,
         ) {
             Ok(session) => {

--- a/crates/con-app/src/workspace/lifecycle.rs
+++ b/crates/con-app/src/workspace/lifecycle.rs
@@ -81,6 +81,7 @@ impl ConWorkspace {
             Some(&background_image_position),
             Some(&background_image_fit),
             Some(background_image_repeat),
+            config.terminal.clipboard_write,
         )
         .map(std::sync::Arc::new)
         .unwrap_or_else(|e| panic!("Fatal: failed to initialize Ghostty: {}", e));

--- a/crates/con-app/src/workspace/lifecycle.rs
+++ b/crates/con-app/src/workspace/lifecycle.rs
@@ -268,6 +268,7 @@ impl ConWorkspace {
                         subtitle: presentation.subtitle,
                         is_ssh: presentation.is_ssh,
                         needs_attention: false,
+                        progress: None,
                         icon: presentation.icon,
                         has_user_label: tab.user_label.is_some(),
                         pane_count,
@@ -908,6 +909,9 @@ impl ConWorkspace {
         });
         editor_focus.focus(window, cx);
         self.sync_file_tree_from_active_focus(cx);
+        if self.vertical_tabs_enabled() {
+            self.sync_sidebar(cx);
+        }
         cx.notify();
     }
 

--- a/crates/con-app/src/workspace/mod.rs
+++ b/crates/con-app/src/workspace/mod.rs
@@ -63,11 +63,12 @@ use crate::sidebar::{
 };
 use crate::sidebar_search_view::SidebarSearchView;
 use crate::terminal_pane::{TerminalPane, subscribe_terminal_pane};
+use con_ghostty::TerminalProgress;
 use con_terminal::TerminalTheme;
 
 use crate::ghostty_view::{
     GhosttyBell, GhosttyCwdChanged, GhosttyFocusChanged, GhosttyProcessExited,
-    GhosttySplitRequested, GhosttyTitleChanged, GhosttyView,
+    GhosttyProgressChanged, GhosttySplitRequested, GhosttyTitleChanged, GhosttyView,
 };
 use crate::{
     AddWorkspaceLayoutTabs, AskAi, ClearRestoredTerminalHistory, ClearTerminal, ClosePane,

--- a/crates/con-app/src/workspace/mod.rs
+++ b/crates/con-app/src/workspace/mod.rs
@@ -66,6 +66,8 @@ use crate::terminal_pane::{TerminalPane, subscribe_terminal_pane};
 use con_ghostty::TerminalProgress;
 use con_terminal::TerminalTheme;
 
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+use crate::ghostty_view::GhosttyDesktopNotification;
 use crate::ghostty_view::{
     GhosttyBell, GhosttyCwdChanged, GhosttyFocusChanged, GhosttyProcessExited,
     GhosttyProgressChanged, GhosttySplitRequested, GhosttyTitleChanged, GhosttyView,

--- a/crates/con-app/src/workspace/mod.rs
+++ b/crates/con-app/src/workspace/mod.rs
@@ -66,8 +66,8 @@ use crate::terminal_pane::{TerminalPane, subscribe_terminal_pane};
 use con_terminal::TerminalTheme;
 
 use crate::ghostty_view::{
-    GhosttyCwdChanged, GhosttyFocusChanged, GhosttyProcessExited, GhosttySplitRequested,
-    GhosttyTitleChanged, GhosttyView,
+    GhosttyBell, GhosttyCwdChanged, GhosttyFocusChanged, GhosttyProcessExited,
+    GhosttySplitRequested, GhosttyTitleChanged, GhosttyView,
 };
 use crate::{
     AddWorkspaceLayoutTabs, AskAi, ClearRestoredTerminalHistory, ClearTerminal, ClosePane,

--- a/crates/con-app/src/workspace/pane_actions.rs
+++ b/crates/con-app/src/workspace/pane_actions.rs
@@ -690,6 +690,9 @@ impl ConWorkspace {
         }
         // Focus the target pane first so toggle_zoom_focused acts on it.
         self.tabs[self.active_tab].pane_tree.focus_pane(pane_id);
+        if self.vertical_tabs_enabled() {
+            self.sync_sidebar(cx);
+        }
         self.toggle_focused_pane_zoom(window, cx);
     }
 
@@ -930,6 +933,9 @@ impl ConWorkspace {
                 }
                 self.sync_active_terminal_focus_states(cx);
             }
+            if self.vertical_tabs_enabled() {
+                self.sync_sidebar(cx);
+            }
             cx.notify();
             return true;
         }
@@ -991,6 +997,9 @@ impl ConWorkspace {
             self.sync_active_terminal_focus_states(cx);
         }
 
+        if self.vertical_tabs_enabled() {
+            self.sync_sidebar(cx);
+        }
         self.save_session(cx);
         cx.notify();
         true

--- a/crates/con-app/src/workspace/render/top_bar.rs
+++ b/crates/con-app/src/workspace/render/top_bar.rs
@@ -393,6 +393,10 @@ impl ConWorkspace {
                 let session_id = tab.summary_id;
                 let tab_id = session_id;
                 let tab_color = tab.color;
+                let terminal_progress = tab
+                    .pane_tree
+                    .focused_pane_terminal()
+                    .and_then(|terminal| terminal.progress(cx));
                 let is_dragged_source = is_dragged_tab_source(dragged_source_id, session_id);
                 let is_editor_only = tab.pane_tree.pane_terminals().is_empty();
                 let (hostname_for_tab, title_for_tab, dir_for_tab) =
@@ -718,6 +722,34 @@ impl ConWorkspace {
                             .rounded(px(1.0))
                             .bg(indicator_color),
                     );
+                }
+
+                if let Some(progress) = terminal_progress {
+                    let (color, percent) = match progress {
+                        TerminalProgress::Running(percent) => (theme.progress_bar, percent),
+                        TerminalProgress::Error(percent) => (theme.danger, percent),
+                        TerminalProgress::Indeterminate => (theme.progress_bar, None),
+                        TerminalProgress::Paused(percent) => (theme.warning, percent),
+                    };
+                    let mut progress_indicator =
+                        div().absolute().left_0().right_0().bottom_0().h(px(2.0));
+                    if let Some(percent) = percent {
+                        progress_indicator = progress_indicator
+                            .bg(color.opacity(if is_active { 0.16 } else { 0.10 }))
+                            .child(
+                                div()
+                                    .h_full()
+                                    .w(relative(f32::from(percent) / 100.0))
+                                    .bg(color.opacity(if is_active { 0.82 } else { 0.58 })),
+                            );
+                    } else {
+                        progress_indicator = progress_indicator.bg(color.opacity(if is_active {
+                            0.62
+                        } else {
+                            0.42
+                        }));
+                    }
+                    tab_el = tab_el.child(progress_indicator);
                 }
 
                 let mut tab_content = div()

--- a/crates/con-app/src/workspace/sidebar_settings.rs
+++ b/crates/con-app/src/workspace/sidebar_settings.rs
@@ -634,6 +634,10 @@ impl ConWorkspace {
                     subtitle: presentation.subtitle,
                     is_ssh: presentation.is_ssh,
                     needs_attention: tab.needs_attention,
+                    progress: tab
+                        .pane_tree
+                        .focused_pane_terminal()
+                        .and_then(|terminal| terminal.progress(cx)),
                     icon: presentation.icon,
                     has_user_label: tab.user_label.is_some(),
                     pane_count,

--- a/crates/con-app/src/workspace/sidebar_settings.rs
+++ b/crates/con-app/src/workspace/sidebar_settings.rs
@@ -898,6 +898,23 @@ impl ConWorkspace {
 
         let term_config = full_config.terminal.clone();
         let appearance_config = full_config.appearance.clone();
+        match self
+            .ghostty_app
+            .set_clipboard_write_enabled(term_config.clipboard_write)
+        {
+            Ok(()) => {
+                for tab in &self.tabs {
+                    for terminal in tab.pane_tree.all_surface_terminals() {
+                        if let Err(err) =
+                            terminal.set_clipboard_write_enabled(term_config.clipboard_write, cx)
+                        {
+                            log::error!("Failed to update terminal clipboard write policy: {err}");
+                        }
+                    }
+                }
+            }
+            Err(err) => log::error!("Failed to update clipboard write policy: {err}"),
+        }
         self.apply_terminal_and_ui_appearance(&term_config, &appearance_config, window, cx);
         self.sync_tab_strip_motion();
         if restore_terminal_text_was_enabled && !appearance_config.restore_terminal_text {

--- a/crates/con-app/src/workspace/tab_actions.rs
+++ b/crates/con-app/src/workspace/tab_actions.rs
@@ -558,6 +558,54 @@ impl ConWorkspace {
         window.play_system_bell();
     }
 
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    pub(crate) fn on_terminal_desktop_notification(
+        &mut self,
+        _entity: &Entity<GhosttyView>,
+        event: &GhosttyDesktopNotification,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let title = if event.0.title.is_empty() {
+            "Con".to_owned()
+        } else {
+            event.0.title.clone()
+        };
+        let body = event.0.body.clone();
+
+        #[cfg(target_os = "linux")]
+        {
+            let notification_id = format!("co.nowledge.con.terminal.{}", uuid::Uuid::new_v4());
+            cx.spawn(async move |_, _| {
+                use ashpd::desktop::notification::{Notification, NotificationProxy};
+
+                let proxy = match NotificationProxy::new().await {
+                    Ok(proxy) => proxy,
+                    Err(err) => {
+                        log::warn!("Failed to connect to desktop notification portal: {err}");
+                        return;
+                    }
+                };
+                let notification =
+                    Notification::new(&title).body((!body.is_empty()).then_some(body.as_str()));
+                if let Err(err) = proxy.add_notification(&notification_id, notification).await {
+                    log::warn!("Failed to show desktop notification: {err}");
+                }
+            })
+            .detach();
+        }
+
+        #[cfg(target_os = "windows")]
+        {
+            use gpui_component::{WindowExt as _, notification::Notification};
+
+            _window.push_notification(Notification::new().title(title).message(body), cx);
+            if !_window.is_window_active() {
+                flash_windows_taskbar(_window);
+            }
+        }
+    }
+
     pub(crate) fn on_terminal_progress_changed(
         &mut self,
         entity: &Entity<GhosttyView>,
@@ -922,5 +970,31 @@ impl ConWorkspace {
         if let Some(index) = self.tab_index_for_summary_id(tab_id) {
             self.set_tab_color(index, color, cx);
         }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn flash_windows_taskbar(window: &Window) {
+    use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+    use windows::Win32::Foundation::HWND;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        FLASHW_TIMERNOFG, FLASHW_TRAY, FLASHWINFO, FlashWindowEx,
+    };
+
+    let Ok(handle) = HasWindowHandle::window_handle(window) else {
+        return;
+    };
+    let RawWindowHandle::Win32(handle) = handle.as_raw() else {
+        return;
+    };
+    let info = FLASHWINFO {
+        cbSize: std::mem::size_of::<FLASHWINFO>() as u32,
+        hwnd: HWND(handle.hwnd.get() as *mut std::ffi::c_void),
+        dwFlags: FLASHW_TRAY | FLASHW_TIMERNOFG,
+        uCount: 0,
+        dwTimeout: 0,
+    };
+    unsafe {
+        let _ = FlashWindowEx(&info);
     }
 }

--- a/crates/con-app/src/workspace/tab_actions.rs
+++ b/crates/con-app/src/workspace/tab_actions.rs
@@ -539,6 +539,16 @@ impl ConWorkspace {
         cx.notify();
     }
 
+    pub(crate) fn on_terminal_bell(
+        &mut self,
+        _entity: &Entity<GhosttyView>,
+        _event: &GhosttyBell,
+        window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
+        window.play_system_bell();
+    }
+
     pub(crate) fn on_terminal_cwd_changed(
         &mut self,
         entity: &Entity<GhosttyView>,

--- a/crates/con-app/src/workspace/tab_actions.rs
+++ b/crates/con-app/src/workspace/tab_actions.rs
@@ -366,6 +366,9 @@ impl ConWorkspace {
         self.tabs[self.active_tab].pane_tree.focus_pane(pane_id);
         self.clear_terminal_focus_states_for_active_tab(cx);
         self.sync_active_tab_native_view_visibility(cx);
+        if self.vertical_tabs_enabled() {
+            self.sync_sidebar(cx);
+        }
         let editor_view = self.tabs[self.active_tab]
             .pane_tree
             .editor_view_for_pane(pane_id);
@@ -439,6 +442,9 @@ impl ConWorkspace {
             pane_tree.focus(pane_id);
             entity.focus_handle(cx).focus(window, cx);
             self.sync_active_terminal_focus_states(cx);
+            if self.vertical_tabs_enabled() {
+                self.sync_sidebar(cx);
+            }
         }
         cx.notify();
     }
@@ -497,6 +503,9 @@ impl ConWorkspace {
                 }
                 self.sync_active_terminal_focus_states(cx);
             }
+            if self.vertical_tabs_enabled() {
+                self.sync_sidebar(cx);
+            }
             self.save_session(cx);
             cx.notify();
             return;
@@ -547,6 +556,27 @@ impl ConWorkspace {
         _cx: &mut Context<Self>,
     ) {
         window.play_system_bell();
+    }
+
+    pub(crate) fn on_terminal_progress_changed(
+        &mut self,
+        entity: &Entity<GhosttyView>,
+        _event: &GhosttyProgressChanged,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let entity_id = entity.entity_id();
+        if !self
+            .tabs
+            .iter()
+            .any(|tab| tab.pane_tree.focused_terminal_entity_id() == Some(entity_id))
+        {
+            return;
+        }
+        if self.vertical_tabs_enabled() {
+            self.sync_sidebar(cx);
+        }
+        cx.notify();
     }
 
     pub(crate) fn on_terminal_cwd_changed(

--- a/crates/con-core/src/config.rs
+++ b/crates/con-core/src/config.rs
@@ -83,6 +83,7 @@ pub struct TerminalConfig {
     pub font_size: f32,
     pub theme: String,
     pub cursor_style: String,
+    pub clipboard_write: bool,
 }
 
 impl Default for TerminalConfig {
@@ -92,6 +93,7 @@ impl Default for TerminalConfig {
             font_size: default_font_size(),
             theme: default_theme(),
             cursor_style: default_cursor_style(),
+            clipboard_write: false,
         }
     }
 }

--- a/crates/con-ghostty/src/ffi.rs
+++ b/crates/con-ghostty/src/ffi.rs
@@ -367,6 +367,13 @@ pub struct ghostty_action_pwd_s {
     pub pwd: *const c_char,
 }
 
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct ghostty_action_progress_report_s {
+    pub state: c_int,
+    pub progress: i8,
+}
+
 /// Action payload for COMMAND_FINISHED (shell integration OSC 133;D).
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
@@ -442,6 +449,7 @@ pub union ghostty_action_u {
     pub desktop_notification: ghostty_action_desktop_notification_s,
     pub set_title: ghostty_action_set_title_s,
     pub pwd: ghostty_action_pwd_s,
+    pub progress_report: ghostty_action_progress_report_s,
     pub command_finished: ghostty_action_command_finished_s,
     pub start_search: ghostty_action_start_search_s,
     pub search_total: ghostty_action_search_total_s,
@@ -460,6 +468,7 @@ pub struct ghostty_action_s {
 // must exactly match ghostty.h at the pinned Ghostty revision.
 const _: [(); 16] = [(); std::mem::size_of::<ghostty_action_desktop_notification_s>()];
 const _: [(); 16] = [(); std::mem::size_of::<ghostty_surface_message_childexited_s>()];
+const _: [(); 8] = [(); std::mem::size_of::<ghostty_action_progress_report_s>()];
 const _: [(); 8] = [(); std::mem::size_of::<ghostty_action_start_search_s>()];
 const _: [(); 8] = [(); std::mem::size_of::<ghostty_action_search_total_s>()];
 const _: [(); 8] = [(); std::mem::size_of::<ghostty_action_search_selected_s>()];

--- a/crates/con-ghostty/src/lib.rs
+++ b/crates/con-ghostty/src/lib.rs
@@ -16,6 +16,8 @@
 // Suppress warnings from objc 0.2's `sel_impl!` and `class!` macros.
 #![allow(unexpected_cfgs)]
 
+use std::time::Duration;
+
 pub fn restored_terminal_output_text(lines: &[String]) -> Option<String> {
     if lines.is_empty() {
         return None;
@@ -43,6 +45,32 @@ pub(crate) fn clipboard_mime_is_text(mime: &[u8]) -> bool {
         || mime.eq_ignore_ascii_case(b"TEXT")
         || mime.eq_ignore_ascii_case(b"STRING")
         || media_type.eq_ignore_ascii_case(b"text/plain")
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TerminalProgress {
+    Running(Option<u8>),
+    Error(Option<u8>),
+    Indeterminate,
+    Paused(Option<u8>),
+}
+
+pub(crate) const TERMINAL_PROGRESS_TIMEOUT: Duration = Duration::from_secs(15);
+
+impl TerminalProgress {
+    pub(crate) fn from_ghostty_report(state: i32, progress: i8) -> Option<Option<Self>> {
+        let percent = u8::try_from(progress)
+            .ok()
+            .filter(|percent| *percent <= 100);
+        match state {
+            0 => Some(None),
+            1 => Some(Some(Self::Running(percent))),
+            2 => Some(Some(Self::Error(percent))),
+            3 => Some(Some(Self::Indeterminate)),
+            4 => Some(Some(Self::Paused(percent))),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]

--- a/crates/con-ghostty/src/lib.rs
+++ b/crates/con-ghostty/src/lib.rs
@@ -20,8 +20,8 @@
 use std::collections::hash_map::DefaultHasher;
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 use std::hash::{Hash, Hasher};
-#[cfg(any(target_os = "windows", target_os = "linux"))]
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 use std::time::Instant;
@@ -34,6 +34,33 @@ pub(crate) const CLIPBOARD_WRITE_LIMIT_BYTES: usize = 1024 * 1024;
 const DESKTOP_NOTIFICATION_TITLE_LIMIT_BYTES: usize = 63;
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 const DESKTOP_NOTIFICATION_BODY_LIMIT_BYTES: usize = 255;
+
+pub(crate) struct ClipboardWritePolicy {
+    enabled: AtomicBool,
+}
+
+impl ClipboardWritePolicy {
+    pub(crate) fn new(enabled: bool) -> Self {
+        Self {
+            enabled: AtomicBool::new(enabled),
+        }
+    }
+
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn set_enabled(&self, enabled: bool) {
+        self.enabled.store(enabled, Ordering::Release);
+    }
+}
+
+pub(crate) fn clipboard_write_policy(initially_enabled: bool) -> Arc<ClipboardWritePolicy> {
+    static POLICY: OnceLock<Arc<ClipboardWritePolicy>> = OnceLock::new();
+    POLICY
+        .get_or_init(|| Arc::new(ClipboardWritePolicy::new(initially_enabled)))
+        .clone()
+}
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -87,42 +114,57 @@ impl DesktopNotificationLimiter {
 }
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]
-#[derive(Default)]
-struct DesktopNotificationState {
-    limiter: DesktopNotificationLimiter,
-    pending: Option<DesktopNotification>,
+pub struct DesktopNotificationPolicy {
+    limiter: Arc<Mutex<DesktopNotificationLimiter>>,
+    pending: Mutex<Option<DesktopNotification>>,
 }
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]
-#[derive(Default)]
-pub struct DesktopNotificationPolicy {
-    state: Mutex<DesktopNotificationState>,
+impl Default for DesktopNotificationPolicy {
+    fn default() -> Self {
+        Self {
+            limiter: Arc::new(Mutex::new(DesktopNotificationLimiter::default())),
+            pending: Mutex::new(None),
+        }
+    }
 }
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 impl DesktopNotificationPolicy {
+    fn with_limiter(limiter: Arc<Mutex<DesktopNotificationLimiter>>) -> Self {
+        Self {
+            limiter,
+            pending: Mutex::new(None),
+        }
+    }
+
     pub(crate) fn push(&self, title: &[u8], body: &[u8]) -> bool {
-        let mut state = self.state.lock();
-        if !state.limiter.accept(title, body) {
+        let title = &title[..title.len().min(DESKTOP_NOTIFICATION_TITLE_LIMIT_BYTES)];
+        let body = &body[..body.len().min(DESKTOP_NOTIFICATION_BODY_LIMIT_BYTES)];
+        if !self.limiter.lock().accept(title, body) {
             return false;
         }
-        state.pending = Some(DesktopNotification::from_bytes(title, body));
+        *self.pending.lock() = Some(DesktopNotification::from_bytes(title, body));
         true
     }
 
     fn take(&self) -> Option<DesktopNotification> {
-        self.state.lock().pending.take()
+        self.pending.lock().take()
     }
 }
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 pub(crate) fn desktop_notification_policy() -> Arc<DesktopNotificationPolicy> {
-    Arc::new(DesktopNotificationPolicy::default())
+    static LIMITER: OnceLock<Arc<Mutex<DesktopNotificationLimiter>>> = OnceLock::new();
+    let limiter = LIMITER
+        .get_or_init(|| Arc::new(Mutex::new(DesktopNotificationLimiter::default())))
+        .clone();
+    Arc::new(DesktopNotificationPolicy::with_limiter(limiter))
 }
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 fn bounded_lossy_utf8(bytes: &[u8], limit: usize) -> String {
-    let text = String::from_utf8_lossy(bytes);
+    let text = String::from_utf8_lossy(&bytes[..bytes.len().min(limit)]);
     let mut end = text.len().min(limit);
     while !text.is_char_boundary(end) {
         end -= 1;
@@ -259,9 +301,9 @@ pub use stub::{
 
 #[cfg(test)]
 mod tests {
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
-    use super::DesktopNotificationPolicy;
     use super::clipboard_mime_is_text;
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    use super::{DesktopNotificationPolicy, bounded_lossy_utf8};
     #[cfg(any(target_os = "windows", target_os = "linux"))]
     use std::time::{Duration, Instant};
 
@@ -279,17 +321,27 @@ mod tests {
 
     #[cfg(any(target_os = "windows", target_os = "linux"))]
     #[test]
-    fn desktop_notification_limiter_rejects_bursts_and_recent_duplicates() {
-        let policy = DesktopNotificationPolicy::default();
+    fn desktop_notification_limiter_is_shared_without_crossing_pending_mailboxes() {
+        let first = DesktopNotificationPolicy::default();
+        let second = DesktopNotificationPolicy::with_limiter(first.limiter.clone());
 
-        assert!(policy.push(b"Build", b"Complete"));
-        assert!(!policy.push(b"Deploy", b"Complete"));
-        assert_eq!(policy.take().expect("pending notification").title, "Build");
+        assert!(first.push(b"Build", b"Complete"));
+        assert!(!second.push(b"Deploy", b"Complete"));
+        assert_eq!(first.take().expect("pending notification").title, "Build");
+        assert_eq!(second.take(), None);
 
-        policy.state.lock().limiter.last_accepted_at =
-            Some(Instant::now() - Duration::from_secs(2));
-        assert!(!policy.push(b"Build", b"Complete"));
-        assert!(policy.push(b"Deploy", b"Complete"));
-        assert_eq!(policy.take().expect("pending notification").title, "Deploy");
+        first.limiter.lock().last_accepted_at = Some(Instant::now() - Duration::from_secs(2));
+        assert!(!second.push(b"Build", b"Complete"));
+        assert!(second.push(b"Deploy", b"Complete"));
+        assert_eq!(second.take().expect("pending notification").title, "Deploy");
+        assert_eq!(first.take(), None);
+    }
+
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[test]
+    fn bounded_lossy_utf8_does_not_decode_past_the_output_limit() {
+        let bytes = [vec![b'a'; 62], "é".as_bytes().to_vec(), vec![0xff; 1024]].concat();
+
+        assert_eq!(bounded_lossy_utf8(&bytes, 63), "a".repeat(62));
     }
 }

--- a/crates/con-ghostty/src/lib.rs
+++ b/crates/con-ghostty/src/lib.rs
@@ -16,9 +16,119 @@
 // Suppress warnings from objc 0.2's `sel_impl!` and `class!` macros.
 #![allow(unexpected_cfgs)]
 
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+use std::collections::hash_map::DefaultHasher;
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+use std::hash::{Hash, Hasher};
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+use std::sync::Arc;
 use std::time::Duration;
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+use std::time::Instant;
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+use parking_lot::Mutex;
 
 pub(crate) const CLIPBOARD_WRITE_LIMIT_BYTES: usize = 1024 * 1024;
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+const DESKTOP_NOTIFICATION_TITLE_LIMIT_BYTES: usize = 63;
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+const DESKTOP_NOTIFICATION_BODY_LIMIT_BYTES: usize = 255;
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DesktopNotification {
+    pub title: String,
+    pub body: String,
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+impl DesktopNotification {
+    pub(crate) fn from_bytes(title: &[u8], body: &[u8]) -> Self {
+        Self {
+            title: bounded_lossy_utf8(title, DESKTOP_NOTIFICATION_TITLE_LIMIT_BYTES),
+            body: bounded_lossy_utf8(body, DESKTOP_NOTIFICATION_BODY_LIMIT_BYTES),
+        }
+    }
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[derive(Default)]
+struct DesktopNotificationLimiter {
+    last_accepted_at: Option<Instant>,
+    last_digest: u64,
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+impl DesktopNotificationLimiter {
+    fn accept(&mut self, title: &[u8], body: &[u8]) -> bool {
+        let now = Instant::now();
+        let elapsed = self
+            .last_accepted_at
+            .map(|last| now.saturating_duration_since(last));
+        if elapsed.is_some_and(|elapsed| elapsed < Duration::from_secs(1)) {
+            return false;
+        }
+
+        let mut hasher = DefaultHasher::new();
+        title.hash(&mut hasher);
+        body.hash(&mut hasher);
+        let digest = hasher.finish();
+        if digest == self.last_digest
+            && elapsed.is_some_and(|elapsed| elapsed < Duration::from_secs(5))
+        {
+            return false;
+        }
+
+        self.last_accepted_at = Some(now);
+        self.last_digest = digest;
+        true
+    }
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[derive(Default)]
+struct DesktopNotificationState {
+    limiter: DesktopNotificationLimiter,
+    pending: Option<DesktopNotification>,
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+#[derive(Default)]
+pub struct DesktopNotificationPolicy {
+    state: Mutex<DesktopNotificationState>,
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+impl DesktopNotificationPolicy {
+    pub(crate) fn push(&self, title: &[u8], body: &[u8]) -> bool {
+        let mut state = self.state.lock();
+        if !state.limiter.accept(title, body) {
+            return false;
+        }
+        state.pending = Some(DesktopNotification::from_bytes(title, body));
+        true
+    }
+
+    fn take(&self) -> Option<DesktopNotification> {
+        self.state.lock().pending.take()
+    }
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+pub(crate) fn desktop_notification_policy() -> Arc<DesktopNotificationPolicy> {
+    Arc::new(DesktopNotificationPolicy::default())
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+fn bounded_lossy_utf8(bytes: &[u8], limit: usize) -> String {
+    let text = String::from_utf8_lossy(bytes);
+    let mut end = text.len().min(limit);
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    text[..end].to_owned()
+}
 
 pub fn restored_terminal_output_text(lines: &[String]) -> Option<String> {
     if lines.is_empty() {
@@ -149,7 +259,11 @@ pub use stub::{
 
 #[cfg(test)]
 mod tests {
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    use super::DesktopNotificationPolicy;
     use super::clipboard_mime_is_text;
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    use std::time::{Duration, Instant};
 
     #[test]
     fn clipboard_text_mime_matching_is_exact_and_case_insensitive() {
@@ -161,5 +275,21 @@ mod tests {
         assert!(clipboard_mime_is_text(b"STRING"));
         assert!(!clipboard_mime_is_text(b"text/plainEVIL"));
         assert!(!clipboard_mime_is_text(b"image/png"));
+    }
+
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[test]
+    fn desktop_notification_limiter_rejects_bursts_and_recent_duplicates() {
+        let policy = DesktopNotificationPolicy::default();
+
+        assert!(policy.push(b"Build", b"Complete"));
+        assert!(!policy.push(b"Deploy", b"Complete"));
+        assert_eq!(policy.take().expect("pending notification").title, "Build");
+
+        policy.state.lock().limiter.last_accepted_at =
+            Some(Instant::now() - Duration::from_secs(2));
+        assert!(!policy.push(b"Build", b"Complete"));
+        assert!(policy.push(b"Deploy", b"Complete"));
+        assert_eq!(policy.take().expect("pending notification").title, "Deploy");
     }
 }

--- a/crates/con-ghostty/src/lib.rs
+++ b/crates/con-ghostty/src/lib.rs
@@ -18,6 +18,8 @@
 
 use std::time::Duration;
 
+pub(crate) const CLIPBOARD_WRITE_LIMIT_BYTES: usize = 1024 * 1024;
+
 pub fn restored_terminal_output_text(lines: &[String]) -> Option<String> {
     if lines.is_empty() {
         return None;

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -11,6 +11,7 @@ use crate::stub::{
     GhosttySurfaceEvent, MouseButton, SurfaceSize, TerminalColors,
 };
 use crate::vt::{ScreenSnapshot, VtKeyEvent, VtKeyOutcome};
+use crate::{DesktopNotificationPolicy, desktop_notification_policy};
 
 #[derive(Debug, Clone)]
 pub struct LinuxBackendConfig {
@@ -53,6 +54,7 @@ impl Default for LinuxBackendConfig {
 pub struct LinuxGhosttyApp {
     config: Mutex<LinuxBackendConfig>,
     wake_generation: Arc<AtomicU64>,
+    desktop_notification_policy: Arc<DesktopNotificationPolicy>,
 }
 
 impl LinuxGhosttyApp {
@@ -82,6 +84,7 @@ impl LinuxGhosttyApp {
                 clipboard_write,
             }),
             wake_generation: Arc::new(AtomicU64::new(1)),
+            desktop_notification_policy: desktop_notification_policy(),
         })
     }
 
@@ -152,6 +155,7 @@ impl LinuxGhosttyApp {
             wake_generation: Some(self.wake_generation.clone()),
             theme: config.colors,
             clipboard_write: config.clipboard_write,
+            desktop_notification_policy: self.desktop_notification_policy.clone(),
             ..LinuxPtyOptions::default()
         }
     }
@@ -466,6 +470,13 @@ impl LinuxGhosttyTerminal {
             .lock()
             .as_ref()
             .and_then(LinuxPtySession::take_clipboard_write)
+    }
+
+    pub fn take_desktop_notification(&self) -> Option<crate::DesktopNotification> {
+        self.inner
+            .lock()
+            .as_ref()
+            .and_then(LinuxPtySession::take_desktop_notification)
     }
 
     pub fn current_dir(&self) -> Option<String> {

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -430,6 +430,13 @@ impl LinuxGhosttyTerminal {
         self.inner.lock().as_ref().and_then(LinuxPtySession::title)
     }
 
+    pub fn take_bell(&self) -> bool {
+        self.inner
+            .lock()
+            .as_ref()
+            .is_some_and(LinuxPtySession::take_bell)
+    }
+
     pub fn current_dir(&self) -> Option<String> {
         self.inner
             .lock()

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -11,7 +11,10 @@ use crate::stub::{
     GhosttySurfaceEvent, MouseButton, SurfaceSize, TerminalColors,
 };
 use crate::vt::{ScreenSnapshot, VtKeyEvent, VtKeyOutcome};
-use crate::{DesktopNotificationPolicy, desktop_notification_policy};
+use crate::{
+    ClipboardWritePolicy, DesktopNotificationPolicy, clipboard_write_policy,
+    desktop_notification_policy,
+};
 
 #[derive(Debug, Clone)]
 pub struct LinuxBackendConfig {
@@ -54,6 +57,7 @@ impl Default for LinuxBackendConfig {
 pub struct LinuxGhosttyApp {
     config: Mutex<LinuxBackendConfig>,
     wake_generation: Arc<AtomicU64>,
+    clipboard_write_policy: Arc<ClipboardWritePolicy>,
     desktop_notification_policy: Arc<DesktopNotificationPolicy>,
 }
 
@@ -84,6 +88,7 @@ impl LinuxGhosttyApp {
                 clipboard_write,
             }),
             wake_generation: Arc::new(AtomicU64::new(1)),
+            clipboard_write_policy: clipboard_write_policy(clipboard_write),
             desktop_notification_policy: desktop_notification_policy(),
         })
     }
@@ -139,7 +144,13 @@ impl LinuxGhosttyApp {
     pub fn set_color_scheme(&self, _dark: bool) {}
 
     pub fn set_clipboard_write_enabled(&self, enabled: bool) -> Result<(), String> {
+        if !enabled {
+            self.clipboard_write_policy.set_enabled(false);
+        }
         self.config.lock().clipboard_write = enabled;
+        if enabled {
+            self.clipboard_write_policy.set_enabled(true);
+        }
         Ok(())
     }
 
@@ -155,6 +166,7 @@ impl LinuxGhosttyApp {
             wake_generation: Some(self.wake_generation.clone()),
             theme: config.colors,
             clipboard_write: config.clipboard_write,
+            clipboard_write_policy: self.clipboard_write_policy.clone(),
             desktop_notification_policy: self.desktop_notification_policy.clone(),
             ..LinuxPtyOptions::default()
         }

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -437,6 +437,13 @@ impl LinuxGhosttyTerminal {
             .is_some_and(LinuxPtySession::take_bell)
     }
 
+    pub fn progress(&self) -> Option<crate::TerminalProgress> {
+        self.inner
+            .lock()
+            .as_ref()
+            .and_then(LinuxPtySession::progress)
+    }
+
     pub fn current_dir(&self) -> Option<String> {
         self.inner
             .lock()

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -31,6 +31,7 @@ pub struct LinuxBackendConfig {
     /// itself — the `WindowBackgroundAppearance::Blurred` toggle is
     /// applied at the GPUI window level in `con-app/main.rs`.
     pub background_blur: bool,
+    pub clipboard_write: bool,
 }
 
 impl Default for LinuxBackendConfig {
@@ -42,6 +43,7 @@ impl Default for LinuxBackendConfig {
             colors: None,
             background_opacity: 1.0,
             background_blur: false,
+            clipboard_write: false,
         }
     }
 }
@@ -67,6 +69,7 @@ impl LinuxGhosttyApp {
         _background_image_position: Option<&str>,
         _background_image_fit: Option<&str>,
         _background_image_repeat: Option<bool>,
+        clipboard_write: bool,
     ) -> Result<Self, String> {
         Ok(Self {
             config: Mutex::new(LinuxBackendConfig {
@@ -76,6 +79,7 @@ impl LinuxGhosttyApp {
                 colors: colors.cloned(),
                 background_opacity: clamp_opacity(background_opacity.unwrap_or(1.0)),
                 background_blur: background_blur.unwrap_or(false),
+                clipboard_write,
             }),
             wake_generation: Arc::new(AtomicU64::new(1)),
         })
@@ -131,6 +135,11 @@ impl LinuxGhosttyApp {
 
     pub fn set_color_scheme(&self, _dark: bool) {}
 
+    pub fn set_clipboard_write_enabled(&self, enabled: bool) -> Result<(), String> {
+        self.config.lock().clipboard_write = enabled;
+        Ok(())
+    }
+
     pub fn backend_config(&self) -> LinuxBackendConfig {
         self.config.lock().clone()
     }
@@ -142,6 +151,7 @@ impl LinuxGhosttyApp {
             program: config.shell_program,
             wake_generation: Some(self.wake_generation.clone()),
             theme: config.colors,
+            clipboard_write: config.clipboard_write,
             ..LinuxPtyOptions::default()
         }
     }
@@ -442,6 +452,20 @@ impl LinuxGhosttyTerminal {
             .lock()
             .as_ref()
             .and_then(LinuxPtySession::progress)
+    }
+
+    pub fn set_clipboard_write_enabled(&self, enabled: bool) -> Result<(), String> {
+        if let Some(session) = self.inner.lock().as_ref() {
+            session.set_clipboard_write_enabled(enabled)?;
+        }
+        Ok(())
+    }
+
+    pub fn take_clipboard_write(&self) -> Option<String> {
+        self.inner
+            .lock()
+            .as_ref()
+            .and_then(LinuxPtySession::take_clipboard_write)
     }
 
     pub fn current_dir(&self) -> Option<String> {

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -18,7 +18,7 @@ use crate::vt::{
     PtyWriteClass, ScreenSnapshot, ThemeColors, VtKeyEvent, VtKeyOutcome, VtPasteResult,
     VtPasteSource, VtScreen,
 };
-use crate::{DesktopNotificationPolicy, desktop_notification_policy};
+use crate::{ClipboardWritePolicy, DesktopNotificationPolicy};
 
 const DEFAULT_COLUMNS: u16 = 80;
 const DEFAULT_ROWS: u16 = 24;
@@ -90,6 +90,7 @@ pub struct LinuxPtyOptions {
     pub wake_callback: Option<LinuxWakeCallback>,
     pub theme: Option<TerminalColors>,
     pub clipboard_write: bool,
+    pub(crate) clipboard_write_policy: Arc<ClipboardWritePolicy>,
     pub(crate) desktop_notification_policy: Arc<DesktopNotificationPolicy>,
 }
 
@@ -113,7 +114,8 @@ impl Default for LinuxPtyOptions {
             wake_callback: None,
             theme: None,
             clipboard_write: false,
-            desktop_notification_policy: desktop_notification_policy(),
+            clipboard_write_policy: Arc::new(ClipboardWritePolicy::new(true)),
+            desktop_notification_policy: Arc::new(DesktopNotificationPolicy::default()),
         }
     }
 }
@@ -737,6 +739,7 @@ fn spawn_local(
         )
         .context("failed to create linux vt screen")?,
     );
+    screen.set_clipboard_write_policy(options.clipboard_write_policy.clone());
     screen.set_desktop_notification_policy(options.desktop_notification_policy.clone());
     screen
         .set_clipboard_write_enabled(options.clipboard_write)
@@ -1061,6 +1064,7 @@ fn spawn_host_bridge(
         )
         .context("failed to create linux vt screen")?,
     );
+    screen.set_clipboard_write_policy(options.clipboard_write_policy.clone());
     screen.set_desktop_notification_policy(options.desktop_notification_policy.clone());
     screen
         .set_clipboard_write_enabled(options.clipboard_write)

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -88,6 +88,7 @@ pub struct LinuxPtyOptions {
     pub wake_generation: Option<Arc<AtomicU64>>,
     pub wake_callback: Option<LinuxWakeCallback>,
     pub theme: Option<TerminalColors>,
+    pub clipboard_write: bool,
 }
 
 impl Default for LinuxPtyOptions {
@@ -109,6 +110,7 @@ impl Default for LinuxPtyOptions {
             wake_generation: None,
             wake_callback: None,
             theme: None,
+            clipboard_write: false,
         }
     }
 }
@@ -516,6 +518,14 @@ impl LinuxPtySession {
         self.shared.screen.progress()
     }
 
+    pub fn set_clipboard_write_enabled(&self, enabled: bool) -> Result<(), String> {
+        self.shared.screen.set_clipboard_write_enabled(enabled)
+    }
+
+    pub fn take_clipboard_write(&self) -> Option<String> {
+        self.shared.screen.take_clipboard_write()
+    }
+
     pub fn current_dir(&self) -> Option<String> {
         self.shared
             .screen
@@ -720,6 +730,9 @@ fn spawn_local(
         )
         .context("failed to create linux vt screen")?,
     );
+    screen
+        .set_clipboard_write_enabled(options.clipboard_write)
+        .map_err(anyhow::Error::msg)?;
     if let Some(output) = options
         .initial_output
         .as_deref()

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -512,6 +512,10 @@ impl LinuxPtySession {
         self.shared.screen.take_bell()
     }
 
+    pub fn progress(&self) -> Option<crate::TerminalProgress> {
+        self.shared.screen.progress()
+    }
+
     pub fn current_dir(&self) -> Option<String> {
         self.shared
             .screen

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -18,6 +18,7 @@ use crate::vt::{
     PtyWriteClass, ScreenSnapshot, ThemeColors, VtKeyEvent, VtKeyOutcome, VtPasteResult,
     VtPasteSource, VtScreen,
 };
+use crate::{DesktopNotificationPolicy, desktop_notification_policy};
 
 const DEFAULT_COLUMNS: u16 = 80;
 const DEFAULT_ROWS: u16 = 24;
@@ -89,6 +90,7 @@ pub struct LinuxPtyOptions {
     pub wake_callback: Option<LinuxWakeCallback>,
     pub theme: Option<TerminalColors>,
     pub clipboard_write: bool,
+    pub(crate) desktop_notification_policy: Arc<DesktopNotificationPolicy>,
 }
 
 impl Default for LinuxPtyOptions {
@@ -111,6 +113,7 @@ impl Default for LinuxPtyOptions {
             wake_callback: None,
             theme: None,
             clipboard_write: false,
+            desktop_notification_policy: desktop_notification_policy(),
         }
     }
 }
@@ -526,6 +529,10 @@ impl LinuxPtySession {
         self.shared.screen.take_clipboard_write()
     }
 
+    pub fn take_desktop_notification(&self) -> Option<crate::DesktopNotification> {
+        self.shared.screen.take_desktop_notification()
+    }
+
     pub fn current_dir(&self) -> Option<String> {
         self.shared
             .screen
@@ -730,6 +737,7 @@ fn spawn_local(
         )
         .context("failed to create linux vt screen")?,
     );
+    screen.set_desktop_notification_policy(options.desktop_notification_policy.clone());
     screen
         .set_clipboard_write_enabled(options.clipboard_write)
         .map_err(anyhow::Error::msg)?;
@@ -1053,6 +1061,7 @@ fn spawn_host_bridge(
         )
         .context("failed to create linux vt screen")?,
     );
+    screen.set_desktop_notification_policy(options.desktop_notification_policy.clone());
 
     if let Some(output) = options
         .initial_output

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -508,6 +508,10 @@ impl LinuxPtySession {
             .unwrap_or_else(|| self.title.clone())
     }
 
+    pub fn take_bell(&self) -> bool {
+        self.shared.screen.take_bell()
+    }
+
     pub fn current_dir(&self) -> Option<String> {
         self.shared
             .screen

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -502,7 +502,10 @@ impl LinuxPtySession {
     }
 
     pub fn title(&self) -> Option<String> {
-        self.title.clone()
+        self.shared
+            .screen
+            .reported_title()
+            .unwrap_or_else(|| self.title.clone())
     }
 
     pub fn current_dir(&self) -> Option<String> {

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -1062,6 +1062,13 @@ fn spawn_host_bridge(
         .context("failed to create linux vt screen")?,
     );
     screen.set_desktop_notification_policy(options.desktop_notification_policy.clone());
+    screen
+        .set_clipboard_write_enabled(options.clipboard_write)
+        .map_err(|message| {
+            stop_host_bridge_child(&mut child);
+            let _ = std::fs::remove_file(&socket_path);
+            anyhow::Error::msg(message)
+        })?;
 
     if let Some(output) = options
         .initial_output

--- a/crates/con-ghostty/src/stub.rs
+++ b/crates/con-ghostty/src/stub.rs
@@ -233,6 +233,9 @@ impl GhosttyTerminal {
     pub fn current_dir(&self) -> Option<String> {
         None
     }
+    pub fn progress(&self) -> Option<crate::TerminalProgress> {
+        None
+    }
     pub fn is_alive(&self) -> bool {
         false
     }

--- a/crates/con-ghostty/src/stub.rs
+++ b/crates/con-ghostty/src/stub.rs
@@ -42,6 +42,7 @@ pub struct GhosttyConfigPatch {
     pub background_image_position: Option<String>,
     pub background_image_fit: Option<String>,
     pub background_image_repeat: Option<bool>,
+    pub clipboard_write: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -119,6 +120,7 @@ impl GhosttyApp {
         _background_image_position: Option<&str>,
         _background_image_fit: Option<&str>,
         _background_image_repeat: Option<bool>,
+        _clipboard_write_enabled: bool,
     ) -> Result<Self, String> {
         Ok(Self { _sealed: () })
     }
@@ -158,6 +160,10 @@ impl GhosttyApp {
     }
 
     pub fn set_color_scheme(&self, _dark: bool) {}
+
+    pub fn set_clipboard_write_enabled(&self, _enabled: bool) -> Result<(), String> {
+        Ok(())
+    }
 }
 
 // SAFETY: the stub has no interior state, so it is trivially Send+Sync.
@@ -189,6 +195,9 @@ impl GhosttyTerminal {
     pub fn set_focus(&self, _focused: bool) {}
     pub fn set_occlusion(&self, _occluded: bool) {}
     pub fn set_color_scheme(&self, _dark: bool) {}
+    pub fn set_clipboard_write_enabled(&self, _enabled: bool) -> Result<(), String> {
+        Ok(())
+    }
     pub fn perform_binding_action(&self, _action: &str) -> Result<bool, String> {
         Ok(false)
     }

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -23,7 +23,7 @@ use std::time::Instant;
 use dispatch::Queue;
 use parking_lot::Mutex;
 
-use crate::ffi;
+use crate::{TERMINAL_PROGRESS_TIMEOUT, TerminalProgress, ffi};
 
 const DEFAULT_GHOSTTY_FONT_FAMILY: &str = "Ioskeley Mono";
 // Con does not ship Ghostty's `+ssh-cache` CLI helper. Do not advertise
@@ -292,6 +292,8 @@ pub struct TerminalState {
     pub pwd: Option<String>,
     pub needs_render: bool,
     pub bell_pending: bool,
+    pub progress: Option<TerminalProgress>,
+    pub progress_updated_at: Option<Instant>,
     pub child_exited: bool,
     /// Last exit code from COMMAND_FINISHED (persists across commands).
     pub last_exit_code: Option<i32>,
@@ -326,6 +328,8 @@ impl Default for TerminalState {
             pwd: None,
             needs_render: false,
             bell_pending: false,
+            progress: None,
+            progress_updated_at: None,
             child_exited: false,
             last_exit_code: None,
             last_command_duration: None,
@@ -1056,6 +1060,20 @@ impl GhosttyTerminal {
         self.state.lock().pwd.clone()
     }
 
+    pub fn progress(&self) -> Option<TerminalProgress> {
+        let mut state = self.state.lock();
+        let progress = state.progress?;
+        if state
+            .progress_updated_at
+            .is_some_and(|updated_at| updated_at.elapsed() < TERMINAL_PROGRESS_TIMEOUT)
+        {
+            return Some(progress);
+        }
+        state.progress = None;
+        state.progress_updated_at = None;
+        None
+    }
+
     /// Whether the child process has exited.
     pub fn is_alive(&self) -> bool {
         !unsafe { ffi::ghostty_surface_process_exited(self.surface) }
@@ -1597,6 +1615,17 @@ unsafe extern "C" fn action_callback(
             }
             ffi::ghostty_action_tag_e::GHOSTTY_ACTION_RING_BELL => {
                 state.lock().bell_pending = true;
+                true
+            }
+            ffi::ghostty_action_tag_e::GHOSTTY_ACTION_PROGRESS_REPORT => {
+                let report = action.action.progress_report;
+                if let Some(progress) =
+                    TerminalProgress::from_ghostty_report(report.state, report.progress)
+                {
+                    let mut state = state.lock();
+                    state.progress = progress;
+                    state.progress_updated_at = progress.map(|_| Instant::now());
+                }
                 true
             }
             _ => false,

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -291,6 +291,7 @@ pub struct TerminalState {
     pub title: Option<String>,
     pub pwd: Option<String>,
     pub needs_render: bool,
+    pub bell_pending: bool,
     pub child_exited: bool,
     /// Last exit code from COMMAND_FINISHED (persists across commands).
     pub last_exit_code: Option<i32>,
@@ -324,6 +325,7 @@ impl Default for TerminalState {
             title: None,
             pwd: None,
             needs_render: false,
+            bell_pending: false,
             child_exited: false,
             last_exit_code: None,
             last_command_duration: None,
@@ -1267,6 +1269,14 @@ impl GhosttyTerminal {
         r
     }
 
+    /// Consume one or more bells coalesced since the previous drain.
+    pub fn take_bell(&self) -> bool {
+        let mut state = self.state.lock();
+        let pending = state.bell_pending;
+        state.bell_pending = false;
+        pending
+    }
+
     /// Access the per-surface state.
     pub fn state(&self) -> &StateRef {
         &self.state
@@ -1586,14 +1596,7 @@ unsafe extern "C" fn action_callback(
                 true
             }
             ffi::ghostty_action_tag_e::GHOSTTY_ACTION_RING_BELL => {
-                // macOS system beep
-                #[cfg(target_os = "macos")]
-                {
-                    unsafe extern "C" {
-                        fn NSBeep();
-                    }
-                    NSBeep();
-                }
+                state.lock().bell_pending = true;
                 true
             }
             _ => false,

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -23,7 +23,7 @@ use std::time::Instant;
 use dispatch::Queue;
 use parking_lot::Mutex;
 
-use crate::{TERMINAL_PROGRESS_TIMEOUT, TerminalProgress, ffi};
+use crate::{CLIPBOARD_WRITE_LIMIT_BYTES, TERMINAL_PROGRESS_TIMEOUT, TerminalProgress, ffi};
 
 const DEFAULT_GHOSTTY_FONT_FAMILY: &str = "Ioskeley Mono";
 // Con does not ship Ghostty's `+ssh-cache` CLI helper. Do not advertise
@@ -83,6 +83,7 @@ pub struct GhosttyConfigPatch {
     pub background_image_position: Option<String>,
     pub background_image_fit: Option<String>,
     pub background_image_repeat: Option<bool>,
+    pub clipboard_write: Option<bool>,
 }
 
 impl GhosttyConfigPatch {
@@ -122,6 +123,9 @@ impl GhosttyConfigPatch {
         }
         if let Some(background_image_repeat) = patch.background_image_repeat {
             self.background_image_repeat = Some(background_image_repeat);
+        }
+        if let Some(clipboard_write) = patch.clipboard_write {
+            self.clipboard_write = Some(clipboard_write);
         }
     }
 
@@ -167,14 +171,20 @@ impl GhosttyConfigPatch {
         s.push_str("shell-integration-features = ");
         s.push_str(CON_SHELL_INTEGRATION_FEATURES);
         s.push('\n');
-        // Force Kitty writes through Ghostty's confirmation request so Con can
-        // reject them until it has a user-visible permission flow. OSC 52 uses
-        // the write callback's `confirm` flag instead; that callback preserves
-        // Con's existing unconditional-write behavior during this migration.
-        s.push_str("clipboard-write = ask\n");
-        // This limit applies only to Kitty OSC 5522, not OSC 52. Avoid buffering
-        // an untrusted 64 MiB transaction just to reject it at confirmation.
-        s.push_str("clipboard-write-limit-bytes = 0\n");
+        let clipboard_write = self.clipboard_write.unwrap_or(false);
+        s.push_str(if clipboard_write {
+            "clipboard-write = allow\n"
+        } else {
+            "clipboard-write = deny\n"
+        });
+        let clipboard_write_limit = if clipboard_write {
+            CLIPBOARD_WRITE_LIMIT_BYTES
+        } else {
+            0
+        };
+        s.push_str(&format!(
+            "clipboard-write-limit-bytes = {clipboard_write_limit}\n"
+        ));
         if let Some(background_image) = &self.background_image {
             s.push_str(&format!("background-image = {:?}\n", background_image));
             if let Some(background_image_opacity) = self.background_image_opacity {
@@ -313,6 +323,7 @@ pub struct TerminalState {
     pub last_command_finished_input_generation: u64,
     /// Surface handle — stored so clipboard callbacks can complete requests.
     pub surface: ffi::ghostty_surface_t,
+    clipboard_write_enabled: Arc<AtomicBool>,
     /// Pending host-side events emitted by Ghostty actions for this surface.
     pub pending_events: VecDeque<GhosttySurfaceEvent>,
     /// Latest viewport scrollbar state emitted by Ghostty.
@@ -339,6 +350,7 @@ impl Default for TerminalState {
             input_generation: 0,
             last_command_finished_input_generation: 0,
             surface: std::ptr::null_mut(),
+            clipboard_write_enabled: Arc::new(AtomicBool::new(false)),
             pending_events: VecDeque::new(),
             scrollbar: None,
         }
@@ -469,6 +481,7 @@ struct GhosttyWakeHandle {
     app: AtomicPtr<c_void>,
     tick_scheduled: AtomicBool,
     generation: AtomicU64,
+    clipboard_write_enabled: Arc<AtomicBool>,
 }
 
 impl Default for GhosttyWakeHandle {
@@ -477,6 +490,7 @@ impl Default for GhosttyWakeHandle {
             app: AtomicPtr::new(std::ptr::null_mut()),
             tick_scheduled: AtomicBool::new(false),
             generation: AtomicU64::new(0),
+            clipboard_write_enabled: Arc::new(AtomicBool::new(false)),
         }
     }
 }
@@ -495,6 +509,7 @@ impl GhosttyApp {
         background_image_position: Option<&str>,
         background_image_fit: Option<&str>,
         background_image_repeat: Option<bool>,
+        clipboard_write_enabled: bool,
     ) -> Result<Self, String> {
         ensure_ghostty_init()?;
 
@@ -513,10 +528,14 @@ impl GhosttyApp {
             background_image_position: background_image_position.map(ToOwned::to_owned),
             background_image_fit: background_image_fit.map(ToOwned::to_owned),
             background_image_repeat,
+            clipboard_write: Some(clipboard_write_enabled),
         };
         let config = build_ghostty_config(&appearance)?;
 
         let wake_handle = Arc::new(GhosttyWakeHandle::default());
+        wake_handle
+            .clipboard_write_enabled
+            .store(clipboard_write_enabled, Ordering::Release);
         let runtime_config = Box::new(ffi::ghostty_runtime_config_s {
             userdata: Arc::as_ptr(&wake_handle) as *mut c_void,
             supports_selection_clipboard: false,
@@ -603,6 +622,7 @@ impl GhosttyApp {
             background_image_position: None,
             background_image_fit: None,
             background_image_repeat: None,
+            clipboard_write: None,
         })
     }
 
@@ -633,20 +653,20 @@ impl GhosttyApp {
             background_image_position: background_image_position.map(ToOwned::to_owned),
             background_image_fit: background_image_fit.map(ToOwned::to_owned),
             background_image_repeat: background_image.map(|_| background_image_repeat),
+            clipboard_write: None,
         })
     }
 
     pub fn update_config(&self, patch: &GhosttyConfigPatch) -> Result<(), String> {
-        let merged = {
-            let mut appearance = self.appearance.lock();
-            appearance.merge(patch);
-            appearance.clone()
-        };
+        let mut appearance = self.appearance.lock();
+        let mut merged = appearance.clone();
+        merged.merge(patch);
         let config = build_ghostty_config(&merged)?;
         unsafe {
             ffi::ghostty_app_update_config(self.app, config);
             ffi::ghostty_config_free(config);
         }
+        *appearance = merged;
         Ok(())
     }
 
@@ -658,6 +678,24 @@ impl GhosttyApp {
             ffi::ghostty_color_scheme_e::GHOSTTY_COLOR_SCHEME_LIGHT
         };
         unsafe { ffi::ghostty_app_set_color_scheme(self.app, scheme) }
+    }
+
+    pub fn set_clipboard_write_enabled(&self, enabled: bool) -> Result<(), String> {
+        if !enabled {
+            self.wake_handle
+                .clipboard_write_enabled
+                .store(false, Ordering::Release);
+        }
+        self.update_config(&GhosttyConfigPatch {
+            clipboard_write: Some(enabled),
+            ..Default::default()
+        })?;
+        if enabled {
+            self.wake_handle
+                .clipboard_write_enabled
+                .store(true, Ordering::Release);
+        }
+        Ok(())
     }
 
     /// Create a new terminal surface. The `nsview` must be a valid NSView pointer
@@ -675,7 +713,10 @@ impl GhosttyApp {
     ) -> Result<GhosttyTerminal, String> {
         // Per-surface state — stored as surface userdata so callbacks can
         // update the correct terminal's state.
-        let state: StateRef = Arc::new(Mutex::new(TerminalState::default()));
+        let state: StateRef = Arc::new(Mutex::new(TerminalState {
+            clipboard_write_enabled: self.wake_handle.clipboard_write_enabled.clone(),
+            ..TerminalState::default()
+        }));
         let surface_userdata = Box::into_raw(Box::new(state.clone())) as *mut c_void;
 
         let mut config = unsafe { ffi::ghostty_surface_config_new() };
@@ -825,6 +866,10 @@ impl GhosttyTerminal {
         unsafe { ffi::ghostty_surface_set_color_scheme(self.surface, scheme) }
     }
 
+    pub fn set_clipboard_write_enabled(&self, _enabled: bool) -> Result<(), String> {
+        Ok(())
+    }
+
     pub fn perform_binding_action(&self, action: &str) -> Result<bool, String> {
         let action = CString::new(action).map_err(|e| format!("CString: {}", e))?;
         Ok(unsafe {
@@ -916,6 +961,7 @@ impl GhosttyTerminal {
             background_image_position: background_image_position.map(ToOwned::to_owned),
             background_image_fit: background_image_fit.map(ToOwned::to_owned),
             background_image_repeat: background_image.map(|_| background_image_repeat),
+            clipboard_write: None,
         })?;
         self.refresh();
         Ok(())
@@ -1777,20 +1823,23 @@ unsafe extern "C" fn confirm_read_clipboard_callback(
     }
 }
 
-/// Clipboard write — ghostty wants to copy (selection, OSC 52). Write to macOS pasteboard.
+/// Clipboard write — ghostty wants to copy plain text to the macOS pasteboard.
 unsafe extern "C" fn write_clipboard_callback(
-    _userdata: *mut c_void,
+    userdata: *mut c_void,
     clipboard: ffi::ghostty_clipboard_e,
     content: *const ffi::ghostty_clipboard_content_s,
     content_count: usize,
     _confirm: bool,
 ) {
     unsafe {
-        // Standard and selection both map to the macOS general pasteboard;
-        // primary is unsupported on this platform.
-        if clipboard == ffi::ghostty_clipboard_e::GHOSTTY_CLIPBOARD_PRIMARY
-            || content.is_null()
-            || content_count == 0
+        if userdata.is_null()
+            || !(*(userdata as *const StateRef))
+                .lock()
+                .clipboard_write_enabled
+                .load(Ordering::Acquire)
+            || clipboard != ffi::ghostty_clipboard_e::GHOSTTY_CLIPBOARD_STANDARD
+            || content_count > 1
+            || (content.is_null() && content_count > 0)
         {
             return;
         }
@@ -1800,34 +1849,41 @@ unsafe extern "C" fn write_clipboard_callback(
             use objc::runtime::Object;
             use objc::{class, msg_send, sel, sel_impl};
 
-            let items = std::slice::from_raw_parts(content, content_count);
-
-            for item in items {
-                if !clipboard_c_mime_is_text(item.mime) || (item.data.is_null() && item.len > 0) {
-                    continue;
+            let (data, len) = if content_count == 0 {
+                (c"".as_ptr(), 0)
+            } else {
+                let item = &*content;
+                if !clipboard_c_mime_is_text(item.mime) {
+                    return;
                 }
-                let data = if item.len == 0 {
-                    c"".as_ptr()
-                } else {
-                    item.data
-                };
-                let ns_str: *mut Object = msg_send![
-                    class!(NSString),
-                    stringWithBytes: data
-                    length: item.len
-                    encoding: 4usize
-                ];
-                if ns_str.is_null() {
-                    continue;
+                if item.len > CLIPBOARD_WRITE_LIMIT_BYTES || (item.data.is_null() && item.len > 0) {
+                    return;
                 }
+                (
+                    if item.len == 0 {
+                        c"".as_ptr()
+                    } else {
+                        item.data
+                    },
+                    item.len,
+                )
+            };
 
-                // NSPasteboardTypeString = @"public.utf8-plain-text"
-                let ns_type: *mut Object = msg_send![class!(NSString), stringWithUTF8String: c"public.utf8-plain-text".as_ptr()];
-                let pb: *mut Object = msg_send![class!(NSPasteboard), generalPasteboard];
-                let _: () = msg_send![pb, clearContents];
-                let _success: bool = msg_send![pb, setString: ns_str forType: ns_type];
+            let ns_str: *mut Object = msg_send![
+                class!(NSString),
+                stringWithBytes: data
+                length: len
+                encoding: 4usize
+            ];
+            if ns_str.is_null() {
                 return;
             }
+
+            // NSPasteboardTypeString = @"public.utf8-plain-text"
+            let ns_type: *mut Object = msg_send![class!(NSString), stringWithUTF8String: c"public.utf8-plain-text".as_ptr()];
+            let pb: *mut Object = msg_send![class!(NSPasteboard), generalPasteboard];
+            let _: () = msg_send![pb, clearContents];
+            let _success: bool = msg_send![pb, setString: ns_str forType: ns_type];
         }
     }
 }
@@ -1962,11 +2018,18 @@ mod tests {
     }
 
     #[test]
-    fn ghostty_config_rejects_kitty_clipboard_writes_until_permission_ui_exists() {
-        let config = GhosttyConfigPatch::default().to_config_string();
+    fn ghostty_config_gates_kitty_clipboard_writes() {
+        let disabled = GhosttyConfigPatch::default().to_config_string();
+        let enabled = GhosttyConfigPatch {
+            clipboard_write: Some(true),
+            ..Default::default()
+        }
+        .to_config_string();
 
-        assert!(config.contains("clipboard-write = ask"));
-        assert!(config.contains("clipboard-write-limit-bytes = 0"));
+        assert!(disabled.contains("clipboard-write = deny"));
+        assert!(disabled.contains("clipboard-write-limit-bytes = 0"));
+        assert!(enabled.contains("clipboard-write = allow"));
+        assert!(enabled.contains("clipboard-write-limit-bytes = 1048576"));
     }
 
     #[test]

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -23,7 +23,10 @@ use std::time::Instant;
 use dispatch::Queue;
 use parking_lot::Mutex;
 
-use crate::{CLIPBOARD_WRITE_LIMIT_BYTES, TERMINAL_PROGRESS_TIMEOUT, TerminalProgress, ffi};
+use crate::{
+    CLIPBOARD_WRITE_LIMIT_BYTES, ClipboardWritePolicy, TERMINAL_PROGRESS_TIMEOUT, TerminalProgress,
+    clipboard_write_policy, ffi,
+};
 
 const DEFAULT_GHOSTTY_FONT_FAMILY: &str = "Ioskeley Mono";
 // Con does not ship Ghostty's `+ssh-cache` CLI helper. Do not advertise
@@ -323,7 +326,7 @@ pub struct TerminalState {
     pub last_command_finished_input_generation: u64,
     /// Surface handle — stored so clipboard callbacks can complete requests.
     pub surface: ffi::ghostty_surface_t,
-    clipboard_write_enabled: Arc<AtomicBool>,
+    clipboard_write_policy: Arc<ClipboardWritePolicy>,
     /// Pending host-side events emitted by Ghostty actions for this surface.
     pub pending_events: VecDeque<GhosttySurfaceEvent>,
     /// Latest viewport scrollbar state emitted by Ghostty.
@@ -350,7 +353,7 @@ impl Default for TerminalState {
             input_generation: 0,
             last_command_finished_input_generation: 0,
             surface: std::ptr::null_mut(),
-            clipboard_write_enabled: Arc::new(AtomicBool::new(false)),
+            clipboard_write_policy: Arc::new(ClipboardWritePolicy::new(false)),
             pending_events: VecDeque::new(),
             scrollbar: None,
         }
@@ -481,7 +484,7 @@ struct GhosttyWakeHandle {
     app: AtomicPtr<c_void>,
     tick_scheduled: AtomicBool,
     generation: AtomicU64,
-    clipboard_write_enabled: Arc<AtomicBool>,
+    clipboard_write_policy: Arc<ClipboardWritePolicy>,
 }
 
 impl Default for GhosttyWakeHandle {
@@ -490,7 +493,7 @@ impl Default for GhosttyWakeHandle {
             app: AtomicPtr::new(std::ptr::null_mut()),
             tick_scheduled: AtomicBool::new(false),
             generation: AtomicU64::new(0),
-            clipboard_write_enabled: Arc::new(AtomicBool::new(false)),
+            clipboard_write_policy: Arc::new(ClipboardWritePolicy::new(false)),
         }
     }
 }
@@ -532,10 +535,10 @@ impl GhosttyApp {
         };
         let config = build_ghostty_config(&appearance)?;
 
-        let wake_handle = Arc::new(GhosttyWakeHandle::default());
-        wake_handle
-            .clipboard_write_enabled
-            .store(clipboard_write_enabled, Ordering::Release);
+        let wake_handle = Arc::new(GhosttyWakeHandle {
+            clipboard_write_policy: clipboard_write_policy(clipboard_write_enabled),
+            ..GhosttyWakeHandle::default()
+        });
         let runtime_config = Box::new(ffi::ghostty_runtime_config_s {
             userdata: Arc::as_ptr(&wake_handle) as *mut c_void,
             supports_selection_clipboard: false,
@@ -682,18 +685,14 @@ impl GhosttyApp {
 
     pub fn set_clipboard_write_enabled(&self, enabled: bool) -> Result<(), String> {
         if !enabled {
-            self.wake_handle
-                .clipboard_write_enabled
-                .store(false, Ordering::Release);
+            self.wake_handle.clipboard_write_policy.set_enabled(false);
         }
         self.update_config(&GhosttyConfigPatch {
             clipboard_write: Some(enabled),
             ..Default::default()
         })?;
         if enabled {
-            self.wake_handle
-                .clipboard_write_enabled
-                .store(true, Ordering::Release);
+            self.wake_handle.clipboard_write_policy.set_enabled(true);
         }
         Ok(())
     }
@@ -714,7 +713,7 @@ impl GhosttyApp {
         // Per-surface state — stored as surface userdata so callbacks can
         // update the correct terminal's state.
         let state: StateRef = Arc::new(Mutex::new(TerminalState {
-            clipboard_write_enabled: self.wake_handle.clipboard_write_enabled.clone(),
+            clipboard_write_policy: self.wake_handle.clipboard_write_policy.clone(),
             ..TerminalState::default()
         }));
         let surface_userdata = Box::into_raw(Box::new(state.clone())) as *mut c_void;
@@ -1835,8 +1834,8 @@ unsafe extern "C" fn write_clipboard_callback(
         if userdata.is_null()
             || !(*(userdata as *const StateRef))
                 .lock()
-                .clipboard_write_enabled
-                .load(Ordering::Acquire)
+                .clipboard_write_policy
+                .is_enabled()
             || clipboard != ffi::ghostty_clipboard_e::GHOSTTY_CLIPBOARD_STANDARD
             || content_count > 1
             || (content.is_null() && content_count > 0)

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -33,7 +33,7 @@ use std::io::Cursor as IoCursor;
 use std::os::raw::{c_char, c_int, c_void};
 use std::sync::Arc;
 use std::sync::OnceLock;
-use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU16, AtomicU32, AtomicU64, Ordering};
 use std::time::Instant;
 
 use crate::stub::GhosttyScrollbar;
@@ -105,6 +105,8 @@ const GHOSTTY_MODS_ALT: u16 = 1 << 2;
 const GHOSTTY_MODS_SUPER: u16 = 1 << 3;
 const GHOSTTY_KITTY_KEY_REPORT_EVENTS: u8 = 1 << 1;
 const TEXT_PLAIN_MIME: &[u8] = b"text/plain";
+const METADATA_DIRTY_TITLE: u8 = 1 << 0;
+const METADATA_DIRTY_PWD: u8 = 1 << 1;
 
 // ── Enums (keys) ───────────────────────────────────────────────────────
 //
@@ -198,6 +200,7 @@ pub enum GhosttyTerminalOption {
     /// `GhosttyColorRgb[256]*` — full 256-entry palette.
     ColorPalette = 14,
     KittyImageStorageLimit = 15,
+    PwdChanged = 25,
     ScrollbackMaxLines = 28,
     ClipboardRead = 38,
 }
@@ -1174,7 +1177,7 @@ impl PendingPasteWrite {
 }
 
 struct VtCallbackState {
-    write_pty: PtyWriteCallback,
+    write_pty: Option<PtyWriteCallback>,
     /// Serializes host callback entry. `send_key` acquires this while it still
     /// owns the VT mutex, then releases the VT mutex before invoking the host;
     /// a parser reply therefore cannot overtake the already-encoded key.
@@ -1198,6 +1201,7 @@ struct VtCallbackState {
     cell_height: AtomicU32,
     dark_mode: AtomicBool,
     device_attributes: GhosttyDeviceAttributes,
+    metadata_dirty: AtomicU8,
 }
 
 struct VtInner {
@@ -1211,7 +1215,10 @@ struct VtInner {
     kitty_image_cache: HashMap<u32, Arc<KittyImage>>,
     kitty_placements: Arc<[KittyPlacement]>,
     kitty_snapshot_generation: u64,
-    callback_state: Option<Box<VtCallbackState>>,
+    callback_state: Box<VtCallbackState>,
+    title: Option<String>,
+    title_reported: bool,
+    current_dir: Option<String>,
     cols: u16,
     rows: u16,
     generation: u64,
@@ -1516,32 +1523,30 @@ impl VtScreen {
             anyhow::bail!("ghostty_terminal_set(KITTY_IMAGE_STORAGE_LIMIT) failed: rc={rc}");
         }
 
-        let mut callback_state = write_pty.map(|write_pty| {
-            Box::new(VtCallbackState {
-                write_pty,
-                write_order: Arc::new(Mutex::new(())),
-                enquiry_response: b"con".to_vec().into_boxed_slice(),
-                clipboard_text: Mutex::new(None),
-                write_failed: Arc::new(AtomicBool::new(false)),
-                pending_paste_write: Mutex::new(None),
-                rows: AtomicU16::new(rows),
-                cols: AtomicU16::new(cols),
-                cell_width: AtomicU32::new(1),
-                cell_height: AtomicU32::new(1),
-                dark_mode: AtomicBool::new(false),
-                device_attributes: default_device_attributes(),
-            })
+        let mut callback_state = Box::new(VtCallbackState {
+            write_pty,
+            write_order: Arc::new(Mutex::new(())),
+            enquiry_response: b"con".to_vec().into_boxed_slice(),
+            clipboard_text: Mutex::new(None),
+            write_failed: Arc::new(AtomicBool::new(false)),
+            pending_paste_write: Mutex::new(None),
+            rows: AtomicU16::new(rows),
+            cols: AtomicU16::new(cols),
+            cell_width: AtomicU32::new(1),
+            cell_height: AtomicU32::new(1),
+            dark_mode: AtomicBool::new(false),
+            device_attributes: default_device_attributes(),
+            metadata_dirty: AtomicU8::new(0),
         });
-        if let Some(state) = callback_state.as_mut() {
-            let userdata = state.as_mut() as *mut VtCallbackState as *mut c_void;
-            let rc = unsafe {
-                ghostty_terminal_set(terminal, GhosttyTerminalOption::Userdata, userdata)
-            };
-            if rc != 0 {
-                unsafe { ghostty_terminal_free(terminal) };
-                anyhow::bail!("ghostty_terminal_set(USERDATA) failed: rc={rc}");
-            }
+        let userdata = callback_state.as_mut() as *mut VtCallbackState as *mut c_void;
+        let rc =
+            unsafe { ghostty_terminal_set(terminal, GhosttyTerminalOption::Userdata, userdata) };
+        if rc != 0 {
+            unsafe { ghostty_terminal_free(terminal) };
+            anyhow::bail!("ghostty_terminal_set(USERDATA) failed: rc={rc}");
+        }
 
+        if callback_state.write_pty.is_some() {
             let rc = unsafe {
                 ghostty_terminal_set(
                     terminal,
@@ -1593,6 +1598,26 @@ impl VtScreen {
                     unsafe { ghostty_terminal_free(terminal) };
                     anyhow::bail!("ghostty_terminal_set({label}) failed: rc={rc}");
                 }
+            }
+        }
+
+        let effect_callbacks = [
+            (
+                GhosttyTerminalOption::TitleChanged,
+                vt_title_changed_callback as *const c_void,
+                "TITLE_CHANGED",
+            ),
+            (
+                GhosttyTerminalOption::PwdChanged,
+                vt_pwd_changed_callback as *const c_void,
+                "PWD_CHANGED",
+            ),
+        ];
+        for (option, callback, label) in effect_callbacks {
+            let rc = unsafe { ghostty_terminal_set(terminal, option, callback) };
+            if rc != 0 {
+                unsafe { ghostty_terminal_free(terminal) };
+                anyhow::bail!("ghostty_terminal_set({label}) failed: rc={rc}");
             }
         }
 
@@ -1719,6 +1744,9 @@ impl VtScreen {
                 kitty_placements: Arc::from([]),
                 kitty_snapshot_generation: u64::MAX,
                 callback_state,
+                title: None,
+                title_reported: false,
+                current_dir: None,
                 cols,
                 rows,
                 generation: 0,
@@ -1759,8 +1787,8 @@ impl VtScreen {
         self.inner
             .lock()
             .callback_state
-            .as_ref()
-            .is_some_and(|state| state.write_failed.load(Ordering::Acquire))
+            .write_failed
+            .load(Ordering::Acquire)
     }
 
     /// Enqueue raw user input through the same ordering boundary as encoded
@@ -1780,13 +1808,13 @@ impl VtScreen {
             return Ok(());
         }
         let inner = self.inner.lock();
-        let Some(callback_state) = inner.callback_state.as_ref() else {
+        let callback_state = &inner.callback_state;
+        let Some(write_pty) = callback_state.write_pty.clone() else {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::NotConnected,
                 "terminal input requires a WRITE_PTY callback",
             ));
         };
-        let write_pty = callback_state.write_pty.clone();
         let write_failed = callback_state.write_failed.clone();
         let write_order = callback_state.write_order.clone();
         let write_guard = write_order.lock();
@@ -1807,6 +1835,7 @@ impl VtScreen {
         let mut inner = self.inner.lock();
         // SAFETY: terminal valid; bytes live for the call.
         unsafe { ghostty_terminal_vt_write(inner.terminal, bytes.as_ptr(), bytes.len()) };
+        refresh_terminal_metadata(&mut inner);
         inner.generation = inner.generation.wrapping_add(1);
     }
 
@@ -1818,10 +1847,10 @@ impl VtScreen {
     /// change between parsing output and encoding the next key.
     pub fn send_key(&self, event: &VtKeyEvent<'_>) -> anyhow::Result<VtKeyOutcome> {
         let inner = self.inner.lock();
-        let Some(callback_state) = inner.callback_state.as_ref() else {
+        let callback_state = &inner.callback_state;
+        let Some(write_pty) = callback_state.write_pty.clone() else {
             anyhow::bail!("terminal key encoding requires a WRITE_PTY callback");
         };
-        let write_pty = callback_state.write_pty.clone();
         let write_failed = callback_state.write_failed.clone();
         let write_order = callback_state.write_order.clone();
 
@@ -1951,7 +1980,8 @@ impl VtScreen {
         }
 
         let inner = self.inner.lock();
-        let Some(callback_state) = inner.callback_state.as_ref() else {
+        let callback_state = &inner.callback_state;
+        let Some(write_pty) = callback_state.write_pty.as_ref() else {
             anyhow::bail!("terminal paste requires a WRITE_PTY callback");
         };
         let previous = callback_state
@@ -2001,7 +2031,7 @@ impl VtScreen {
                     // one-time Kitty grant is installed before a program can
                     // react to the event and request its clipboard payload.
                     let _write_guard = callback_state.write_order.lock();
-                    (callback_state.write_pty)(&output, PtyWriteClass::Regular).map_err(|err| {
+                    write_pty(&output, PtyWriteClass::Regular).map_err(|err| {
                         anyhow::anyhow!("terminal paste failed to enqueue PTY bytes: {err}")
                     })?;
                 }
@@ -2049,16 +2079,15 @@ impl VtScreen {
         }
         inner.cols = cols;
         inner.rows = rows;
-        if let Some(state) = inner.callback_state.as_ref() {
-            state.cols.store(cols, Ordering::Release);
-            state.rows.store(rows, Ordering::Release);
-            state
-                .cell_width
-                .store(cell_width_px.max(1), Ordering::Release);
-            state
-                .cell_height
-                .store(cell_height_px.max(1), Ordering::Release);
-        }
+        let state = &inner.callback_state;
+        state.cols.store(cols, Ordering::Release);
+        state.rows.store(rows, Ordering::Release);
+        state
+            .cell_width
+            .store(cell_width_px.max(1), Ordering::Release);
+        state
+            .cell_height
+            .store(cell_height_px.max(1), Ordering::Release);
         let total = cols as usize * rows as usize;
         inner.scratch.clear();
         inner.scratch.resize(total, Cell::default());
@@ -2381,9 +2410,10 @@ impl VtScreen {
 
     pub fn set_dark_mode(&self, dark: bool) {
         let inner = self.inner.lock();
-        if let Some(state) = inner.callback_state.as_ref() {
-            state.dark_mode.store(dark, Ordering::Release);
-        }
+        inner
+            .callback_state
+            .dark_mode
+            .store(dark, Ordering::Release);
     }
 
     /// Returns `true` when at least one mouse-tracking mode is set
@@ -2421,37 +2451,24 @@ impl VtScreen {
         read_scrollbar(inner.terminal)
     }
 
-    /// Current working directory reported by shell integration (OSC 7).
-    ///
-    /// Returns `None` when the shell has not reported a cwd yet. Callers
-    /// should keep their launch cwd as a fallback for plain shells.
-    pub fn current_dir(&self) -> Option<String> {
-        let inner = self.inner.lock();
-        if inner.terminal.is_null() {
-            return None;
-        }
-        let mut pwd = GhosttyString::default();
-        let rc = unsafe {
-            ghostty_terminal_get(
-                inner.terminal,
-                GhosttyTerminalData::Pwd,
-                &mut pwd as *mut _ as *mut c_void,
-            )
-        };
-        if rc != 0 || pwd.ptr.is_null() || pwd.len == 0 {
-            return None;
-        }
+    /// Current title reported by OSC 0/2.
+    pub fn title(&self) -> Option<String> {
+        self.inner.lock().title.clone()
+    }
 
-        let bytes = unsafe { std::slice::from_raw_parts(pwd.ptr, pwd.len) };
-        let pwd = std::str::from_utf8(bytes).ok()?;
-        if pwd.is_empty() {
-            return None;
-        }
-        if pwd.starts_with("file://") {
-            parse_osc7_cwd(pwd)
-        } else {
-            Some(pwd.to_string())
-        }
+    /// Distinguishes no title report from an explicit title clear.
+    pub(crate) fn reported_title(&self) -> Option<Option<String>> {
+        let inner = self.inner.lock();
+        inner.title_reported.then(|| inner.title.clone())
+    }
+
+    /// Current working directory reported by shell integration.
+    ///
+    /// OSC 7 file URIs are decoded when the callback fires; OSC 9 and OSC 1337
+    /// paths are retained as reported. Returns `None` when the shell has not
+    /// reported a cwd or explicitly clears it.
+    pub fn current_dir(&self) -> Option<String> {
+        self.inner.lock().current_dir.clone()
     }
 
     /// Returns `true` while the alternate screen buffer is active.
@@ -2541,6 +2558,57 @@ impl VtScreen {
         };
         rc == 0 && config.value
     }
+}
+
+fn refresh_terminal_metadata(inner: &mut VtInner) {
+    let dirty = inner
+        .callback_state
+        .metadata_dirty
+        .swap(0, Ordering::Relaxed);
+    if dirty & METADATA_DIRTY_TITLE != 0 {
+        let title = with_terminal_bytes(inner.terminal, GhosttyTerminalData::Title, |bytes| {
+            (!bytes.is_empty()).then(|| String::from_utf8_lossy(bytes).into_owned())
+        });
+        if let Some(title) = title {
+            inner.title_reported = true;
+            inner.title = title;
+        }
+    }
+
+    if dirty & METADATA_DIRTY_PWD != 0 {
+        let current_dir = with_terminal_bytes(inner.terminal, GhosttyTerminalData::Pwd, |bytes| {
+            let pwd = std::str::from_utf8(bytes).ok()?;
+            if pwd.is_empty() {
+                None
+            } else if pwd.starts_with("file://") {
+                parse_osc7_cwd(pwd)
+            } else {
+                Some(pwd.to_owned())
+            }
+        });
+        if let Some(current_dir) = current_dir {
+            inner.current_dir = current_dir;
+        }
+    }
+}
+
+fn with_terminal_bytes<R>(
+    terminal: GhosttyTerminal,
+    data: GhosttyTerminalData,
+    read: impl FnOnce(&[u8]) -> R,
+) -> Option<R> {
+    let mut value = GhosttyString::default();
+    let rc =
+        unsafe { ghostty_terminal_get(terminal, data, (&mut value as *mut GhosttyString).cast()) };
+    if rc != GHOSTTY_SUCCESS || (value.ptr.is_null() && value.len > 0) {
+        return None;
+    }
+    if value.len == 0 {
+        return Some(read(&[]));
+    }
+    Some(read(unsafe {
+        std::slice::from_raw_parts(value.ptr, value.len)
+    }))
 }
 
 unsafe extern "C" fn vt_paste_read_callback(
@@ -2689,6 +2757,9 @@ unsafe extern "C" fn vt_write_pty_callback(
     }
 
     let state = unsafe { &*(userdata as *const VtCallbackState) };
+    let Some(write_pty) = state.write_pty.as_ref() else {
+        return;
+    };
     let bytes = unsafe { std::slice::from_raw_parts(data, len) };
     {
         let mut pending = state.pending_paste_write.lock();
@@ -2699,9 +2770,29 @@ unsafe extern "C" fn vt_write_pty_callback(
     }
 
     let _write_guard = state.write_order.lock();
-    if let Err(err) = (state.write_pty)(bytes, PtyWriteClass::ReservedControl) {
+    if let Err(err) = write_pty(bytes, PtyWriteClass::ReservedControl) {
         mark_control_write_failed(&state.write_failed, &err);
     }
+}
+
+unsafe extern "C" fn vt_title_changed_callback(_terminal: GhosttyTerminal, userdata: *mut c_void) {
+    if userdata.is_null() {
+        return;
+    }
+    let state = unsafe { &*(userdata as *const VtCallbackState) };
+    state
+        .metadata_dirty
+        .fetch_or(METADATA_DIRTY_TITLE, Ordering::Relaxed);
+}
+
+unsafe extern "C" fn vt_pwd_changed_callback(_terminal: GhosttyTerminal, userdata: *mut c_void) {
+    if userdata.is_null() {
+        return;
+    }
+    let state = unsafe { &*(userdata as *const VtCallbackState) };
+    state
+        .metadata_dirty
+        .fetch_or(METADATA_DIRTY_PWD, Ordering::Relaxed);
 }
 
 fn mark_control_write_failed(write_failed: &AtomicBool, err: &std::io::Error) {
@@ -3335,6 +3426,14 @@ mod tests {
         assert_eq!(
             types["GhosttyTerminalOption"]["values"]["CLIPBOARD_READ"].as_i64(),
             Some(GhosttyTerminalOption::ClipboardRead as i64)
+        );
+        assert_eq!(
+            types["GhosttyTerminalOption"]["values"]["TITLE_CHANGED"].as_i64(),
+            Some(GhosttyTerminalOption::TitleChanged as i64)
+        );
+        assert_eq!(
+            types["GhosttyTerminalOption"]["values"]["PWD_CHANGED"].as_i64(),
+            Some(GhosttyTerminalOption::PwdChanged as i64)
         );
         for (name, size, align) in [
             (
@@ -4076,8 +4175,6 @@ mod tests {
                     .inner
                     .lock()
                     .callback_state
-                    .as_ref()
-                    .expect("callback state")
                     .clipboard_text
                     .lock()
                     .as_deref(),
@@ -4111,6 +4208,27 @@ mod tests {
     }
 
     #[test]
+    fn vt_screen_tracks_title_effects_without_a_pty_writer() {
+        let screen = VtScreen::new(80, 24, None).expect("create vt screen");
+
+        assert_eq!(screen.reported_title(), None);
+        assert_eq!(screen.title(), None);
+
+        screen.feed(b"\x1b]0;first title\x07\x1b]2;final title\x1b\\");
+
+        assert_eq!(
+            screen.reported_title(),
+            Some(Some("final title".to_owned()))
+        );
+        assert_eq!(screen.title().as_deref(), Some("final title"));
+
+        screen.feed(b"\x1b]2;\x07");
+
+        assert_eq!(screen.reported_title(), Some(None));
+        assert_eq!(screen.title(), None);
+    }
+
+    #[test]
     fn vt_screen_reports_osc7_current_dir() {
         let screen = VtScreen::new(80, 24, None).expect("create vt screen");
 
@@ -4118,6 +4236,19 @@ mod tests {
         screen.feed(b"\x1b]7;file:///tmp/con-vt-cwd\x07");
 
         assert_eq!(screen.current_dir().as_deref(), Some("/tmp/con-vt-cwd"));
+    }
+
+    #[test]
+    fn vt_screen_coalesces_and_clears_current_dir_effects_without_a_pty_writer() {
+        let screen = VtScreen::new(80, 24, None).expect("create vt screen");
+
+        screen.feed(b"\x1b]7;file:///tmp/first\x07\x1b]9;9;/tmp/final\x1b\\");
+
+        assert_eq!(screen.current_dir().as_deref(), Some("/tmp/final"));
+
+        screen.feed(b"\x1b]7;\x07");
+
+        assert_eq!(screen.current_dir(), None);
     }
 
     #[test]

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -37,7 +37,7 @@ use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU16, AtomicU32, AtomicU64, O
 use std::time::Instant;
 
 use crate::stub::GhosttyScrollbar;
-use crate::{TERMINAL_PROGRESS_TIMEOUT, TerminalProgress};
+use crate::{CLIPBOARD_WRITE_LIMIT_BYTES, TERMINAL_PROGRESS_TIMEOUT, TerminalProgress};
 
 use image::{ImageFormat, ImageReader, Limits};
 use parking_lot::Mutex;
@@ -205,11 +205,13 @@ pub enum GhosttyTerminalOption {
     ColorPalette = 14,
     KittyImageStorageLimit = 15,
     PwdChanged = 25,
+    ClipboardWrite = 26,
     ScrollbackMaxLines = 28,
     ProgressReport = 30,
     UnknownSequence = 35,
     UnknownMaxBytes = 36,
     ClipboardRead = 38,
+    ClipboardWriteMaxBytes = 39,
 }
 
 /// `GHOSTTY_SYS_OPT_*` keys for process-global optional services.
@@ -492,6 +494,40 @@ pub struct GhosttyClipboardContent {
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GhosttyClipboardWriteResult {
+    Success = 0,
+    Denied = 1,
+    Unsupported = 2,
+    Busy = 3,
+    InvalidData = 4,
+    IoError = 5,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct GhosttyClipboardWriteReply {
+    pub size: usize,
+    pub result: GhosttyClipboardWriteResult,
+    pub remember: bool,
+}
+
+#[repr(C)]
+pub struct GhosttyClipboardWrite {
+    pub size: usize,
+    pub location: GhosttyClipboardLocation,
+    pub contents: *const GhosttyClipboardContent,
+    pub contents_len: usize,
+    pub name: GhosttyString,
+    pub granted: bool,
+    pub can_remember: bool,
+    pub ctx: *const c_void,
+    pub reply: Option<
+        unsafe extern "C" fn(*const GhosttyClipboardWrite, *const GhosttyClipboardWriteReply),
+    >,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GhosttyClipboardReadResult {
     Success = 0,
     Denied = 1,
@@ -567,6 +603,8 @@ const _: [(); 16] = [(); std::mem::size_of::<GhosttyWriter>()];
 const _: [(); 16] = [(); std::mem::size_of::<GhosttyMimeReader>()];
 const _: [(); 56] = [(); std::mem::size_of::<GhosttyPaste>()];
 const _: [(); 32] = [(); std::mem::size_of::<GhosttyClipboardContent>()];
+const _: [(); 16] = [(); std::mem::size_of::<GhosttyClipboardWriteReply>()];
+const _: [(); 72] = [(); std::mem::size_of::<GhosttyClipboardWrite>()];
 const _: [(); 56] = [(); std::mem::size_of::<GhosttyClipboardReadReply>()];
 const _: [(); 80] = [(); std::mem::size_of::<GhosttyClipboardRead>()];
 const _: [(); 24] = [(); std::mem::size_of::<GhosttySysImage>()];
@@ -1229,6 +1267,8 @@ struct VtCallbackState {
     /// callback ABI. If its reserved queue capacity is exhausted, fail the
     /// session explicitly rather than continuing with desynchronized state.
     write_failed: Arc<AtomicBool>,
+    clipboard_write_enabled: AtomicBool,
+    pending_clipboard_write: Mutex<Option<String>>,
     /// Active only during `ghostty_terminal_paste`. The C callback cannot
     /// return an I/O result, so buffer the complete logical paste and perform
     /// one fallible host enqueue after libghostty returns.
@@ -1565,12 +1605,27 @@ impl VtScreen {
             anyhow::bail!("ghostty_terminal_set(KITTY_IMAGE_STORAGE_LIMIT) failed: rc={rc}");
         }
 
+        let clipboard_write_max_bytes = CLIPBOARD_WRITE_LIMIT_BYTES;
+        let rc = unsafe {
+            ghostty_terminal_set(
+                terminal,
+                GhosttyTerminalOption::ClipboardWriteMaxBytes,
+                &clipboard_write_max_bytes as *const _ as *const c_void,
+            )
+        };
+        if rc != 0 {
+            unsafe { ghostty_terminal_free(terminal) };
+            anyhow::bail!("ghostty_terminal_set(CLIPBOARD_WRITE_MAX_BYTES) failed: rc={rc}");
+        }
+
         let mut callback_state = Box::new(VtCallbackState {
             write_pty,
             write_order: Arc::new(Mutex::new(())),
             enquiry_response: b"con".to_vec().into_boxed_slice(),
             clipboard_text: Mutex::new(None),
             write_failed: Arc::new(AtomicBool::new(false)),
+            clipboard_write_enabled: AtomicBool::new(false),
+            pending_clipboard_write: Mutex::new(None),
             pending_paste_write: Mutex::new(None),
             rows: AtomicU16::new(rows),
             cols: AtomicU16::new(cols),
@@ -1839,6 +1894,50 @@ impl VtScreen {
                 last_cursor: Cursor::default(),
             })),
         })
+    }
+
+    pub fn set_clipboard_write_enabled(&self, enabled: bool) -> Result<(), String> {
+        let inner = self.inner.lock();
+        if !enabled {
+            inner
+                .callback_state
+                .clipboard_write_enabled
+                .store(false, Ordering::Release);
+            inner.callback_state.pending_clipboard_write.lock().take();
+        }
+        let callback = if enabled {
+            vt_clipboard_write_callback as *const c_void
+        } else {
+            std::ptr::null()
+        };
+        let rc = unsafe {
+            ghostty_terminal_set(
+                inner.terminal,
+                GhosttyTerminalOption::ClipboardWrite,
+                callback,
+            )
+        };
+        if rc != 0 {
+            return Err(format!(
+                "ghostty_terminal_set(CLIPBOARD_WRITE) failed: rc={rc}"
+            ));
+        }
+        if enabled {
+            inner
+                .callback_state
+                .clipboard_write_enabled
+                .store(true, Ordering::Release);
+        }
+        Ok(())
+    }
+
+    pub fn take_clipboard_write(&self) -> Option<String> {
+        self.inner
+            .lock()
+            .callback_state
+            .pending_clipboard_write
+            .lock()
+            .take()
     }
 
     /// Replace the default fg/bg/palette. Bumps the snapshot
@@ -2737,6 +2836,81 @@ unsafe extern "C" fn vt_paste_read_callback(
         return true;
     }
     unsafe { write(writer.userdata, reader.text.as_ptr(), reader.text.len()) }
+}
+
+unsafe extern "C" fn vt_clipboard_write_callback(
+    _terminal: GhosttyTerminal,
+    userdata: *mut c_void,
+    write: *const GhosttyClipboardWrite,
+) {
+    if userdata.is_null() || write.is_null() {
+        return;
+    }
+    if unsafe { (*write).size } < std::mem::size_of::<GhosttyClipboardWrite>() {
+        return;
+    }
+
+    let state = unsafe { &*(userdata as *const VtCallbackState) };
+    let write = unsafe { &*write };
+    if write.reply.is_none() {
+        return;
+    }
+
+    let result = if !state.clipboard_write_enabled.load(Ordering::Acquire) {
+        GhosttyClipboardWriteResult::Denied
+    } else if write.location != GhosttyClipboardLocation::Standard {
+        GhosttyClipboardWriteResult::Unsupported
+    } else {
+        let text = if write.contents_len == 0 {
+            Ok("")
+        } else if write.contents_len > 1 {
+            Err(GhosttyClipboardWriteResult::Unsupported)
+        } else if write.contents.is_null() {
+            Err(GhosttyClipboardWriteResult::InvalidData)
+        } else {
+            let content = unsafe { &*write.contents };
+            if !ghostty_string_is_supported_text(content.mime) {
+                Err(GhosttyClipboardWriteResult::Unsupported)
+            } else if content.data.len > CLIPBOARD_WRITE_LIMIT_BYTES
+                || (content.data.ptr.is_null() && content.data.len > 0)
+            {
+                Err(GhosttyClipboardWriteResult::InvalidData)
+            } else {
+                let bytes = if content.data.len == 0 {
+                    &[]
+                } else {
+                    unsafe { std::slice::from_raw_parts(content.data.ptr, content.data.len) }
+                };
+                std::str::from_utf8(bytes).map_err(|_| GhosttyClipboardWriteResult::InvalidData)
+            }
+        };
+        match text {
+            Err(result) => result,
+            Ok(text) => {
+                let mut pending = state.pending_clipboard_write.lock();
+                if !state.clipboard_write_enabled.load(Ordering::Acquire) {
+                    GhosttyClipboardWriteResult::Denied
+                } else {
+                    *pending = Some(text.to_owned());
+                    GhosttyClipboardWriteResult::Success
+                }
+            }
+        }
+    };
+
+    reply_clipboard_write(write, result);
+}
+
+fn reply_clipboard_write(write: &GhosttyClipboardWrite, result: GhosttyClipboardWriteResult) {
+    let Some(reply) = write.reply else {
+        return;
+    };
+    let reply_value = GhosttyClipboardWriteReply {
+        size: std::mem::size_of::<GhosttyClipboardWriteReply>(),
+        result,
+        remember: false,
+    };
+    unsafe { reply(write, &reply_value) };
 }
 
 /// Clipboard reads initiated by a running program are denied by default.
@@ -3684,6 +3858,14 @@ mod tests {
             Some(GhosttyTerminalOption::ClipboardRead as i64)
         );
         assert_eq!(
+            types["GhosttyTerminalOption"]["values"]["CLIPBOARD_WRITE"].as_i64(),
+            Some(GhosttyTerminalOption::ClipboardWrite as i64)
+        );
+        assert_eq!(
+            types["GhosttyTerminalOption"]["values"]["CLIPBOARD_WRITE_MAX_BYTES"].as_i64(),
+            Some(GhosttyTerminalOption::ClipboardWriteMaxBytes as i64)
+        );
+        assert_eq!(
             types["GhosttyTerminalOption"]["values"]["BELL"].as_i64(),
             Some(GhosttyTerminalOption::Bell as i64)
         );
@@ -3727,6 +3909,16 @@ mod tests {
                 "GhosttyClipboardContent",
                 std::mem::size_of::<GhosttyClipboardContent>(),
                 std::mem::align_of::<GhosttyClipboardContent>(),
+            ),
+            (
+                "GhosttyClipboardWriteReply",
+                std::mem::size_of::<GhosttyClipboardWriteReply>(),
+                std::mem::align_of::<GhosttyClipboardWriteReply>(),
+            ),
+            (
+                "GhosttyClipboardWrite",
+                std::mem::size_of::<GhosttyClipboardWrite>(),
+                std::mem::align_of::<GhosttyClipboardWrite>(),
             ),
             (
                 "GhosttyClipboardReadReply",
@@ -3799,6 +3991,20 @@ mod tests {
                 types["GhosttyPasteSource"]["values"][name].as_i64(),
                 Some(value as i64),
                 "GhosttyPasteSource::{name}"
+            );
+        }
+        for (name, value) in [
+            ("SUCCESS", GhosttyClipboardWriteResult::Success),
+            ("DENIED", GhosttyClipboardWriteResult::Denied),
+            ("UNSUPPORTED", GhosttyClipboardWriteResult::Unsupported),
+            ("BUSY", GhosttyClipboardWriteResult::Busy),
+            ("INVALID_DATA", GhosttyClipboardWriteResult::InvalidData),
+            ("IO_ERROR", GhosttyClipboardWriteResult::IoError),
+        ] {
+            assert_eq!(
+                types["GhosttyClipboardWriteResult"]["values"][name].as_i64(),
+                Some(value as i64),
+                "GhosttyClipboardWriteResult::{name}"
             );
         }
         for (name, value) in [
@@ -4308,6 +4514,34 @@ mod tests {
 
         assert_eq!(rc, 0);
         assert_eq!(max_lines, 10_000);
+    }
+
+    #[test]
+    fn terminal_clipboard_writes_require_opt_in_and_coalesce_pending_text() {
+        let screen = VtScreen::new(80, 24, None).expect("create vt screen");
+
+        screen.feed(b"\x1b]52;c;aGVsbG8=\x07");
+        assert_eq!(screen.take_clipboard_write(), None);
+
+        screen
+            .set_clipboard_write_enabled(true)
+            .expect("enable clipboard writes");
+        screen.feed(b"\x1b]52;c;aGVsbG8=\x07");
+        screen.feed(b"\x1b]52;c;d29ybGQ=\x07");
+        assert_eq!(screen.take_clipboard_write().as_deref(), Some("world"));
+        assert_eq!(screen.take_clipboard_write(), None);
+
+        screen.feed(b"\x1b]52;c;/w==\x07");
+        assert_eq!(screen.take_clipboard_write(), None);
+
+        screen.feed(b"\x1b]52;c;\x07");
+        assert_eq!(screen.take_clipboard_write().as_deref(), Some(""));
+
+        screen.feed(b"\x1b]52;c;YWdhaW4=\x07");
+        screen
+            .set_clipboard_write_enabled(false)
+            .expect("disable clipboard writes");
+        assert_eq!(screen.take_clipboard_write(), None);
     }
 
     #[test]

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -1202,6 +1202,7 @@ struct VtCallbackState {
     dark_mode: AtomicBool,
     device_attributes: GhosttyDeviceAttributes,
     metadata_dirty: AtomicU8,
+    bell_pending: AtomicBool,
 }
 
 struct VtInner {
@@ -1537,6 +1538,7 @@ impl VtScreen {
             dark_mode: AtomicBool::new(false),
             device_attributes: default_device_attributes(),
             metadata_dirty: AtomicU8::new(0),
+            bell_pending: AtomicBool::new(false),
         });
         let userdata = callback_state.as_mut() as *mut VtCallbackState as *mut c_void;
         let rc =
@@ -1602,6 +1604,11 @@ impl VtScreen {
         }
 
         let effect_callbacks = [
+            (
+                GhosttyTerminalOption::Bell,
+                vt_bell_callback as *const c_void,
+                "BELL",
+            ),
             (
                 GhosttyTerminalOption::TitleChanged,
                 vt_title_changed_callback as *const c_void,
@@ -1781,6 +1788,15 @@ impl VtScreen {
 
     pub fn generation(&self) -> u64 {
         self.inner.lock().generation
+    }
+
+    /// Consume one or more bells coalesced since the previous drain.
+    pub fn take_bell(&self) -> bool {
+        self.inner
+            .lock()
+            .callback_state
+            .bell_pending
+            .swap(false, Ordering::Relaxed)
     }
 
     pub fn is_write_desynchronized(&self) -> bool {
@@ -2775,6 +2791,14 @@ unsafe extern "C" fn vt_write_pty_callback(
     }
 }
 
+unsafe extern "C" fn vt_bell_callback(_terminal: GhosttyTerminal, userdata: *mut c_void) {
+    if userdata.is_null() {
+        return;
+    }
+    let state = unsafe { &*(userdata as *const VtCallbackState) };
+    state.bell_pending.store(true, Ordering::Relaxed);
+}
+
 unsafe extern "C" fn vt_title_changed_callback(_terminal: GhosttyTerminal, userdata: *mut c_void) {
     if userdata.is_null() {
         return;
@@ -3426,6 +3450,10 @@ mod tests {
         assert_eq!(
             types["GhosttyTerminalOption"]["values"]["CLIPBOARD_READ"].as_i64(),
             Some(GhosttyTerminalOption::ClipboardRead as i64)
+        );
+        assert_eq!(
+            types["GhosttyTerminalOption"]["values"]["BELL"].as_i64(),
+            Some(GhosttyTerminalOption::Bell as i64)
         );
         assert_eq!(
             types["GhosttyTerminalOption"]["values"]["TITLE_CHANGED"].as_i64(),
@@ -4205,6 +4233,21 @@ mod tests {
             .expect_err("oversized paste must be rejected");
 
         assert!(err.to_string().contains("safety limit"));
+    }
+
+    #[test]
+    fn vt_screen_coalesces_bell_effects_until_the_host_drains_them() {
+        let screen = VtScreen::new(80, 24, None).expect("create vt screen");
+
+        screen.feed(b"\x1b]2;OSC terminator\x07");
+        assert!(
+            !screen.take_bell(),
+            "an OSC terminator is not a bell effect"
+        );
+
+        screen.feed(b"\x07\x07");
+        assert!(screen.take_bell());
+        assert!(!screen.take_bell());
     }
 
     #[test]

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -37,6 +37,7 @@ use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU16, AtomicU32, AtomicU64, O
 use std::time::Instant;
 
 use crate::stub::GhosttyScrollbar;
+use crate::{TERMINAL_PROGRESS_TIMEOUT, TerminalProgress};
 
 use image::{ImageFormat, ImageReader, Limits};
 use parking_lot::Mutex;
@@ -205,6 +206,7 @@ pub enum GhosttyTerminalOption {
     KittyImageStorageLimit = 15,
     PwdChanged = 25,
     ScrollbackMaxLines = 28,
+    ProgressReport = 30,
     UnknownSequence = 35,
     UnknownMaxBytes = 36,
     ClipboardRead = 38,
@@ -407,6 +409,14 @@ pub struct GhosttyColorRgb {
 pub struct GhosttyString {
     pub ptr: *const u8,
     pub len: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct GhosttyTerminalProgressReport {
+    pub size: usize,
+    pub state: i32,
+    pub progress: i8,
 }
 
 const GHOSTTY_TERMINAL_UNKNOWN_SEQUENCE_APC: i32 = 0;
@@ -1231,6 +1241,8 @@ struct VtCallbackState {
     device_attributes: GhosttyDeviceAttributes,
     metadata_dirty: AtomicU8,
     bell_pending: AtomicBool,
+    progress_epoch: Instant,
+    progress: AtomicU64,
     unknown_sequence_log_count: AtomicU8,
 }
 
@@ -1568,6 +1580,8 @@ impl VtScreen {
             device_attributes: default_device_attributes(),
             metadata_dirty: AtomicU8::new(0),
             bell_pending: AtomicBool::new(false),
+            progress_epoch: Instant::now(),
+            progress: AtomicU64::new(0),
             unknown_sequence_log_count: AtomicU8::new(0),
         });
         let userdata = callback_state.as_mut() as *mut VtCallbackState as *mut c_void;
@@ -1648,6 +1662,11 @@ impl VtScreen {
                 GhosttyTerminalOption::PwdChanged,
                 vt_pwd_changed_callback as *const c_void,
                 "PWD_CHANGED",
+            ),
+            (
+                GhosttyTerminalOption::ProgressReport,
+                vt_progress_report_callback as *const c_void,
+                "PROGRESS_REPORT",
             ),
         ];
         for (option, callback, label) in effect_callbacks {
@@ -1853,6 +1872,24 @@ impl VtScreen {
             .callback_state
             .bell_pending
             .swap(false, Ordering::Relaxed)
+    }
+
+    pub fn progress(&self) -> Option<TerminalProgress> {
+        let inner = self.inner.lock();
+        let state = &inner.callback_state;
+        let encoded = state.progress.load(Ordering::Relaxed);
+        if encoded == 0 {
+            return None;
+        }
+        let progress =
+            decode_timed_terminal_progress(encoded, terminal_progress_tick(&state.progress_epoch));
+        if progress.is_none() {
+            let _ =
+                state
+                    .progress
+                    .compare_exchange(encoded, 0, Ordering::Relaxed, Ordering::Relaxed);
+        }
+        progress
     }
 
     pub fn is_write_desynchronized(&self) -> bool {
@@ -2855,6 +2892,84 @@ unsafe extern "C" fn vt_bell_callback(_terminal: GhosttyTerminal, userdata: *mut
     state.bell_pending.store(true, Ordering::Relaxed);
 }
 
+unsafe extern "C" fn vt_progress_report_callback(
+    _terminal: GhosttyTerminal,
+    userdata: *mut c_void,
+    report: *const GhosttyTerminalProgressReport,
+) {
+    if userdata.is_null() || report.is_null() {
+        return;
+    }
+    if unsafe { report.cast::<usize>().read_unaligned() }
+        < std::mem::size_of::<GhosttyTerminalProgressReport>()
+    {
+        return;
+    }
+    let report = unsafe { &*report };
+    let Some(progress) = TerminalProgress::from_ghostty_report(report.state, report.progress)
+    else {
+        return;
+    };
+    let state = unsafe { &*(userdata as *const VtCallbackState) };
+    state.progress.store(
+        encode_timed_terminal_progress(progress, terminal_progress_tick(&state.progress_epoch)),
+        Ordering::Relaxed,
+    );
+}
+
+fn encode_terminal_progress(progress: Option<TerminalProgress>) -> u16 {
+    let (state, percent) = match progress {
+        None => return 0,
+        Some(TerminalProgress::Running(percent)) => (1, percent),
+        Some(TerminalProgress::Error(percent)) => (2, percent),
+        Some(TerminalProgress::Indeterminate) => (3, None),
+        Some(TerminalProgress::Paused(percent)) => (4, percent),
+    };
+    (state << 8) | percent.map_or(0, |percent| u16::from(percent) + 1)
+}
+
+fn terminal_progress_tick(epoch: &Instant) -> u64 {
+    const MAX_TICK: u64 = u64::MAX >> u16::BITS;
+    u64::try_from(epoch.elapsed().as_millis())
+        .unwrap_or(u64::MAX)
+        .min(MAX_TICK - 1)
+        + 1
+}
+
+fn encode_timed_terminal_progress(progress: Option<TerminalProgress>, tick: u64) -> u64 {
+    let progress = encode_terminal_progress(progress);
+    if progress == 0 {
+        0
+    } else {
+        (tick << u16::BITS) | u64::from(progress)
+    }
+}
+
+fn decode_timed_terminal_progress(value: u64, now: u64) -> Option<TerminalProgress> {
+    let updated_at = value >> u16::BITS;
+    if updated_at == 0
+        || now.saturating_sub(updated_at)
+            >= u64::try_from(TERMINAL_PROGRESS_TIMEOUT.as_millis()).unwrap_or(u64::MAX)
+    {
+        return None;
+    }
+    decode_terminal_progress(value as u16)
+}
+
+fn decode_terminal_progress(value: u16) -> Option<TerminalProgress> {
+    let percent = match value & 0xff {
+        0 => None,
+        value => Some((value - 1) as u8),
+    };
+    match value >> 8 {
+        1 => Some(TerminalProgress::Running(percent)),
+        2 => Some(TerminalProgress::Error(percent)),
+        3 => Some(TerminalProgress::Indeterminate),
+        4 => Some(TerminalProgress::Paused(percent)),
+        _ => None,
+    }
+}
+
 unsafe extern "C" fn vt_unknown_sequence_callback(
     _terminal: GhosttyTerminal,
     userdata: *mut c_void,
@@ -3581,6 +3696,10 @@ mod tests {
             Some(GhosttyTerminalOption::PwdChanged as i64)
         );
         assert_eq!(
+            types["GhosttyTerminalOption"]["values"]["PROGRESS_REPORT"].as_i64(),
+            Some(GhosttyTerminalOption::ProgressReport as i64)
+        );
+        assert_eq!(
             types["GhosttyTerminalOption"]["values"]["UNKNOWN_SEQUENCE"].as_i64(),
             Some(GhosttyTerminalOption::UnknownSequence as i64)
         );
@@ -3618,6 +3737,11 @@ mod tests {
                 "GhosttyClipboardRead",
                 std::mem::size_of::<GhosttyClipboardRead>(),
                 std::mem::align_of::<GhosttyClipboardRead>(),
+            ),
+            (
+                "GhosttyTerminalProgressReport",
+                std::mem::size_of::<GhosttyTerminalProgressReport>(),
+                std::mem::align_of::<GhosttyTerminalProgressReport>(),
             ),
             (
                 "GhosttyTerminalUnknownStringSequence",
@@ -4388,6 +4512,41 @@ mod tests {
         screen.feed(b"\x07\x07");
         assert!(screen.take_bell());
         assert!(!screen.take_bell());
+    }
+
+    #[test]
+    fn vt_screen_tracks_latest_progress_report() {
+        let screen = VtScreen::new(80, 24, None).expect("create vt screen");
+
+        screen.feed(b"\x1b]9;4;1;42\x07\x1b]9;4;4;75\x1b\\");
+        assert_eq!(screen.progress(), Some(TerminalProgress::Paused(Some(75))));
+
+        screen.feed(b"\x1b]9;4;2");
+        screen.feed(b";7\x1b\\");
+        assert_eq!(screen.progress(), Some(TerminalProgress::Error(Some(7))));
+
+        screen.feed(b"\x1b]9;4;3\x07");
+        assert_eq!(screen.progress(), Some(TerminalProgress::Indeterminate));
+
+        screen.feed(b"\x1b]9;4;0\x07");
+        assert_eq!(screen.progress(), None);
+    }
+
+    #[test]
+    fn terminal_progress_expires_without_a_fresh_report() {
+        let progress = Some(TerminalProgress::Running(Some(42)));
+        let reported_at = 10;
+        let encoded = encode_timed_terminal_progress(progress, reported_at);
+        let timeout = u64::try_from(TERMINAL_PROGRESS_TIMEOUT.as_millis()).unwrap();
+
+        assert_eq!(
+            decode_timed_terminal_progress(encoded, reported_at + timeout - 1),
+            progress
+        );
+        assert_eq!(
+            decode_timed_terminal_progress(encoded, reported_at + timeout),
+            None
+        );
     }
 
     #[test]

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -38,8 +38,8 @@ use std::time::Instant;
 
 use crate::stub::GhosttyScrollbar;
 use crate::{
-    CLIPBOARD_WRITE_LIMIT_BYTES, DesktopNotification, DesktopNotificationPolicy,
-    TERMINAL_PROGRESS_TIMEOUT, TerminalProgress, desktop_notification_policy,
+    CLIPBOARD_WRITE_LIMIT_BYTES, ClipboardWritePolicy, DesktopNotification,
+    DesktopNotificationPolicy, TERMINAL_PROGRESS_TIMEOUT, TerminalProgress,
 };
 
 use image::{ImageFormat, ImageReader, Limits};
@@ -140,6 +140,7 @@ pub enum GhosttyTerminalData {
     KittyGraphics = 30,
     ScrollbackMaxLines = 35,
     Mode = 37,
+    ClipboardWriteMaxBytes = 40,
 }
 
 /// `GhosttyTerminalScrollbar` — current viewport position in the full
@@ -1281,6 +1282,7 @@ struct VtCallbackState {
     /// session explicitly rather than continuing with desynchronized state.
     write_failed: Arc<AtomicBool>,
     clipboard_write_enabled: AtomicBool,
+    clipboard_write_policy: Arc<ClipboardWritePolicy>,
     pending_clipboard_write: Mutex<Option<String>>,
     /// Active only during `ghostty_terminal_paste`. The C callback cannot
     /// return an I/O result, so buffer the complete logical paste and perform
@@ -1619,7 +1621,7 @@ impl VtScreen {
             anyhow::bail!("ghostty_terminal_set(KITTY_IMAGE_STORAGE_LIMIT) failed: rc={rc}");
         }
 
-        let clipboard_write_max_bytes = CLIPBOARD_WRITE_LIMIT_BYTES;
+        let clipboard_write_max_bytes = 0_usize;
         let rc = unsafe {
             ghostty_terminal_set(
                 terminal,
@@ -1639,6 +1641,7 @@ impl VtScreen {
             clipboard_text: Mutex::new(None),
             write_failed: Arc::new(AtomicBool::new(false)),
             clipboard_write_enabled: AtomicBool::new(false),
+            clipboard_write_policy: Arc::new(ClipboardWritePolicy::new(true)),
             pending_clipboard_write: Mutex::new(None),
             pending_paste_write: Mutex::new(None),
             rows: AtomicU16::new(rows),
@@ -1649,7 +1652,7 @@ impl VtScreen {
             device_attributes: default_device_attributes(),
             metadata_dirty: AtomicU8::new(0),
             bell_pending: AtomicBool::new(false),
-            desktop_notification_policy: desktop_notification_policy(),
+            desktop_notification_policy: Arc::new(DesktopNotificationPolicy::default()),
             progress_epoch: Instant::now(),
             progress: AtomicU64::new(0),
             unknown_sequence_log_count: AtomicU8::new(0),
@@ -1918,46 +1921,98 @@ impl VtScreen {
 
     pub fn set_clipboard_write_enabled(&self, enabled: bool) -> Result<(), String> {
         let inner = self.inner.lock();
-        if !enabled {
-            inner
-                .callback_state
-                .clipboard_write_enabled
-                .store(false, Ordering::Release);
-            inner.callback_state.pending_clipboard_write.lock().take();
-        }
-        let callback = if enabled {
-            vt_clipboard_write_callback as *const c_void
-        } else {
-            std::ptr::null()
-        };
-        let rc = unsafe {
-            ghostty_terminal_set(
-                inner.terminal,
-                GhosttyTerminalOption::ClipboardWrite,
-                callback,
-            )
-        };
-        if rc != 0 {
-            return Err(format!(
-                "ghostty_terminal_set(CLIPBOARD_WRITE) failed: rc={rc}"
-            ));
-        }
         if enabled {
+            let clipboard_write_max_bytes = CLIPBOARD_WRITE_LIMIT_BYTES;
+            let rc = unsafe {
+                ghostty_terminal_set(
+                    inner.terminal,
+                    GhosttyTerminalOption::ClipboardWriteMaxBytes,
+                    &clipboard_write_max_bytes as *const _ as *const c_void,
+                )
+            };
+            if rc != 0 {
+                return Err(format!(
+                    "ghostty_terminal_set(CLIPBOARD_WRITE_MAX_BYTES) failed: rc={rc}"
+                ));
+            }
+
+            let rc = unsafe {
+                ghostty_terminal_set(
+                    inner.terminal,
+                    GhosttyTerminalOption::ClipboardWrite,
+                    vt_clipboard_write_callback as *const c_void,
+                )
+            };
+            if rc != 0 {
+                let disabled_limit = 0_usize;
+                let _ = unsafe {
+                    ghostty_terminal_set(
+                        inner.terminal,
+                        GhosttyTerminalOption::ClipboardWriteMaxBytes,
+                        &disabled_limit as *const _ as *const c_void,
+                    )
+                };
+                return Err(format!(
+                    "ghostty_terminal_set(CLIPBOARD_WRITE) failed: rc={rc}"
+                ));
+            }
             inner
                 .callback_state
                 .clipboard_write_enabled
                 .store(true, Ordering::Release);
+            return Ok(());
+        }
+
+        inner
+            .callback_state
+            .clipboard_write_enabled
+            .store(false, Ordering::Release);
+        inner.callback_state.pending_clipboard_write.lock().take();
+        let callback_rc = unsafe {
+            ghostty_terminal_set(
+                inner.terminal,
+                GhosttyTerminalOption::ClipboardWrite,
+                std::ptr::null(),
+            )
+        };
+        let disabled_limit = 0_usize;
+        let limit_rc = unsafe {
+            ghostty_terminal_set(
+                inner.terminal,
+                GhosttyTerminalOption::ClipboardWriteMaxBytes,
+                &disabled_limit as *const _ as *const c_void,
+            )
+        };
+        if callback_rc != 0 {
+            return Err(format!(
+                "ghostty_terminal_set(CLIPBOARD_WRITE) failed: rc={callback_rc}"
+            ));
+        }
+        if limit_rc != 0 {
+            return Err(format!(
+                "ghostty_terminal_set(CLIPBOARD_WRITE_MAX_BYTES) failed: rc={limit_rc}"
+            ));
         }
         Ok(())
     }
 
     pub fn take_clipboard_write(&self) -> Option<String> {
-        self.inner
-            .lock()
-            .callback_state
-            .pending_clipboard_write
-            .lock()
-            .take()
+        let inner = self.inner.lock();
+        let state = &inner.callback_state;
+        let pending = state.pending_clipboard_write.lock().take();
+        if state.clipboard_write_policy.is_enabled() {
+            pending
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn set_clipboard_write_policy(&self, policy: Arc<ClipboardWritePolicy>) {
+        let mut inner = self.inner.lock();
+        if !policy.is_enabled() {
+            inner.callback_state.pending_clipboard_write.lock().take();
+        }
+        inner.callback_state.clipboard_write_policy = policy;
     }
 
     pub fn take_desktop_notification(&self) -> Option<DesktopNotification> {
@@ -2888,7 +2943,9 @@ unsafe extern "C" fn vt_clipboard_write_callback(
         return;
     }
 
-    let result = if !state.clipboard_write_enabled.load(Ordering::Acquire) {
+    let result = if !state.clipboard_write_enabled.load(Ordering::Acquire)
+        || !state.clipboard_write_policy.is_enabled()
+    {
         GhosttyClipboardWriteResult::Denied
     } else if write.location != GhosttyClipboardLocation::Standard {
         GhosttyClipboardWriteResult::Unsupported
@@ -2920,7 +2977,9 @@ unsafe extern "C" fn vt_clipboard_write_callback(
             Err(result) => result,
             Ok(text) => {
                 let mut pending = state.pending_clipboard_write.lock();
-                if !state.clipboard_write_enabled.load(Ordering::Acquire) {
+                if !state.clipboard_write_enabled.load(Ordering::Acquire)
+                    || !state.clipboard_write_policy.is_enabled()
+                {
                     GhosttyClipboardWriteResult::Denied
                 } else {
                     *pending = Some(text.to_owned());
@@ -3961,6 +4020,10 @@ mod tests {
             types["GhosttyTerminalOption"]["values"]["UNKNOWN_MAX_BYTES"].as_i64(),
             Some(GhosttyTerminalOption::UnknownMaxBytes as i64)
         );
+        assert_eq!(
+            types["GhosttyTerminalData"]["values"]["CLIPBOARD_WRITE_MAX_BYTES"].as_i64(),
+            Some(GhosttyTerminalData::ClipboardWriteMaxBytes as i64)
+        );
         for (name, size, align) in [
             (
                 "GhosttyWriter",
@@ -4596,13 +4659,30 @@ mod tests {
     #[test]
     fn terminal_clipboard_writes_require_opt_in_and_coalesce_pending_text() {
         let screen = VtScreen::new(80, 24, None).expect("create vt screen");
+        let policy = Arc::new(ClipboardWritePolicy::new(true));
+        screen.set_clipboard_write_policy(policy.clone());
+        let clipboard_write_limit = || {
+            let inner = screen.inner.lock();
+            let mut limit = usize::MAX;
+            let rc = unsafe {
+                ghostty_terminal_get(
+                    inner.terminal,
+                    GhosttyTerminalData::ClipboardWriteMaxBytes,
+                    &mut limit as *mut _ as *mut c_void,
+                )
+            };
+            assert_eq!(rc, 0);
+            limit
+        };
 
+        assert_eq!(clipboard_write_limit(), 0);
         screen.feed(b"\x1b]52;c;aGVsbG8=\x07");
         assert_eq!(screen.take_clipboard_write(), None);
 
         screen
             .set_clipboard_write_enabled(true)
             .expect("enable clipboard writes");
+        assert_eq!(clipboard_write_limit(), CLIPBOARD_WRITE_LIMIT_BYTES);
         screen.feed(b"\x1b]52;c;aGVsbG8=\x07");
         screen.feed(b"\x1b]52;c;d29ybGQ=\x07");
         assert_eq!(screen.take_clipboard_write().as_deref(), Some("world"));
@@ -4614,10 +4694,18 @@ mod tests {
         screen.feed(b"\x1b]52;c;\x07");
         assert_eq!(screen.take_clipboard_write().as_deref(), Some(""));
 
+        screen.feed(b"\x1b]52;c;YmxvY2tlZA==\x07");
+        policy.set_enabled(false);
+        assert_eq!(screen.take_clipboard_write(), None);
+        screen.feed(b"\x1b]52;c;ZGVuaWVk\x07");
+        policy.set_enabled(true);
+        assert_eq!(screen.take_clipboard_write(), None);
+
         screen.feed(b"\x1b]52;c;YWdhaW4=\x07");
         screen
             .set_clipboard_write_enabled(false)
             .expect("disable clipboard writes");
+        assert_eq!(clipboard_write_limit(), 0);
         assert_eq!(screen.take_clipboard_write(), None);
     }
 

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -107,6 +107,9 @@ const GHOSTTY_KITTY_KEY_REPORT_EVENTS: u8 = 1 << 1;
 const TEXT_PLAIN_MIME: &[u8] = b"text/plain";
 const METADATA_DIRTY_TITLE: u8 = 1 << 0;
 const METADATA_DIRTY_PWD: u8 = 1 << 1;
+const UNKNOWN_SEQUENCE_LOG_TARGET: &str = "con_ghostty::vt::unknown_sequence";
+const UNKNOWN_SEQUENCE_MAX_BYTES: usize = 256;
+const UNKNOWN_SEQUENCE_LOG_LIMIT: u8 = 16;
 
 // ── Enums (keys) ───────────────────────────────────────────────────────
 //
@@ -202,6 +205,8 @@ pub enum GhosttyTerminalOption {
     KittyImageStorageLimit = 15,
     PwdChanged = 25,
     ScrollbackMaxLines = 28,
+    UnknownSequence = 35,
+    UnknownMaxBytes = 36,
     ClipboardRead = 38,
 }
 
@@ -402,6 +407,29 @@ pub struct GhosttyColorRgb {
 pub struct GhosttyString {
     pub ptr: *const u8,
     pub len: usize,
+}
+
+const GHOSTTY_TERMINAL_UNKNOWN_SEQUENCE_APC: i32 = 0;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct GhosttyTerminalUnknownStringSequence {
+    pub truncated: bool,
+    pub content: GhosttyString,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union GhosttyTerminalUnknownSequenceValue {
+    pub apc: GhosttyTerminalUnknownStringSequence,
+    pub _padding: [u64; 16],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct GhosttyTerminalUnknownSequence {
+    pub tag: i32,
+    pub value: GhosttyTerminalUnknownSequenceValue,
 }
 
 #[repr(C)]
@@ -1203,6 +1231,7 @@ struct VtCallbackState {
     device_attributes: GhosttyDeviceAttributes,
     metadata_dirty: AtomicU8,
     bell_pending: AtomicBool,
+    unknown_sequence_log_count: AtomicU8,
 }
 
 struct VtInner {
@@ -1539,6 +1568,7 @@ impl VtScreen {
             device_attributes: default_device_attributes(),
             metadata_dirty: AtomicU8::new(0),
             bell_pending: AtomicBool::new(false),
+            unknown_sequence_log_count: AtomicU8::new(0),
         });
         let userdata = callback_state.as_mut() as *mut VtCallbackState as *mut c_void;
         let rc =
@@ -1625,6 +1655,32 @@ impl VtScreen {
             if rc != 0 {
                 unsafe { ghostty_terminal_free(terminal) };
                 anyhow::bail!("ghostty_terminal_set({label}) failed: rc={rc}");
+            }
+        }
+
+        if log::log_enabled!(target: UNKNOWN_SEQUENCE_LOG_TARGET, log::Level::Debug) {
+            let rc = unsafe {
+                ghostty_terminal_set(
+                    terminal,
+                    GhosttyTerminalOption::UnknownMaxBytes,
+                    &UNKNOWN_SEQUENCE_MAX_BYTES as *const _ as *const c_void,
+                )
+            };
+            if rc != 0 {
+                unsafe { ghostty_terminal_free(terminal) };
+                anyhow::bail!("ghostty_terminal_set(UNKNOWN_MAX_BYTES) failed: rc={rc}");
+            }
+
+            let rc = unsafe {
+                ghostty_terminal_set(
+                    terminal,
+                    GhosttyTerminalOption::UnknownSequence,
+                    vt_unknown_sequence_callback as *const c_void,
+                )
+            };
+            if rc != 0 {
+                unsafe { ghostty_terminal_free(terminal) };
+                anyhow::bail!("ghostty_terminal_set(UNKNOWN_SEQUENCE) failed: rc={rc}");
             }
         }
 
@@ -2799,6 +2855,67 @@ unsafe extern "C" fn vt_bell_callback(_terminal: GhosttyTerminal, userdata: *mut
     state.bell_pending.store(true, Ordering::Relaxed);
 }
 
+unsafe extern "C" fn vt_unknown_sequence_callback(
+    _terminal: GhosttyTerminal,
+    userdata: *mut c_void,
+    sequence: *const GhosttyTerminalUnknownSequence,
+) {
+    if userdata.is_null()
+        || sequence.is_null()
+        || !log::log_enabled!(target: UNKNOWN_SEQUENCE_LOG_TARGET, log::Level::Debug)
+    {
+        return;
+    }
+
+    let state = unsafe { &*(userdata as *const VtCallbackState) };
+    let Ok(log_index) = state.unknown_sequence_log_count.fetch_update(
+        Ordering::Relaxed,
+        Ordering::Relaxed,
+        |count| (count <= UNKNOWN_SEQUENCE_LOG_LIMIT).then_some(count + 1),
+    ) else {
+        return;
+    };
+    if log_index == UNKNOWN_SEQUENCE_LOG_LIMIT {
+        log::debug!(
+            target: UNKNOWN_SEQUENCE_LOG_TARGET,
+            "further unknown terminal sequences suppressed"
+        );
+        return;
+    }
+
+    let sequence = unsafe { &*sequence };
+    if sequence.tag != GHOSTTY_TERMINAL_UNKNOWN_SEQUENCE_APC {
+        log::debug!(
+            target: UNKNOWN_SEQUENCE_LOG_TARGET,
+            "unknown terminal sequence tag={}",
+            sequence.tag
+        );
+        return;
+    }
+
+    let apc = unsafe { sequence.value.apc };
+    if apc.content.ptr.is_null() && apc.content.len != 0 {
+        log::debug!(
+            target: UNKNOWN_SEQUENCE_LOG_TARGET,
+            "unknown APC has invalid content pointer len={} truncated={}",
+            apc.content.len,
+            apc.truncated
+        );
+        return;
+    }
+    let content = if apc.content.len == 0 {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(apc.content.ptr, apc.content.len) }
+    };
+    log::debug!(
+        target: UNKNOWN_SEQUENCE_LOG_TARGET,
+        "unknown APC len={} truncated={} content={content:02x?}",
+        content.len(),
+        apc.truncated
+    );
+}
+
 unsafe extern "C" fn vt_title_changed_callback(_terminal: GhosttyTerminal, userdata: *mut c_void) {
     if userdata.is_null() {
         return;
@@ -3463,6 +3580,14 @@ mod tests {
             types["GhosttyTerminalOption"]["values"]["PWD_CHANGED"].as_i64(),
             Some(GhosttyTerminalOption::PwdChanged as i64)
         );
+        assert_eq!(
+            types["GhosttyTerminalOption"]["values"]["UNKNOWN_SEQUENCE"].as_i64(),
+            Some(GhosttyTerminalOption::UnknownSequence as i64)
+        );
+        assert_eq!(
+            types["GhosttyTerminalOption"]["values"]["UNKNOWN_MAX_BYTES"].as_i64(),
+            Some(GhosttyTerminalOption::UnknownMaxBytes as i64)
+        );
         for (name, size, align) in [
             (
                 "GhosttyWriter",
@@ -3493,6 +3618,21 @@ mod tests {
                 "GhosttyClipboardRead",
                 std::mem::size_of::<GhosttyClipboardRead>(),
                 std::mem::align_of::<GhosttyClipboardRead>(),
+            ),
+            (
+                "GhosttyTerminalUnknownStringSequence",
+                std::mem::size_of::<GhosttyTerminalUnknownStringSequence>(),
+                std::mem::align_of::<GhosttyTerminalUnknownStringSequence>(),
+            ),
+            (
+                "GhosttyTerminalUnknownSequenceValue",
+                std::mem::size_of::<GhosttyTerminalUnknownSequenceValue>(),
+                std::mem::align_of::<GhosttyTerminalUnknownSequenceValue>(),
+            ),
+            (
+                "GhosttyTerminalUnknownSequence",
+                std::mem::size_of::<GhosttyTerminalUnknownSequence>(),
+                std::mem::align_of::<GhosttyTerminalUnknownSequence>(),
             ),
             (
                 "GhosttySysImage",

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -37,7 +37,10 @@ use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU16, AtomicU32, AtomicU64, O
 use std::time::Instant;
 
 use crate::stub::GhosttyScrollbar;
-use crate::{CLIPBOARD_WRITE_LIMIT_BYTES, TERMINAL_PROGRESS_TIMEOUT, TerminalProgress};
+use crate::{
+    CLIPBOARD_WRITE_LIMIT_BYTES, DesktopNotification, DesktopNotificationPolicy,
+    TERMINAL_PROGRESS_TIMEOUT, TerminalProgress, desktop_notification_policy,
+};
 
 use image::{ImageFormat, ImageReader, Limits};
 use parking_lot::Mutex;
@@ -207,6 +210,7 @@ pub enum GhosttyTerminalOption {
     PwdChanged = 25,
     ClipboardWrite = 26,
     ScrollbackMaxLines = 28,
+    DesktopNotification = 29,
     ProgressReport = 30,
     UnknownSequence = 35,
     UnknownMaxBytes = 36,
@@ -414,6 +418,14 @@ pub struct GhosttyString {
 }
 
 #[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct GhosttyTerminalDesktopNotification {
+    pub size: usize,
+    pub title: GhosttyString,
+    pub body: GhosttyString,
+}
+
+#[repr(C)]
 #[derive(Clone, Copy)]
 pub struct GhosttyTerminalProgressReport {
     pub size: usize,
@@ -607,6 +619,7 @@ const _: [(); 16] = [(); std::mem::size_of::<GhosttyClipboardWriteReply>()];
 const _: [(); 72] = [(); std::mem::size_of::<GhosttyClipboardWrite>()];
 const _: [(); 56] = [(); std::mem::size_of::<GhosttyClipboardReadReply>()];
 const _: [(); 80] = [(); std::mem::size_of::<GhosttyClipboardRead>()];
+const _: [(); 40] = [(); std::mem::size_of::<GhosttyTerminalDesktopNotification>()];
 const _: [(); 24] = [(); std::mem::size_of::<GhosttySysImage>()];
 const _: [(); 56] = [(); std::mem::size_of::<GhosttyKittyGraphicsPlacementRenderInfo>()];
 
@@ -1281,6 +1294,7 @@ struct VtCallbackState {
     device_attributes: GhosttyDeviceAttributes,
     metadata_dirty: AtomicU8,
     bell_pending: AtomicBool,
+    desktop_notification_policy: Arc<DesktopNotificationPolicy>,
     progress_epoch: Instant,
     progress: AtomicU64,
     unknown_sequence_log_count: AtomicU8,
@@ -1635,6 +1649,7 @@ impl VtScreen {
             device_attributes: default_device_attributes(),
             metadata_dirty: AtomicU8::new(0),
             bell_pending: AtomicBool::new(false),
+            desktop_notification_policy: desktop_notification_policy(),
             progress_epoch: Instant::now(),
             progress: AtomicU64::new(0),
             unknown_sequence_log_count: AtomicU8::new(0),
@@ -1717,6 +1732,11 @@ impl VtScreen {
                 GhosttyTerminalOption::PwdChanged,
                 vt_pwd_changed_callback as *const c_void,
                 "PWD_CHANGED",
+            ),
+            (
+                GhosttyTerminalOption::DesktopNotification,
+                vt_desktop_notification_callback as *const c_void,
+                "DESKTOP_NOTIFICATION",
             ),
             (
                 GhosttyTerminalOption::ProgressReport,
@@ -1938,6 +1958,18 @@ impl VtScreen {
             .pending_clipboard_write
             .lock()
             .take()
+    }
+
+    pub fn take_desktop_notification(&self) -> Option<DesktopNotification> {
+        self.inner
+            .lock()
+            .callback_state
+            .desktop_notification_policy
+            .take()
+    }
+
+    pub(crate) fn set_desktop_notification_policy(&self, policy: Arc<DesktopNotificationPolicy>) {
+        self.inner.lock().callback_state.desktop_notification_policy = policy;
     }
 
     /// Replace the default fg/bg/palette. Bumps the snapshot
@@ -3066,6 +3098,42 @@ unsafe extern "C" fn vt_bell_callback(_terminal: GhosttyTerminal, userdata: *mut
     state.bell_pending.store(true, Ordering::Relaxed);
 }
 
+unsafe extern "C" fn vt_desktop_notification_callback(
+    _terminal: GhosttyTerminal,
+    userdata: *mut c_void,
+    notification: *const GhosttyTerminalDesktopNotification,
+) {
+    if userdata.is_null() || notification.is_null() {
+        return;
+    }
+    if unsafe { notification.cast::<usize>().read_unaligned() }
+        < std::mem::size_of::<GhosttyTerminalDesktopNotification>()
+    {
+        return;
+    }
+
+    let notification = unsafe { &*notification };
+    let Some(title) = (unsafe { ghostty_string_bytes(&notification.title) }) else {
+        return;
+    };
+    let Some(body) = (unsafe { ghostty_string_bytes(&notification.body) }) else {
+        return;
+    };
+    let state = unsafe { &*(userdata as *const VtCallbackState) };
+    state.desktop_notification_policy.push(title, body);
+}
+
+unsafe fn ghostty_string_bytes(value: &GhosttyString) -> Option<&[u8]> {
+    if value.ptr.is_null() && value.len > 0 {
+        return None;
+    }
+    Some(if value.len == 0 {
+        &[]
+    } else {
+        unsafe { std::slice::from_raw_parts(value.ptr, value.len) }
+    })
+}
+
 unsafe extern "C" fn vt_progress_report_callback(
     _terminal: GhosttyTerminal,
     userdata: *mut c_void,
@@ -3878,6 +3946,10 @@ mod tests {
             Some(GhosttyTerminalOption::PwdChanged as i64)
         );
         assert_eq!(
+            types["GhosttyTerminalOption"]["values"]["DESKTOP_NOTIFICATION"].as_i64(),
+            Some(GhosttyTerminalOption::DesktopNotification as i64)
+        );
+        assert_eq!(
             types["GhosttyTerminalOption"]["values"]["PROGRESS_REPORT"].as_i64(),
             Some(GhosttyTerminalOption::ProgressReport as i64)
         );
@@ -3929,6 +4001,11 @@ mod tests {
                 "GhosttyClipboardRead",
                 std::mem::size_of::<GhosttyClipboardRead>(),
                 std::mem::align_of::<GhosttyClipboardRead>(),
+            ),
+            (
+                "GhosttyTerminalDesktopNotification",
+                std::mem::size_of::<GhosttyTerminalDesktopNotification>(),
+                std::mem::align_of::<GhosttyTerminalDesktopNotification>(),
             ),
             (
                 "GhosttyTerminalProgressReport",
@@ -4542,6 +4619,22 @@ mod tests {
             .set_clipboard_write_enabled(false)
             .expect("disable clipboard writes");
         assert_eq!(screen.take_clipboard_write(), None);
+    }
+
+    #[test]
+    fn terminal_desktop_notifications_are_bounded_on_utf8_boundaries() {
+        let screen = VtScreen::new(80, 24, None).expect("create vt screen");
+        let title = format!("{}é", "a".repeat(62));
+        let sequence = format!("\x1b]777;notify;{title};Needs attention\x07");
+
+        screen.feed(sequence.as_bytes());
+
+        let notification = screen
+            .take_desktop_notification()
+            .expect("desktop notification");
+        assert_eq!(notification.title, "a".repeat(62));
+        assert_eq!(notification.body, "Needs attention");
+        assert_eq!(screen.take_desktop_notification(), None);
     }
 
     #[test]

--- a/crates/con-ghostty/src/windows/backend.rs
+++ b/crates/con-ghostty/src/windows/backend.rs
@@ -17,7 +17,10 @@ use crate::stub::{
     GhosttySplitDirection, GhosttySurfaceEvent, MouseButton, SurfaceSize, TerminalColors,
 };
 use crate::vt::{VtKeyEvent, VtKeyOutcome};
-use crate::{DesktopNotificationPolicy, desktop_notification_policy};
+use crate::{
+    ClipboardWritePolicy, DesktopNotificationPolicy, clipboard_write_policy,
+    desktop_notification_policy,
+};
 
 fn theme_from_colors(colors: &TerminalColors) -> ThemeColors {
     ThemeColors::from_ansi16(colors.foreground, colors.background, colors.palette)
@@ -31,6 +34,7 @@ fn clamp_opacity(v: f32) -> f32 {
 pub struct WindowsGhosttyApp {
     config: Mutex<RendererConfig>,
     clipboard_write_enabled: AtomicBool,
+    clipboard_write_policy: Arc<ClipboardWritePolicy>,
     desktop_notification_policy: Arc<DesktopNotificationPolicy>,
 }
 
@@ -73,6 +77,7 @@ impl WindowsGhosttyApp {
         Ok(Self {
             config: Mutex::new(config),
             clipboard_write_enabled: AtomicBool::new(clipboard_write_enabled),
+            clipboard_write_policy: clipboard_write_policy(clipboard_write_enabled),
             desktop_notification_policy: desktop_notification_policy(),
         })
     }
@@ -129,8 +134,14 @@ impl WindowsGhosttyApp {
     pub fn set_color_scheme(&self, _dark: bool) {}
 
     pub fn set_clipboard_write_enabled(&self, enabled: bool) -> Result<(), String> {
+        if !enabled {
+            self.clipboard_write_policy.set_enabled(false);
+        }
         self.clipboard_write_enabled
             .store(enabled, Ordering::Release);
+        if enabled {
+            self.clipboard_write_policy.set_enabled(true);
+        }
         Ok(())
     }
 

--- a/crates/con-ghostty/src/windows/backend.rs
+++ b/crates/con-ghostty/src/windows/backend.rs
@@ -17,6 +17,7 @@ use crate::stub::{
     GhosttySplitDirection, GhosttySurfaceEvent, MouseButton, SurfaceSize, TerminalColors,
 };
 use crate::vt::{VtKeyEvent, VtKeyOutcome};
+use crate::{DesktopNotificationPolicy, desktop_notification_policy};
 
 fn theme_from_colors(colors: &TerminalColors) -> ThemeColors {
     ThemeColors::from_ansi16(colors.foreground, colors.background, colors.palette)
@@ -30,6 +31,7 @@ fn clamp_opacity(v: f32) -> f32 {
 pub struct WindowsGhosttyApp {
     config: Mutex<RendererConfig>,
     clipboard_write_enabled: AtomicBool,
+    desktop_notification_policy: Arc<DesktopNotificationPolicy>,
 }
 
 impl WindowsGhosttyApp {
@@ -71,6 +73,7 @@ impl WindowsGhosttyApp {
         Ok(Self {
             config: Mutex::new(config),
             clipboard_write_enabled: AtomicBool::new(clipboard_write_enabled),
+            desktop_notification_policy: desktop_notification_policy(),
         })
     }
 
@@ -79,6 +82,10 @@ impl WindowsGhosttyApp {
     /// Stub for parity with the macOS `GhosttyApp::wake_generation`.
     pub fn wake_generation(&self) -> u64 {
         0
+    }
+
+    pub fn desktop_notification_policy(&self) -> Arc<DesktopNotificationPolicy> {
+        self.desktop_notification_policy.clone()
     }
 
     pub fn update_colors(&self, _colors: &TerminalColors) -> Result<(), String> {
@@ -301,6 +308,12 @@ impl WindowsGhosttyTerminal {
             .lock()
             .as_ref()
             .and_then(RenderSession::take_clipboard_write)
+    }
+    pub fn take_desktop_notification(&self) -> Option<crate::DesktopNotification> {
+        self.inner
+            .lock()
+            .as_ref()
+            .and_then(RenderSession::take_desktop_notification)
     }
     pub fn current_dir(&self) -> Option<String> {
         self.inner

--- a/crates/con-ghostty/src/windows/backend.rs
+++ b/crates/con-ghostty/src/windows/backend.rs
@@ -5,6 +5,7 @@
 //! across platforms.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use parking_lot::Mutex;
@@ -28,6 +29,7 @@ fn clamp_opacity(v: f32) -> f32 {
 /// One per GPUI window. Holds shared, app-wide terminal config.
 pub struct WindowsGhosttyApp {
     config: Mutex<RendererConfig>,
+    clipboard_write_enabled: AtomicBool,
 }
 
 impl WindowsGhosttyApp {
@@ -44,6 +46,7 @@ impl WindowsGhosttyApp {
         _background_image_position: Option<&str>,
         _background_image_fit: Option<&str>,
         _background_image_repeat: Option<bool>,
+        clipboard_write_enabled: bool,
     ) -> Result<Self, String> {
         let mut config = RendererConfig::default();
         if let Some(family) = font_family {
@@ -67,6 +70,7 @@ impl WindowsGhosttyApp {
         }
         Ok(Self {
             config: Mutex::new(config),
+            clipboard_write_enabled: AtomicBool::new(clipboard_write_enabled),
         })
     }
 
@@ -116,6 +120,16 @@ impl WindowsGhosttyApp {
     }
 
     pub fn set_color_scheme(&self, _dark: bool) {}
+
+    pub fn set_clipboard_write_enabled(&self, enabled: bool) -> Result<(), String> {
+        self.clipboard_write_enabled
+            .store(enabled, Ordering::Release);
+        Ok(())
+    }
+
+    pub fn clipboard_write_enabled(&self) -> bool {
+        self.clipboard_write_enabled.load(Ordering::Acquire)
+    }
 
     /// Snapshot the current renderer config — used by `WindowsTerminalView`
     /// when constructing a new `RenderSession`.
@@ -275,6 +289,18 @@ impl WindowsGhosttyTerminal {
     }
     pub fn progress(&self) -> Option<crate::TerminalProgress> {
         self.inner.lock().as_ref().and_then(RenderSession::progress)
+    }
+    pub fn set_clipboard_write_enabled(&self, enabled: bool) -> Result<(), String> {
+        if let Some(session) = self.inner.lock().as_ref() {
+            session.set_clipboard_write_enabled(enabled)?;
+        }
+        Ok(())
+    }
+    pub fn take_clipboard_write(&self) -> Option<String> {
+        self.inner
+            .lock()
+            .as_ref()
+            .and_then(RenderSession::take_clipboard_write)
     }
     pub fn current_dir(&self) -> Option<String> {
         self.inner

--- a/crates/con-ghostty/src/windows/backend.rs
+++ b/crates/con-ghostty/src/windows/backend.rs
@@ -273,6 +273,9 @@ impl WindowsGhosttyTerminal {
             .as_ref()
             .is_some_and(RenderSession::take_bell)
     }
+    pub fn progress(&self) -> Option<crate::TerminalProgress> {
+        self.inner.lock().as_ref().and_then(RenderSession::progress)
+    }
     pub fn current_dir(&self) -> Option<String> {
         self.inner
             .lock()

--- a/crates/con-ghostty/src/windows/backend.rs
+++ b/crates/con-ghostty/src/windows/backend.rs
@@ -267,6 +267,12 @@ impl WindowsGhosttyTerminal {
     pub fn title(&self) -> Option<String> {
         self.inner.lock().as_ref().and_then(RenderSession::title)
     }
+    pub fn take_bell(&self) -> bool {
+        self.inner
+            .lock()
+            .as_ref()
+            .is_some_and(RenderSession::take_bell)
+    }
     pub fn current_dir(&self) -> Option<String> {
         self.inner
             .lock()

--- a/crates/con-ghostty/src/windows/backend.rs
+++ b/crates/con-ghostty/src/windows/backend.rs
@@ -265,7 +265,7 @@ impl WindowsGhosttyTerminal {
     }
 
     pub fn title(&self) -> Option<String> {
-        None
+        self.inner.lock().as_ref().and_then(RenderSession::title)
     }
     pub fn current_dir(&self) -> Option<String> {
         self.inner

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -746,6 +746,10 @@ impl RenderSession {
         snapshot_to_lines(&self.vt.snapshot(), max_lines)
     }
 
+    pub fn title(&self) -> Option<String> {
+        self.vt.title()
+    }
+
     pub fn current_dir(&self) -> Option<String> {
         self.vt.current_dir().or_else(|| {
             self.shell_cwd

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -139,6 +139,7 @@ impl RenderSession {
         config: RendererConfig,
         cwd: Option<PathBuf>,
         initial_output: Option<Vec<u8>>,
+        clipboard_write_enabled: bool,
         wake: W,
     ) -> Result<Self>
     where
@@ -182,6 +183,8 @@ impl RenderSession {
             )
             .context("VtScreen::new failed")?,
         );
+        vt.set_clipboard_write_enabled(clipboard_write_enabled)
+            .map_err(anyhow::Error::msg)?;
         let metrics = renderer.metrics();
         let cell_width_px = metrics.cell_width_px.max(1);
         let cell_height_px = metrics.cell_height_px.max(1);
@@ -756,6 +759,14 @@ impl RenderSession {
 
     pub fn progress(&self) -> Option<crate::TerminalProgress> {
         self.vt.progress()
+    }
+
+    pub fn set_clipboard_write_enabled(&self, enabled: bool) -> Result<(), String> {
+        self.vt.set_clipboard_write_enabled(enabled)
+    }
+
+    pub fn take_clipboard_write(&self) -> Option<String> {
+        self.vt.take_clipboard_write()
     }
 
     pub fn current_dir(&self) -> Option<String> {

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -750,6 +750,10 @@ impl RenderSession {
         self.vt.title()
     }
 
+    pub fn take_bell(&self) -> bool {
+        self.vt.take_bell()
+    }
+
     pub fn current_dir(&self) -> Option<String> {
         self.vt.current_dir().or_else(|| {
             self.shell_cwd

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -24,6 +24,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result};
 use parking_lot::Mutex;
 
+use crate::DesktopNotificationPolicy;
 use crate::stub::GhosttyScrollbar;
 use crate::transcript::{TranscriptBuffer, snapshot_to_lines};
 
@@ -140,6 +141,7 @@ impl RenderSession {
         cwd: Option<PathBuf>,
         initial_output: Option<Vec<u8>>,
         clipboard_write_enabled: bool,
+        desktop_notification_policy: Arc<DesktopNotificationPolicy>,
         wake: W,
     ) -> Result<Self>
     where
@@ -183,6 +185,7 @@ impl RenderSession {
             )
             .context("VtScreen::new failed")?,
         );
+        vt.set_desktop_notification_policy(desktop_notification_policy);
         vt.set_clipboard_write_enabled(clipboard_write_enabled)
             .map_err(anyhow::Error::msg)?;
         let metrics = renderer.metrics();
@@ -767,6 +770,10 @@ impl RenderSession {
 
     pub fn take_clipboard_write(&self) -> Option<String> {
         self.vt.take_clipboard_write()
+    }
+
+    pub fn take_desktop_notification(&self) -> Option<crate::DesktopNotification> {
+        self.vt.take_desktop_notification()
     }
 
     pub fn current_dir(&self) -> Option<String> {

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -24,9 +24,9 @@ use std::time::{Duration, Instant};
 use anyhow::{Context, Result};
 use parking_lot::Mutex;
 
-use crate::DesktopNotificationPolicy;
 use crate::stub::GhosttyScrollbar;
 use crate::transcript::{TranscriptBuffer, snapshot_to_lines};
+use crate::{DesktopNotificationPolicy, clipboard_write_policy};
 
 use super::conpty::{ConPty, PtySize};
 use super::profile::{perf_trace_enabled, perf_trace_verbose};
@@ -185,6 +185,7 @@ impl RenderSession {
             )
             .context("VtScreen::new failed")?,
         );
+        vt.set_clipboard_write_policy(clipboard_write_policy(clipboard_write_enabled));
         vt.set_desktop_notification_policy(desktop_notification_policy);
         vt.set_clipboard_write_enabled(clipboard_write_enabled)
             .map_err(anyhow::Error::msg)?;

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -754,6 +754,10 @@ impl RenderSession {
         self.vt.take_bell()
     }
 
+    pub fn progress(&self) -> Option<crate::TerminalProgress> {
+        self.vt.progress()
+    }
+
     pub fn current_dir(&self) -> Option<String> {
         self.vt.current_dir().or_else(|| {
             self.shell_cwd


### PR DESCRIPTION
## Summary

- Connect Ghostty's portable callbacks for title, working directory, bell, progress, desktop notifications, clipboard writes, and unknown-sequence diagnostics.
- Bring Windows and Linux terminal effects in line with the existing macOS behavior.
- Bound terminal-controlled payloads and apply shared policies across every open window.

## Behavior

- Terminal titles and working directories now update from Ghostty callbacks instead of relying on polling.
- Bells use the platform system alert.
- OSC 9;4 progress appears in tabs and the sidebar, then expires after 15 seconds without an update.
- Windows and Linux can deliver bounded, rate-limited desktop notifications.
- Unknown escape sequences are logged only in debug builds, with bounded diagnostic output.
- Terminal clipboard writes remain disabled by default and require the existing clipboard access setting.
- Clipboard writes accept only standard clipboard text with a supported MIME type, valid UTF-8, and a maximum decoded size of 1 MiB.
- Disabling clipboard access takes effect across all open windows and discards pending writes.
- Linux Flatpak sessions honor the same clipboard policy when using the portal.

## Security

Terminal-controlled clipboard and notification payloads are treated as untrusted input. Clipboard access uses a process-wide fail-closed policy, while notification size and delivery frequency are limited before decoding or dispatch.

## Validation

- macOS: `cargo check -p con` with warnings denied.
- macOS: `cargo test -p con-ghostty` passed 12 tests.
- Linux: native `cargo check -p con` completed successfully.
- Linux: native `cargo test -p con-ghostty` passed 52 tests.
- Windows GNU: `cargo wcheck -p con --target x86_64-pc-windows-gnu` completed with warnings denied and `CON_SKIP_GHOSTTY_VT=1`.
- Targeted semantic prompt tests, Rust formatting, ABI manifest coverage, conflict-marker scanning, and `git diff --check` passed.

The Windows check covers cross-platform compilation but does not replace a full MSVC link and runtime test.