### PR TITLE
ci(macos): verify SSH compatibility entry point

### DIFF
--- a/scripts/release/verify-artifacts.sh
+++ b/scripts/release/verify-artifacts.sh
@@ -28,6 +28,14 @@ require_executable() {
   [[ -x "$path" ]] || fail "missing executable: $path"
 }
 
+require_symlink_target() {
+  local path="$1"
+  local expected_target="$2"
+  [[ -L "$path" ]] || fail "missing symlink: $path"
+  [[ "$(readlink "$path")" == "$expected_target" ]] \
+    || fail "$path must point to $expected_target"
+}
+
 require_desktop_entry() {
   local desktop="$1"
   local entry="$2"
@@ -112,6 +120,7 @@ verify_macos() {
 
   require_executable "$app/Contents/MacOS/con"
   require_executable "$app/Contents/MacOS/con-cli"
+  require_symlink_target "$app/Contents/MacOS/ghostty" con-cli
   "$app/Contents/MacOS/con-cli" --help >/dev/null
 
   log "checking macOS checksum"
@@ -123,6 +132,8 @@ verify_macos() {
   log "checking macOS ZIP layout"
   unzip -l "$zip" | grep -F ".app/Contents/MacOS/con-cli" >/dev/null \
     || fail "$(basename "$zip") does not contain bundled con-cli"
+  unzip -l "$zip" | grep -F ".app/Contents/MacOS/ghostty" >/dev/null \
+    || fail "$(basename "$zip") does not contain Ghostty SSH compatibility entry point"
 
   log "checking macOS DMG layout"
   local mount_point
@@ -140,6 +151,7 @@ verify_macos() {
   [[ -n "$mounted_app" ]] || fail "$(basename "$dmg") does not contain an app bundle"
   require_executable "$mounted_app/Contents/MacOS/con"
   require_executable "$mounted_app/Contents/MacOS/con-cli"
+  require_symlink_target "$mounted_app/Contents/MacOS/ghostty" con-cli
   "$mounted_app/Contents/MacOS/con-cli" --help >/dev/null
 
   log "macOS artifact OK: $(basename "$dmg")"


### PR DESCRIPTION
## Summary
- fail the macOS release gate when the bundled `ghostty -> con-cli` compatibility entry point is missing or points elsewhere
- verify the entry point in the app, ZIP, and mounted DMG

This prevents the original issue #320 regression from reaching users. It does not change runtime behavior or Windows/Linux packaging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only add release-time assertions in a shell script; no production code, auth, or data paths are modified.
> 
> **Overview**
> Extends the macOS release artifact gate in `verify-artifacts.sh` so a broken **Ghostty SSH compatibility** entry point fails before upload.
> 
> A new `require_symlink_target` helper asserts `Contents/MacOS/ghostty` is a symlink to `con-cli`. That check runs on the built app bundle and on the app inside a mounted DMG. The ZIP layout check also requires a `ghostty` path under `Contents/MacOS`, matching what `build-app.sh` creates for shell integration.
> 
> **No runtime or packaging behavior changes**—only stricter CI for issue #320-style regressions. Linux and Windows release checks are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8d6cbece4db97f3a3c3b53db38e0f778f8a6ddb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->