### PR TITLE
ci(release): verify macOS SSH entry point in all artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ con is still pre-release, so entries may group related beta work while the produ
   [#335](https://github.com/nowledge-co/con-terminal/pull/335) by
   [@wey-gu](https://github.com/wey-gu))_
 
+**Windows and Linux**
+
+- Terminal updates now consume incremental dirty-row changes, reducing
+  unnecessary parser and renderer work during continuous output and window
+  resizing. _(PR
+  [#336](https://github.com/nowledge-co/con-terminal/pull/336) by
+  [@yyhhyyyyyy](https://github.com/yyhhyyyyyy))_
+
 **Developer tools**
 
 - Terminal execution now recognizes semantic shell prompt state on Windows and
@@ -38,6 +46,11 @@ con is still pre-release, so entries may group related beta work while the produ
   macOS panes when the terminal backend supports those details. _(PR
   [#332](https://github.com/nowledge-co/con-terminal/pull/332) by
   [@yyhhyyyyyy](https://github.com/yyhhyyyyyy))_
+- macOS release validation now checks the bundle-local SSH compatibility
+  entry point in the app bundle, ZIP, and DMG before artifacts can be
+  published. _(PR [#334](https://github.com/nowledge-co/con-terminal/pull/334)
+  and PR [#337](https://github.com/nowledge-co/con-terminal/pull/337) by
+  [@wey-gu](https://github.com/wey-gu))_
 
 ---
 

--- a/scripts/release/verify-artifacts.sh
+++ b/scripts/release/verify-artifacts.sh
@@ -52,6 +52,14 @@ verify_terminal_desktop_contract() {
   require_desktop_entry "$desktop" "X-TerminalArgAppId=--app-id="
 }
 
+verify_macos_app_contract() {
+  local app="$1"
+  require_executable "$app/Contents/MacOS/con"
+  require_executable "$app/Contents/MacOS/con-cli"
+  require_symlink_target "$app/Contents/MacOS/ghostty" con-cli
+  "$app/Contents/MacOS/con-cli" --help >/dev/null
+}
+
 verify_linux() {
   local tarball="$1"
   local checksum="$2"
@@ -118,10 +126,7 @@ verify_macos() {
   require_file "$dmg"
   require_file "$checksum"
 
-  require_executable "$app/Contents/MacOS/con"
-  require_executable "$app/Contents/MacOS/con-cli"
-  require_symlink_target "$app/Contents/MacOS/ghostty" con-cli
-  "$app/Contents/MacOS/con-cli" --help >/dev/null
+  verify_macos_app_contract "$app"
 
   log "checking macOS checksum"
   (
@@ -130,10 +135,19 @@ verify_macos() {
   )
 
   log "checking macOS ZIP layout"
-  unzip -l "$zip" | grep -F ".app/Contents/MacOS/con-cli" >/dev/null \
-    || fail "$(basename "$zip") does not contain bundled con-cli"
-  unzip -l "$zip" | grep -F ".app/Contents/MacOS/ghostty" >/dev/null \
-    || fail "$(basename "$zip") does not contain Ghostty SSH compatibility entry point"
+  local zip_root
+  zip_root="$(mktemp -d)"
+  unzip -q "$zip" -d "$zip_root"
+  local zip_app=""
+  for candidate in "$zip_root"/*.app; do
+    if [[ -d "$candidate" ]]; then
+      zip_app="$candidate"
+      break
+    fi
+  done
+  [[ -n "$zip_app" ]] || fail "$(basename "$zip") does not contain an app bundle"
+  verify_macos_app_contract "$zip_app"
+  rm -rf "$zip_root"
 
   log "checking macOS DMG layout"
   local mount_point
@@ -149,10 +163,7 @@ verify_macos() {
     fi
   done
   [[ -n "$mounted_app" ]] || fail "$(basename "$dmg") does not contain an app bundle"
-  require_executable "$mounted_app/Contents/MacOS/con"
-  require_executable "$mounted_app/Contents/MacOS/con-cli"
-  require_symlink_target "$mounted_app/Contents/MacOS/ghostty" con-cli
-  "$mounted_app/Contents/MacOS/con-cli" --help >/dev/null
+  verify_macos_app_contract "$mounted_app"
 
   log "macOS artifact OK: $(basename "$dmg")"
 }


### PR DESCRIPTION
## Summary
- validate the bundle-local `ghostty -> con-cli` SSH compatibility entry point in the app bundle
- unpack the ZIP and validate the actual symlink target, not only the archive path
- reuse the same contract for the DMG-mounted app

This closes the release-validation gap identified after PR #334: a malformed or missing compatibility entry could pass the ZIP layout check while breaking Ghostty-style `+ssh` discovery.

References: #334, #335

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to release CI verification and changelog; no runtime app behavior is modified.
> 
> **Overview**
> **macOS release verification** now enforces the bundle-local Ghostty SSH compatibility layout (`con`, `con-cli`, `ghostty` → `con-cli`, and a working `con-cli --help`) through a shared **`verify_macos_app_contract`** helper used for the built app, the ZIP, and the DMG.
> 
> **ZIP checks** unpack the archive and validate the extracted `.app` instead of only grepping the file list, so a broken or missing symlink can’t pass while the path string still appears in the archive.
> 
> The **changelog** documents that macOS artifacts must pass this SSH entry-point validation before publish (PR #337).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5966bdf7a79ecc56e2e1a5695703ba742bf5a6b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->