### PR TITLE
perf(con-ghostty): use Ghostty's incremental render ABI

### DIFF
--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -1252,6 +1252,7 @@ impl GhosttyView {
             line_height,
         };
         let shape = (snapshot.cols, snapshot.rows);
+        let generation = snapshot.generation;
         let force_full_rebuild = self.row_cache_style.as_ref() != Some(&style)
             || self.row_cache_shape != Some(shape)
             || self.row_cache.len() != usize::from(snapshot.rows);
@@ -1281,7 +1282,7 @@ impl GhosttyView {
             let row_start = row_idx * usize::from(snapshot.cols);
             let row_end = row_start + usize::from(snapshot.cols);
             let Some(cells) = snapshot.cells.get(row_start..row_end) else {
-                break;
+                return;
             };
             let cursor_for_row = cursor_col_for_row(snapshot.cursor, row_idx);
             self.row_cache[row_idx] = build_terminal_row(
@@ -1299,6 +1300,9 @@ impl GhosttyView {
         self.row_cache_cursor = Some(snapshot.cursor);
         self.row_cache_style = Some(style);
         self.row_cache_shape = Some(shape);
+        if let Some(terminal) = self.terminal.as_ref() {
+            terminal.acknowledge_snapshot(generation);
+        }
     }
 }
 

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -318,6 +318,12 @@ impl LinuxGhosttyTerminal {
         self.inner.lock().as_ref().map(LinuxPtySession::snapshot)
     }
 
+    pub fn acknowledge_snapshot(&self, generation: u64) {
+        if let Some(session) = self.inner.lock().as_ref() {
+            session.acknowledge_snapshot(generation);
+        }
+    }
+
     pub fn write_to_pty(&self, data: &[u8]) {
         if let Some(session) = self.inner.lock().as_ref() {
             if let Err(err) = session.write_input(data) {

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -311,11 +311,14 @@ impl LinuxGhosttyTerminal {
         Ok(())
     }
 
-    /// Returns the current libghostty-vt screen snapshot, if a PTY
-    /// session has been spawned. Used by `con-app/src/linux_view.rs`
-    /// to drive the styled-cell paint path.
+    /// Returns the current libghostty-vt screen snapshot when a PTY
+    /// session exists and render extraction succeeds. Used by
+    /// `con-app/src/linux_view.rs` to drive the styled-cell paint path.
     pub fn snapshot(&self) -> Option<ScreenSnapshot> {
-        self.inner.lock().as_ref().map(LinuxPtySession::snapshot)
+        self.inner
+            .lock()
+            .as_ref()
+            .and_then(LinuxPtySession::snapshot)
     }
 
     pub fn acknowledge_snapshot(&self, generation: u64) {

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -550,6 +550,10 @@ impl LinuxPtySession {
         self.shared.screen.snapshot()
     }
 
+    pub fn acknowledge_snapshot(&self, generation: u64) {
+        self.shared.screen.acknowledge_snapshot(generation);
+    }
+
     pub fn set_theme(&self, colors: &TerminalColors) {
         let theme = theme_colors_to_vt(colors);
         self.shared.screen.set_theme(&theme);

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -546,8 +546,12 @@ impl LinuxPtySession {
 
     /// Drive the libghostty-vt render-state pipeline once and return a
     /// fresh `ScreenSnapshot`.
-    pub fn snapshot(&self) -> ScreenSnapshot {
-        self.shared.screen.snapshot()
+    pub fn snapshot(&self) -> Option<ScreenSnapshot> {
+        let snapshot = self.shared.screen.try_snapshot();
+        if snapshot.is_none() {
+            self.mark_needs_render();
+        }
+        snapshot
     }
 
     pub fn acknowledge_snapshot(&self, generation: u64) {

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -10,7 +10,8 @@
 //! 4. `cells    = ghostty_render_state_row_cells_new(NULL_alloc)`
 //!
 //! Per-frame:
-//!   - `ghostty_render_state_update(state, terminal)` to refresh
+//!   - `ghostty_render_state_begin_update(state, terminal)` under the parser lock
+//!   - release the parser lock, then call `ghostty_render_state_end_update(state)`
 //!   - `ghostty_render_state_get_multi(...)` to read state metadata and bind the iterator
 //!   - while `row_iterator_next_dirty(iter, &row)` is true:
 //!       - `row_get(iter, CELLS, &cells)` to bind the dirty row
@@ -22,9 +23,10 @@
 //! key and writes to a typed `void*` out; key→type contract is per
 //! upstream header comments.
 //!
-//! libghostty-vt is NOT thread-safe; we serialize via a Mutex. The
-//! renderer reads a cloned `ScreenSnapshot` so the parser lock is
-//! released between feeds and frames.
+//! libghostty-vt terminal and render state access are serialized by
+//! separate mutexes. The parser lock is held only through the begin
+//! phase and terminal-owned metadata capture; render extraction and
+//! snapshot cloning proceed without blocking parser feeds.
 
 #![allow(non_camel_case_types, dead_code)]
 
@@ -1194,6 +1196,16 @@ struct SnapshotMetadata {
     generation: u64,
 }
 
+struct SnapshotEpoch {
+    fallback_cols: u16,
+    fallback_rows: u16,
+    kitty_placements: Arc<[KittyPlacement]>,
+    alternate_screen: bool,
+    scrollbar: Option<GhosttyScrollbar>,
+    generation: u64,
+    required_full_snapshot_generation: u64,
+}
+
 impl SnapshotMetadata {
     fn snapshot(&self, cells: &[Cell]) -> ScreenSnapshot {
         ScreenSnapshot {
@@ -1215,6 +1227,7 @@ impl SnapshotMetadata {
 
 pub struct VtScreen {
     inner: Arc<Mutex<VtInner>>,
+    render: Mutex<VtRenderState>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1330,9 +1343,6 @@ struct VtCallbackState {
 
 struct VtInner {
     terminal: GhosttyTerminal,
-    render_state: GhosttyRenderState,
-    row_iter: GhosttyRowIterator,
-    row_cells: GhosttyRowCells,
     key_encoder: GhosttyKeyEncoder,
     key_event: GhosttyKeyEvent,
     kitty_placement_iter: GhosttyKittyGraphicsPlacementIterator,
@@ -1343,6 +1353,14 @@ struct VtInner {
     cols: u16,
     rows: u16,
     generation: u64,
+    required_full_snapshot_generation: u64,
+}
+
+struct VtRenderState {
+    render_state: GhosttyRenderState,
+    row_iter: GhosttyRowIterator,
+    row_cells: GhosttyRowCells,
+    applied_full_snapshot_generation: u64,
     force_full_snapshot: bool,
     scratch_cols: u16,
     scratch_rows: u16,
@@ -1352,6 +1370,7 @@ struct VtInner {
 }
 
 unsafe impl Send for VtInner {}
+unsafe impl Send for VtRenderState {}
 
 #[repr(i32)]
 #[derive(Debug, Clone, Copy)]
@@ -1838,9 +1857,6 @@ impl VtScreen {
         Ok(Self {
             inner: Arc::new(Mutex::new(VtInner {
                 terminal,
-                render_state,
-                row_iter,
-                row_cells,
                 key_encoder,
                 key_event,
                 kitty_placement_iter,
@@ -1851,13 +1867,20 @@ impl VtScreen {
                 cols,
                 rows,
                 generation: 0,
-                force_full_snapshot: true,
+                required_full_snapshot_generation: 0,
+            })),
+            render: Mutex::new(VtRenderState {
+                render_state,
+                row_iter,
+                row_cells,
+                applied_full_snapshot_generation: u64::MAX,
+                force_full_snapshot: false,
                 scratch_cols: cols,
                 scratch_rows: rows,
                 scratch: Vec::with_capacity(cols as usize * rows as usize),
                 last_cursor: Cursor::default(),
                 snapshot_metadata: None,
-            })),
+            }),
         })
     }
 
@@ -1866,8 +1889,8 @@ impl VtScreen {
     pub fn set_theme(&self, theme: &ThemeColors) {
         let mut inner = self.inner.lock();
         unsafe { apply_theme_to_terminal(inner.terminal, theme) };
-        inner.force_full_snapshot = true;
         inner.generation = inner.generation.wrapping_add(1);
+        inner.required_full_snapshot_generation = inner.generation;
     }
 
     /// Force the next `snapshot()` to report a new generation so the
@@ -1886,9 +1909,9 @@ impl VtScreen {
     }
 
     pub(crate) fn acknowledge_snapshot(&self, generation: u64) {
-        let mut inner = self.inner.lock();
-        if inner.generation != generation
-            || !inner
+        let mut render = self.render.lock();
+        if self.inner.lock().generation != generation
+            || !render
                 .snapshot_metadata
                 .as_ref()
                 .is_some_and(|metadata| metadata.generation == generation)
@@ -1896,12 +1919,12 @@ impl VtScreen {
             return;
         }
 
-        let rc = unsafe { ghostty_render_state_clean(inner.render_state) };
+        let rc = unsafe { ghostty_render_state_clean(render.render_state) };
         if rc != GHOSTTY_SUCCESS {
             log::warn!("ghostty_render_state_clean rc={rc} generation={generation}");
             return;
         }
-        if let Some(metadata) = inner.snapshot_metadata.as_mut() {
+        if let Some(metadata) = render.snapshot_metadata.as_mut() {
             metadata.dirty_rows.clear();
         }
     }
@@ -2210,54 +2233,76 @@ impl VtScreen {
                 .cell_height
                 .store(cell_height_px.max(1), Ordering::Release);
         }
-        let total = cols as usize * rows as usize;
-        inner.scratch.clear();
-        inner.scratch.resize(total, Cell::default());
-        inner.scratch_cols = cols;
-        inner.scratch_rows = rows;
-        inner.force_full_snapshot = true;
         inner.generation = inner.generation.wrapping_add(1);
+        inner.required_full_snapshot_generation = inner.generation;
         Ok(())
     }
 
     pub fn snapshot(&self) -> ScreenSnapshot {
         let snapshot_started = perf_trace_enabled().then(Instant::now);
-        let mut inner = self.inner.lock();
+        let mut render = self.render.lock();
+        let epoch = {
+            let mut inner = self.inner.lock();
+            let fallback_cols = inner.cols;
+            let fallback_rows = inner.rows;
 
-        let fallback_cols = inner.cols;
-        let fallback_rows = inner.rows;
+            if render.render_state.is_null() {
+                return empty_snapshot(fallback_cols, fallback_rows, inner.generation);
+            }
 
-        if inner.render_state.is_null() {
-            // Render-state path disabled — return empty snapshot. The
-            // renderer still clears the pane to the background.
-            return ScreenSnapshot {
-                cols: fallback_cols,
-                rows: fallback_rows,
-                cells: Vec::new(),
-                kitty_placements: Arc::from([]),
-                dirty_rows: Vec::new(),
-                cursor: Cursor::default(),
-                alternate_screen: false,
-                scrollbar: None,
-                title: None,
-                generation: inner.generation,
+            if render
+                .snapshot_metadata
+                .as_ref()
+                .is_some_and(|metadata| metadata.generation == inner.generation)
+            {
+                drop(inner);
+                let metadata = render
+                    .snapshot_metadata
+                    .as_ref()
+                    .expect("snapshot metadata checked above");
+                return metadata.snapshot(&render.scratch);
+            }
+
+            let mut active_screen = GhosttyTerminalScreen::Primary;
+            let rc = unsafe {
+                ghostty_terminal_get(
+                    inner.terminal,
+                    GhosttyTerminalData::ActiveScreen,
+                    &mut active_screen as *mut _ as *mut c_void,
+                )
             };
-        }
+            if rc != GHOSTTY_SUCCESS {
+                log::warn!("ghostty_terminal_get(ACTIVE_SCREEN) rc={rc}");
+                render.force_full_snapshot = true;
+                return empty_snapshot(fallback_cols, fallback_rows, inner.generation);
+            }
 
-        if let Some(metadata) = inner
-            .snapshot_metadata
-            .as_ref()
-            .filter(|metadata| metadata.generation == inner.generation)
-        {
-            return metadata.snapshot(&inner.scratch);
-        }
+            let kitty_placements = snapshot_kitty_placements(&mut inner);
+            let epoch = SnapshotEpoch {
+                fallback_cols,
+                fallback_rows,
+                kitty_placements,
+                alternate_screen: active_screen == GhosttyTerminalScreen::Alternate,
+                scrollbar: read_scrollbar(inner.terminal),
+                generation: inner.generation,
+                required_full_snapshot_generation: inner.required_full_snapshot_generation,
+            };
 
-        // SAFETY: state + terminal valid for the lifetime of `inner`.
-        let rc = unsafe { ghostty_render_state_update(inner.render_state, inner.terminal) };
+            let rc =
+                unsafe { ghostty_render_state_begin_update(render.render_state, inner.terminal) };
+            if rc != GHOSTTY_SUCCESS {
+                log::warn!("ghostty_render_state_begin_update rc={rc}");
+                render.force_full_snapshot = true;
+                return empty_snapshot(fallback_cols, fallback_rows, inner.generation);
+            }
+            epoch
+        };
+
+        let rc = unsafe { ghostty_render_state_end_update(render.render_state) };
         if rc != GHOSTTY_SUCCESS {
-            log::warn!("ghostty_render_state_update rc={rc}");
-            inner.force_full_snapshot = true;
-            return empty_snapshot(fallback_cols, fallback_rows, inner.generation);
+            log::warn!("ghostty_render_state_end_update rc={rc}");
+            render.force_full_snapshot = true;
+            return empty_snapshot(epoch.fallback_cols, epoch.fallback_rows, epoch.generation);
         }
 
         let mut default_fg = GhosttyColorRgb {
@@ -2266,11 +2311,11 @@ impl VtScreen {
             b: 0xCC,
         };
         let mut default_bg = GhosttyColorRgb::default();
-        let mut cols = fallback_cols;
-        let mut rows = fallback_rows;
+        let mut cols = epoch.fallback_cols;
+        let mut rows = epoch.fallback_rows;
         let mut state_dirty = GhosttyRenderStateDirty::False;
         let mut cursor_data = GhosttyRenderStateCursor::default();
-        let render_state = inner.render_state;
+        let render_state = render.render_state;
         let state_keys = [
             GhosttyRenderStateData::ColorForeground,
             GhosttyRenderStateData::ColorBackground,
@@ -2286,7 +2331,7 @@ impl VtScreen {
             &mut cols as *mut _ as *mut c_void,
             &mut rows as *mut _ as *mut c_void,
             &mut state_dirty as *mut _ as *mut c_void,
-            &mut inner.row_iter as *mut _ as *mut c_void,
+            &mut render.row_iter as *mut _ as *mut c_void,
             &mut cursor_data as *mut _ as *mut c_void,
         ];
         let mut state_written = 0_usize;
@@ -2304,8 +2349,8 @@ impl VtScreen {
                 "ghostty_render_state_get_multi rc={rc} written={state_written}/{}",
                 state_keys.len()
             );
-            inner.force_full_snapshot = true;
-            return empty_snapshot(fallback_cols, fallback_rows, inner.generation);
+            render.force_full_snapshot = true;
+            return empty_snapshot(epoch.fallback_cols, epoch.fallback_rows, epoch.generation);
         }
 
         // Ghostty's render-state dimensions can lag the host resize by a
@@ -2314,33 +2359,21 @@ impl VtScreen {
         cols = cols.max(1);
         rows = rows.max(1);
 
-        let mut active_screen = GhosttyTerminalScreen::Primary;
-        let active_screen_rc = unsafe {
-            ghostty_terminal_get(
-                inner.terminal,
-                GhosttyTerminalData::ActiveScreen,
-                &mut active_screen as *mut _ as *mut c_void,
-            )
-        };
-        if active_screen_rc != GHOSTTY_SUCCESS {
-            log::warn!("ghostty_terminal_get(ACTIVE_SCREEN) rc={active_screen_rc}");
-            inner.force_full_snapshot = true;
-            return empty_snapshot(cols, rows, inner.generation);
-        }
-        let alternate_screen = active_screen == GhosttyTerminalScreen::Alternate;
-
-        let mut full_redraw = inner.force_full_snapshot;
+        let mut full_redraw = render.force_full_snapshot
+            || render.applied_full_snapshot_generation != epoch.required_full_snapshot_generation;
         if state_dirty == GhosttyRenderStateDirty::Full {
             full_redraw = true;
         }
 
         let total = cols as usize * rows as usize;
-        if inner.scratch.len() != total || inner.scratch_cols != cols || inner.scratch_rows != rows
+        if render.scratch.len() != total
+            || render.scratch_cols != cols
+            || render.scratch_rows != rows
         {
-            inner.scratch.clear();
-            inner.scratch.resize(total, Cell::default());
-            inner.scratch_cols = cols;
-            inner.scratch_rows = rows;
+            render.scratch.clear();
+            render.scratch.resize(total, Cell::default());
+            render.scratch_cols = cols;
+            render.scratch_rows = rows;
             full_redraw = true;
         }
 
@@ -2348,7 +2381,7 @@ impl VtScreen {
         let mut next_full_row = 0_u16;
         loop {
             let row_idx = if full_redraw {
-                if !unsafe { ghostty_render_state_row_iterator_next(inner.row_iter) } {
+                if !unsafe { ghostty_render_state_row_iterator_next(render.row_iter) } {
                     break;
                 }
                 let row = next_full_row;
@@ -2357,7 +2390,7 @@ impl VtScreen {
             } else {
                 let mut row = 0_u16;
                 if !unsafe {
-                    ghostty_render_state_row_iterator_next_dirty(inner.row_iter, &mut row)
+                    ghostty_render_state_row_iterator_next_dirty(render.row_iter, &mut row)
                 } {
                     break;
                 }
@@ -2368,49 +2401,52 @@ impl VtScreen {
                     log::warn!(
                         "ghostty_render_state_row_iterator_next_dirty returned row {row_idx} for {rows} rows"
                     );
-                    inner.force_full_snapshot = true;
-                    return empty_snapshot(cols, rows, inner.generation);
+                    render.force_full_snapshot = true;
+                    return empty_snapshot(cols, rows, epoch.generation);
                 }
                 break;
             }
 
             let rc = unsafe {
                 ghostty_render_state_row_get(
-                    inner.row_iter,
+                    render.row_iter,
                     GhosttyRenderStateRowData::Cells,
-                    &mut inner.row_cells as *mut _ as *mut c_void,
+                    &mut render.row_cells as *mut _ as *mut c_void,
                 )
             };
             if rc != GHOSTTY_SUCCESS {
                 log::warn!("ghostty_render_state_row_get(CELLS) rc={rc} at row {row_idx}");
-                inner.force_full_snapshot = true;
-                return empty_snapshot(cols, rows, inner.generation);
+                render.force_full_snapshot = true;
+                return empty_snapshot(cols, rows, epoch.generation);
             }
 
             let row_start = row_idx as usize * cols as usize;
             let mut col_idx: u16 = 0;
             // SAFETY: cells valid; `_next` returns bool.
-            while unsafe { ghostty_render_state_row_cells_next(inner.row_cells) } {
+            while unsafe { ghostty_render_state_row_cells_next(render.row_cells) } {
                 if col_idx >= cols {
                     break;
                 }
-                let Some(cell) =
-                    read_cell(inner.row_cells, default_fg, default_bg, alternate_screen)
-                else {
+                let Some(cell) = read_cell(
+                    render.row_cells,
+                    default_fg,
+                    default_bg,
+                    epoch.alternate_screen,
+                ) else {
                     log::warn!("failed to read render cell at row={row_idx} col={col_idx}");
-                    inner.force_full_snapshot = true;
-                    return empty_snapshot(cols, rows, inner.generation);
+                    render.force_full_snapshot = true;
+                    return empty_snapshot(cols, rows, epoch.generation);
                 };
                 let idx = row_start + col_idx as usize;
-                inner.scratch[idx] = cell;
+                render.scratch[idx] = cell;
                 col_idx += 1;
             }
             if col_idx != cols {
                 log::warn!(
                     "vt snapshot row ended early: row={row_idx} cells={col_idx} expected={cols}"
                 );
-                inner.force_full_snapshot = true;
-                return empty_snapshot(cols, rows, inner.generation);
+                render.force_full_snapshot = true;
+                return empty_snapshot(cols, rows, epoch.generation);
             }
 
             dirty_rows.push(row_idx);
@@ -2420,11 +2456,12 @@ impl VtScreen {
             log::warn!(
                 "vt snapshot full redraw ended early: iter_rows={next_full_row} expected_rows={rows} cols={cols}"
             );
-            inner.force_full_snapshot = true;
-            return empty_snapshot(cols, rows, inner.generation);
+            render.force_full_snapshot = true;
+            return empty_snapshot(cols, rows, epoch.generation);
         }
 
-        inner.force_full_snapshot = false;
+        render.force_full_snapshot = false;
+        render.applied_full_snapshot_generation = epoch.required_full_snapshot_generation;
 
         let cursor = if cursor_data.viewport_has_value {
             Cursor {
@@ -2435,7 +2472,7 @@ impl VtScreen {
         } else {
             Cursor::default()
         };
-        let previous_cursor = inner.last_cursor;
+        let previous_cursor = render.last_cursor;
         if previous_cursor != cursor {
             if previous_cursor.visible && previous_cursor.row < rows {
                 push_unique_row(&mut dirty_rows, previous_cursor.row);
@@ -2443,26 +2480,25 @@ impl VtScreen {
             if cursor.visible && cursor.row < rows {
                 push_unique_row(&mut dirty_rows, cursor.row);
             }
-            inner.last_cursor = cursor;
+            render.last_cursor = cursor;
         }
         dirty_rows.sort_unstable();
 
-        let kitty_placements = snapshot_kitty_placements(&mut inner);
         let metadata = SnapshotMetadata {
             cols,
             rows,
-            kitty_placements,
+            kitty_placements: epoch.kitty_placements,
             dirty_rows,
             cursor,
-            alternate_screen,
-            scrollbar: read_scrollbar(inner.terminal),
-            generation: inner.generation,
+            alternate_screen: epoch.alternate_screen,
+            scrollbar: epoch.scrollbar,
+            generation: epoch.generation,
         };
         let clone_started = perf_trace_enabled().then(Instant::now);
-        let snapshot = metadata.snapshot(&inner.scratch);
+        let snapshot = metadata.snapshot(&render.scratch);
         let clone_elapsed_ms =
             clone_started.map(|started| started.elapsed().as_secs_f64() * 1000.0);
-        inner.snapshot_metadata = Some(metadata);
+        render.snapshot_metadata = Some(metadata);
 
         if let Some(started) = snapshot_started {
             let total_ms = started.elapsed().as_secs_f64() * 1000.0;
@@ -2608,8 +2644,8 @@ impl VtScreen {
             value: GhosttyTerminalScrollViewportValue { delta: delta_rows },
         };
         unsafe { ghostty_terminal_scroll_viewport(inner.terminal, behavior) };
-        inner.force_full_snapshot = true;
         inner.generation = inner.generation.wrapping_add(1);
+        inner.required_full_snapshot_generation = inner.generation;
         true
     }
 
@@ -2626,8 +2662,8 @@ impl VtScreen {
             value: GhosttyTerminalScrollViewportValue { delta: 0 },
         };
         unsafe { ghostty_terminal_scroll_viewport(inner.terminal, behavior) };
-        inner.force_full_snapshot = true;
         inner.generation = inner.generation.wrapping_add(1);
+        inner.required_full_snapshot_generation = inner.generation;
         true
     }
 
@@ -3380,6 +3416,7 @@ impl Drop for VtScreen {
     fn drop(&mut self) {
         if let Some(mutex) = Arc::get_mut(&mut self.inner) {
             let inner = mutex.get_mut();
+            let render = self.render.get_mut();
             // Free in reverse-creation order: key event/encoder, render
             // helpers, then terminal.
             // SAFETY: unique owner via Arc::get_mut.
@@ -3397,17 +3434,17 @@ impl Drop for VtScreen {
                 };
                 inner.kitty_placement_iter = std::ptr::null_mut();
             }
-            if !inner.row_cells.is_null() {
-                unsafe { ghostty_render_state_row_cells_free(inner.row_cells) };
-                inner.row_cells = std::ptr::null_mut();
+            if !render.row_cells.is_null() {
+                unsafe { ghostty_render_state_row_cells_free(render.row_cells) };
+                render.row_cells = std::ptr::null_mut();
             }
-            if !inner.row_iter.is_null() {
-                unsafe { ghostty_render_state_row_iterator_free(inner.row_iter) };
-                inner.row_iter = std::ptr::null_mut();
+            if !render.row_iter.is_null() {
+                unsafe { ghostty_render_state_row_iterator_free(render.row_iter) };
+                render.row_iter = std::ptr::null_mut();
             }
-            if !inner.render_state.is_null() {
-                unsafe { ghostty_render_state_free(inner.render_state) };
-                inner.render_state = std::ptr::null_mut();
+            if !render.render_state.is_null() {
+                unsafe { ghostty_render_state_free(render.render_state) };
+                render.render_state = std::ptr::null_mut();
             }
             if !inner.terminal.is_null() {
                 unsafe { ghostty_terminal_free(inner.terminal) };

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -12,10 +12,11 @@
 //! Per-frame:
 //!   - `ghostty_render_state_update(state, terminal)` to refresh
 //!   - `ghostty_render_state_get_multi(...)` to read state metadata and bind the iterator
-//!   - while `row_iterator_next(iter)` is true:
-//!       - `row_get_multi(iter, DIRTY|CELLS, ...)`, skip if clean
+//!   - while `row_iterator_next_dirty(iter, &row)` is true:
+//!       - `row_get(iter, CELLS, &cells)` to bind the dirty row
 //!       - while `row_cells_next(cells)` is true:
 //!           - `row_cells_get_multi(cells, RAW|STYLE|FG|BG, ...)`
+//!   - `acknowledge_snapshot(generation)` cleans damage after renderer acceptance
 //!
 //! All `_next` functions return `bool`. The `_get` family uses an enum
 //! key and writes to a typed `void*` out; key→type contract is per
@@ -1182,6 +1183,34 @@ pub struct ScreenSnapshot {
     pub generation: u64,
 }
 
+struct SnapshotMetadata {
+    cols: u16,
+    rows: u16,
+    kitty_placements: Arc<[KittyPlacement]>,
+    dirty_rows: Vec<u16>,
+    cursor: Cursor,
+    alternate_screen: bool,
+    scrollbar: Option<GhosttyScrollbar>,
+    generation: u64,
+}
+
+impl SnapshotMetadata {
+    fn snapshot(&self, cells: &[Cell]) -> ScreenSnapshot {
+        ScreenSnapshot {
+            cols: self.cols,
+            rows: self.rows,
+            cells: cells.to_vec(),
+            kitty_placements: self.kitty_placements.clone(),
+            dirty_rows: self.dirty_rows.clone(),
+            cursor: self.cursor,
+            alternate_screen: self.alternate_screen,
+            scrollbar: self.scrollbar,
+            title: None,
+            generation: self.generation,
+        }
+    }
+}
+
 // ── Safe wrapper ───────────────────────────────────────────────────────
 
 pub struct VtScreen {
@@ -1319,6 +1348,7 @@ struct VtInner {
     scratch_rows: u16,
     scratch: Vec<Cell>,
     last_cursor: Cursor,
+    snapshot_metadata: Option<SnapshotMetadata>,
 }
 
 unsafe impl Send for VtInner {}
@@ -1826,6 +1856,7 @@ impl VtScreen {
                 scratch_rows: rows,
                 scratch: Vec::with_capacity(cols as usize * rows as usize),
                 last_cursor: Cursor::default(),
+                snapshot_metadata: None,
             })),
         })
     }
@@ -1852,6 +1883,27 @@ impl VtScreen {
 
     pub fn generation(&self) -> u64 {
         self.inner.lock().generation
+    }
+
+    pub(crate) fn acknowledge_snapshot(&self, generation: u64) {
+        let mut inner = self.inner.lock();
+        if inner.generation != generation
+            || !inner
+                .snapshot_metadata
+                .as_ref()
+                .is_some_and(|metadata| metadata.generation == generation)
+        {
+            return;
+        }
+
+        let rc = unsafe { ghostty_render_state_clean(inner.render_state) };
+        if rc != GHOSTTY_SUCCESS {
+            log::warn!("ghostty_render_state_clean rc={rc} generation={generation}");
+            return;
+        }
+        if let Some(metadata) = inner.snapshot_metadata.as_mut() {
+            metadata.dirty_rows.clear();
+        }
     }
 
     pub fn is_write_desynchronized(&self) -> bool {
@@ -2192,10 +2244,20 @@ impl VtScreen {
             };
         }
 
+        if let Some(metadata) = inner
+            .snapshot_metadata
+            .as_ref()
+            .filter(|metadata| metadata.generation == inner.generation)
+        {
+            return metadata.snapshot(&inner.scratch);
+        }
+
         // SAFETY: state + terminal valid for the lifetime of `inner`.
         let rc = unsafe { ghostty_render_state_update(inner.render_state, inner.terminal) };
-        if rc != 0 {
+        if rc != GHOSTTY_SUCCESS {
             log::warn!("ghostty_render_state_update rc={rc}");
+            inner.force_full_snapshot = true;
+            return empty_snapshot(fallback_cols, fallback_rows, inner.generation);
         }
 
         let mut default_fg = GhosttyColorRgb {
@@ -2260,11 +2322,14 @@ impl VtScreen {
                 &mut active_screen as *mut _ as *mut c_void,
             )
         };
-        let alternate_screen =
-            active_screen_rc == 0 && active_screen == GhosttyTerminalScreen::Alternate;
+        if active_screen_rc != GHOSTTY_SUCCESS {
+            log::warn!("ghostty_terminal_get(ACTIVE_SCREEN) rc={active_screen_rc}");
+            inner.force_full_snapshot = true;
+            return empty_snapshot(cols, rows, inner.generation);
+        }
+        let alternate_screen = active_screen == GhosttyTerminalScreen::Alternate;
 
-        let mut force_all_dirty = inner.force_full_snapshot;
-        let mut full_redraw = force_all_dirty;
+        let mut full_redraw = inner.force_full_snapshot;
         if state_dirty == GhosttyRenderStateDirty::Full {
             full_redraw = true;
         }
@@ -2276,53 +2341,51 @@ impl VtScreen {
             inner.scratch.resize(total, Cell::default());
             inner.scratch_cols = cols;
             inner.scratch_rows = rows;
-            force_all_dirty = true;
             full_redraw = true;
         }
 
         let mut dirty_rows: Vec<u16> = Vec::new();
-
-        let mut row_idx: u16 = 0;
-        // SAFETY: row_iter valid; `_next` returns bool.
-        while unsafe { ghostty_render_state_row_iterator_next(inner.row_iter) } {
+        let mut next_full_row = 0_u16;
+        loop {
+            let row_idx = if full_redraw {
+                if !unsafe { ghostty_render_state_row_iterator_next(inner.row_iter) } {
+                    break;
+                }
+                let row = next_full_row;
+                next_full_row = next_full_row.saturating_add(1);
+                row
+            } else {
+                let mut row = 0_u16;
+                if !unsafe {
+                    ghostty_render_state_row_iterator_next_dirty(inner.row_iter, &mut row)
+                } {
+                    break;
+                }
+                row
+            };
             if row_idx >= rows {
+                if !full_redraw {
+                    log::warn!(
+                        "ghostty_render_state_row_iterator_next_dirty returned row {row_idx} for {rows} rows"
+                    );
+                    inner.force_full_snapshot = true;
+                    return empty_snapshot(cols, rows, inner.generation);
+                }
                 break;
             }
 
-            let mut dirty = GhosttyRenderStateDirty::False;
-            let row_iter = inner.row_iter;
-            let row_keys = [
-                GhosttyRenderStateRowData::Dirty,
-                GhosttyRenderStateRowData::Cells,
-            ];
-            let mut row_values = [
-                &mut dirty as *mut _ as *mut c_void,
-                &mut inner.row_cells as *mut _ as *mut c_void,
-            ];
-            let mut row_written = 0_usize;
             let rc = unsafe {
-                ghostty_render_state_row_get_multi(
-                    row_iter,
-                    row_keys.len(),
-                    row_keys.as_ptr(),
-                    row_values.as_mut_ptr(),
-                    &mut row_written,
+                ghostty_render_state_row_get(
+                    inner.row_iter,
+                    GhosttyRenderStateRowData::Cells,
+                    &mut inner.row_cells as *mut _ as *mut c_void,
                 )
             };
-            if rc != GHOSTTY_SUCCESS || row_written != row_keys.len() {
-                log::warn!(
-                    "ghostty_render_state_row_get_multi rc={rc} written={row_written}/{} at row {row_idx}",
-                    row_keys.len()
-                );
+            if rc != GHOSTTY_SUCCESS {
+                log::warn!("ghostty_render_state_row_get(CELLS) rc={rc} at row {row_idx}");
                 inner.force_full_snapshot = true;
                 return empty_snapshot(cols, rows, inner.generation);
             }
-
-            if !full_redraw && dirty == GhosttyRenderStateDirty::False {
-                row_idx += 1;
-                continue;
-            }
-            let mut row_changed = force_all_dirty;
 
             let row_start = row_idx as usize * cols as usize;
             let mut col_idx: u16 = 0;
@@ -2339,40 +2402,26 @@ impl VtScreen {
                     return empty_snapshot(cols, rows, inner.generation);
                 };
                 let idx = row_start + col_idx as usize;
-                row_changed |= inner.scratch[idx] != cell;
                 inner.scratch[idx] = cell;
                 col_idx += 1;
             }
-            // Clear trailing cells in the row.
-            for c in col_idx..cols {
-                let idx = row_start + c as usize;
-                row_changed |= inner.scratch[idx] != Cell::default();
-                inner.scratch[idx] = Cell::default();
+            if col_idx != cols {
+                log::warn!(
+                    "vt snapshot row ended early: row={row_idx} cells={col_idx} expected={cols}"
+                );
+                inner.force_full_snapshot = true;
+                return empty_snapshot(cols, rows, inner.generation);
             }
 
-            if row_changed {
-                dirty_rows.push(row_idx);
-            }
-
-            row_idx += 1;
+            dirty_rows.push(row_idx);
         }
 
-        if full_redraw && row_idx < rows {
+        if full_redraw && next_full_row != rows {
             log::warn!(
-                "vt snapshot full redraw ended early: iter_rows={row_idx} expected_rows={rows} cols={cols}"
+                "vt snapshot full redraw ended early: iter_rows={next_full_row} expected_rows={rows} cols={cols}"
             );
-            for trailing_row in row_idx..rows {
-                let row_start = trailing_row as usize * cols as usize;
-                let row_end = row_start + cols as usize;
-                let mut row_changed = force_all_dirty;
-                for cell in &mut inner.scratch[row_start..row_end] {
-                    row_changed |= *cell != Cell::default();
-                    *cell = Cell::default();
-                }
-                if row_changed {
-                    dirty_rows.push(trailing_row);
-                }
-            }
+            inner.force_full_snapshot = true;
+            return empty_snapshot(cols, rows, inner.generation);
         }
 
         inner.force_full_snapshot = false;
@@ -2399,22 +2448,21 @@ impl VtScreen {
         dirty_rows.sort_unstable();
 
         let kitty_placements = snapshot_kitty_placements(&mut inner);
-        let clone_started = perf_trace_enabled().then(Instant::now);
-        let cells = inner.scratch.clone();
-        let clone_elapsed_ms =
-            clone_started.map(|started| started.elapsed().as_secs_f64() * 1000.0);
-        let snapshot = ScreenSnapshot {
+        let metadata = SnapshotMetadata {
             cols,
             rows,
-            cells,
             kitty_placements,
             dirty_rows,
             cursor,
             alternate_screen,
             scrollbar: read_scrollbar(inner.terminal),
-            title: None,
             generation: inner.generation,
         };
+        let clone_started = perf_trace_enabled().then(Instant::now);
+        let snapshot = metadata.snapshot(&inner.scratch);
+        let clone_elapsed_ms =
+            clone_started.map(|started| started.elapsed().as_secs_f64() * 1000.0);
+        inner.snapshot_metadata = Some(metadata);
 
         if let Some(started) = snapshot_started {
             let total_ms = started.elapsed().as_secs_f64() * 1000.0;
@@ -3805,6 +3853,28 @@ mod tests {
         ] {
             assert_eq!(keys[name].as_i64(), Some(key as i64), "GhosttyKey::{key:?}");
         }
+    }
+
+    #[test]
+    fn snapshot_damage_accumulates_until_acknowledged() {
+        let screen = VtScreen::new(4, 3, None).expect("create vt screen");
+
+        screen.feed(b"\x1b[?25l");
+        let baseline = screen.snapshot();
+        screen.acknowledge_snapshot(baseline.generation);
+
+        screen.feed(b"A");
+        let first = screen.snapshot();
+        assert_eq!(first.dirty_rows, vec![0]);
+        assert_eq!(screen.snapshot().dirty_rows, first.dirty_rows);
+
+        screen.feed(b"\x1b[2;1HB");
+        screen.acknowledge_snapshot(first.generation);
+        let combined = screen.snapshot();
+        assert_eq!(combined.dirty_rows, vec![0, 1]);
+
+        screen.acknowledge_snapshot(combined.generation);
+        assert!(screen.snapshot().dirty_rows.is_empty());
     }
 
     #[test]

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -1910,15 +1910,16 @@ impl VtScreen {
 
     pub(crate) fn acknowledge_snapshot(&self, generation: u64) {
         let mut render = self.render.lock();
-        if self.inner.lock().generation != generation
-            || !render
-                .snapshot_metadata
-                .as_ref()
-                .is_some_and(|metadata| metadata.generation == generation)
+        if !render
+            .snapshot_metadata
+            .as_ref()
+            .is_some_and(|metadata| metadata.generation == generation)
         {
             return;
         }
 
+        // Newer terminal output remains terminal-dirty until the next begin;
+        // only a newer render snapshot makes this acknowledgment stale.
         let rc = unsafe { ghostty_render_state_clean(render.render_state) };
         if rc != GHOSTTY_SUCCESS {
             log::warn!("ghostty_render_state_clean rc={rc} generation={generation}");
@@ -3893,22 +3894,28 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_damage_accumulates_until_acknowledged() {
+    fn snapshot_damage_tracks_render_acknowledgment() {
         let screen = VtScreen::new(4, 3, None).expect("create vt screen");
 
         screen.feed(b"\x1b[?25l");
         let baseline = screen.snapshot();
         screen.acknowledge_snapshot(baseline.generation);
 
-        screen.feed(b"A");
+        screen.feed(b"A\x1b[3;1H");
         let first = screen.snapshot();
-        assert_eq!(first.dirty_rows, vec![0]);
+        assert!(first.dirty_rows.contains(&0));
         assert_eq!(screen.snapshot().dirty_rows, first.dirty_rows);
 
-        screen.feed(b"\x1b[2;1HB");
+        screen.feed(b"B");
         screen.acknowledge_snapshot(first.generation);
+        let second = screen.snapshot();
+        assert_eq!(second.dirty_rows, vec![2]);
+
+        screen.feed(b"\x1b[2;1HC");
         let combined = screen.snapshot();
-        assert_eq!(combined.dirty_rows, vec![0, 1]);
+        assert_eq!(combined.dirty_rows, vec![1, 2]);
+        screen.acknowledge_snapshot(second.generation);
+        assert_eq!(screen.snapshot().dirty_rows, combined.dirty_rows);
 
         screen.acknowledge_snapshot(combined.generation);
         assert!(screen.snapshot().dirty_rows.is_empty());

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -278,6 +278,8 @@ pub enum GhosttyRenderStateData {
     CursorViewportX = 15,
     CursorViewportY = 16,
     CursorViewportWideTail = 17,
+    Cursor = 18,
+    Colors = 19,
 }
 
 #[repr(C)]
@@ -297,6 +299,8 @@ pub enum GhosttyRenderStateRowData {
     Dirty = 1,
     Raw = 2,
     Cells = 3,
+    Selection = 4,
+    CellsRaw = 5,
 }
 
 /// `GHOSTTY_RENDER_STATE_ROW_CELLS_DATA_*` keys.
@@ -310,6 +314,9 @@ pub enum GhosttyRenderStateRowCellsData {
     GraphemesBuf = 4,
     BgColor = 5,
     FgColor = 6,
+    Selected = 7,
+    HasStyling = 8,
+    GraphemesUtf8 = 9,
 }
 
 /// `GHOSTTY_CELL_DATA_*` keys for `ghostty_cell_get`. Integer values
@@ -392,6 +399,60 @@ pub struct GhosttyColorRgb {
     pub r: u8,
     pub g: u8,
     pub b: u8,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct GhosttyRenderStateCursor {
+    pub size: usize,
+    pub viewport_has_value: bool,
+    pub viewport_x: u16,
+    pub viewport_y: u16,
+    pub wide_tail: bool,
+    pub visible: bool,
+    pub blinking: bool,
+    pub password_input: bool,
+    pub visual_style: c_int,
+}
+
+impl Default for GhosttyRenderStateCursor {
+    fn default() -> Self {
+        Self {
+            size: std::mem::size_of::<Self>(),
+            viewport_has_value: false,
+            viewport_x: 0,
+            viewport_y: 0,
+            wide_tail: false,
+            visible: false,
+            blinking: false,
+            password_input: false,
+            visual_style: 0,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct GhosttyRenderStateColors {
+    pub size: usize,
+    pub background: GhosttyColorRgb,
+    pub foreground: GhosttyColorRgb,
+    pub cursor: GhosttyColorRgb,
+    pub cursor_has_value: bool,
+    pub palette: [GhosttyColorRgb; 256],
+}
+
+impl Default for GhosttyRenderStateColors {
+    fn default() -> Self {
+        Self {
+            size: std::mem::size_of::<Self>(),
+            background: GhosttyColorRgb::default(),
+            foreground: GhosttyColorRgb::default(),
+            cursor: GhosttyColorRgb::default(),
+            cursor_has_value: false,
+            palette: [GhosttyColorRgb::default(); 256],
+        }
+    }
 }
 
 #[repr(C)]
@@ -799,10 +860,23 @@ unsafe extern "C" {
         state: GhosttyRenderState,
         terminal: GhosttyTerminal,
     ) -> GhosttyResult;
+    pub fn ghostty_render_state_begin_update(
+        state: GhosttyRenderState,
+        terminal: GhosttyTerminal,
+    ) -> GhosttyResult;
+    pub fn ghostty_render_state_end_update(state: GhosttyRenderState) -> GhosttyResult;
+    pub fn ghostty_render_state_clean(state: GhosttyRenderState) -> GhosttyResult;
     pub fn ghostty_render_state_get(
         state: GhosttyRenderState,
         key: GhosttyRenderStateData,
         out: *mut c_void,
+    ) -> GhosttyResult;
+    pub fn ghostty_render_state_get_multi(
+        state: GhosttyRenderState,
+        count: usize,
+        keys: *const GhosttyRenderStateData,
+        values: *mut *mut c_void,
+        out_written: *mut usize,
     ) -> GhosttyResult;
 
     pub fn ghostty_render_state_row_iterator_new(
@@ -813,10 +887,21 @@ unsafe extern "C" {
     /// Returns `bool` per upstream signature. Rust `bool` is 1 byte —
     /// matches MSVC/gcc/clang C99 `_Bool` layout.
     pub fn ghostty_render_state_row_iterator_next(iter: GhosttyRowIterator) -> bool;
+    pub fn ghostty_render_state_row_iterator_next_dirty(
+        iter: GhosttyRowIterator,
+        out_y: *mut u16,
+    ) -> bool;
     pub fn ghostty_render_state_row_get(
         iter: GhosttyRowIterator,
         key: GhosttyRenderStateRowData,
         out: *mut c_void,
+    ) -> GhosttyResult;
+    pub fn ghostty_render_state_row_get_multi(
+        iter: GhosttyRowIterator,
+        count: usize,
+        keys: *const GhosttyRenderStateRowData,
+        values: *mut *mut c_void,
+        out_written: *mut usize,
     ) -> GhosttyResult;
 
     pub fn ghostty_render_state_row_cells_new(
@@ -830,6 +915,13 @@ unsafe extern "C" {
         key: GhosttyRenderStateRowCellsData,
         out: *mut c_void,
     ) -> GhosttyResult;
+    pub fn ghostty_render_state_row_cells_get_multi(
+        cells: GhosttyRowCells,
+        count: usize,
+        keys: *const GhosttyRenderStateRowCellsData,
+        values: *mut *mut c_void,
+        out_written: *mut usize,
+    ) -> GhosttyResult;
 
     // Cell accessor (`screen.h`). Decodes fields out of the opaque
     // `GhosttyCell` u64 we get from row_cells RAW.
@@ -837,6 +929,13 @@ unsafe extern "C" {
         cell: GhosttyCell,
         key: GhosttyCellData,
         out: *mut c_void,
+    ) -> GhosttyResult;
+    pub fn ghostty_cell_get_multi(
+        cell: GhosttyCell,
+        count: usize,
+        keys: *const GhosttyCellData,
+        values: *mut *mut c_void,
+        out_written: *mut usize,
     ) -> GhosttyResult;
 }
 
@@ -3377,6 +3476,16 @@ mod tests {
                 std::mem::size_of::<GhosttyKittyGraphicsPlacementRenderInfo>(),
                 std::mem::align_of::<GhosttyKittyGraphicsPlacementRenderInfo>(),
             ),
+            (
+                "GhosttyRenderStateCursor",
+                std::mem::size_of::<GhosttyRenderStateCursor>(),
+                std::mem::align_of::<GhosttyRenderStateCursor>(),
+            ),
+            (
+                "GhosttyRenderStateColors",
+                std::mem::size_of::<GhosttyRenderStateColors>(),
+                std::mem::align_of::<GhosttyRenderStateColors>(),
+            ),
         ] {
             assert_eq!(
                 types[name]["size"].as_u64(),
@@ -3387,6 +3496,78 @@ mod tests {
                 types[name]["align"].as_u64(),
                 Some(align as u64),
                 "{name} alignment"
+            );
+        }
+        let cursor_fields = &types["GhosttyRenderStateCursor"]["fields"];
+        for (name, offset) in [
+            ("size", std::mem::offset_of!(GhosttyRenderStateCursor, size)),
+            (
+                "viewport_has_value",
+                std::mem::offset_of!(GhosttyRenderStateCursor, viewport_has_value),
+            ),
+            (
+                "viewport_x",
+                std::mem::offset_of!(GhosttyRenderStateCursor, viewport_x),
+            ),
+            (
+                "viewport_y",
+                std::mem::offset_of!(GhosttyRenderStateCursor, viewport_y),
+            ),
+            (
+                "wide_tail",
+                std::mem::offset_of!(GhosttyRenderStateCursor, wide_tail),
+            ),
+            (
+                "visible",
+                std::mem::offset_of!(GhosttyRenderStateCursor, visible),
+            ),
+            (
+                "blinking",
+                std::mem::offset_of!(GhosttyRenderStateCursor, blinking),
+            ),
+            (
+                "password_input",
+                std::mem::offset_of!(GhosttyRenderStateCursor, password_input),
+            ),
+            (
+                "visual_style",
+                std::mem::offset_of!(GhosttyRenderStateCursor, visual_style),
+            ),
+        ] {
+            assert_eq!(
+                cursor_fields[name]["offset"].as_u64(),
+                Some(offset as u64),
+                "GhosttyRenderStateCursor::{name} offset"
+            );
+        }
+        let colors_fields = &types["GhosttyRenderStateColors"]["fields"];
+        for (name, offset) in [
+            ("size", std::mem::offset_of!(GhosttyRenderStateColors, size)),
+            (
+                "background",
+                std::mem::offset_of!(GhosttyRenderStateColors, background),
+            ),
+            (
+                "foreground",
+                std::mem::offset_of!(GhosttyRenderStateColors, foreground),
+            ),
+            (
+                "cursor",
+                std::mem::offset_of!(GhosttyRenderStateColors, cursor),
+            ),
+            (
+                "cursor_has_value",
+                std::mem::offset_of!(GhosttyRenderStateColors, cursor_has_value),
+            ),
+            (
+                "palette",
+                std::mem::offset_of!(GhosttyRenderStateColors, palette),
+            ),
+        ] {
+            assert_eq!(
+                colors_fields[name]["offset"].as_u64(),
+                Some(offset as u64),
+                "GhosttyRenderStateColors::{name} offset"
             );
         }
         for (name, value) in [
@@ -3431,6 +3612,40 @@ mod tests {
             types["GhosttyResult"]["values"]["REJECTED"].as_i64(),
             Some(GHOSTTY_REJECTED as i64)
         );
+        for (name, value) in [
+            ("CURSOR", GhosttyRenderStateData::Cursor),
+            ("COLORS", GhosttyRenderStateData::Colors),
+        ] {
+            assert_eq!(
+                types["GhosttyRenderStateData"]["values"][name].as_i64(),
+                Some(value as i64),
+                "GhosttyRenderStateData::{name}"
+            );
+        }
+        for (name, value) in [
+            ("SELECTION", GhosttyRenderStateRowData::Selection),
+            ("CELLS_RAW", GhosttyRenderStateRowData::CellsRaw),
+        ] {
+            assert_eq!(
+                types["GhosttyRenderStateRowData"]["values"][name].as_i64(),
+                Some(value as i64),
+                "GhosttyRenderStateRowData::{name}"
+            );
+        }
+        for (name, value) in [
+            ("SELECTED", GhosttyRenderStateRowCellsData::Selected),
+            ("HAS_STYLING", GhosttyRenderStateRowCellsData::HasStyling),
+            (
+                "GRAPHEMES_UTF8",
+                GhosttyRenderStateRowCellsData::GraphemesUtf8,
+            ),
+        ] {
+            assert_eq!(
+                types["GhosttyRenderStateRowCellsData"]["values"][name].as_i64(),
+                Some(value as i64),
+                "GhosttyRenderStateRowCellsData::{name}"
+            );
+        }
         assert_eq!(
             types["GhosttyTerminalData"]["values"]["MODE"].as_i64(),
             Some(GhosttyTerminalData::Mode as i64)

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -11,12 +11,11 @@
 //!
 //! Per-frame:
 //!   - `ghostty_render_state_update(state, terminal)` to refresh
-//!   - `ghostty_render_state_get(state, DATA_ROW_ITERATOR, &iter)` to bind iterator
+//!   - `ghostty_render_state_get_multi(...)` to read state metadata and bind the iterator
 //!   - while `row_iterator_next(iter)` is true:
-//!       - `row_get(iter, DIRTY, &dirty)`, skip if false
-//!       - `row_get(iter, CELLS, &cells)` to bind cells iterator to the current row
+//!       - `row_get_multi(iter, DIRTY|CELLS, ...)`, skip if clean
 //!       - while `row_cells_next(cells)` is true:
-//!           - `row_cells_get(cells, RAW|STYLE|BG|FG, &out)`
+//!           - `row_cells_get_multi(cells, RAW|STYLE|FG|BG, ...)`
 //!
 //! All `_next` functions return `bool`. The `_get` family uses an enum
 //! key and writes to a typed `void*` out; key→type contract is per
@@ -70,6 +69,7 @@ pub type GhosttyAllocator = c_void;
 pub type GhosttyResult = c_int;
 
 const GHOSTTY_SUCCESS: GhosttyResult = 0;
+const GHOSTTY_INVALID_VALUE: GhosttyResult = -2;
 const GHOSTTY_OUT_OF_SPACE: GhosttyResult = -3;
 const GHOSTTY_IO_ERROR: GhosttyResult = -5;
 const GHOSTTY_REJECTED: GhosttyResult = -7;
@@ -2198,49 +2198,57 @@ impl VtScreen {
             log::warn!("ghostty_render_state_update rc={rc}");
         }
 
-        // Palette defaults. Cells with no explicit SGR color report
-        // FG_COLOR / BG_COLOR as (0,0,0) — the renderer is expected to
-        // substitute the terminal's default foreground/background from
-        // the render state. Without this, the pwsh banner (and any
-        // unstyled text) renders black-on-black.
         let mut default_fg = GhosttyColorRgb {
             r: 0xCC,
             g: 0xCC,
             b: 0xCC,
         };
         let mut default_bg = GhosttyColorRgb::default();
-        // SAFETY: out params typed as GhosttyColorRgb per render.h.
-        unsafe {
-            let _ = ghostty_render_state_get(
-                inner.render_state,
-                GhosttyRenderStateData::ColorForeground,
-                &mut default_fg as *mut _ as *mut c_void,
+        let mut cols = fallback_cols;
+        let mut rows = fallback_rows;
+        let mut state_dirty = GhosttyRenderStateDirty::False;
+        let mut cursor_data = GhosttyRenderStateCursor::default();
+        let render_state = inner.render_state;
+        let state_keys = [
+            GhosttyRenderStateData::ColorForeground,
+            GhosttyRenderStateData::ColorBackground,
+            GhosttyRenderStateData::Cols,
+            GhosttyRenderStateData::Rows,
+            GhosttyRenderStateData::Dirty,
+            GhosttyRenderStateData::RowIterator,
+            GhosttyRenderStateData::Cursor,
+        ];
+        let mut state_values = [
+            &mut default_fg as *mut _ as *mut c_void,
+            &mut default_bg as *mut _ as *mut c_void,
+            &mut cols as *mut _ as *mut c_void,
+            &mut rows as *mut _ as *mut c_void,
+            &mut state_dirty as *mut _ as *mut c_void,
+            &mut inner.row_iter as *mut _ as *mut c_void,
+            &mut cursor_data as *mut _ as *mut c_void,
+        ];
+        let mut state_written = 0_usize;
+        let rc = unsafe {
+            ghostty_render_state_get_multi(
+                render_state,
+                state_keys.len(),
+                state_keys.as_ptr(),
+                state_values.as_mut_ptr(),
+                &mut state_written,
+            )
+        };
+        if rc != GHOSTTY_SUCCESS || state_written != state_keys.len() {
+            log::warn!(
+                "ghostty_render_state_get_multi rc={rc} written={state_written}/{}",
+                state_keys.len()
             );
-            let _ = ghostty_render_state_get(
-                inner.render_state,
-                GhosttyRenderStateData::ColorBackground,
-                &mut default_bg as *mut _ as *mut c_void,
-            );
+            inner.force_full_snapshot = true;
+            return empty_snapshot(fallback_cols, fallback_rows, inner.generation);
         }
 
         // Ghostty's render-state dimensions can lag the host resize by a
-        // frame or two. Snapshot the actual render-state geometry so we
-        // don't invent blank tail rows from our requested size while the
-        // terminal catches up asynchronously.
-        let mut cols = fallback_cols;
-        let mut rows = fallback_rows;
-        unsafe {
-            let _ = ghostty_render_state_get(
-                inner.render_state,
-                GhosttyRenderStateData::Cols,
-                &mut cols as *mut _ as *mut c_void,
-            );
-            let _ = ghostty_render_state_get(
-                inner.render_state,
-                GhosttyRenderStateData::Rows,
-                &mut rows as *mut _ as *mut c_void,
-            );
-        }
+        // frame or two. Snapshot its actual geometry instead of inventing
+        // blank tail rows from the requested host size.
         cols = cols.max(1);
         rows = rows.max(1);
 
@@ -2257,15 +2265,6 @@ impl VtScreen {
 
         let mut force_all_dirty = inner.force_full_snapshot;
         let mut full_redraw = force_all_dirty;
-        let mut state_dirty = GhosttyRenderStateDirty::False;
-        // SAFETY: DIRTY out param is sized for the enum.
-        unsafe {
-            let _ = ghostty_render_state_get(
-                inner.render_state,
-                GhosttyRenderStateData::Dirty,
-                &mut state_dirty as *mut _ as *mut c_void,
-            );
-        }
         if state_dirty == GhosttyRenderStateDirty::Full {
             full_redraw = true;
         }
@@ -2283,20 +2282,6 @@ impl VtScreen {
 
         let mut dirty_rows: Vec<u16> = Vec::new();
 
-        // Bind the row iterator to the current state.
-        // SAFETY: state + iter valid.
-        let rc = unsafe {
-            ghostty_render_state_get(
-                inner.render_state,
-                GhosttyRenderStateData::RowIterator,
-                &mut inner.row_iter as *mut _ as *mut c_void,
-            )
-        };
-        if rc != 0 {
-            log::warn!("ghostty_render_state_get(ROW_ITERATOR) rc={rc}");
-            return empty_snapshot(cols, rows, inner.generation);
-        }
-
         let mut row_idx: u16 = 0;
         // SAFETY: row_iter valid; `_next` returns bool.
         while unsafe { ghostty_render_state_row_iterator_next(inner.row_iter) } {
@@ -2305,13 +2290,32 @@ impl VtScreen {
             }
 
             let mut dirty = GhosttyRenderStateDirty::False;
-            // SAFETY: DIRTY out param is sized for the enum.
-            unsafe {
-                let _ = ghostty_render_state_row_get(
-                    inner.row_iter,
-                    GhosttyRenderStateRowData::Dirty,
-                    &mut dirty as *mut _ as *mut c_void,
+            let row_iter = inner.row_iter;
+            let row_keys = [
+                GhosttyRenderStateRowData::Dirty,
+                GhosttyRenderStateRowData::Cells,
+            ];
+            let mut row_values = [
+                &mut dirty as *mut _ as *mut c_void,
+                &mut inner.row_cells as *mut _ as *mut c_void,
+            ];
+            let mut row_written = 0_usize;
+            let rc = unsafe {
+                ghostty_render_state_row_get_multi(
+                    row_iter,
+                    row_keys.len(),
+                    row_keys.as_ptr(),
+                    row_values.as_mut_ptr(),
+                    &mut row_written,
+                )
+            };
+            if rc != GHOSTTY_SUCCESS || row_written != row_keys.len() {
+                log::warn!(
+                    "ghostty_render_state_row_get_multi rc={rc} written={row_written}/{} at row {row_idx}",
+                    row_keys.len()
                 );
+                inner.force_full_snapshot = true;
+                return empty_snapshot(cols, rows, inner.generation);
             }
 
             if !full_redraw && dirty == GhosttyRenderStateDirty::False {
@@ -2320,21 +2324,6 @@ impl VtScreen {
             }
             let mut row_changed = force_all_dirty;
 
-            // Bind the cells iterator to the current row.
-            // SAFETY: iter + cells valid.
-            let rc = unsafe {
-                ghostty_render_state_row_get(
-                    inner.row_iter,
-                    GhosttyRenderStateRowData::Cells,
-                    &mut inner.row_cells as *mut _ as *mut c_void,
-                )
-            };
-            if rc != 0 {
-                log::warn!("row_get(CELLS) rc={rc} at row {row_idx}");
-                row_idx += 1;
-                continue;
-            }
-
             let row_start = row_idx as usize * cols as usize;
             let mut col_idx: u16 = 0;
             // SAFETY: cells valid; `_next` returns bool.
@@ -2342,7 +2331,13 @@ impl VtScreen {
                 if col_idx >= cols {
                     break;
                 }
-                let cell = read_cell(inner.row_cells, default_fg, default_bg, alternate_screen);
+                let Some(cell) =
+                    read_cell(inner.row_cells, default_fg, default_bg, alternate_screen)
+                else {
+                    log::warn!("failed to read render cell at row={row_idx} col={col_idx}");
+                    inner.force_full_snapshot = true;
+                    return empty_snapshot(cols, rows, inner.generation);
+                };
                 let idx = row_start + col_idx as usize;
                 row_changed |= inner.scratch[idx] != cell;
                 inner.scratch[idx] = cell;
@@ -2382,34 +2377,14 @@ impl VtScreen {
 
         inner.force_full_snapshot = false;
 
-        // Cursor read from the render state keys (not the terminal, to
-        // stay consistent with the render snapshot).
-        let mut visible: bool = false;
-        let mut col_u16: u16 = 0;
-        let mut row_u16: u16 = 0;
-        // SAFETY: out params sized per upstream render.h.
-        unsafe {
-            let _ = ghostty_render_state_get(
-                inner.render_state,
-                GhosttyRenderStateData::CursorViewportX,
-                &mut col_u16 as *mut _ as *mut c_void,
-            );
-            let _ = ghostty_render_state_get(
-                inner.render_state,
-                GhosttyRenderStateData::CursorViewportY,
-                &mut row_u16 as *mut _ as *mut c_void,
-            );
-            let _ = ghostty_render_state_get(
-                inner.render_state,
-                GhosttyRenderStateData::CursorVisible,
-                &mut visible as *mut _ as *mut c_void,
-            );
-        }
-
-        let cursor = Cursor {
-            col: col_u16,
-            row: row_u16,
-            visible,
+        let cursor = if cursor_data.viewport_has_value {
+            Cursor {
+                col: cursor_data.viewport_x,
+                row: cursor_data.viewport_y,
+                visible: cursor_data.visible,
+            }
+        } else {
+            Cursor::default()
         };
         let previous_cursor = inner.last_cursor;
         if previous_cursor != cursor {
@@ -3215,74 +3190,85 @@ fn read_cell(
     default_fg: GhosttyColorRgb,
     default_bg: GhosttyColorRgb,
     alternate_screen: bool,
-) -> Cell {
+) -> Option<Cell> {
     // RAW here is an **opaque `GhosttyCell` u64 snapshot**, not a packed
     // codepoint. Decode fields via `ghostty_cell_get(cell, KEY, &out)`
     // per `screen.h`. Previous code bitshifted RAW directly and produced
     // nonsense codepoints (U+015C etc. for the "PowerShell" banner).
     let mut raw: GhosttyCell = 0;
     let mut style = GhosttyStyle::new();
-    // BG_COLOR / FG_COLOR write a `GhosttyColorRgb` (3 bytes: R, G, B)
-    // to the out pointer — NOT a packed u32.
-    let mut bg = GhosttyColorRgb::default();
-    let mut fg = GhosttyColorRgb::default();
-
-    // SAFETY: out params typed per upstream contract (RAW=GhosttyCell u64,
-    // STYLE=GhosttyStyle by value with `size` set to sizeof, BG/FG=GhosttyColorRgb).
-    unsafe {
-        let _ = ghostty_render_state_row_cells_get(
+    let mut fg = default_fg;
+    let mut bg = default_bg;
+    let keys = [
+        GhosttyRenderStateRowCellsData::Raw,
+        GhosttyRenderStateRowCellsData::Style,
+        GhosttyRenderStateRowCellsData::FgColor,
+        GhosttyRenderStateRowCellsData::BgColor,
+    ];
+    let mut values = [
+        &mut raw as *mut _ as *mut c_void,
+        &mut style as *mut _ as *mut c_void,
+        &mut fg as *mut _ as *mut c_void,
+        &mut bg as *mut _ as *mut c_void,
+    ];
+    let mut written = 0_usize;
+    let rc = unsafe {
+        ghostty_render_state_row_cells_get_multi(
             cells,
-            GhosttyRenderStateRowCellsData::Raw,
-            &mut raw as *mut _ as *mut c_void,
-        );
-        let _ = ghostty_render_state_row_cells_get(
-            cells,
-            GhosttyRenderStateRowCellsData::Style,
-            &mut style as *mut _ as *mut c_void,
-        );
-        let _ = ghostty_render_state_row_cells_get(
-            cells,
-            GhosttyRenderStateRowCellsData::BgColor,
-            &mut bg as *mut _ as *mut c_void,
-        );
-        let _ = ghostty_render_state_row_cells_get(
-            cells,
-            GhosttyRenderStateRowCellsData::FgColor,
-            &mut fg as *mut _ as *mut c_void,
-        );
-    }
+            keys.len(),
+            keys.as_ptr(),
+            values.as_mut_ptr(),
+            &mut written,
+        )
+    };
+    let bg_was_default = match (rc, written) {
+        (GHOSTTY_SUCCESS, 4) => false,
+        (GHOSTTY_INVALID_VALUE, 2) => {
+            let rc = unsafe {
+                ghostty_render_state_row_cells_get(
+                    cells,
+                    GhosttyRenderStateRowCellsData::BgColor,
+                    &mut bg as *mut _ as *mut c_void,
+                )
+            };
+            match rc {
+                GHOSTTY_SUCCESS => false,
+                GHOSTTY_INVALID_VALUE => true,
+                _ => return None,
+            }
+        }
+        (GHOSTTY_INVALID_VALUE, 3) => true,
+        _ => return None,
+    };
 
     // Gate codepoint decode on HAS_TEXT — blank cells carry a bogus
     // grapheme-tag codepoint we'd otherwise rasterize.
     let mut has_text: bool = false;
     let mut codepoint: u32 = 0;
-    // SAFETY: `has_text` is a C `_Bool` (1 byte); `codepoint` is uint32.
-    unsafe {
-        let _ = ghostty_cell_get(
+    let cell_keys = [GhosttyCellData::HasText, GhosttyCellData::Codepoint];
+    let mut cell_values = [
+        &mut has_text as *mut _ as *mut c_void,
+        &mut codepoint as *mut _ as *mut c_void,
+    ];
+    let mut cell_written = 0_usize;
+    let rc = unsafe {
+        ghostty_cell_get_multi(
             raw,
-            GhosttyCellData::HasText,
-            &mut has_text as *mut _ as *mut c_void,
-        );
-        if has_text {
-            let _ = ghostty_cell_get(
-                raw,
-                GhosttyCellData::Codepoint,
-                &mut codepoint as *mut _ as *mut c_void,
-            );
-        }
+            cell_keys.len(),
+            cell_keys.as_ptr(),
+            cell_values.as_mut_ptr(),
+            &mut cell_written,
+        )
+    };
+    if rc != GHOSTTY_SUCCESS || cell_written != cell_keys.len() {
+        return None;
+    }
+    if !has_text {
+        codepoint = 0;
     }
 
-    // Substitute the palette's default fg/bg when the cell's style
-    // reports no SGR override (tag == GHOSTTY_STYLE_COLOR_NONE). The
-    // row_cells FG_COLOR / BG_COLOR accessors return (0,0,0) for
-    // unstyled cells, so without this substitution default-bg cells
-    // would paint pure black. Key off the style tag, not the RGB value:
-    // explicit black may still resolve to the same RGB as the default.
-    const STYLE_COLOR_TAG_NONE: u32 = 0;
     const STYLE_COLOR_TAG_PALETTE: u32 = 1;
     const PALETTE_BLACK: u8 = 0;
-    let fg_was_default = style.fg_color.tag == STYLE_COLOR_TAG_NONE;
-    let bg_was_default = style.bg_color.tag == STYLE_COLOR_TAG_NONE;
     // Curses-style full-screen apps often paint their canvas with SGR
     // 40 instead of default background. For themes whose ANSI black is
     // a raised surface (Catppuccin, Nord, Everforest), that makes htop
@@ -3293,7 +3279,6 @@ fn read_cell(
     let bg_is_alt_canvas_black = alternate_screen
         && style.bg_color.tag == STYLE_COLOR_TAG_PALETTE
         && style.bg_color.value as u8 == PALETTE_BLACK;
-    let fg = if fg_was_default { default_fg } else { fg };
     let bg = if bg_was_default || bg_is_alt_canvas_black {
         default_bg
     } else {
@@ -3334,13 +3319,13 @@ fn read_cell(
         attrs |= ATTR_INVERSE;
     }
 
-    Cell {
+    Some(Cell {
         codepoint,
         fg: pack(fg, 0xFF),
         bg: pack(bg, bg_alpha),
         attrs,
         _pad: [0; 3],
-    }
+    })
 }
 
 impl Drop for VtScreen {
@@ -3607,6 +3592,10 @@ mod tests {
         assert_eq!(
             types["GhosttyResult"]["values"]["IO_ERROR"].as_i64(),
             Some(GHOSTTY_IO_ERROR as i64)
+        );
+        assert_eq!(
+            types["GhosttyResult"]["values"]["INVALID_VALUE"].as_i64(),
+            Some(GHOSTTY_INVALID_VALUE as i64)
         );
         assert_eq!(
             types["GhosttyResult"]["values"]["REJECTED"].as_i64(),

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -1369,6 +1369,39 @@ struct VtRenderState {
     snapshot_metadata: Option<SnapshotMetadata>,
 }
 
+impl VtRenderState {
+    fn ensure_render_state(&mut self) -> bool {
+        if !self.render_state.is_null() {
+            return true;
+        }
+
+        let mut render_state: GhosttyRenderState = std::ptr::null_mut();
+        let rc = unsafe { ghostty_render_state_new(std::ptr::null(), &mut render_state) };
+        if rc != GHOSTTY_SUCCESS || render_state.is_null() {
+            log::warn!("ghostty_render_state_new retry rc={rc}");
+            return false;
+        }
+
+        self.render_state = render_state;
+        self.applied_full_snapshot_generation = u64::MAX;
+        self.force_full_snapshot = true;
+        self.last_cursor = Cursor::default();
+        self.snapshot_metadata = None;
+        true
+    }
+
+    fn invalidate_render_state(&mut self) {
+        if !self.render_state.is_null() {
+            unsafe { ghostty_render_state_free(self.render_state) };
+            self.render_state = std::ptr::null_mut();
+        }
+        self.applied_full_snapshot_generation = u64::MAX;
+        self.force_full_snapshot = true;
+        self.last_cursor = Cursor::default();
+        self.snapshot_metadata = None;
+    }
+}
+
 unsafe impl Send for VtInner {}
 unsafe impl Send for VtRenderState {}
 
@@ -2240,16 +2273,22 @@ impl VtScreen {
     }
 
     pub fn snapshot(&self) -> ScreenSnapshot {
+        self.try_snapshot().unwrap_or_else(|| {
+            let inner = self.inner.lock();
+            empty_snapshot(inner.cols, inner.rows, inner.generation)
+        })
+    }
+
+    pub(crate) fn try_snapshot(&self) -> Option<ScreenSnapshot> {
         let snapshot_started = perf_trace_enabled().then(Instant::now);
         let mut render = self.render.lock();
+        if !render.ensure_render_state() {
+            return None;
+        }
         let epoch = {
             let mut inner = self.inner.lock();
             let fallback_cols = inner.cols;
             let fallback_rows = inner.rows;
-
-            if render.render_state.is_null() {
-                return empty_snapshot(fallback_cols, fallback_rows, inner.generation);
-            }
 
             if render
                 .snapshot_metadata
@@ -2261,7 +2300,7 @@ impl VtScreen {
                     .snapshot_metadata
                     .as_ref()
                     .expect("snapshot metadata checked above");
-                return metadata.snapshot(&render.scratch);
+                return Some(metadata.snapshot(&render.scratch));
             }
 
             let mut active_screen = GhosttyTerminalScreen::Primary;
@@ -2275,7 +2314,7 @@ impl VtScreen {
             if rc != GHOSTTY_SUCCESS {
                 log::warn!("ghostty_terminal_get(ACTIVE_SCREEN) rc={rc}");
                 render.force_full_snapshot = true;
-                return empty_snapshot(fallback_cols, fallback_rows, inner.generation);
+                return None;
             }
 
             let kitty_placements = snapshot_kitty_placements(&mut inner);
@@ -2293,8 +2332,11 @@ impl VtScreen {
                 unsafe { ghostty_render_state_begin_update(render.render_state, inner.terminal) };
             if rc != GHOSTTY_SUCCESS {
                 log::warn!("ghostty_render_state_begin_update rc={rc}");
-                render.force_full_snapshot = true;
-                return empty_snapshot(fallback_cols, fallback_rows, inner.generation);
+                // begin_update may consume terminal dirty state before an
+                // allocation fails. A new state forces the retry to rebuild
+                // from the terminal instead of reusing a partial update.
+                render.invalidate_render_state();
+                return None;
             }
             epoch
         };
@@ -2302,8 +2344,8 @@ impl VtScreen {
         let rc = unsafe { ghostty_render_state_end_update(render.render_state) };
         if rc != GHOSTTY_SUCCESS {
             log::warn!("ghostty_render_state_end_update rc={rc}");
-            render.force_full_snapshot = true;
-            return empty_snapshot(epoch.fallback_cols, epoch.fallback_rows, epoch.generation);
+            render.invalidate_render_state();
+            return None;
         }
 
         let mut default_fg = GhosttyColorRgb {
@@ -2351,7 +2393,7 @@ impl VtScreen {
                 state_keys.len()
             );
             render.force_full_snapshot = true;
-            return empty_snapshot(epoch.fallback_cols, epoch.fallback_rows, epoch.generation);
+            return None;
         }
 
         // Ghostty's render-state dimensions can lag the host resize by a
@@ -2403,7 +2445,7 @@ impl VtScreen {
                         "ghostty_render_state_row_iterator_next_dirty returned row {row_idx} for {rows} rows"
                     );
                     render.force_full_snapshot = true;
-                    return empty_snapshot(cols, rows, epoch.generation);
+                    return None;
                 }
                 break;
             }
@@ -2418,7 +2460,7 @@ impl VtScreen {
             if rc != GHOSTTY_SUCCESS {
                 log::warn!("ghostty_render_state_row_get(CELLS) rc={rc} at row {row_idx}");
                 render.force_full_snapshot = true;
-                return empty_snapshot(cols, rows, epoch.generation);
+                return None;
             }
 
             let row_start = row_idx as usize * cols as usize;
@@ -2436,7 +2478,7 @@ impl VtScreen {
                 ) else {
                     log::warn!("failed to read render cell at row={row_idx} col={col_idx}");
                     render.force_full_snapshot = true;
-                    return empty_snapshot(cols, rows, epoch.generation);
+                    return None;
                 };
                 let idx = row_start + col_idx as usize;
                 render.scratch[idx] = cell;
@@ -2447,7 +2489,7 @@ impl VtScreen {
                     "vt snapshot row ended early: row={row_idx} cells={col_idx} expected={cols}"
                 );
                 render.force_full_snapshot = true;
-                return empty_snapshot(cols, rows, epoch.generation);
+                return None;
             }
 
             dirty_rows.push(row_idx);
@@ -2458,7 +2500,7 @@ impl VtScreen {
                 "vt snapshot full redraw ended early: iter_rows={next_full_row} expected_rows={rows} cols={cols}"
             );
             render.force_full_snapshot = true;
-            return empty_snapshot(cols, rows, epoch.generation);
+            return None;
         }
 
         render.force_full_snapshot = false;
@@ -2530,7 +2572,7 @@ impl VtScreen {
             }
         }
 
-        snapshot
+        Some(snapshot)
     }
 
     pub fn size(&self) -> (u16, u16) {
@@ -3919,6 +3961,22 @@ mod tests {
 
         screen.acknowledge_snapshot(combined.generation);
         assert!(screen.snapshot().dirty_rows.is_empty());
+    }
+
+    #[test]
+    fn discarded_render_state_rebuilds_from_clean_terminal() {
+        let screen = VtScreen::new(4, 3, None).expect("create vt screen");
+
+        screen.feed(b"A");
+        let first = screen.try_snapshot().expect("extract initial snapshot");
+        assert_eq!(first.cells[0].codepoint, u32::from('A'));
+
+        screen.render.lock().invalidate_render_state();
+
+        let recovered = screen.try_snapshot().expect("rebuild render state");
+        assert_eq!(recovered.generation, first.generation);
+        assert_eq!(recovered.cells[0].codepoint, u32::from('A'));
+        assert_eq!(recovered.cells.len(), 12);
     }
 
     #[test]

--- a/crates/con-ghostty/src/windows/ghostty_vt_stub.c
+++ b/crates/con-ghostty/src/windows/ghostty_vt_stub.c
@@ -250,6 +250,29 @@ GhosttyResult ghostty_cell_get(uint64_t cell, int key, void* out) {
     return 0;
 }
 
+GhosttyResult ghostty_cell_get_multi(
+    uint64_t cell, size_t count, const int* keys,
+    void** values, size_t* out_written
+) {
+    if (!keys || !values) {
+        if (out_written) { *out_written = 0; }
+        return -2;
+    }
+    for (size_t i = 0; i < count; ++i) {
+        if (!values[i]) {
+            if (out_written) { *out_written = i; }
+            return -2;
+        }
+        GhosttyResult result = ghostty_cell_get(cell, keys[i], values[i]);
+        if (result != 0) {
+            if (out_written) { *out_written = i; }
+            return result;
+        }
+    }
+    if (out_written) { *out_written = count; }
+    return 0;
+}
+
 /* ── Render state ───────────────────────────────────────────────── */
 
 GhosttyResult ghostty_render_state_new(
@@ -269,11 +292,51 @@ GhosttyResult ghostty_render_state_update(
     return 0;
 }
 
+GhosttyResult ghostty_render_state_begin_update(
+    GhosttyRenderState state, GhosttyTerminal terminal
+) {
+    (void)state; (void)terminal;
+    return 0;
+}
+
+GhosttyResult ghostty_render_state_end_update(GhosttyRenderState state) {
+    (void)state;
+    return 0;
+}
+
+GhosttyResult ghostty_render_state_clean(GhosttyRenderState state) {
+    (void)state;
+    return 0;
+}
+
 GhosttyResult ghostty_render_state_get(
     GhosttyRenderState state, int key, void* out
 ) {
     (void)state; (void)key;
     if (out) { *(uint8_t*)out = 0; }
+    return 0;
+}
+
+GhosttyResult ghostty_render_state_get_multi(
+    GhosttyRenderState state, size_t count, const int* keys,
+    void** values, size_t* out_written
+) {
+    if (!keys || !values) {
+        if (out_written) { *out_written = 0; }
+        return -2;
+    }
+    for (size_t i = 0; i < count; ++i) {
+        if (!values[i]) {
+            if (out_written) { *out_written = i; }
+            return -2;
+        }
+        GhosttyResult result = ghostty_render_state_get(state, keys[i], values[i]);
+        if (result != 0) {
+            if (out_written) { *out_written = i; }
+            return result;
+        }
+    }
+    if (out_written) { *out_written = count; }
     return 0;
 }
 
@@ -286,12 +349,41 @@ GhosttyResult ghostty_render_state_row_iterator_new(
 }
 void ghostty_render_state_row_iterator_free(GhosttyRowIterator iter) { (void)iter; }
 bool ghostty_render_state_row_iterator_next(GhosttyRowIterator iter) { (void)iter; return false; }
+bool ghostty_render_state_row_iterator_next_dirty(
+    GhosttyRowIterator iter, uint16_t* out_y
+) {
+    (void)iter; (void)out_y;
+    return false;
+}
 
 GhosttyResult ghostty_render_state_row_get(
     GhosttyRowIterator iter, int key, void* out
 ) {
     (void)iter; (void)key;
     if (out) { *(uint8_t*)out = 0; }
+    return 0;
+}
+
+GhosttyResult ghostty_render_state_row_get_multi(
+    GhosttyRowIterator iter, size_t count, const int* keys,
+    void** values, size_t* out_written
+) {
+    if (!keys || !values) {
+        if (out_written) { *out_written = 0; }
+        return -2;
+    }
+    for (size_t i = 0; i < count; ++i) {
+        if (!values[i]) {
+            if (out_written) { *out_written = i; }
+            return -2;
+        }
+        GhosttyResult result = ghostty_render_state_row_get(iter, keys[i], values[i]);
+        if (result != 0) {
+            if (out_written) { *out_written = i; }
+            return result;
+        }
+    }
+    if (out_written) { *out_written = count; }
     return 0;
 }
 
@@ -310,5 +402,28 @@ GhosttyResult ghostty_render_state_row_cells_get(
 ) {
     (void)cells; (void)key;
     if (out) { *(uint8_t*)out = 0; }
+    return 0;
+}
+
+GhosttyResult ghostty_render_state_row_cells_get_multi(
+    GhosttyRowCells cells, size_t count, const int* keys,
+    void** values, size_t* out_written
+) {
+    if (!keys || !values) {
+        if (out_written) { *out_written = 0; }
+        return -2;
+    }
+    for (size_t i = 0; i < count; ++i) {
+        if (!values[i]) {
+            if (out_written) { *out_written = i; }
+            return -2;
+        }
+        GhosttyResult result = ghostty_render_state_row_cells_get(cells, keys[i], values[i]);
+        if (result != 0) {
+            if (out_written) { *out_written = i; }
+            return result;
+        }
+    }
+    if (out_written) { *out_written = count; }
     return 0;
 }

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -264,6 +264,7 @@ impl RenderSession {
         let prefer_latest = immediate || generation_ready || burst_active;
         let render_started = perf_trace_enabled().then(Instant::now);
         let outcome = renderer.render(&snapshot, &config, prefer_latest)?;
+        self.vt.acknowledge_snapshot(snapshot.generation);
         let render_ms = render_started
             .map(|started| started.elapsed().as_secs_f64() * 1000.0)
             .unwrap_or(0.0);

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -253,7 +253,9 @@ impl RenderSession {
         let renderer = self.renderer.lock();
         let config = self.config.lock().clone();
         let snapshot_started = perf_trace_enabled().then(Instant::now);
-        let snapshot = self.vt.snapshot();
+        let Some(snapshot) = self.vt.try_snapshot() else {
+            return Ok(RenderOutcome::Pending);
+        };
         let snapshot_ms = snapshot_started
             .map(|started| started.elapsed().as_secs_f64() * 1000.0)
             .unwrap_or(0.0);

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -467,18 +467,11 @@ impl Renderer {
             .generation
             .wrapping_mul(0x9E37_79B9_7F4A_7C15)
             .wrapping_add(sel_hash ^ geometry_hash.rotate_left(13));
-        let needs_draw = {
-            let mut last = self
-                .last_generation
-                .lock()
-                .expect("last_generation mutex poisoned in render()");
-            if *last == combined {
-                false
-            } else {
-                *last = combined;
-                true
-            }
-        };
+        let needs_draw = *self
+            .last_generation
+            .lock()
+            .expect("last_generation mutex poisoned in render()")
+            != combined;
 
         let mut ring = self
             .staging_ring
@@ -586,6 +579,10 @@ impl Renderer {
                 &readback_regions,
                 kitty_visuals,
             ));
+            *self
+                .last_generation
+                .lock()
+                .expect("last_generation mutex poisoned after submit") = combined;
             submit_ms = submit_started
                 .map(|started| started.elapsed().as_secs_f64() * 1000.0)
                 .unwrap_or(0.0);

--- a/postmortem/2026-09-01-render-update-failure-recovery.md
+++ b/postmortem/2026-09-01-render-update-failure-recovery.md
@@ -1,0 +1,51 @@
+# Render update failure recovery
+
+## What Happened
+
+The incremental Render ABI review found that Con treated every render-state
+update failure as a temporary extraction failure. It returned an empty
+`ScreenSnapshot` for the current terminal generation and retried later with
+the same `GhosttyRenderState`.
+
+That behavior was unsafe for an out-of-memory failure from
+`ghostty_render_state_begin_update`. It could leave the renderer with a
+partial render state, and platform consumers could mistake the empty
+snapshot for a successfully extracted frame.
+
+## Root Cause
+
+Con assumed `begin_update` was transactional. Ghostty's implementation can
+clear terminal page and row dirty flags before a later row rebuild or style
+allocation fails. Retrying the same render state therefore cannot reliably
+reconstruct the consumed rows.
+
+The snapshot API also had no internal failure boundary. Extraction failures
+were represented as valid empty snapshots carrying the current generation,
+so Linux or Windows could cache that generation instead of preserving the
+last valid frame and retrying it.
+
+## Fix Applied
+
+- Added an internal fallible snapshot path for platform renderers while
+  preserving the existing owned `snapshot()` interface for compatibility.
+- Invalidated the render state after a failed begin or end phase. The next
+  attempt creates a new render state, which forces Ghostty to rebuild the
+  complete viewport even if terminal dirty flags were already consumed.
+- Made Windows return `Pending` when extraction fails so the current image is
+  retained and another prepaint is scheduled.
+- Made Linux restore its `needs_render` flag and wake the workspace loop when
+  extraction fails.
+- Added a regression test that consumes terminal dirty state, discards the
+  render state, and verifies that the same generation is rebuilt correctly.
+
+## What We Learned
+
+- A foreign update function that mutates state before returning an error must
+  not be assumed transactional unless its contract explicitly guarantees it.
+- Renderer acknowledgment must represent successful consumption, not merely
+  an attempted snapshot for a generation.
+- Retryable extraction failures need an explicit internal boundary so callers
+  can preserve the last valid frame without changing stable public snapshot
+  ownership.
+- Recovery tests should start from consumed terminal damage; rebuilding only
+  after new output would hide the state-loss case.


### PR DESCRIPTION

## Summary

- Bind Ghostty's batched render getters and structured cursor data.
- Read only dirty rows, then clean render damage after Linux or Windows accepts the snapshot.
- Split render updates into `begin_update` and `end_update`, releasing the parser mutex before extraction and cloning.
- Recreate the render state after an update failure so partially consumed dirty state cannot be acknowledged as a valid frame.

## Scope

`ScreenSnapshot` remains an owned full-screen clone. This PR reduces FFI calls and parser lock time without changing renderer ownership or architecture.

## Testing

- `cargo check -p con`
- `cargo test -p con --bin con semantic_prompt`
- 54 `con-ghostty` tests against local libghostty-vt on Linux x86_64
- Linux and Windows `con-ghostty` test-target checks
- `clang -fsyntax-only -std=c11 -Wall -Wextra -Werror crates/con-ghostty/src/windows/ghostty_vt_stub.c`