### PR TITLE
feat(con-cli): support Ghostty +ssh integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ### Added
 
+**macOS**
+
+- SSH shell integration now supports Ghostty's `+ssh` wrapper through Con's
+  bundle-local `con-cli`, including terminal environment forwarding and
+  best-effort `xterm-ghostty` terminfo setup. If setup is unavailable, SSH
+  continues with the standard `xterm-256color` terminal type. _(PR
+  [#335](https://github.com/nowledge-co/con-terminal/pull/335) by
+  [@wey-gu](https://github.com/wey-gu))_
+
 **Developer tools**
 
 - Terminal execution now recognizes semantic shell prompt state on Windows and

--- a/crates/con-cli/src/main.rs
+++ b/crates/con-cli/src/main.rs
@@ -12,6 +12,7 @@ use serde_json::{Value, json};
 
 mod pty_bridge;
 use pty_bridge::{PtyBridgeArgs, run_pty_bridge};
+mod ssh;
 mod ssh_cache;
 
 #[derive(Parser)]
@@ -350,6 +351,9 @@ fn main() -> Result<()> {
     let raw_args: Vec<_> = std::env::args_os().collect();
     if raw_args.get(1).is_some_and(|arg| arg == "+ssh-cache") {
         std::process::exit(ssh_cache::run(&raw_args[2..]));
+    }
+    if raw_args.get(1).is_some_and(|arg| arg == "+ssh") {
+        std::process::exit(ssh::run(&raw_args[2..]));
     }
     let cli = Cli::parse();
     let socket_path = cli.socket.clone().unwrap_or_else(control_socket_path);

--- a/crates/con-cli/src/ssh.rs
+++ b/crates/con-cli/src/ssh.rs
@@ -210,6 +210,7 @@ fn resolve_destination(ssh: &OsStr, args: &[OsString]) -> Option<String> {
     let text = String::from_utf8_lossy(&output.stdout);
     let mut user = None;
     let mut host = None;
+    let mut port = None;
     for line in text.lines() {
         let Some((key, value)) = line.split_once(' ') else {
             continue;
@@ -217,15 +218,22 @@ fn resolve_destination(ssh: &OsStr, args: &[OsString]) -> Option<String> {
         match key {
             "user" => user = Some(value),
             "hostname" => host = Some(value),
+            "port" => port = Some(value),
             _ => {}
         }
     }
-    Some(format!("{}@{}", user?, host?))
+    Some(match port {
+        Some(port) => format!("{}@{}:{port}", user?, host?),
+        None => format!("{}@{}", user?, host?),
+    })
 }
 
 fn local_terminfo() -> Option<Vec<u8>> {
     let mut command = Command::new("infocmp");
-    command.args(["-0", "-Q2", "-q", TERMINFO_NAME]);
+    // `-Q2` asks infocmp for a compiled description. `tic -x -` expects the
+    // source form, so keep this as source output and never pipe `b64:` data to
+    // the remote compiler.
+    command.args(["-0", "-q", TERMINFO_NAME]);
     if std::env::var_os("TERMINFO").is_none() {
         if let Some(path) = bundled_terminfo_dir() {
             command.env("TERMINFO", path);
@@ -331,20 +339,22 @@ mod tests {
 
     #[test]
     fn parses_destination_from_ssh_config_output() {
-        let output = "hostname example.com\nuser alice\n";
+        let output = "hostname example.com\nuser alice\nport 2222\n";
         let mut user = None;
         let mut host = None;
+        let mut port = None;
         for line in output.lines() {
             let (key, value) = line.split_once(' ').unwrap();
             match key {
                 "user" => user = Some(value),
                 "hostname" => host = Some(value),
+                "port" => port = Some(value),
                 _ => {}
             }
         }
         assert_eq!(
-            format!("{}@{}", user.unwrap(), host.unwrap()),
-            "alice@example.com"
+            format!("{}@{}:{}", user.unwrap(), host.unwrap(), port.unwrap()),
+            "alice@example.com:2222"
         );
     }
 }

--- a/crates/con-cli/src/ssh.rs
+++ b/crates/con-cli/src/ssh.rs
@@ -1,0 +1,350 @@
+//! Con's compatibility implementation of Ghostty's `+ssh` helper.
+//!
+//! The shell integration is intentionally a thin wrapper around this command.
+//! SSH arguments are kept as OsStrings and are passed to the real ssh process
+//! without going through a shell.
+
+use std::ffi::{OsStr, OsString};
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::ssh_cache::Cache;
+
+const TERMINFO_NAME: &str = "xterm-ghostty";
+const FALLBACK_TERM: &str = "xterm-256color";
+const CON_TERM: &str = "xterm-ghostty";
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct Options {
+    forward_env: bool,
+    terminfo: bool,
+    cache: bool,
+    ssh: OsString,
+    verbose: bool,
+    ssh_args: Vec<OsString>,
+}
+
+impl Options {
+    fn parse(args: &[OsString]) -> Result<Self, String> {
+        let mut options = Self {
+            forward_env: true,
+            terminfo: true,
+            cache: true,
+            ssh: OsString::from("ssh"),
+            ..Default::default()
+        };
+        let mut index = 0;
+        while index < args.len() {
+            let arg = &args[index];
+            if arg == "--" {
+                options.ssh_args.extend(args[index + 1..].iter().cloned());
+                break;
+            }
+            if !arg.to_string_lossy().starts_with("--") {
+                options.ssh_args.extend(args[index..].iter().cloned());
+                break;
+            }
+
+            let value = arg.to_string_lossy();
+            match value.as_ref() {
+                "--help" => return Err(usage()),
+                "--verbose" => options.verbose = true,
+                "--forward-env" => options.forward_env = true,
+                "--forward-env=false" => options.forward_env = false,
+                "--terminfo" => options.terminfo = true,
+                "--terminfo=false" => options.terminfo = false,
+                "--cache" => options.cache = true,
+                "--cache=false" => options.cache = false,
+                value if value.starts_with("--ssh=") => {
+                    let path = &value[6..];
+                    if path.is_empty() {
+                        return Err("--ssh requires a path".to_string());
+                    }
+                    options.ssh = OsString::from(path);
+                }
+                value if value.starts_with("--forward-env=") => {
+                    options.forward_env = parse_bool("--forward-env", &value[14..])?;
+                }
+                value if value.starts_with("--terminfo=") => {
+                    options.terminfo = parse_bool("--terminfo", &value[11..])?;
+                }
+                value if value.starts_with("--cache=") => {
+                    options.cache = parse_bool("--cache", &value[8..])?;
+                }
+                _ => return Err(format!("unknown +ssh flag: {arg:?}\n\n{}", usage())),
+            }
+            index += 1;
+        }
+        if options.ssh_args.is_empty() {
+            return Err(format!("no ssh arguments provided\n\n{}", usage()));
+        }
+        Ok(options)
+    }
+}
+
+fn parse_bool(name: &str, value: &str) -> Result<bool, String> {
+    match value {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        _ => Err(format!("{name} expects true or false")),
+    }
+}
+
+fn usage() -> String {
+    "Usage: con-cli +ssh [flags] [--] <ssh args...>\n\n\
+Flags:\n\
+  --forward-env[=bool]  Forward terminal environment (default: true)\n\
+  --terminfo[=bool]     Install xterm-ghostty terminfo (default: true)\n\
+  --cache[=bool]        Use the Con terminfo cache (default: true)\n\
+  --ssh=<path>          SSH executable (default: ssh)\n\
+  --verbose             Print setup diagnostics\n\
+  --help                Show this help\n"
+        .to_string()
+}
+
+pub fn run(args: &[OsString]) -> i32 {
+    let options = match Options::parse(args) {
+        Ok(options) => options,
+        Err(error) if error.starts_with("Usage:") => {
+            println!("{error}");
+            return 0;
+        }
+        Err(error) => {
+            eprintln!("con-cli +ssh: {error}");
+            return 2;
+        }
+    };
+    run_with_options(&options)
+}
+
+fn run_with_options(options: &Options) -> i32 {
+    let destination = resolve_destination(&options.ssh, &options.ssh_args);
+    let mut term = FALLBACK_TERM;
+    let mut cache_entry = None;
+    let mut control_path = None;
+
+    if options.terminfo {
+        if let Some(destination) = destination.as_deref() {
+            let cached =
+                options.cache && Cache::user().contains(destination, None).unwrap_or(false);
+            if cached {
+                term = CON_TERM;
+                verbose(options, "terminfo cache hit for {destination}");
+            } else if let Some(payload) = local_terminfo() {
+                match install_terminfo(options, &payload) {
+                    Ok(path) => {
+                        term = CON_TERM;
+                        control_path = Some(path);
+                        if options.cache {
+                            cache_entry = Some(destination.to_string());
+                        }
+                    }
+                    Err(error) => verbose(options, &format!("terminfo setup skipped: {error}")),
+                }
+            } else {
+                verbose(
+                    options,
+                    "terminfo setup skipped: local {TERMINFO_NAME} entry unavailable",
+                );
+            }
+        } else {
+            verbose(
+                options,
+                "terminfo setup skipped: could not resolve SSH destination",
+            );
+        }
+    }
+
+    let mut command = Command::new(&options.ssh);
+    if options.forward_env {
+        let term_option = format!("SetEnv=TERM={term}");
+        command.arg("-o").arg(term_option);
+        command.args(["-o", "SendEnv=COLORTERM"]);
+        command.args(["-o", "SendEnv=TERM_PROGRAM"]);
+        command.args(["-o", "SendEnv=TERM_PROGRAM_VERSION"]);
+    }
+    if let Some(path) = control_path.as_ref() {
+        let control_option = format!("ControlPath={}", path);
+        command.arg("-o").arg(control_option);
+    }
+    command.args(&options.ssh_args);
+    verbose(options, &format!("exec: {:?}", command));
+    let status = match command.status() {
+        Ok(status) => status,
+        Err(error) => {
+            eprintln!("con-cli +ssh: failed to run {:?}: {error}", options.ssh);
+            return 1;
+        }
+    };
+
+    if status.success() {
+        if let Some(destination) = cache_entry {
+            if Cache::user().add(&destination).is_ok() {
+                verbose(options, &format!("cache: wrote {destination}"));
+            }
+        }
+    }
+    if let Some(path) = control_path {
+        let _ = fs::remove_file(&path);
+        if let Some(parent) = Path::new(&path).parent() {
+            let _ = fs::remove_dir(parent);
+        }
+    }
+    status.code().unwrap_or(1)
+}
+
+fn verbose(options: &Options, message: &str) {
+    if options.verbose {
+        eprintln!("+ssh: {message}");
+    }
+}
+
+fn resolve_destination(ssh: &OsStr, args: &[OsString]) -> Option<String> {
+    let output = Command::new(ssh).arg("-G").args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut user = None;
+    let mut host = None;
+    for line in text.lines() {
+        let Some((key, value)) = line.split_once(' ') else {
+            continue;
+        };
+        match key {
+            "user" => user = Some(value),
+            "hostname" => host = Some(value),
+            _ => {}
+        }
+    }
+    Some(format!("{}@{}", user?, host?))
+}
+
+fn local_terminfo() -> Option<Vec<u8>> {
+    let mut command = Command::new("infocmp");
+    command.args(["-0", "-Q2", "-q", TERMINFO_NAME]);
+    if std::env::var_os("TERMINFO").is_none() {
+        if let Some(path) = bundled_terminfo_dir() {
+            command.env("TERMINFO", path);
+        }
+    }
+    let output = command.output().ok()?;
+    output.status.success().then_some(output.stdout)
+}
+
+fn bundled_terminfo_dir() -> Option<PathBuf> {
+    let executable = std::env::current_exe().ok()?;
+    executable
+        .ancestors()
+        .find(|path| path.extension().is_some_and(|ext| ext == "app"))
+        .map(|app| app.join("Contents/Resources/terminfo"))
+        .filter(|path| path.is_dir())
+}
+
+fn install_terminfo(options: &Options, payload: &[u8]) -> io::Result<String> {
+    let directory = unique_temp_dir()?;
+    let control_path = directory.join("socket");
+    let control_path_string = control_path.to_string_lossy().into_owned();
+    let control_option = format!("ControlPath={control_path_string}");
+    let result = (|| {
+        let mut command = Command::new(&options.ssh);
+        command
+            .args(["-o", "ControlMaster=yes"])
+            .args(["-o", "ControlPersist=no"])
+            .args(["-o", &control_option])
+            .args(&options.ssh_args)
+            .arg("command -v tic >/dev/null 2>&1 || exit 1; mkdir -p ~/.terminfo 2>/dev/null && tic -x - 2>/dev/null");
+        command.stdin(Stdio::piped()).stdout(Stdio::null());
+        if !options.verbose {
+            command.stderr(Stdio::null());
+        }
+        let mut child = command.spawn()?;
+        if let Some(stdin) = child.stdin.as_mut() {
+            stdin.write_all(payload)?;
+        }
+        let status = child.wait()?;
+        if status.success() {
+            Ok(control_path_string)
+        } else {
+            Err(io::Error::other("remote terminfo installation failed"))
+        }
+    })();
+    if result.is_err() {
+        let _ = fs::remove_dir(&directory);
+    }
+    result
+}
+
+fn unique_temp_dir() -> io::Result<PathBuf> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!("con-ssh-{}-{timestamp}", std::process::id()));
+    fs::create_dir(&path)?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(values: &[&str]) -> Vec<OsString> {
+        values.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn parses_wrapper_flags_and_forwards_ssh_args() {
+        let parsed = Options::parse(&args(&[
+            "--forward-env=false",
+            "--terminfo=false",
+            "--cache=false",
+            "--verbose",
+            "--ssh=/custom/ssh",
+            "--",
+            "-p",
+            "2222",
+            "user@example.com",
+        ]))
+        .unwrap();
+        assert!(!parsed.forward_env);
+        assert!(!parsed.terminfo);
+        assert!(!parsed.cache);
+        assert!(parsed.verbose);
+        assert_eq!(parsed.ssh, "/custom/ssh");
+        assert_eq!(parsed.ssh_args, args(&["-p", "2222", "user@example.com"]));
+    }
+
+    #[test]
+    fn first_ssh_argument_stops_wrapper_parsing() {
+        let parsed = Options::parse(&args(&["-p", "2222", "user@example.com"])).unwrap();
+        assert_eq!(parsed.ssh_args, args(&["-p", "2222", "user@example.com"]));
+    }
+
+    #[test]
+    fn rejects_unknown_wrapper_flags() {
+        assert!(Options::parse(&args(&["--wat", "host"])).is_err());
+    }
+
+    #[test]
+    fn parses_destination_from_ssh_config_output() {
+        let output = "hostname example.com\nuser alice\n";
+        let mut user = None;
+        let mut host = None;
+        for line in output.lines() {
+            let (key, value) = line.split_once(' ').unwrap();
+            match key {
+                "user" => user = Some(value),
+                "hostname" => host = Some(value),
+                _ => {}
+            }
+        }
+        assert_eq!(
+            format!("{}@{}", user.unwrap(), host.unwrap()),
+            "alice@example.com"
+        );
+    }
+}

--- a/crates/con-cli/src/ssh.rs
+++ b/crates/con-cli/src/ssh.rs
@@ -271,10 +271,12 @@ fn ssh_connection_args(args: &[OsString]) -> Vec<OsString> {
             break;
         }
         connection.push(arg.clone());
-        if value.len() == 2 && ssh_option_takes_value(value.as_bytes()[1] as char) {
-            if let Some(value) = args.get(index + 1) {
-                connection.push(value.clone());
-                index += 1;
+        if let Some(consumes_next) = short_option_value_form(&value) {
+            if consumes_next {
+                if let Some(value) = args.get(index + 1) {
+                    connection.push(value.clone());
+                    index += 1;
+                }
             }
         }
         index += 1;
@@ -282,10 +284,31 @@ fn ssh_connection_args(args: &[OsString]) -> Vec<OsString> {
     connection
 }
 
+/// Return whether a short-option token needs the following argv item.
+///
+/// OpenSSH accepts both clustered flags (`-vT`) and an option argument
+/// attached to the last flag (`-vp2222`, `-oProxyJump=bastion`). Once an
+/// option requiring a value is encountered, the remainder of the token is
+/// that value; otherwise the next argv item is its value.
+fn short_option_value_form(arg: &str) -> Option<bool> {
+    let bytes = arg.as_bytes();
+    if bytes.len() < 2 || bytes[0] != b'-' || bytes[1] == b'-' {
+        return None;
+    }
+
+    for (offset, byte) in bytes[1..].iter().enumerate() {
+        if ssh_option_takes_value(*byte as char) {
+            return Some(offset + 2 == bytes.len());
+        }
+    }
+    Some(false)
+}
+
 fn ssh_option_takes_value(option: char) -> bool {
     matches!(
         option,
-        'b' | 'c'
+        'B' | 'b'
+            | 'c'
             | 'D'
             | 'E'
             | 'e'
@@ -405,6 +428,34 @@ mod tests {
         assert_eq!(
             parsed,
             args(&["-p", "2222", "-o", "BatchMode=yes", "user@example.com"])
+        );
+    }
+
+    #[test]
+    fn setup_connection_handles_clustered_and_attached_short_options() {
+        assert_eq!(
+            ssh_connection_args(&args(&["-vp2222", "user@example.com", "echo"])),
+            args(&["-vp2222", "user@example.com"])
+        );
+        assert_eq!(
+            ssh_connection_args(&args(&[
+                "-B",
+                "10.0.0.2",
+                "-oProxyJump=bastion",
+                "user@example.com",
+                "echo",
+            ])),
+            args(&["-B", "10.0.0.2", "-oProxyJump=bastion", "user@example.com"])
+        );
+    }
+
+    #[test]
+    fn setup_connection_handles_clustered_option_with_following_value() {
+        assert_eq!(
+            ssh_connection_args(&args(
+                &["-vo", "BatchMode=yes", "user@example.com", "echo",]
+            )),
+            args(&["-vo", "BatchMode=yes", "user@example.com"])
         );
     }
 

--- a/crates/con-cli/src/ssh.rs
+++ b/crates/con-cli/src/ssh.rs
@@ -132,9 +132,10 @@ fn run_with_options(options: &Options) -> i32 {
                 options.cache && Cache::user().contains(destination, None).unwrap_or(false);
             if cached {
                 term = CON_TERM;
-                verbose(options, "terminfo cache hit for {destination}");
+                verbose(options, &format!("terminfo cache hit for {destination}"));
             } else if let Some(payload) = local_terminfo() {
-                match install_terminfo(options, &payload) {
+                let connection_args = ssh_connection_args(&options.ssh_args);
+                match install_terminfo(options, &connection_args, &payload) {
                     Ok(path) => {
                         term = CON_TERM;
                         control_path = Some(path);
@@ -147,7 +148,7 @@ fn run_with_options(options: &Options) -> i32 {
             } else {
                 verbose(
                     options,
-                    "terminfo setup skipped: local {TERMINFO_NAME} entry unavailable",
+                    &format!("terminfo setup skipped: local {TERMINFO_NAME} entry unavailable"),
                 );
             }
         } else {
@@ -233,7 +234,7 @@ fn local_terminfo() -> Option<Vec<u8>> {
     // `-Q2` asks infocmp for a compiled description. `tic -x -` expects the
     // source form, so keep this as source output and never pipe `b64:` data to
     // the remote compiler.
-    command.args(["-0", "-q", TERMINFO_NAME]);
+    command.args(["-x", "-0", "-q", TERMINFO_NAME]);
     if std::env::var_os("TERMINFO").is_none() {
         if let Some(path) = bundled_terminfo_dir() {
             command.env("TERMINFO", path);
@@ -252,7 +253,65 @@ fn bundled_terminfo_dir() -> Option<PathBuf> {
         .filter(|path| path.is_dir())
 }
 
-fn install_terminfo(options: &Options, payload: &[u8]) -> io::Result<String> {
+fn ssh_connection_args(args: &[OsString]) -> Vec<OsString> {
+    let mut connection = Vec::new();
+    let mut index = 0;
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "--" {
+            connection.push(arg.clone());
+            if let Some(destination) = args.get(index + 1) {
+                connection.push(destination.clone());
+            }
+            break;
+        }
+        let value = arg.to_string_lossy();
+        if !value.starts_with('-') || value == "-" {
+            connection.push(arg.clone());
+            break;
+        }
+        connection.push(arg.clone());
+        if value.len() == 2 && ssh_option_takes_value(value.as_bytes()[1] as char) {
+            if let Some(value) = args.get(index + 1) {
+                connection.push(value.clone());
+                index += 1;
+            }
+        }
+        index += 1;
+    }
+    connection
+}
+
+fn ssh_option_takes_value(option: char) -> bool {
+    matches!(
+        option,
+        'b' | 'c'
+            | 'D'
+            | 'E'
+            | 'e'
+            | 'F'
+            | 'I'
+            | 'i'
+            | 'J'
+            | 'L'
+            | 'l'
+            | 'm'
+            | 'O'
+            | 'o'
+            | 'p'
+            | 'Q'
+            | 'R'
+            | 'S'
+            | 'W'
+            | 'w'
+    )
+}
+
+fn install_terminfo(
+    options: &Options,
+    connection_args: &[OsString],
+    payload: &[u8],
+) -> io::Result<String> {
     let directory = unique_temp_dir()?;
     let control_path = directory.join("socket");
     let control_path_string = control_path.to_string_lossy().into_owned();
@@ -263,7 +322,7 @@ fn install_terminfo(options: &Options, payload: &[u8]) -> io::Result<String> {
             .args(["-o", "ControlMaster=yes"])
             .args(["-o", "ControlPersist=no"])
             .args(["-o", &control_option])
-            .args(&options.ssh_args)
+            .args(connection_args)
             .arg("command -v tic >/dev/null 2>&1 || exit 1; mkdir -p ~/.terminfo 2>/dev/null && tic -x - 2>/dev/null");
         command.stdin(Stdio::piped()).stdout(Stdio::null());
         if !options.verbose {
@@ -330,6 +389,23 @@ mod tests {
     fn first_ssh_argument_stops_wrapper_parsing() {
         let parsed = Options::parse(&args(&["-p", "2222", "user@example.com"])).unwrap();
         assert_eq!(parsed.ssh_args, args(&["-p", "2222", "user@example.com"]));
+    }
+
+    #[test]
+    fn setup_connection_drops_remote_command_but_keeps_connection_options() {
+        let parsed = ssh_connection_args(&args(&[
+            "-p",
+            "2222",
+            "-o",
+            "BatchMode=yes",
+            "user@example.com",
+            "echo",
+            "do not run this during setup",
+        ]));
+        assert_eq!(
+            parsed,
+            args(&["-p", "2222", "-o", "BatchMode=yes", "user@example.com"])
+        );
     }
 
     #[test]

--- a/docs/impl/socket-api.md
+++ b/docs/impl/socket-api.md
@@ -111,6 +111,10 @@ JSON-RPC 2.0 over a Unix domain socket, one JSON request per line and one JSON r
 
 The first shipped client is `con-cli`.
 
+The same binary also provides the macOS shell-integration compatibility
+commands `+ssh` and `+ssh-cache`. Their protocol and fallback behavior are
+documented in [`ssh-integration.md`](ssh-integration.md).
+
 Examples:
 
 ```bash

--- a/docs/impl/ssh-integration.md
+++ b/docs/impl/ssh-integration.md
@@ -43,9 +43,11 @@ Supported wrapper options are:
    SSH control connection.
 4. If any local or remote setup step fails, Con falls back to
    `TERM=xterm-256color` and continues with the user's SSH command.
-5. A successful setup and successful SSH session add the destination to
-   Con's cache. The cache contains host metadata only; it is not a shared
-   Ghostty cache format.
+5. A successful setup and successful SSH session add the resolved
+   `user@hostname:port` destination to Con's cache. Including the resolved port
+   prevents two SSH endpoints that share a hostname from reusing one another's
+   installation state. The cache contains host metadata only; it is not a
+   shared Ghostty cache format.
 
 Environment forwarding uses OpenSSH options rather than a shell command:
 

--- a/docs/impl/ssh-integration.md
+++ b/docs/impl/ssh-integration.md
@@ -1,0 +1,85 @@
+# SSH Integration
+
+Con embeds Ghostty's shell integration on macOS. The integration runs before
+an SSH connection and invokes the bundle-local `ghostty` compatibility entry
+point. In a release app this entry point resolves to `con-cli`, so Con owns the
+helper protocol rather than depending on a separately installed Ghostty.
+
+## Protocol boundary
+
+Ghostty's current shell integration invokes:
+
+```text
+ghostty +ssh [Ghostty options] -- [ssh arguments]
+```
+
+`con-cli` accepts the same wrapper boundary:
+
+```text
+con-cli +ssh [options] -- [ssh arguments]
+```
+
+Options before `--` belong to Con. Everything after `--` is passed to the
+selected SSH executable without a shell or argument rewriting. For backward
+compatibility, the wrapper also follows Ghostty's convention that the first
+non-`--` argument begins the SSH argument list.
+
+Supported wrapper options are:
+
+- `--forward-env[=bool]` controls `TERM` and terminal identification forwarding.
+- `--terminfo[=bool]` enables remote `xterm-ghostty` installation.
+- `--cache[=bool]` controls Con's local terminfo-install cache.
+- `--ssh=<path>` selects the SSH executable instead of resolving `ssh` from `PATH`.
+- `--verbose` prints setup and execution diagnostics to stderr.
+
+## Connection flow
+
+1. `con-cli +ssh` resolves the destination with `ssh -G`. Failure to resolve
+   it does not prevent the normal SSH command from running.
+2. If terminfo setup is enabled and the destination is cached, Con selects
+   `TERM=xterm-ghostty` without another remote setup connection.
+3. Otherwise Con asks the local `infocmp` for the bundled
+   `xterm-ghostty` entry and sends it to the remote `tic` through a short-lived
+   SSH control connection.
+4. If any local or remote setup step fails, Con falls back to
+   `TERM=xterm-256color` and continues with the user's SSH command.
+5. A successful setup and successful SSH session add the destination to
+   Con's cache. The cache contains host metadata only; it is not a shared
+   Ghostty cache format.
+
+Environment forwarding uses OpenSSH options rather than a shell command:
+
+- `SetEnv=TERM=...`
+- `SendEnv=COLORTERM`
+- `SendEnv=TERM_PROGRAM`
+- `SendEnv=TERM_PROGRAM_VERSION`
+
+The remote SSH server must accept forwarded variables for them to arrive.
+Terminfo installation does not depend on those variables.
+
+## Compatibility and release rules
+
+The `+ssh` helper is a compatibility boundary for shell integration, not a
+terminal-rendering feature. It must remain isolated from the Windows and Linux
+terminal backends. Those platforms continue to build and test `con-cli`, but
+their terminal sessions do not enable the macOS bundle integration path.
+
+When bumping Ghostty, inspect the generated shell integration before enabling
+`ssh-terminfo`. A revision that invokes `+ssh` requires a helper supporting
+`+ssh`; a revision that invokes only `+ssh-cache` requires the cache command.
+Release verification must check both the helper entry point and the relevant
+CLI action before publishing an appcast or archive.
+
+For diagnostics, reproduce with:
+
+```bash
+con-cli +ssh --verbose -- user@example.com
+```
+
+If the wrapper is not reached, inspect the active shell function and binary:
+
+```bash
+type -a ghostty
+print -r -- ${GHOSTTY_BIN_DIR:-<unset>}
+functions ssh
+```


### PR DESCRIPTION
## Summary

Implement the Con-owned `con-cli +ssh` compatibility protocol used by current Ghostty shell integration.

- Parse Ghostty wrapper flags while preserving SSH arguments after `--`.
- Forward terminal identity with OpenSSH options without invoking a shell.
- Install bundled `xterm-ghostty` terminfo through a short-lived control connection when available.
- Reuse Con's existing cache and fall back to `xterm-256color` whenever setup cannot complete.
- Keep the existing `+ssh-cache` command and all Windows/Linux terminal backends unchanged.
- Document the protocol boundary, fallback behavior, and Ghostty bump/release rules.

Closes #320

## Verification

- `cargo test -p con-cli`
- `RUSTFLAGS='-D warnings' cargo check -p con-cli`
- `con-cli +ssh --terminfo=false --ssh=/bin/echo -- host.example`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The helper spawns SSH and runs a remote setup command for terminfo installation, but failures are non-blocking and the surface is isolated to the macOS shell-integration compatibility path.
> 
> **Overview**
> Adds **`con-cli +ssh`**, a Ghostty-compatible helper so macOS shell integration can route through Con’s bundle-local CLI instead of a separate Ghostty install.
> 
> The wrapper parses Con/Ghostty flags (`--forward-env`, `--terminfo`, `--cache`, `--ssh`, etc.), then **execs OpenSSH** with the user’s arguments unchanged. When terminfo setup is enabled, it resolves the destination via `ssh -G`, reuses the existing **`+ssh-cache`** host list when possible, otherwise pushes bundled **`xterm-ghostty`** to the remote via a short-lived control connection and `tic`. Any failure keeps SSH working with **`TERM=xterm-256color`**. Terminal identity is forwarded with OpenSSH **`SetEnv`/`SendEnv`** options rather than a shell.
> 
> Docs cover the protocol boundary, fallback behavior, and Ghostty bump checks; the changelog notes the macOS SSH integration path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49f453045320edfeae0ff332a9176cde293c51c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->