### PR TITLE
feat(terminal): move Windows and Linux selection to libghostty-vt

### DIFF
--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -1684,8 +1684,8 @@ impl GhosttyView {
         terminal.send_mouse_pos(x, y, mods);
         let consumed = terminal.send_mouse_button(true, button, mods);
         match button {
-            MouseButton::Left => self.left_mouse_sequence.press_sent(mods),
-            MouseButton::Right => self.right_mouse_sequence.press_sent(mods),
+            MouseButton::Left => self.left_mouse_sequence.begin(mods),
+            MouseButton::Right => self.right_mouse_sequence.begin(mods),
             MouseButton::Middle => {}
         }
         Some(consumed)

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -1517,9 +1517,16 @@ impl Render for GhosttyView {
 
         if let Some(snapshot) = self.snapshot.as_ref() {
             for row_idx in 0..usize::from(snapshot.rows) {
-                if let Some(selection_cols) =
-                    selection.and_then(|selection| selection.row_range(row_idx, snapshot))
-                {
+                let selection_cols = match selection {
+                    Some(selection) => selection.row_range(row_idx, snapshot),
+                    None => snapshot
+                        .selection_ranges
+                        .get(row_idx)
+                        .copied()
+                        .flatten()
+                        .map(|range| (usize::from(range.start), usize::from(range.end))),
+                };
+                if let Some(selection_cols) = selection_cols {
                     let row_start = row_idx * usize::from(snapshot.cols);
                     let row_end = row_start + usize::from(snapshot.cols);
                     if let Some(cells) = snapshot.cells.get(row_start..row_end) {
@@ -2941,6 +2948,7 @@ mod tests {
             cols: 5,
             rows: 3,
             cells: Vec::new(),
+            selection_ranges: vec![None; 3],
             kitty_placements: Default::default(),
             dirty_rows: Vec::new(),
             cursor: VtCursor {
@@ -2973,6 +2981,7 @@ mod tests {
             cols: 4,
             rows: 3,
             cells,
+            selection_ranges: vec![None; 3],
             kitty_placements: Default::default(),
             dirty_rows: Vec::new(),
             cursor: VtCursor {
@@ -3003,6 +3012,7 @@ mod tests {
             cols: 4,
             rows: 3,
             cells: vec![Default::default(); 12],
+            selection_ranges: vec![None; 3],
             kitty_placements: Default::default(),
             dirty_rows: vec![1],
             cursor: VtCursor {

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -16,8 +16,12 @@
 use std::collections::{HashMap, HashSet};
 use std::ops::Range;
 use std::sync::Arc;
+use std::time::Duration;
 
-use con_ghostty::vt::{VtKeyAction, VtKeyEvent, VtKeyModifiers, VtPasteResult, VtPasteSource};
+use con_ghostty::vt::{
+    SelectionAutoscroll, SelectionGeometry, SelectionPoint, VtKeyAction, VtKeyEvent,
+    VtKeyModifiers, VtPasteResult, VtPasteSource,
+};
 use con_ghostty::{
     ATTR_BOLD, ATTR_INVERSE, ATTR_ITALIC, ATTR_STRIKE, ATTR_UNDERLINE, DesktopNotification,
     GhosttyApp, GhosttySplitDirection, GhosttyTerminal, KittyImage, KittyPlacement, ScreenSnapshot,
@@ -36,7 +40,8 @@ use crate::mouse_sequence::MouseButtonSequence;
 use crate::terminal_ime::{TerminalImeInputHandler, TerminalImeView};
 use crate::terminal_links::{self, TerminalLink};
 use crate::terminal_paste::{
-    TerminalPastePayload, payload_from_clipboard, payload_from_external_paths, unsafe_paste_preview,
+    TerminalPastePayload, copy_selection_to_clipboard, payload_from_clipboard,
+    payload_from_external_paths, unsafe_paste_preview,
 };
 use crate::terminal_restore::restored_terminal_output;
 
@@ -47,6 +52,7 @@ const DEFAULT_CELL_HEIGHT_RATIO: f32 = 1.45;
 const TERMINAL_PADDING_X_PX: f32 = 12.0;
 const TERMINAL_PADDING_Y_PX: f32 = 10.0;
 const KITTY_BELOW_BACKGROUND_LIMIT: i32 = i32::MIN / 2;
+const SELECTION_AUTOSCROLL_INTERVAL: Duration = Duration::from_millis(15);
 
 /// Resolved logical font size used for both the cell-grid estimate
 /// (`estimate_surface_size`) and the actual paint (`render`). Both
@@ -105,6 +111,12 @@ impl EventEmitter<GhosttyCwdChanged> for GhosttyView {}
 impl EventEmitter<GhosttyProgressChanged> for GhosttyView {}
 impl EventEmitter<GhosttyDesktopNotification> for GhosttyView {}
 
+#[derive(Clone, Copy)]
+enum LeftMouseSequence {
+    LocalSelection,
+    TerminalReport,
+}
+
 pub struct GhosttyView {
     app: Arc<GhosttyApp>,
     terminal: Option<Arc<GhosttyTerminal>>,
@@ -144,13 +156,14 @@ pub struct GhosttyView {
     suppress_link_mouse_up: bool,
     hovered_link: Option<TerminalLink>,
     last_mouse_position: Option<Point<Pixels>>,
-    selection: Option<TerminalSelection>,
-    drag_anchor: Option<(u16, u64)>,
+    terminal_left_mouse_sequence: MouseButtonSequence<LeftMouseSequence>,
     /// Whether the most recent right-button press was consumed by the
     /// terminal app (an SGR report emitted). The context-menu builder
     /// suppresses con's menu only when this is true.
     terminal_mouse_right_consumed: Option<bool>,
     terminal_right_mouse_sequence: MouseButtonSequence<bool>,
+    selection_autoscroll_epoch: u64,
+    selection_autoscroll_active: bool,
     keys_awaiting_release: HashMap<String, crate::terminal_keys::TrackedVtKey>,
     pending_unsafe_paste: Option<(String, VtPasteSource)>,
 }
@@ -237,10 +250,11 @@ impl GhosttyView {
             suppress_link_mouse_up: false,
             hovered_link: None,
             last_mouse_position: None,
-            selection: None,
-            drag_anchor: None,
+            terminal_left_mouse_sequence: MouseButtonSequence::default(),
             terminal_mouse_right_consumed: None,
             terminal_right_mouse_sequence: MouseButtonSequence::default(),
+            selection_autoscroll_epoch: 0,
+            selection_autoscroll_active: false,
             keys_awaiting_release: HashMap::new(),
             pending_unsafe_paste: None,
         }
@@ -298,39 +312,33 @@ impl GhosttyView {
     }
 
     pub fn selection_text(&self) -> Option<String> {
-        extract_selection_text(self.snapshot.as_ref()?, self.selection?)
+        self.terminal
+            .as_ref()
+            .and_then(|terminal| terminal.selection_text())
     }
 
     pub fn release_mouse_selection(&mut self, cx: &mut Context<Self>) {
         let Some(position) = self.last_mouse_position else {
             return;
         };
-        if self.finish_selection(position) {
+        if self.finish_left_mouse_sequence(position) {
             cx.notify();
         }
     }
 
     fn clear_selection(&mut self) -> bool {
-        let changed = self.selection.take().is_some() || self.drag_anchor.take().is_some();
+        let Some(terminal) = self.terminal.as_ref() else {
+            return false;
+        };
+        let changed = terminal.has_selection();
+        terminal.clear_selection();
         changed
     }
 
     fn copy_current_selection_to_clipboard(&mut self, cx: &mut App) -> bool {
-        if self.selection.is_none() {
-            return false;
-        }
-
-        let Some(selection) = self
-            .selection_text()
-            .filter(|selection| !selection.is_empty())
-        else {
-            self.clear_selection();
-            return true;
-        };
-
-        cx.write_to_clipboard(ClipboardItem::new_string(selection));
-        self.clear_selection();
-        true
+        self.terminal
+            .as_ref()
+            .is_some_and(|terminal| copy_selection_to_clipboard(terminal, cx))
     }
 
     pub fn shutdown_surface(&mut self, mut window: Option<&mut Window>, cx: &mut App) {
@@ -362,10 +370,10 @@ impl GhosttyView {
         self.suppress_link_mouse_up = false;
         self.hovered_link = None;
         self.last_mouse_position = None;
-        self.selection = None;
-        self.drag_anchor = None;
+        self.terminal_left_mouse_sequence = MouseButtonSequence::default();
         self.terminal_mouse_right_consumed = None;
         self.terminal_right_mouse_sequence = MouseButtonSequence::default();
+        self.stop_selection_autoscroll();
         self.keys_awaiting_release.clear();
         self.pending_unsafe_paste = None;
     }
@@ -616,7 +624,6 @@ impl GhosttyView {
         {
             self.seen_any_output = true;
         }
-        self.clear_selection();
         self.snapshot = Some(snapshot);
         true
     }
@@ -634,7 +641,6 @@ impl GhosttyView {
             return false;
         }
 
-        self.clear_selection();
         if let Err(err) = terminal.resize_surface(size) {
             // Do not cache a resize that never reached the PTY. A later layout
             // or render pass can retry the same dimensions after backpressure
@@ -695,30 +701,59 @@ impl GhosttyView {
         pos: Point<Pixels>,
         clamp_to_grid: bool,
     ) -> Option<(u16, u16)> {
+        self.selection_input_from_event_position(pos, clamp_to_grid)
+            .map(|(point, _)| (point.col, point.row))
+    }
+
+    fn selection_input_from_event_position(
+        &self,
+        pos: Point<Pixels>,
+        clamp_to_grid: bool,
+    ) -> Option<(SelectionPoint, SelectionGeometry)> {
         let bounds = self.pane_bounds?;
         let snapshot = self.snapshot.as_ref()?;
+        if snapshot.cols == 0 || snapshot.rows == 0 {
+            return None;
+        }
         let font_size_px = effective_font_size(self.initial_font_size);
-        let cell_width_px = cell_width_px(font_size_px);
-        let cell_height_px = cell_height_px(font_size_px);
-
-        let mut local_x = f32::from(pos.x) - f32::from(bounds.origin.x) - TERMINAL_PADDING_X_PX;
-        let mut local_y = f32::from(pos.y) - f32::from(bounds.origin.y) - TERMINAL_PADDING_Y_PX;
-        let grid_width = snapshot.cols as f32 * cell_width_px;
-        let grid_height = snapshot.rows as f32 * cell_height_px;
-        if clamp_to_grid {
-            local_x = local_x.clamp(0.0, (grid_width - f32::EPSILON).max(0.0));
-            local_y = local_y.clamp(0.0, (grid_height - f32::EPSILON).max(0.0));
-        } else if local_x < 0.0 || local_y < 0.0 || local_x >= grid_width || local_y >= grid_height
+        let scale = self.scale_factor.max(f32::EPSILON);
+        let (cell_width, cell_height) = physical_cell_size(font_size_px, scale);
+        let surface_x = (f32::from(pos.x) - f32::from(bounds.origin.x)) * scale;
+        let surface_y = (f32::from(pos.y) - f32::from(bounds.origin.y)) * scale;
+        let padding_left = (TERMINAL_PADDING_X_PX * scale).round().max(0.0) as u32;
+        let padding_top = (TERMINAL_PADDING_Y_PX * scale).round().max(0.0) as u32;
+        let grid_x = surface_x - padding_left as f32;
+        let grid_y = surface_y - padding_top as f32;
+        let grid_width = f32::from(snapshot.cols) * cell_width as f32;
+        let grid_height = f32::from(snapshot.rows) * cell_height as f32;
+        if !clamp_to_grid
+            && (grid_x < 0.0 || grid_y < 0.0 || grid_x >= grid_width || grid_y >= grid_height)
         {
             return None;
         }
 
-        let col = (local_x / cell_width_px).floor() as u16;
-        let row = (local_y / cell_height_px).floor() as u16;
-        if col >= snapshot.cols || row >= snapshot.rows {
-            return None;
-        }
-        Some((col, row))
+        let grid_x = grid_x.clamp(0.0, (grid_width - f32::EPSILON).max(0.0));
+        let grid_y = grid_y.clamp(0.0, (grid_height - f32::EPSILON).max(0.0));
+        let col = ((grid_x as u32) / cell_width).min(u32::from(snapshot.cols - 1)) as u16;
+        let row = ((grid_y as u32) / cell_height).min(u32::from(snapshot.rows - 1)) as u16;
+        let screen_height_px = self.last_surface_size.map_or_else(
+            || ((f32::from(bounds.size.height) * scale).ceil() as u32).max(1),
+            |size| size.height_px.max(1),
+        );
+        Some((
+            SelectionPoint {
+                col,
+                row,
+                surface_x_px: f64::from(surface_x),
+                surface_y_px: f64::from(surface_y),
+            },
+            SelectionGeometry {
+                columns: u32::from(snapshot.cols),
+                cell_width_px: cell_width,
+                padding_left_px: padding_left,
+                screen_height_px,
+            },
+        ))
     }
 
     fn link_at_position(&self, pos: Point<Pixels>) -> Option<TerminalLink> {
@@ -743,55 +778,96 @@ impl GhosttyView {
 
     fn clear_hovered_link(&mut self) -> bool {
         let changed = self.hovered_link.take().is_some();
-        if self.drag_anchor.is_none() && !self.terminal_right_mouse_sequence.is_active() {
+        if !self.terminal_left_mouse_sequence.is_active()
+            && !self.terminal_right_mouse_sequence.is_active()
+        {
             self.last_mouse_position = None;
         }
         changed
     }
 
-    fn begin_selection(&mut self, pos: Point<Pixels>) -> bool {
-        let Some(point) = self.selection_point_from_event_position(pos) else {
-            return self.clear_selection();
+    fn begin_local_selection(&mut self, pos: Point<Pixels>, shift: bool) -> bool {
+        let Some((point, geometry)) = self.selection_input_from_event_position(pos, false) else {
+            return false;
         };
-        self.drag_anchor = Some(point);
-        self.selection = Some(TerminalSelection {
-            anchor: point,
-            extent: point,
-        });
-        true
+        let Some(terminal) = self.terminal.as_ref() else {
+            return false;
+        };
+        let result = if shift && terminal.has_selection() {
+            terminal.selection_drag(point, geometry).map(|_| ())
+        } else {
+            terminal.selection_press(point, geometry)
+        };
+        match result {
+            Ok(()) => {
+                self.terminal_left_mouse_sequence
+                    .begin(LeftMouseSequence::LocalSelection);
+                true
+            }
+            Err(err) => {
+                log::debug!("linux terminal selection press failed: {err:#}");
+                terminal.selection_cancel_gesture();
+                false
+            }
+        }
     }
 
-    fn update_selection_drag(&mut self, pos: Point<Pixels>) -> bool {
-        let Some(anchor) = self.drag_anchor else {
+    fn update_left_mouse_sequence(&mut self, pos: Point<Pixels>, cx: &mut Context<Self>) -> bool {
+        let Some(sequence) = self.terminal_left_mouse_sequence.payload().copied() else {
             return false;
         };
-        let Some(extent) = self.clamped_selection_point_from_event_position(pos) else {
+        let Some((point, geometry)) = self.selection_input_from_event_position(pos, true) else {
             return false;
         };
-        let next = TerminalSelection { anchor, extent };
-        if self.selection == Some(next) {
+        let Some(terminal) = self.terminal.as_ref() else {
             return false;
+        };
+
+        match sequence {
+            LeftMouseSequence::TerminalReport => {
+                terminal.mouse_motion_report(point.col, point.row, false)
+            }
+            LeftMouseSequence::LocalSelection => match terminal.selection_drag(point, geometry) {
+                Ok(autoscroll) => {
+                    self.update_selection_autoscroll(autoscroll, cx);
+                    true
+                }
+                Err(err) => {
+                    log::debug!("linux terminal selection drag failed: {err:#}");
+                    terminal.selection_cancel_gesture();
+                    self.stop_selection_autoscroll();
+                    false
+                }
+            },
         }
-        self.selection = Some(next);
-        true
     }
 
-    fn finish_selection(&mut self, pos: Point<Pixels>) -> bool {
-        let anchor = self.drag_anchor.take();
-        let Some(anchor) = anchor else {
+    fn finish_left_mouse_sequence(&mut self, pos: Point<Pixels>) -> bool {
+        self.stop_selection_autoscroll();
+        let Some(sequence) = self.terminal_left_mouse_sequence.finish() else {
             return false;
         };
-        let extent = self
-            .clamped_selection_point_from_event_position(pos)
-            .unwrap_or(anchor);
-        if anchor == extent {
-            return self.clear_selection();
+        let point = self
+            .selection_input_from_event_position(pos, true)
+            .map(|(point, _)| point);
+        let Some(terminal) = self.terminal.as_ref() else {
+            return true;
+        };
+        match sequence {
+            LeftMouseSequence::TerminalReport => {
+                if let Some(point) = point {
+                    terminal.mouse_release(0, point.col, point.row, false);
+                }
+            }
+            LeftMouseSequence::LocalSelection => {
+                if let Err(err) =
+                    terminal.selection_release(point.map(|point| (point.col, point.row)))
+                {
+                    log::debug!("linux terminal selection release failed: {err:#}");
+                    terminal.selection_cancel_gesture();
+                }
+            }
         }
-        let next = TerminalSelection { anchor, extent };
-        if self.selection == Some(next) {
-            return false;
-        }
-        self.selection = Some(next);
         true
     }
 
@@ -809,16 +885,24 @@ impl GhosttyView {
     }
 
     fn cancel_left_pointer_interactions(&mut self, position: Point<Pixels>) {
+        self.stop_selection_autoscroll();
         self.mouse_down_link = None;
         self.suppress_link_mouse_up = false;
-        self.finish_selection(position);
+        self.finish_left_mouse_sequence(position);
     }
 
     fn cancel_pointer_interactions(&mut self) {
+        self.stop_selection_autoscroll();
         let Some(position) = self.last_mouse_position else {
             self.mouse_down_link = None;
             self.suppress_link_mouse_up = false;
-            self.drag_anchor = None;
+            if matches!(
+                self.terminal_left_mouse_sequence.finish(),
+                Some(LeftMouseSequence::LocalSelection)
+            ) && let Some(terminal) = self.terminal.as_ref()
+            {
+                terminal.selection_cancel_gesture();
+            }
             self.terminal_right_mouse_sequence.finish();
             return;
         };
@@ -826,26 +910,82 @@ impl GhosttyView {
         self.finish_right_mouse_sequence(position);
     }
 
-    fn selection_point_from_event_position(&self, pos: Point<Pixels>) -> Option<(u16, u64)> {
-        self.cell_from_event_position(pos)
-            .map(|cell| self.selection_point_from_cell(cell))
+    fn update_selection_autoscroll(
+        &mut self,
+        autoscroll: SelectionAutoscroll,
+        cx: &mut Context<Self>,
+    ) {
+        if autoscroll == SelectionAutoscroll::None {
+            self.stop_selection_autoscroll();
+            return;
+        }
+        if self.selection_autoscroll_active {
+            return;
+        }
+
+        self.selection_autoscroll_epoch = self.selection_autoscroll_epoch.wrapping_add(1);
+        let epoch = self.selection_autoscroll_epoch;
+        self.selection_autoscroll_active = true;
+        cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor()
+                    .timer(SELECTION_AUTOSCROLL_INTERVAL)
+                    .await;
+                let keep_scrolling = this
+                    .update(cx, |this, cx| {
+                        if !this.selection_autoscroll_active
+                            || this.selection_autoscroll_epoch != epoch
+                            || !matches!(
+                                this.terminal_left_mouse_sequence.payload(),
+                                Some(LeftMouseSequence::LocalSelection)
+                            )
+                        {
+                            return false;
+                        }
+                        let autoscroll = this.selection_autoscroll_tick();
+                        if autoscroll == SelectionAutoscroll::None {
+                            this.stop_selection_autoscroll();
+                            return false;
+                        }
+                        cx.notify();
+                        true
+                    })
+                    .unwrap_or(false);
+                if !keep_scrolling {
+                    break;
+                }
+            }
+        })
+        .detach();
     }
 
-    fn clamped_selection_point_from_event_position(
-        &self,
-        pos: Point<Pixels>,
-    ) -> Option<(u16, u64)> {
-        self.clamped_cell_from_event_position(pos)
-            .map(|cell| self.selection_point_from_cell(cell))
+    fn selection_autoscroll_tick(&self) -> SelectionAutoscroll {
+        let Some(position) = self.last_mouse_position else {
+            return SelectionAutoscroll::None;
+        };
+        let Some((point, geometry)) = self.selection_input_from_event_position(position, true)
+        else {
+            return SelectionAutoscroll::None;
+        };
+        let Some(terminal) = self.terminal.as_ref() else {
+            return SelectionAutoscroll::None;
+        };
+        match terminal.selection_autoscroll_tick(point, geometry) {
+            Ok(autoscroll) => autoscroll,
+            Err(err) => {
+                log::debug!("linux terminal selection autoscroll failed: {err:#}");
+                terminal.selection_cancel_gesture();
+                SelectionAutoscroll::None
+            }
+        }
     }
 
-    fn selection_point_from_cell(&self, cell: (u16, u16)) -> (u16, u64) {
-        let viewport_offset = self
-            .snapshot
-            .as_ref()
-            .and_then(|snapshot| snapshot.scrollbar)
-            .map_or(0, |scrollbar| scrollbar.offset);
-        (cell.0, viewport_offset.saturating_add(cell.1 as u64))
+    fn stop_selection_autoscroll(&mut self) {
+        if !self.selection_autoscroll_active {
+            return;
+        }
+        self.selection_autoscroll_active = false;
+        self.selection_autoscroll_epoch = self.selection_autoscroll_epoch.wrapping_add(1);
     }
 
     fn render_link_cursor_overlay(
@@ -1470,7 +1610,6 @@ impl Render for GhosttyView {
             configured_pane_opacity
         };
         let pane_background = theme.background.opacity(pane_opacity);
-        let selection = self.selection;
         let selection_bg = theme.selection.opacity(0.42);
         let mut has_kitty_images = false;
         let mut split_terminal_rows = false;
@@ -1517,15 +1656,12 @@ impl Render for GhosttyView {
 
         if let Some(snapshot) = self.snapshot.as_ref() {
             for row_idx in 0..usize::from(snapshot.rows) {
-                let selection_cols = match selection {
-                    Some(selection) => selection.row_range(row_idx, snapshot),
-                    None => snapshot
-                        .selection_ranges
-                        .get(row_idx)
-                        .copied()
-                        .flatten()
-                        .map(|range| (usize::from(range.start), usize::from(range.end))),
-                };
+                let selection_cols = snapshot
+                    .selection_ranges
+                    .get(row_idx)
+                    .copied()
+                    .flatten()
+                    .map(|range| (usize::from(range.start), usize::from(range.end)));
                 if let Some(selection_cols) = selection_cols {
                     let row_start = row_idx * usize::from(snapshot.cols);
                     let row_end = row_start + usize::from(snapshot.cols);
@@ -1820,8 +1956,7 @@ impl Render for GhosttyView {
                         None
                     };
                     if this.terminal_mouse_right_consumed == Some(true) {
-                        this.terminal_right_mouse_sequence
-                            .press_sent(shift_at_press);
+                        this.terminal_right_mouse_sequence.begin(shift_at_press);
                     }
                     cx.emit(GhosttyFocusChanged);
                     cx.notify();
@@ -1846,7 +1981,23 @@ impl Render for GhosttyView {
                         cx.notify();
                         return;
                     }
-                    this.begin_selection(event.position);
+                    let shift = event.modifiers.shift;
+                    let tracking_active = this
+                        .terminal()
+                        .is_some_and(|terminal| terminal.mouse_tracking_active());
+                    if tracking_active && !shift {
+                        if let Some(terminal) = this.terminal() {
+                            terminal.selection_cancel_gesture();
+                            if let Some((col, row)) = this.cell_from_event_position(event.position)
+                                && terminal.mouse_report(0, col, row, false)
+                            {
+                                this.terminal_left_mouse_sequence
+                                    .begin(LeftMouseSequence::TerminalReport);
+                            }
+                        }
+                    } else if !this.begin_local_selection(event.position, shift) && !shift {
+                        this.clear_selection();
+                    }
                     cx.emit(GhosttyFocusChanged);
                     cx.notify();
                 }),
@@ -1882,9 +2033,11 @@ impl Render for GhosttyView {
                 }
                 let mut changed = this.update_hovered_link(&event.modifiers);
                 if event.pressed_button == Some(MouseButton::Left) {
-                    changed |= this.update_selection_drag(event.position);
-                } else if event.pressed_button.is_none() && this.drag_anchor.is_some() {
-                    changed |= this.finish_selection(event.position);
+                    changed |= this.update_left_mouse_sequence(event.position, cx);
+                } else if event.pressed_button.is_none()
+                    && this.terminal_left_mouse_sequence.is_active()
+                {
+                    changed |= this.finish_left_mouse_sequence(event.position);
                 }
                 if event.pressed_button.is_none() && this.terminal_right_mouse_sequence.is_active()
                 {
@@ -1912,7 +2065,7 @@ impl Render for GhosttyView {
                         cx.notify();
                         return;
                     }
-                    let mut changed = this.finish_selection(event.position);
+                    let mut changed = this.finish_left_mouse_sequence(event.position);
                     changed |= this.update_hovered_link(&event.modifiers);
                     if changed {
                         cx.notify();
@@ -1922,13 +2075,15 @@ impl Render for GhosttyView {
             .on_mouse_up_out(
                 MouseButton::Left,
                 cx.listener(|this, event: &MouseUpEvent, _window, cx| {
-                    if this.drag_anchor.is_none() && !this.suppress_link_mouse_up {
+                    if !this.terminal_left_mouse_sequence.is_active()
+                        && !this.suppress_link_mouse_up
+                    {
                         return;
                     }
                     this.last_mouse_position = Some(event.position);
                     this.mouse_down_link = None;
                     this.suppress_link_mouse_up = false;
-                    let mut changed = this.finish_selection(event.position);
+                    let mut changed = this.finish_left_mouse_sequence(event.position);
                     changed |= this.update_hovered_link(&event.modifiers);
                     if changed {
                         cx.notify();
@@ -2228,97 +2383,6 @@ fn render_kitty_image_layer(
     .absolute()
     .size_full()
     .into_any_element()
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct TerminalSelection {
-    anchor: (u16, u64),
-    extent: (u16, u64),
-}
-
-impl TerminalSelection {
-    fn contains(self, col: u16, row: u16, snapshot: &ScreenSnapshot) -> bool {
-        let cols = snapshot.cols;
-        let viewport_offset = snapshot.scrollbar.map_or(0, |scrollbar| scrollbar.offset);
-        let to_linear = |point: (u16, u64)| point.1 as u128 * cols as u128 + point.0 as u128;
-        let anchor = to_linear(self.anchor);
-        let extent = to_linear(self.extent);
-        let (start, end) = if anchor <= extent {
-            (anchor, extent)
-        } else {
-            (extent, anchor)
-        };
-        let current = to_linear((col, viewport_offset.saturating_add(row as u64)));
-        current >= start && current <= end
-    }
-
-    fn row_range(self, row: usize, snapshot: &ScreenSnapshot) -> Option<(usize, usize)> {
-        let cols = snapshot.cols;
-        if cols == 0 || row > u16::MAX as usize {
-            return None;
-        }
-
-        let row = row as u16;
-        let mut start = None;
-        let mut end = None;
-        for col in 0..cols {
-            if self.contains(col, row, snapshot) {
-                start.get_or_insert(usize::from(col));
-                end = Some(usize::from(col));
-            }
-        }
-
-        start.zip(end)
-    }
-}
-
-fn extract_selection_text(
-    snapshot: &ScreenSnapshot,
-    selection: TerminalSelection,
-) -> Option<String> {
-    if snapshot.cols == 0 || snapshot.rows == 0 || snapshot.cells.is_empty() {
-        return None;
-    }
-
-    let cols = usize::from(snapshot.cols);
-    let mut output = String::new();
-    for row in 0..snapshot.rows {
-        let Some((start, end)) = selection.row_range(usize::from(row), snapshot) else {
-            continue;
-        };
-
-        let row_start = usize::from(row) * cols;
-        let Some(cells) = snapshot.cells.get(row_start + start..=row_start + end) else {
-            continue;
-        };
-
-        let mut row_text = String::with_capacity(cells.len());
-        let mut last_non_blank = None;
-        for cell in cells {
-            let ch = match cell.codepoint {
-                0 => ' ',
-                cp => char::from_u32(cp).unwrap_or('\u{FFFD}'),
-            };
-            if ch != ' ' {
-                last_non_blank = Some(row_text.len() + ch.len_utf8());
-            }
-            row_text.push(ch);
-        }
-
-        if let Some(end_byte) = last_non_blank {
-            output.push_str(&row_text[..end_byte]);
-        }
-        output.push('\n');
-    }
-
-    if output.ends_with('\n') {
-        output.pop();
-    }
-    if output.is_empty() {
-        None
-    } else {
-        Some(output)
-    }
 }
 
 #[derive(Clone, Default)]
@@ -2734,9 +2798,9 @@ fn vt_color_to_hsla(packed: u32) -> Option<Hsla> {
 mod tests {
     use super::{
         DEFAULT_FONT_SIZE, KITTY_BELOW_BACKGROUND_LIMIT, KittyImageLayer, MIN_FONT_SIZE_PX,
-        TerminalSelection, build_terminal_row, cell_height_px, cell_width_px, effective_font_size,
-        extract_selection_text, kitty_image_to_render_image, kitty_placement_geometry,
-        physical_cell_size, rows_needing_refresh, vt_color_to_hsla,
+        build_terminal_row, cell_height_px, cell_width_px, effective_font_size,
+        kitty_image_to_render_image, kitty_placement_geometry, physical_cell_size,
+        rows_needing_refresh, vt_color_to_hsla,
     };
     use con_ghostty::{
         ATTR_BOLD, ATTR_INVERSE, ATTR_UNDERLINE, KittyImage, KittyPlacement, ScreenSnapshot,
@@ -2939,70 +3003,6 @@ mod tests {
             row.backgrounds
                 .iter()
                 .any(|run| run.start_col == 2 && run.len == 1 && run.overlay)
-        );
-    }
-
-    #[test]
-    fn terminal_selection_row_range_handles_reverse_drag() {
-        let snapshot = ScreenSnapshot {
-            cols: 5,
-            rows: 3,
-            cells: Vec::new(),
-            selection_ranges: vec![None; 3],
-            kitty_placements: Default::default(),
-            dirty_rows: Vec::new(),
-            cursor: VtCursor {
-                col: 0,
-                row: 0,
-                visible: false,
-            },
-            alternate_screen: false,
-            scrollbar: None,
-            title: None,
-            generation: 1,
-        };
-        let selection = TerminalSelection {
-            anchor: (3, 1),
-            extent: (1, 0),
-        };
-
-        assert_eq!(selection.row_range(0, &snapshot), Some((1, 4)));
-        assert_eq!(selection.row_range(1, &snapshot), Some((0, 3)));
-        assert_eq!(selection.row_range(2, &snapshot), None);
-    }
-
-    #[test]
-    fn extracts_selected_text_from_snapshot() {
-        let mut cells = vec![VtCell::default(); 12];
-        for (idx, ch) in "one two     ".chars().enumerate() {
-            cells[idx].codepoint = ch as u32;
-        }
-        let snapshot = ScreenSnapshot {
-            cols: 4,
-            rows: 3,
-            cells,
-            selection_ranges: vec![None; 3],
-            kitty_placements: Default::default(),
-            dirty_rows: Vec::new(),
-            cursor: VtCursor {
-                col: 0,
-                row: 0,
-                visible: false,
-            },
-            alternate_screen: false,
-            scrollbar: None,
-            title: None,
-            generation: 1,
-        };
-
-        let selection = TerminalSelection {
-            anchor: (1, 0),
-            extent: (2, 1),
-        };
-
-        assert_eq!(
-            extract_selection_text(&snapshot, selection),
-            Some("ne\ntwo".to_string())
         );
     }
 

--- a/crates/con-app/src/linux_view.rs
+++ b/crates/con-app/src/linux_view.rs
@@ -19,8 +19,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use con_ghostty::vt::{
-    SelectionAutoscroll, SelectionGeometry, SelectionPoint, VtKeyAction, VtKeyEvent,
-    VtKeyModifiers, VtPasteResult, VtPasteSource,
+    SelectionAutoscroll, SelectionAutoscrollUpdate, SelectionGeometry, SelectionPoint, VtKeyAction,
+    VtKeyEvent, VtKeyModifiers, VtPasteResult, VtPasteSource,
 };
 use con_ghostty::{
     ATTR_BOLD, ATTR_INVERSE, ATTR_ITALIC, ATTR_STRIKE, ATTR_UNDERLINE, DesktopNotification,
@@ -786,18 +786,20 @@ impl GhosttyView {
         changed
     }
 
-    fn begin_local_selection(&mut self, pos: Point<Pixels>, shift: bool) -> bool {
+    fn begin_local_selection(
+        &mut self,
+        pos: Point<Pixels>,
+        shift: bool,
+        click_count: usize,
+    ) -> bool {
         let Some((point, geometry)) = self.selection_input_from_event_position(pos, false) else {
             return false;
         };
         let Some(terminal) = self.terminal.as_ref() else {
             return false;
         };
-        let result = if shift && terminal.has_selection() {
-            terminal.selection_drag(point, geometry).map(|_| ())
-        } else {
-            terminal.selection_press(point, geometry)
-        };
+        let click_count = u8::try_from(click_count).unwrap_or(u8::MAX);
+        let result = terminal.selection_press(point, geometry, click_count, shift);
         match result {
             Ok(()) => {
                 self.terminal_left_mouse_sequence
@@ -942,12 +944,14 @@ impl GhosttyView {
                         {
                             return false;
                         }
-                        let autoscroll = this.selection_autoscroll_tick();
-                        if autoscroll == SelectionAutoscroll::None {
+                        let update = this.selection_autoscroll_tick();
+                        if update.direction == SelectionAutoscroll::None {
                             this.stop_selection_autoscroll();
                             return false;
                         }
-                        cx.notify();
+                        if update.changed {
+                            cx.notify();
+                        }
                         true
                     })
                     .unwrap_or(false);
@@ -959,23 +963,23 @@ impl GhosttyView {
         .detach();
     }
 
-    fn selection_autoscroll_tick(&self) -> SelectionAutoscroll {
+    fn selection_autoscroll_tick(&self) -> SelectionAutoscrollUpdate {
         let Some(position) = self.last_mouse_position else {
-            return SelectionAutoscroll::None;
+            return SelectionAutoscrollUpdate::default();
         };
         let Some((point, geometry)) = self.selection_input_from_event_position(position, true)
         else {
-            return SelectionAutoscroll::None;
+            return SelectionAutoscrollUpdate::default();
         };
         let Some(terminal) = self.terminal.as_ref() else {
-            return SelectionAutoscroll::None;
+            return SelectionAutoscrollUpdate::default();
         };
         match terminal.selection_autoscroll_tick(point, geometry) {
-            Ok(autoscroll) => autoscroll,
+            Ok(update) => update,
             Err(err) => {
                 log::debug!("linux terminal selection autoscroll failed: {err:#}");
                 terminal.selection_cancel_gesture();
-                SelectionAutoscroll::None
+                SelectionAutoscrollUpdate::default()
             }
         }
     }
@@ -1995,7 +1999,9 @@ impl Render for GhosttyView {
                                     .begin(LeftMouseSequence::TerminalReport);
                             }
                         }
-                    } else if !this.begin_local_selection(event.position, shift) && !shift {
+                    } else if !this.begin_local_selection(event.position, shift, event.click_count)
+                        && !shift
+                    {
                         this.clear_selection();
                     }
                     cx.emit(GhosttyFocusChanged);

--- a/crates/con-app/src/mouse_sequence.rs
+++ b/crates/con-app/src/mouse_sequence.rs
@@ -1,32 +1,30 @@
 pub(crate) struct MouseButtonSequence<M> {
-    press_modifiers: Option<M>,
+    payload: Option<M>,
 }
 
 impl<M> Default for MouseButtonSequence<M> {
     fn default() -> Self {
-        Self {
-            press_modifiers: None,
-        }
+        Self { payload: None }
     }
 }
 
 impl<M> MouseButtonSequence<M> {
     pub(crate) fn is_active(&self) -> bool {
-        self.press_modifiers.is_some()
+        self.payload.is_some()
     }
 
-    #[cfg(target_os = "windows")]
-    pub(crate) fn press_modifiers(&self) -> Option<&M> {
-        self.press_modifiers.as_ref()
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    pub(crate) fn payload(&self) -> Option<&M> {
+        self.payload.as_ref()
     }
 
-    pub(crate) fn press_sent(&mut self, modifiers: M) {
-        debug_assert!(self.press_modifiers.is_none());
-        self.press_modifiers = Some(modifiers);
+    pub(crate) fn begin(&mut self, payload: M) {
+        debug_assert!(self.payload.is_none());
+        self.payload = Some(payload);
     }
 
     pub(crate) fn finish(&mut self) -> Option<M> {
-        self.press_modifiers.take()
+        self.payload.take()
     }
 }
 
@@ -39,8 +37,8 @@ mod tests {
         let mut left = MouseButtonSequence::default();
         let mut right = MouseButtonSequence::default();
 
-        left.press_sent(1);
-        right.press_sent(2);
+        left.begin(1);
+        right.begin(2);
 
         assert_eq!(left.finish(), Some(1));
         assert!(!left.is_active());

--- a/crates/con-app/src/terminal_paste.rs
+++ b/crates/con-app/src/terminal_paste.rs
@@ -110,17 +110,12 @@ pub fn payload_from_external_paths(paths: &ExternalPaths) -> Option<TerminalPast
 
 #[cfg(any(target_os = "windows", target_os = "linux"))]
 pub fn copy_selection_to_clipboard(terminal: &GhosttyTerminal, cx: &mut gpui::App) -> bool {
-    let has_selection = terminal.has_selection();
-    let selection = has_selection.then(|| terminal.selection_text()).flatten();
-    match copy_selection_decision(has_selection, selection.as_deref()) {
+    let selection = terminal.take_selection_text();
+    match copy_selection_decision(selection.as_deref()) {
         CopySelectionDecision::NoSelection => false,
-        CopySelectionDecision::ClearOnly => {
-            terminal.clear_selection();
-            true
-        }
+        CopySelectionDecision::ClearOnly => true,
         CopySelectionDecision::CopyAndClear(selection) => {
             cx.write_to_clipboard(ClipboardItem::new_string(selection.to_string()));
-            terminal.clear_selection();
             true
         }
     }
@@ -135,16 +130,11 @@ enum CopySelectionDecision<'a> {
 }
 
 #[cfg(any(target_os = "windows", target_os = "linux", test))]
-fn copy_selection_decision(
-    has_selection: bool,
-    selection: Option<&str>,
-) -> CopySelectionDecision<'_> {
-    if !has_selection {
-        return CopySelectionDecision::NoSelection;
-    }
+fn copy_selection_decision(selection: Option<&str>) -> CopySelectionDecision<'_> {
     match selection {
         Some(selection) if !selection.is_empty() => CopySelectionDecision::CopyAndClear(selection),
-        _ => CopySelectionDecision::ClearOnly,
+        Some(_) => CopySelectionDecision::ClearOnly,
+        None => CopySelectionDecision::NoSelection,
     }
 }
 
@@ -283,19 +273,15 @@ mod tests {
     #[test]
     fn copy_selection_decision_distinguishes_empty_and_absent_selection() {
         assert_eq!(
-            copy_selection_decision(false, Some("ignored")),
+            copy_selection_decision(None),
             CopySelectionDecision::NoSelection
         );
         assert_eq!(
-            copy_selection_decision(true, None),
+            copy_selection_decision(Some("")),
             CopySelectionDecision::ClearOnly
         );
         assert_eq!(
-            copy_selection_decision(true, Some("")),
-            CopySelectionDecision::ClearOnly
-        );
-        assert_eq!(
-            copy_selection_decision(true, Some("selected")),
+            copy_selection_decision(Some("selected")),
             CopySelectionDecision::CopyAndClear("selected")
         );
     }

--- a/crates/con-app/src/terminal_paste.rs
+++ b/crates/con-app/src/terminal_paste.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 use con_ghostty::GhosttyTerminal;
 use gpui::{ClipboardEntry, ClipboardItem, ExternalPaths};
 
@@ -108,7 +108,7 @@ pub fn payload_from_external_paths(paths: &ExternalPaths) -> Option<TerminalPast
     quoted_paths_text(paths.paths()).map(TerminalPastePayload::Text)
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 pub fn copy_selection_to_clipboard(terminal: &GhosttyTerminal, cx: &mut gpui::App) -> bool {
     let has_selection = terminal.has_selection();
     let selection = has_selection.then(|| terminal.selection_text()).flatten();
@@ -127,14 +127,14 @@ pub fn copy_selection_to_clipboard(terminal: &GhosttyTerminal, cx: &mut gpui::Ap
 }
 
 #[derive(Debug, Eq, PartialEq)]
-#[cfg(any(target_os = "windows", test))]
+#[cfg(any(target_os = "windows", target_os = "linux", test))]
 enum CopySelectionDecision<'a> {
     NoSelection,
     ClearOnly,
     CopyAndClear(&'a str),
 }
 
-#[cfg(any(target_os = "windows", test))]
+#[cfg(any(target_os = "windows", target_os = "linux", test))]
 fn copy_selection_decision(
     has_selection: bool,
     selection: Option<&str>,

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -43,8 +43,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use con_ghostty::vt::{
-    SelectionAutoscroll, SelectionGeometry, SelectionPoint, VtKeyAction, VtKeyEvent,
-    VtKeyModifiers, VtPasteResult, VtPasteSource,
+    SelectionAutoscroll, SelectionAutoscrollUpdate, SelectionGeometry, SelectionPoint, VtKeyAction,
+    VtKeyEvent, VtKeyModifiers, VtPasteResult, VtPasteSource,
 };
 use con_ghostty::{DesktopNotification, TerminalProgress};
 use con_ghostty::{GhosttyApp, GhosttyScrollbar, GhosttySplitDirection, GhosttyTerminal};
@@ -871,15 +871,7 @@ impl GhosttyView {
     /// (col, row) cell address. Returns `None` when we don't yet have a
     /// session / bounds to project into.
     fn cell_from_event_position(&self, pos: Point<Pixels>) -> Option<(u16, u16)> {
-        self.cell_from_event_position_impl(pos, false)
-    }
-
-    fn cell_from_event_position_impl(
-        &self,
-        pos: Point<Pixels>,
-        clamp_to_grid: bool,
-    ) -> Option<(u16, u16)> {
-        self.selection_input_from_event_position(pos, clamp_to_grid)
+        self.selection_input_from_event_position(pos, false)
             .map(|(point, _)| (point.col, point.row))
     }
 
@@ -1003,12 +995,19 @@ impl GhosttyView {
         button: u8,
         pos: Point<Pixels>,
         mods: MouseEventMods,
+        click_count: usize,
     ) -> MouseDownRoute {
         if let Some((point, geometry)) = self.selection_input_from_event_position(pos, false) {
             if let Some(terminal) = &self.terminal {
                 let inner = terminal.inner();
                 if let Some(session) = inner.lock().as_ref() {
-                    return session.mouse_down(button, point, geometry, mods);
+                    return session.mouse_down(
+                        button,
+                        point,
+                        geometry,
+                        mods,
+                        u8::try_from(click_count).unwrap_or(u8::MAX),
+                    );
                 }
             }
         }
@@ -1108,12 +1107,14 @@ impl GhosttyView {
                         {
                             return false;
                         }
-                        let autoscroll = this.selection_autoscroll_tick();
-                        if autoscroll == SelectionAutoscroll::None {
+                        let update = this.selection_autoscroll_tick();
+                        if update.direction == SelectionAutoscroll::None {
                             this.stop_selection_autoscroll();
                             return false;
                         }
-                        cx.notify();
+                        if update.changed {
+                            cx.notify();
+                        }
                         true
                     })
                     .unwrap_or(false);
@@ -1125,22 +1126,24 @@ impl GhosttyView {
         .detach();
     }
 
-    fn selection_autoscroll_tick(&self) -> SelectionAutoscroll {
+    fn selection_autoscroll_tick(&self) -> SelectionAutoscrollUpdate {
         let Some(position) = self.last_mouse_position else {
-            return SelectionAutoscroll::None;
+            return SelectionAutoscrollUpdate::default();
         };
         let Some((point, geometry)) = self.selection_input_from_event_position(position, true)
         else {
-            return SelectionAutoscroll::None;
+            return SelectionAutoscrollUpdate::default();
         };
         let Some(terminal) = &self.terminal else {
-            return SelectionAutoscroll::None;
+            return SelectionAutoscrollUpdate::default();
         };
         let inner = terminal.inner();
         let guard = inner.lock();
-        guard.as_ref().map_or(SelectionAutoscroll::None, |session| {
-            session.selection_autoscroll_tick(point, geometry)
-        })
+        guard
+            .as_ref()
+            .map_or(SelectionAutoscrollUpdate::default(), |session| {
+                session.selection_autoscroll_tick(point, geometry)
+            })
     }
 
     fn stop_selection_autoscroll(&mut self) {
@@ -1977,6 +1980,7 @@ impl Render for GhosttyView {
                         2,
                         event.position,
                         mouse_mods_from(&event.modifiers),
+                        event.click_count,
                     ) == MouseDownRoute::TerminalReport;
                     this.terminal_mouse_right_consumed = Some(consumed);
                     if consumed {
@@ -2013,17 +2017,18 @@ impl Render for GhosttyView {
                     // written. Do not continue an SGR sequence after a failed
                     // PTY write.
                     let mods = mouse_mods_from(&event.modifiers);
-                    let route = match this.forward_mouse_down(0, event.position, mods) {
-                        MouseDownRoute::TerminalReport => Some(MousePressRoute {
-                            shift: mods.shift,
-                            local_selection: false,
-                        }),
-                        MouseDownRoute::LocalSelection => Some(MousePressRoute {
-                            shift: mods.shift,
-                            local_selection: true,
-                        }),
-                        MouseDownRoute::Ignored => None,
-                    };
+                    let route =
+                        match this.forward_mouse_down(0, event.position, mods, event.click_count) {
+                            MouseDownRoute::TerminalReport => Some(MousePressRoute {
+                                shift: mods.shift,
+                                local_selection: false,
+                            }),
+                            MouseDownRoute::LocalSelection => Some(MousePressRoute {
+                                shift: mods.shift,
+                                local_selection: true,
+                            }),
+                            MouseDownRoute::Ignored => None,
+                        };
                     if let Some(route) = route {
                         this.terminal_left_mouse_sequence.begin(route);
                     }

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -40,9 +40,12 @@ use std::collections::HashMap;
 use std::ops::Range;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
-use con_ghostty::vt::{VtKeyAction, VtKeyEvent, VtKeyModifiers, VtPasteResult, VtPasteSource};
+use con_ghostty::vt::{
+    SelectionAutoscroll, SelectionGeometry, SelectionPoint, VtKeyAction, VtKeyEvent,
+    VtKeyModifiers, VtPasteResult, VtPasteSource,
+};
 use con_ghostty::{DesktopNotification, TerminalProgress};
 use con_ghostty::{GhosttyApp, GhosttyScrollbar, GhosttySplitDirection, GhosttyTerminal};
 use futures::StreamExt;
@@ -62,14 +65,21 @@ use crate::terminal_paste::{
     payload_from_external_paths, unsafe_paste_preview,
 };
 use crate::terminal_restore::restored_terminal_output;
-use con_ghostty::windows::host_view::{MouseEventMods, RenderSession};
+use con_ghostty::windows::host_view::{MouseDownRoute, MouseEventMods, RenderSession};
 use con_ghostty::windows::render::{FrameBgra, RenderOutcome};
 
 const SCROLLBAR_INSET_PX: f32 = 4.0;
 const SCROLLBAR_WIDTH_PX: f32 = 6.0;
 const SCROLLBAR_MIN_THUMB_PX: f32 = 28.0;
+const SELECTION_AUTOSCROLL_INTERVAL: Duration = Duration::from_millis(15);
 const TERMINAL_PADDING_X_PX: f32 = 10.0;
 const TERMINAL_PADDING_Y_PX: f32 = 8.0;
+
+#[derive(Clone, Copy)]
+struct MousePressRoute {
+    shift: bool,
+    local_selection: bool,
+}
 
 #[derive(Debug, Clone, Copy)]
 struct ScrollbarDrag {
@@ -164,8 +174,8 @@ pub struct GhosttyView {
     /// `Window::drop_image` to evict sprite-atlas tiles.
     images_to_drop: Vec<Arc<RenderImage>>,
     scrollbar_drag: Option<ScrollbarDrag>,
-    terminal_left_mouse_sequence: MouseButtonSequence<bool>,
-    terminal_right_mouse_sequence: MouseButtonSequence<bool>,
+    terminal_left_mouse_sequence: MouseButtonSequence<MousePressRoute>,
+    terminal_right_mouse_sequence: MouseButtonSequence<MousePressRoute>,
     /// Whether the most recent right-button press was consumed by the
     /// terminal app (an SGR report emitted). The context-menu builder
     /// suppresses con's menu only when this is true.
@@ -174,6 +184,8 @@ pub struct GhosttyView {
     suppress_link_mouse_up: bool,
     hovered_link: Option<TerminalLink>,
     last_mouse_position: Option<Point<Pixels>>,
+    selection_autoscroll_epoch: u64,
+    selection_autoscroll_active: bool,
     keys_awaiting_release: HashMap<String, crate::terminal_keys::TrackedVtKey>,
     pending_unsafe_paste: Option<(String, VtPasteSource)>,
     /// Cloned and handed to `RenderSession::new`; the ConPTY reader
@@ -262,6 +274,8 @@ impl GhosttyView {
             suppress_link_mouse_up: false,
             hovered_link: None,
             last_mouse_position: None,
+            selection_autoscroll_epoch: 0,
+            selection_autoscroll_active: false,
             keys_awaiting_release: HashMap::new(),
             pending_unsafe_paste: None,
             wake_tx,
@@ -353,6 +367,7 @@ impl GhosttyView {
         self.suppress_link_mouse_up = false;
         self.hovered_link = None;
         self.last_mouse_position = None;
+        self.stop_selection_autoscroll();
         self.keys_awaiting_release.clear();
         self.pending_unsafe_paste = None;
         self.images_to_drop.clear();
@@ -859,15 +874,20 @@ impl GhosttyView {
         self.cell_from_event_position_impl(pos, false)
     }
 
-    fn clamped_cell_from_event_position(&self, pos: Point<Pixels>) -> Option<(u16, u16)> {
-        self.cell_from_event_position_impl(pos, true)
-    }
-
     fn cell_from_event_position_impl(
         &self,
         pos: Point<Pixels>,
         clamp_to_grid: bool,
     ) -> Option<(u16, u16)> {
+        self.selection_input_from_event_position(pos, clamp_to_grid)
+            .map(|(point, _)| (point.col, point.row))
+    }
+
+    fn selection_input_from_event_position(
+        &self,
+        pos: Point<Pixels>,
+        clamp_to_grid: bool,
+    ) -> Option<(SelectionPoint, SelectionGeometry)> {
         let bounds = self.pane_bounds?;
         let terminal = self.terminal.as_ref()?;
         let inner = terminal.inner();
@@ -880,29 +900,43 @@ impl GhosttyView {
         let scale = self.scale_factor.max(f32::EPSILON);
         let width_px = ((f32::from(bounds.size.width) * scale).ceil() as u32).max(1);
         let height_px = ((f32::from(bounds.size.height) * scale).ceil() as u32).max(1);
-        let cols = (width_px / metrics.cell_width_px.max(1)).max(1);
-        let rows = (height_px / metrics.cell_height_px.max(1)).max(1);
+        let (cols, rows) = session.vt().size();
+        let cols = u32::from(cols.max(1));
+        let rows = u32::from(rows.max(1));
         let grid_width_px = (cols * metrics.cell_width_px.max(1)) as f32;
         let grid_height_px = (rows * metrics.cell_height_px.max(1)) as f32;
         let local_x = f32::from(pos.x) - f32::from(bounds.origin.x);
         let local_y = f32::from(pos.y) - f32::from(bounds.origin.y);
-        let mut phys_x = local_x * scale;
-        let mut phys_y = local_y * scale;
-        if clamp_to_grid {
-            phys_x = phys_x.clamp(0.0, (grid_width_px - f32::EPSILON).max(0.0));
-            phys_y = phys_y.clamp(0.0, (grid_height_px - f32::EPSILON).max(0.0));
-        } else if phys_x < 0.0
-            || phys_y < 0.0
-            || phys_x >= width_px as f32
-            || phys_y >= height_px as f32
-            || phys_x >= grid_width_px
-            || phys_y >= grid_height_px
+        let surface_x = local_x * scale;
+        let surface_y = local_y * scale;
+        if !clamp_to_grid
+            && (surface_x < 0.0
+                || surface_y < 0.0
+                || surface_x >= width_px as f32
+                || surface_y >= height_px as f32
+                || surface_x >= grid_width_px
+                || surface_y >= grid_height_px)
         {
             return None;
         }
-        let col = ((phys_x as u32) / metrics.cell_width_px.max(1)).min(cols - 1) as u16;
-        let row = ((phys_y as u32) / metrics.cell_height_px.max(1)).min(rows - 1) as u16;
-        Some((col, row))
+        let grid_x = surface_x.clamp(0.0, (grid_width_px - f32::EPSILON).max(0.0));
+        let grid_y = surface_y.clamp(0.0, (grid_height_px - f32::EPSILON).max(0.0));
+        let col = ((grid_x as u32) / metrics.cell_width_px.max(1)).min(cols - 1) as u16;
+        let row = ((grid_y as u32) / metrics.cell_height_px.max(1)).min(rows - 1) as u16;
+        Some((
+            SelectionPoint {
+                col,
+                row,
+                surface_x_px: f64::from(surface_x),
+                surface_y_px: f64::from(surface_y),
+            },
+            SelectionGeometry {
+                columns: cols,
+                cell_width_px: metrics.cell_width_px,
+                padding_left_px: 0,
+                screen_height_px: height_px,
+            },
+        ))
     }
 
     fn link_at_position(&self, pos: Point<Pixels>) -> Option<TerminalLink> {
@@ -964,30 +998,21 @@ impl GhosttyView {
         )
     }
 
-    fn forward_mouse_down(&self, button: u8, pos: Point<Pixels>, mods: MouseEventMods) -> bool {
-        if let Some((col, row)) = self.cell_from_event_position(pos) {
+    fn forward_mouse_down(
+        &self,
+        button: u8,
+        pos: Point<Pixels>,
+        mods: MouseEventMods,
+    ) -> MouseDownRoute {
+        if let Some((point, geometry)) = self.selection_input_from_event_position(pos, false) {
             if let Some(terminal) = &self.terminal {
                 let inner = terminal.inner();
                 if let Some(session) = inner.lock().as_ref() {
-                    return session.mouse_down(button, col, row, mods);
+                    return session.mouse_down(button, point, geometry, mods);
                 }
             }
         }
-        false
-    }
-
-    fn terminal_mouse_tracking_active_at(&self, pos: Point<Pixels>) -> bool {
-        if self.cell_from_event_position(pos).is_none() {
-            return false;
-        }
-        let Some(terminal) = &self.terminal else {
-            return false;
-        };
-        let inner = terminal.inner();
-        inner
-            .lock()
-            .as_ref()
-            .is_some_and(|session| session.mouse_tracking_active())
+        MouseDownRoute::Ignored
     }
 
     fn forward_mouse_drag(
@@ -996,34 +1021,34 @@ impl GhosttyView {
         pos: Point<Pixels>,
         mods: MouseEventMods,
         clamp: bool,
-    ) {
-        let cell = if clamp {
-            self.clamped_cell_from_event_position(pos)
-        } else {
-            self.cell_from_event_position(pos)
-        };
-        if let Some((col, row)) = cell {
+        local_selection: bool,
+    ) -> SelectionAutoscroll {
+        if let Some((point, geometry)) = self.selection_input_from_event_position(pos, clamp) {
             if let Some(terminal) = &self.terminal {
                 let inner = terminal.inner();
                 if let Some(session) = inner.lock().as_ref() {
-                    session.mouse_drag(button, col, row, mods);
+                    return session.mouse_drag(button, point, geometry, mods, local_selection);
                 }
             }
         }
+        SelectionAutoscroll::None
     }
 
-    fn forward_mouse_up(&self, button: u8, pos: Point<Pixels>, mods: MouseEventMods, clamp: bool) {
-        let cell = if clamp {
-            self.clamped_cell_from_event_position(pos)
-        } else {
-            self.cell_from_event_position(pos)
-        };
-        if let Some((col, row)) = cell {
-            if let Some(terminal) = &self.terminal {
-                let inner = terminal.inner();
-                if let Some(session) = inner.lock().as_ref() {
-                    session.mouse_up(button, col, row, mods);
-                }
+    fn forward_mouse_up(
+        &self,
+        button: u8,
+        pos: Point<Pixels>,
+        mods: MouseEventMods,
+        clamp: bool,
+        local_selection: bool,
+    ) {
+        let point = self
+            .selection_input_from_event_position(pos, clamp)
+            .map(|(point, _)| point);
+        if let Some(terminal) = &self.terminal {
+            let inner = terminal.inner();
+            if let Some(session) = inner.lock().as_ref() {
+                session.mouse_up(button, point, mods, local_selection);
             }
         }
     }
@@ -1034,21 +1059,100 @@ impl GhosttyView {
         pos: Point<Pixels>,
         mut mods: MouseEventMods,
     ) -> bool {
-        let press_shift = match button {
+        if button == 0 {
+            self.stop_selection_autoscroll();
+        }
+        let route = match button {
             0 => self.terminal_left_mouse_sequence.finish(),
             2 => self.terminal_right_mouse_sequence.finish(),
             _ => None,
         };
-        let Some(press_shift) = press_shift else {
+        let Some(route) = route else {
             return false;
         };
 
-        mods.shift = press_shift;
-        self.forward_mouse_up(button, pos, mods, true);
+        mods.shift = route.shift;
+        self.forward_mouse_up(button, pos, mods, true, route.local_selection);
         true
     }
 
+    fn update_selection_autoscroll(
+        &mut self,
+        autoscroll: SelectionAutoscroll,
+        cx: &mut Context<Self>,
+    ) {
+        if autoscroll == SelectionAutoscroll::None {
+            self.stop_selection_autoscroll();
+            return;
+        }
+        if self.selection_autoscroll_active {
+            return;
+        }
+
+        self.selection_autoscroll_epoch = self.selection_autoscroll_epoch.wrapping_add(1);
+        let epoch = self.selection_autoscroll_epoch;
+        self.selection_autoscroll_active = true;
+        cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor()
+                    .timer(SELECTION_AUTOSCROLL_INTERVAL)
+                    .await;
+                let keep_scrolling = this
+                    .update(cx, |this, cx| {
+                        if !this.selection_autoscroll_active
+                            || this.selection_autoscroll_epoch != epoch
+                            || !this
+                                .terminal_left_mouse_sequence
+                                .payload()
+                                .is_some_and(|route| route.local_selection)
+                        {
+                            return false;
+                        }
+                        let autoscroll = this.selection_autoscroll_tick();
+                        if autoscroll == SelectionAutoscroll::None {
+                            this.stop_selection_autoscroll();
+                            return false;
+                        }
+                        cx.notify();
+                        true
+                    })
+                    .unwrap_or(false);
+                if !keep_scrolling {
+                    break;
+                }
+            }
+        })
+        .detach();
+    }
+
+    fn selection_autoscroll_tick(&self) -> SelectionAutoscroll {
+        let Some(position) = self.last_mouse_position else {
+            return SelectionAutoscroll::None;
+        };
+        let Some((point, geometry)) = self.selection_input_from_event_position(position, true)
+        else {
+            return SelectionAutoscroll::None;
+        };
+        let Some(terminal) = &self.terminal else {
+            return SelectionAutoscroll::None;
+        };
+        let inner = terminal.inner();
+        let guard = inner.lock();
+        guard.as_ref().map_or(SelectionAutoscroll::None, |session| {
+            session.selection_autoscroll_tick(point, geometry)
+        })
+    }
+
+    fn stop_selection_autoscroll(&mut self) {
+        if !self.selection_autoscroll_active {
+            return;
+        }
+        self.selection_autoscroll_active = false;
+        self.selection_autoscroll_epoch = self.selection_autoscroll_epoch.wrapping_add(1);
+    }
+
     fn cancel_left_pointer_interactions(&mut self, position: Point<Pixels>) {
+        self.stop_selection_autoscroll();
         self.scrollbar_drag = None;
         self.mouse_down_link = None;
         self.suppress_link_mouse_up = false;
@@ -1056,6 +1160,7 @@ impl GhosttyView {
     }
 
     fn cancel_pointer_interactions(&mut self) {
+        self.stop_selection_autoscroll();
         if let Some(position) = self.last_mouse_position {
             self.cancel_left_pointer_interactions(position);
             self.finish_terminal_mouse_sequence(2, position, MouseEventMods::default());
@@ -1063,7 +1168,15 @@ impl GhosttyView {
             self.scrollbar_drag = None;
             self.mouse_down_link = None;
             self.suppress_link_mouse_up = false;
-            self.terminal_left_mouse_sequence.finish();
+            if self
+                .terminal_left_mouse_sequence
+                .finish()
+                .is_some_and(|route| route.local_selection)
+                && let Some(terminal) = &self.terminal
+                && let Some(session) = terminal.inner().lock().as_ref()
+            {
+                session.cancel_drag();
+            }
             self.terminal_right_mouse_sequence.finish();
         }
     }
@@ -1864,11 +1977,13 @@ impl Render for GhosttyView {
                         2,
                         event.position,
                         mouse_mods_from(&event.modifiers),
-                    );
+                    ) == MouseDownRoute::TerminalReport;
                     this.terminal_mouse_right_consumed = Some(consumed);
                     if consumed {
-                        this.terminal_right_mouse_sequence
-                            .press_sent(event.modifiers.shift);
+                        this.terminal_right_mouse_sequence.begin(MousePressRoute {
+                            shift: event.modifiers.shift,
+                            local_selection: false,
+                        });
                     }
                     cx.emit(GhosttyFocusChanged);
                     cx.notify();
@@ -1898,15 +2013,19 @@ impl Render for GhosttyView {
                     // written. Do not continue an SGR sequence after a failed
                     // PTY write.
                     let mods = mouse_mods_from(&event.modifiers);
-                    let tracking_active = this.terminal_mouse_tracking_active_at(event.position);
-                    let consumed = this.forward_mouse_down(0, event.position, mods);
-                    if consumed
-                        || ((!tracking_active || mods.shift)
-                            && this.terminal().is_some()
-                            && this.cell_from_event_position(event.position).is_some())
-                    {
-                        this.terminal_left_mouse_sequence
-                            .press_sent(event.modifiers.shift);
+                    let route = match this.forward_mouse_down(0, event.position, mods) {
+                        MouseDownRoute::TerminalReport => Some(MousePressRoute {
+                            shift: mods.shift,
+                            local_selection: false,
+                        }),
+                        MouseDownRoute::LocalSelection => Some(MousePressRoute {
+                            shift: mods.shift,
+                            local_selection: true,
+                        }),
+                        MouseDownRoute::Ignored => None,
+                    };
+                    if let Some(route) = route {
+                        this.terminal_left_mouse_sequence.begin(route);
                     }
                     cx.emit(GhosttyFocusChanged);
                     cx.notify();
@@ -1955,39 +2074,39 @@ impl Render for GhosttyView {
                 }
                 let hover_changed = this.update_hovered_link(&event.modifiers);
                 if event.pressed_button == Some(MouseButton::Left) {
-                    if let Some(shift) =
-                        this.terminal_left_mouse_sequence.press_modifiers().copied()
-                    {
-                        this.forward_mouse_drag(
+                    if let Some(route) = this.terminal_left_mouse_sequence.payload().copied() {
+                        let autoscroll = this.forward_mouse_drag(
                             0,
                             event.position,
                             MouseEventMods {
-                                shift,
+                                shift: route.shift,
                                 ..mouse_mods_from(&event.modifiers)
                             },
                             true,
+                            route.local_selection,
                         );
+                        if route.local_selection {
+                            this.update_selection_autoscroll(autoscroll, cx);
+                        }
                         cx.notify();
                     } else if hover_changed {
                         cx.notify();
                     }
                 } else if event.pressed_button == Some(MouseButton::Right)
-                    && let Some(shift) = this
-                        .terminal_right_mouse_sequence
-                        .press_modifiers()
-                        .copied()
+                    && let Some(route) = this.terminal_right_mouse_sequence.payload().copied()
                 {
                     // Right button is held and the sequence is active: keep
                     // reporting motion (button 2 + 32) instead of treating
                     // this as a release.
-                    this.forward_mouse_drag(
+                    let _ = this.forward_mouse_drag(
                         2,
                         event.position,
                         MouseEventMods {
-                            shift,
+                            shift: route.shift,
                             ..mouse_mods_from(&event.modifiers)
                         },
                         true,
+                        false,
                     );
                     cx.notify();
                 } else if event.pressed_button.is_none()
@@ -2094,18 +2213,21 @@ impl Render for GhosttyView {
                     mouse_mods_from(&event.modifiers),
                 );
                 if scrolled_viewport
-                    && let Some(shift) =
-                        this.terminal_left_mouse_sequence.press_modifiers().copied()
+                    && let Some(route) = this.terminal_left_mouse_sequence.payload().copied()
                 {
-                    this.forward_mouse_drag(
+                    let autoscroll = this.forward_mouse_drag(
                         0,
                         event.position,
                         MouseEventMods {
-                            shift,
+                            shift: route.shift,
                             ..mouse_mods_from(&event.modifiers)
                         },
                         true,
+                        route.local_selection,
                     );
+                    if route.local_selection {
+                        this.update_selection_autoscroll(autoscroll, cx);
+                    }
                 }
                 cx.notify();
             }))

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -11,8 +11,8 @@ use crate::stub::{
     GhosttySurfaceEvent, MouseButton, SurfaceSize, TerminalColors,
 };
 use crate::vt::{
-    ScreenSnapshot, SelectionAutoscroll, SelectionGeometry, SelectionPoint, VtKeyEvent,
-    VtKeyOutcome,
+    ScreenSnapshot, SelectionAutoscroll, SelectionAutoscrollUpdate, SelectionGeometry,
+    SelectionPoint, VtKeyEvent, VtKeyOutcome,
 };
 use crate::{
     ClipboardWritePolicy, DesktopNotificationPolicy, clipboard_write_policy,
@@ -613,6 +613,13 @@ impl LinuxGhosttyTerminal {
             .and_then(LinuxPtySession::selection_text)
     }
 
+    pub fn take_selection_text(&self) -> Option<String> {
+        self.inner
+            .lock()
+            .as_ref()
+            .and_then(LinuxPtySession::take_selection_text)
+    }
+
     pub fn clear_selection(&self) {
         if let Some(session) = self.inner.lock().as_ref() {
             session.clear_selection();
@@ -623,12 +630,14 @@ impl LinuxGhosttyTerminal {
         &self,
         point: SelectionPoint,
         geometry: SelectionGeometry,
+        click_count: u8,
+        extend: bool,
     ) -> anyhow::Result<()> {
         let inner = self.inner.lock();
         let session = inner
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("linux terminal session is not attached"))?;
-        session.selection_press(point, geometry)
+        session.selection_press(point, geometry, click_count, extend)
     }
 
     pub fn selection_drag(
@@ -647,7 +656,7 @@ impl LinuxGhosttyTerminal {
         &self,
         point: SelectionPoint,
         geometry: SelectionGeometry,
-    ) -> anyhow::Result<SelectionAutoscroll> {
+    ) -> anyhow::Result<SelectionAutoscrollUpdate> {
         let inner = self.inner.lock();
         let session = inner
             .as_ref()

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -10,7 +10,10 @@ use crate::stub::{
     CommandFinishedSignal, CommandRecord, GhosttyConfigPatch, GhosttySplitDirection,
     GhosttySurfaceEvent, MouseButton, SurfaceSize, TerminalColors,
 };
-use crate::vt::{ScreenSnapshot, VtKeyEvent, VtKeyOutcome};
+use crate::vt::{
+    ScreenSnapshot, SelectionAutoscroll, SelectionGeometry, SelectionPoint, VtKeyEvent,
+    VtKeyOutcome,
+};
 use crate::{
     ClipboardWritePolicy, DesktopNotificationPolicy, clipboard_write_policy,
     desktop_notification_policy,
@@ -439,6 +442,26 @@ impl LinuxGhosttyTerminal {
         }
     }
 
+    /// Report a left-button drag only for modes that requested pointer motion
+    /// (1002/1003). SGR encodes motion by setting bit 5 on the button code.
+    pub fn mouse_motion_report(&self, col: u16, row: u16, shift: bool) -> bool {
+        let inner = self.inner.lock();
+        let Some(session) = inner.as_ref() else {
+            return false;
+        };
+        if !session.mouse_motion_tracking_active() || !session.is_sgr_mouse() || shift {
+            return false;
+        }
+        let seq = sgr_mouse_sequence(32, col, row, true);
+        match session.write_input(seq.as_bytes()) {
+            Ok(()) => true,
+            Err(err) => {
+                log::debug!("linux pty mouse motion write failed: {err:#}");
+                false
+            }
+        }
+    }
+
     /// Report a mouse button release to the child as an SGR (1006)
     /// sequence, gated on the same mouse-reporting mode as
     /// [`Self::mouse_report`].
@@ -577,14 +600,74 @@ impl LinuxGhosttyTerminal {
     pub fn recover_shell_prompt_state(&self) {}
 
     pub fn has_selection(&self) -> bool {
-        false
+        self.inner
+            .lock()
+            .as_ref()
+            .is_some_and(LinuxPtySession::has_selection)
     }
 
     pub fn selection_text(&self) -> Option<String> {
-        None
+        self.inner
+            .lock()
+            .as_ref()
+            .and_then(LinuxPtySession::selection_text)
     }
 
-    pub fn clear_selection(&self) {}
+    pub fn clear_selection(&self) {
+        if let Some(session) = self.inner.lock().as_ref() {
+            session.clear_selection();
+        }
+    }
+
+    pub fn selection_press(
+        &self,
+        point: SelectionPoint,
+        geometry: SelectionGeometry,
+    ) -> anyhow::Result<()> {
+        let inner = self.inner.lock();
+        let session = inner
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("linux terminal session is not attached"))?;
+        session.selection_press(point, geometry)
+    }
+
+    pub fn selection_drag(
+        &self,
+        point: SelectionPoint,
+        geometry: SelectionGeometry,
+    ) -> anyhow::Result<SelectionAutoscroll> {
+        let inner = self.inner.lock();
+        let session = inner
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("linux terminal session is not attached"))?;
+        session.selection_drag(point, geometry)
+    }
+
+    pub fn selection_autoscroll_tick(
+        &self,
+        point: SelectionPoint,
+        geometry: SelectionGeometry,
+    ) -> anyhow::Result<SelectionAutoscroll> {
+        let inner = self.inner.lock();
+        let session = inner
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("linux terminal session is not attached"))?;
+        session.selection_autoscroll_tick(point, geometry)
+    }
+
+    pub fn selection_release(&self, point: Option<(u16, u16)>) -> anyhow::Result<()> {
+        let inner = self.inner.lock();
+        let session = inner
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("linux terminal session is not attached"))?;
+        session.selection_release(point)
+    }
+
+    pub fn selection_cancel_gesture(&self) {
+        if let Some(session) = self.inner.lock().as_ref() {
+            session.selection_cancel_gesture();
+        }
+    }
 
     pub fn read_screen_text(&self, max_lines: usize) -> Vec<String> {
         self.inner
@@ -655,6 +738,11 @@ mod tests {
     fn sgr_left_press_and_release_terminators() {
         assert_eq!(sgr_mouse_sequence(0, 3, 7, true), "\x1b[<0;4;8M");
         assert_eq!(sgr_mouse_sequence(0, 3, 7, false), "\x1b[<0;4;8m");
+    }
+
+    #[test]
+    fn sgr_left_drag_sets_motion_bit() {
+        assert_eq!(sgr_mouse_sequence(32, 3, 7, true), "\x1b[<32;4;8M");
     }
 
     #[test]

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -15,8 +15,8 @@ use crate::pty_write::{PtyWriteQueue, PtyWriteWorker};
 use crate::stub::{CommandFinishedSignal, SurfaceSize, TerminalColors};
 use crate::transcript::{TranscriptBuffer, snapshot_to_lines};
 use crate::vt::{
-    PtyWriteClass, ScreenSnapshot, ThemeColors, VtKeyEvent, VtKeyOutcome, VtPasteResult,
-    VtPasteSource, VtScreen,
+    PtyWriteClass, ScreenSnapshot, SelectionAutoscroll, SelectionGeometry, SelectionPoint,
+    ThemeColors, VtKeyEvent, VtKeyOutcome, VtPasteResult, VtPasteSource, VtScreen,
 };
 use crate::{ClipboardWritePolicy, DesktopNotificationPolicy};
 
@@ -510,6 +510,61 @@ impl LinuxPtySession {
         }
     }
 
+    pub fn selection_press(
+        &self,
+        point: SelectionPoint,
+        geometry: SelectionGeometry,
+    ) -> Result<()> {
+        self.shared.screen.selection_press(point, geometry)?;
+        self.mark_needs_render();
+        Ok(())
+    }
+
+    pub fn selection_drag(
+        &self,
+        point: SelectionPoint,
+        geometry: SelectionGeometry,
+    ) -> Result<SelectionAutoscroll> {
+        let autoscroll = self.shared.screen.selection_drag(point, geometry)?;
+        self.mark_needs_render();
+        Ok(autoscroll)
+    }
+
+    pub fn selection_autoscroll_tick(
+        &self,
+        point: SelectionPoint,
+        geometry: SelectionGeometry,
+    ) -> Result<SelectionAutoscroll> {
+        let autoscroll = self
+            .shared
+            .screen
+            .selection_autoscroll_tick(point, geometry)?;
+        self.mark_needs_render();
+        Ok(autoscroll)
+    }
+
+    pub fn selection_release(&self, point: Option<(u16, u16)>) -> Result<()> {
+        self.shared.screen.selection_release(point)
+    }
+
+    pub fn selection_cancel_gesture(&self) {
+        self.shared.screen.selection_cancel_gesture();
+    }
+
+    pub fn has_selection(&self) -> bool {
+        self.shared.screen.has_selection()
+    }
+
+    pub fn selection_text(&self) -> Option<String> {
+        self.shared.screen.selection_text()
+    }
+
+    pub fn clear_selection(&self) {
+        if self.shared.screen.clear_selection() {
+            self.mark_needs_render();
+        }
+    }
+
     pub fn title(&self) -> Option<String> {
         self.shared
             .screen
@@ -614,6 +669,10 @@ impl LinuxPtySession {
 
     pub fn mouse_tracking_active(&self) -> bool {
         self.shared.screen.mouse_tracking_active()
+    }
+
+    pub fn mouse_motion_tracking_active(&self) -> bool {
+        self.shared.screen.mouse_motion_tracking_active()
     }
 
     pub fn is_sgr_mouse(&self) -> bool {

--- a/crates/con-ghostty/src/linux/pty.rs
+++ b/crates/con-ghostty/src/linux/pty.rs
@@ -15,8 +15,9 @@ use crate::pty_write::{PtyWriteQueue, PtyWriteWorker};
 use crate::stub::{CommandFinishedSignal, SurfaceSize, TerminalColors};
 use crate::transcript::{TranscriptBuffer, snapshot_to_lines};
 use crate::vt::{
-    PtyWriteClass, ScreenSnapshot, SelectionAutoscroll, SelectionGeometry, SelectionPoint,
-    ThemeColors, VtKeyEvent, VtKeyOutcome, VtPasteResult, VtPasteSource, VtScreen,
+    PtyWriteClass, ScreenSnapshot, SelectionAutoscroll, SelectionAutoscrollUpdate,
+    SelectionGeometry, SelectionPoint, ThemeColors, VtKeyEvent, VtKeyOutcome, VtPasteResult,
+    VtPasteSource, VtScreen,
 };
 use crate::{ClipboardWritePolicy, DesktopNotificationPolicy};
 
@@ -514,8 +515,12 @@ impl LinuxPtySession {
         &self,
         point: SelectionPoint,
         geometry: SelectionGeometry,
+        click_count: u8,
+        extend: bool,
     ) -> Result<()> {
-        self.shared.screen.selection_press(point, geometry)?;
+        self.shared
+            .screen
+            .selection_press(point, geometry, click_count, extend)?;
         self.mark_needs_render();
         Ok(())
     }
@@ -534,13 +539,15 @@ impl LinuxPtySession {
         &self,
         point: SelectionPoint,
         geometry: SelectionGeometry,
-    ) -> Result<SelectionAutoscroll> {
-        let autoscroll = self
+    ) -> Result<SelectionAutoscrollUpdate> {
+        let update = self
             .shared
             .screen
             .selection_autoscroll_tick(point, geometry)?;
-        self.mark_needs_render();
-        Ok(autoscroll)
+        if update.changed {
+            self.mark_needs_render();
+        }
+        Ok(update)
     }
 
     pub fn selection_release(&self, point: Option<(u16, u16)>) -> Result<()> {
@@ -557,6 +564,14 @@ impl LinuxPtySession {
 
     pub fn selection_text(&self) -> Option<String> {
         self.shared.screen.selection_text()
+    }
+
+    pub fn take_selection_text(&self) -> Option<String> {
+        let selection = self.shared.screen.take_selection_text();
+        if selection.is_some() {
+            self.mark_needs_render();
+        }
+        selection
     }
 
     pub fn clear_selection(&self) {

--- a/crates/con-ghostty/src/transcript.rs
+++ b/crates/con-ghostty/src/transcript.rs
@@ -272,6 +272,7 @@ mod tests {
             cols: 3,
             rows: 2,
             cells,
+            selection_ranges: vec![None; 2],
             kitty_placements: Default::default(),
             dirty_rows: vec![0, 1],
             cursor: Cursor::default(),

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -120,7 +120,6 @@ const METADATA_DIRTY_PWD: u8 = 1 << 1;
 const UNKNOWN_SEQUENCE_LOG_TARGET: &str = "con_ghostty::vt::unknown_sequence";
 const UNKNOWN_SEQUENCE_MAX_BYTES: usize = 256;
 const UNKNOWN_SEQUENCE_LOG_LIMIT: u8 = 16;
-const SELECTION_REPEAT_INTERVAL_NS: u64 = 500_000_000;
 
 // ── Enums (keys) ───────────────────────────────────────────────────────
 //
@@ -994,6 +993,7 @@ unsafe extern "C" {
 
     // Allocator + process-global optional services (`allocator.h`, `sys.h`).
     fn ghostty_alloc(allocator: *const GhosttyAllocator, len: usize) -> *mut u8;
+    fn ghostty_free(allocator: *const GhosttyAllocator, ptr: *mut u8, len: usize);
     fn ghostty_sys_set(option: GhosttySysOption, value: *const c_void) -> GhosttyResult;
 
     // Terminal (`terminal.h`)
@@ -1082,12 +1082,12 @@ unsafe extern "C" {
         b: *const GhosttySelection,
         out_equal: *mut bool,
     ) -> GhosttyResult;
-    fn ghostty_terminal_selection_format_buf(
+    fn ghostty_terminal_selection_format_alloc(
         terminal: GhosttyTerminal,
+        allocator: *const GhosttyAllocator,
         options: GhosttyTerminalSelectionFormatOptions,
-        buf: *mut u8,
-        buf_len: usize,
-        out_written: *mut usize,
+        out_ptr: *mut *mut u8,
+        out_len: *mut usize,
     ) -> GhosttyResult;
 
     // Key encoder (`key/{encoder,event}.h`). The encoder and reusable
@@ -1501,14 +1501,10 @@ pub enum SelectionAutoscroll {
     Down,
 }
 
-impl From<GhosttySelectionGestureAutoscroll> for SelectionAutoscroll {
-    fn from(value: GhosttySelectionGestureAutoscroll) -> Self {
-        match value {
-            GhosttySelectionGestureAutoscroll::None => Self::None,
-            GhosttySelectionGestureAutoscroll::Up => Self::Up,
-            GhosttySelectionGestureAutoscroll::Down => Self::Down,
-        }
-    }
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SelectionAutoscrollUpdate {
+    pub direction: SelectionAutoscroll,
+    pub changed: bool,
 }
 
 #[derive(Debug)]
@@ -2624,31 +2620,65 @@ impl VtScreen {
 
     /// Begin a local text-selection gesture at a viewport cell.
     ///
-    /// A first click clears the previous active selection. Repeat clicks use
-    /// Ghostty's default cell/word/line behavior table.
+    /// `click_count` comes from the platform event so OS accessibility
+    /// settings remain authoritative. A shifted single click extends an
+    /// existing active gesture; otherwise Ghostty's default cell/word/line
+    /// behavior is selected from the platform click count.
     pub fn selection_press(
         &self,
         point: SelectionPoint,
         geometry: SelectionGeometry,
+        click_count: u8,
+        extend: bool,
     ) -> anyhow::Result<()> {
         validate_selection_point(point)?;
         let geometry = geometry.to_ffi()?;
         let mut inner = self.inner.lock();
         let terminal = inner.terminal;
-        let grid_ref = selection_grid_ref(terminal, point.col, point.row)?;
 
         if inner.selection_gesture.is_none() {
             inner.selection_gesture = Some(SelectionGestureState::new()?);
         }
+        let can_extend = extend
+            && click_count == 1
+            && has_selection_locked(&inner)?
+            && selection_gesture_click_count(&inner)? > 0;
+        let grid_ref = selection_grid_ref(terminal, point.col, point.row)?;
         let state = inner
             .selection_gesture
-            .as_mut()
+            .as_ref()
             .expect("selection gesture initialized");
-        let event = state.press;
         let gesture = state.gesture;
-        let time_ns = state.time_ns();
         let position = selection_surface_position(point);
+
+        if can_extend {
+            let event = state.drag;
+            selection_event_set(event, GhosttySelectionGestureEventOption::Ref, &grid_ref)?;
+            selection_event_set(
+                event,
+                GhosttySelectionGestureEventOption::Position,
+                &position,
+            )?;
+            selection_event_set(
+                event,
+                GhosttySelectionGestureEventOption::Geometry,
+                &geometry,
+            )?;
+            if let Some(selection) = apply_selection_gesture_event(gesture, terminal, event)? {
+                set_selection_locked(&mut inner, Some(&selection))?;
+            }
+            return Ok(());
+        }
+
+        // GPUI has already applied the platform's repeat interval and distance
+        // policy. Replay the reported count from a clean gesture so Ghostty
+        // selects the matching cell/word/line behavior without a second,
+        // hard-coded timing policy disagreeing with the OS.
+        unsafe { ghostty_selection_gesture_reset(gesture, terminal) };
+        let event = state.press;
+        let time_ns = state.time_ns();
         let repeat_distance = f64::from(geometry.cell_width);
+        let repeat_interval_ns = u64::MAX;
 
         selection_event_set(event, GhosttySelectionGestureEventOption::Ref, &grid_ref)?;
         selection_event_set(
@@ -2665,10 +2695,13 @@ impl VtScreen {
         selection_event_set(
             event,
             GhosttySelectionGestureEventOption::RepeatIntervalNs,
-            &SELECTION_REPEAT_INTERVAL_NS,
+            &repeat_interval_ns,
         )?;
 
-        let selection = apply_selection_gesture_event(gesture, terminal, event)?;
+        let mut selection = None;
+        for _ in 0..click_count.clamp(1, 3) {
+            selection = apply_selection_gesture_event(gesture, terminal, event)?;
+        }
         if let Some(selection) = selection {
             set_selection_locked(&mut inner, Some(&selection))?;
         } else if selection_gesture_click_count(&inner)? == 1 {
@@ -2688,12 +2721,12 @@ impl VtScreen {
         let geometry = geometry.to_ffi()?;
         let mut inner = self.inner.lock();
         let terminal = inner.terminal;
-        let grid_ref = selection_grid_ref(terminal, point.col, point.row)?;
         let Some(state) = inner.selection_gesture.as_ref() else {
             return Ok(SelectionAutoscroll::None);
         };
         let event = state.drag;
         let gesture = state.gesture;
+        let grid_ref = selection_grid_ref(terminal, point.col, point.row)?;
         let position = selection_surface_position(point);
 
         selection_event_set(event, GhosttySelectionGestureEventOption::Ref, &grid_ref)?;
@@ -2723,13 +2756,13 @@ impl VtScreen {
         &self,
         point: SelectionPoint,
         geometry: SelectionGeometry,
-    ) -> anyhow::Result<SelectionAutoscroll> {
+    ) -> anyhow::Result<SelectionAutoscrollUpdate> {
         validate_selection_point(point)?;
         let geometry = geometry.to_ffi()?;
         let mut inner = self.inner.lock();
         let terminal = inner.terminal;
         let Some(state) = inner.selection_gesture.as_ref() else {
-            return Ok(SelectionAutoscroll::None);
+            return Ok(SelectionAutoscrollUpdate::default());
         };
         let event = state.autoscroll_tick;
         let gesture = state.gesture;
@@ -2740,7 +2773,7 @@ impl VtScreen {
         let position = selection_surface_position(point);
         let autoscroll_before = selection_gesture_autoscroll(&inner)?;
         if autoscroll_before == SelectionAutoscroll::None {
-            return Ok(SelectionAutoscroll::None);
+            return Ok(SelectionAutoscrollUpdate::default());
         }
 
         selection_event_set(
@@ -2759,19 +2792,40 @@ impl VtScreen {
             &geometry,
         )?;
 
+        let generation_before = inner.generation;
+        let offset_before = read_scrollbar(terminal).map(|scrollbar| scrollbar.offset);
         let selection = apply_selection_gesture_event(gesture, terminal, event)?;
-        // A successful AUTOSCROLL_TICK may scroll the viewport before any
-        // subsequent gesture query or selection install. Account for that
-        // mutation immediately so even a later FFI error cannot leave snapshot
-        // caching on the old generation.
-        inner.generation = inner.generation.wrapping_add(1);
-        let click_count = selection_gesture_click_count(&inner)?;
-        if let Some(selection) = selection {
-            set_selection_locked(&mut inner, Some(&selection))?;
-        } else if click_count > 0 {
-            set_selection_locked(&mut inner, None)?;
+        let offset_after = read_scrollbar(terminal).map(|scrollbar| scrollbar.offset);
+        let viewport_changed = match (offset_before, offset_after) {
+            (Some(before), Some(after)) => before != after,
+            // Preserve correctness if scrollbar introspection itself fails.
+            _ => true,
+        };
+        let result = (|| {
+            let click_count = selection_gesture_click_count(&inner)?;
+            let selection_changed = if let Some(selection) = selection {
+                set_selection_locked(&mut inner, Some(&selection))?
+            } else if click_count > 0 {
+                set_selection_locked(&mut inner, None)?
+            } else {
+                false
+            };
+            Ok::<_, anyhow::Error>((selection_gesture_autoscroll(&inner)?, selection_changed))
+        })();
+
+        // A successful tick mutates the viewport inside Ghostty. Keep that
+        // mutation and any selection install under this lock, but avoid a new
+        // snapshot generation when both were clamped/equal at a scrollback
+        // boundary. If a later query failed, still publish a real viewport
+        // movement before returning the error.
+        if viewport_changed && inner.generation == generation_before {
+            inner.generation = inner.generation.wrapping_add(1);
         }
-        selection_gesture_autoscroll(&inner)
+        let (direction, selection_changed) = result?;
+        Ok(SelectionAutoscrollUpdate {
+            direction,
+            changed: viewport_changed || selection_changed,
+        })
     }
 
     /// Finish a normal pointer gesture while retaining repeat-click state for
@@ -2819,10 +2873,7 @@ impl VtScreen {
         }
     }
 
-    pub fn selection_autoscroll(&self) -> anyhow::Result<SelectionAutoscroll> {
-        selection_gesture_autoscroll(&self.inner.lock())
-    }
-
+    /// Read selection presence. FFI failures are logged and reported as false.
     pub fn has_selection(&self) -> bool {
         match has_selection_locked(&self.inner.lock()) {
             Ok(has_selection) => has_selection,
@@ -2833,11 +2884,39 @@ impl VtScreen {
         }
     }
 
+    /// Format the active selection. FFI or UTF-8 failures are logged and
+    /// reported as no selection.
     pub fn selection_text(&self) -> Option<String> {
         match selection_text_locked(&self.inner.lock()) {
             Ok(selection) => selection,
             Err(err) => {
                 log::warn!("failed to format terminal selection: {err:#}");
+                None
+            }
+        }
+    }
+
+    /// Atomically format and clear the active selection.
+    ///
+    /// An empty string is a real empty selection; `None` means there was no
+    /// selection or formatting failed. Failures are logged and leave the
+    /// selection installed so a later copy can retry.
+    pub fn take_selection_text(&self) -> Option<String> {
+        let mut inner = self.inner.lock();
+        let result = (|| {
+            let Some(text) = selection_text_locked(&inner)? else {
+                return Ok(None);
+            };
+            if let Some(state) = inner.selection_gesture.as_ref() {
+                unsafe { ghostty_selection_gesture_reset(state.gesture, inner.terminal) };
+            }
+            set_selection_locked(&mut inner, None)?;
+            Ok::<_, anyhow::Error>(Some(text))
+        })();
+        match result {
+            Ok(selection) => selection,
+            Err(err) => {
+                log::warn!("failed to take terminal selection: {err:#}");
                 None
             }
         }
@@ -4417,7 +4496,10 @@ fn selection_gesture_autoscroll(inner: &VtInner) -> anyhow::Result<SelectionAuto
     let Some(state) = inner.selection_gesture.as_ref() else {
         return Ok(SelectionAutoscroll::None);
     };
-    let mut autoscroll = GhosttySelectionGestureAutoscroll::None;
+    // Read C enum output through its integer representation. Writing an
+    // upstream value added after our pinned revision directly into a Rust enum
+    // would create an invalid discriminant before we could validate it.
+    let mut autoscroll = GhosttySelectionGestureAutoscroll::None as c_int;
     let rc = unsafe {
         ghostty_selection_gesture_get(
             state.gesture,
@@ -4429,7 +4511,18 @@ fn selection_gesture_autoscroll(inner: &VtInner) -> anyhow::Result<SelectionAuto
     if rc != GHOSTTY_SUCCESS {
         anyhow::bail!("ghostty_selection_gesture_get(AUTOSCROLL) failed: rc={rc}");
     }
-    Ok(autoscroll.into())
+    match autoscroll {
+        value if value == GhosttySelectionGestureAutoscroll::None as c_int => {
+            Ok(SelectionAutoscroll::None)
+        }
+        value if value == GhosttySelectionGestureAutoscroll::Up as c_int => {
+            Ok(SelectionAutoscroll::Up)
+        }
+        value if value == GhosttySelectionGestureAutoscroll::Down as c_int => {
+            Ok(SelectionAutoscroll::Down)
+        }
+        value => anyhow::bail!("unknown Ghostty selection autoscroll value: {value}"),
+    }
 }
 
 fn selection_locked(inner: &VtInner) -> anyhow::Result<Option<GhosttySelection>> {
@@ -4487,46 +4580,39 @@ fn set_selection_locked(
 
 fn selection_text_locked(inner: &VtInner) -> anyhow::Result<Option<String>> {
     let options = GhosttyTerminalSelectionFormatOptions::default();
-    let mut required = 0_usize;
+    let mut ptr = std::ptr::null_mut();
+    let mut len = 0_usize;
     let rc = unsafe {
-        ghostty_terminal_selection_format_buf(
+        ghostty_terminal_selection_format_alloc(
             inner.terminal,
+            std::ptr::null(),
             options,
-            std::ptr::null_mut(),
-            0,
-            &mut required,
+            &mut ptr,
+            &mut len,
         )
     };
     match rc {
         GHOSTTY_NO_VALUE => return Ok(None),
-        GHOSTTY_OUT_OF_SPACE => {}
-        _ => anyhow::bail!("ghostty_terminal_selection_format_buf(size) failed: rc={rc}"),
+        GHOSTTY_SUCCESS => {}
+        _ => anyhow::bail!("ghostty_terminal_selection_format_alloc failed: rc={rc}"),
     }
-
-    let mut bytes = Vec::new();
-    bytes.try_reserve_exact(required)?;
-    bytes.resize(required, 0);
-    let mut written = 0_usize;
-    let rc = unsafe {
-        ghostty_terminal_selection_format_buf(
-            inner.terminal,
-            options,
-            bytes.as_mut_ptr(),
-            bytes.len(),
-            &mut written,
-        )
-    };
-    if rc != GHOSTTY_SUCCESS {
-        anyhow::bail!("ghostty_terminal_selection_format_buf(write) failed: rc={rc}");
+    if ptr.is_null() && len != 0 {
+        anyhow::bail!("ghostty selection formatter returned a null {len}-byte buffer");
     }
-    if written > bytes.len() {
-        anyhow::bail!(
-            "ghostty_terminal_selection_format_buf wrote {written} bytes into {}-byte buffer",
-            bytes.len()
-        );
-    }
-    bytes.truncate(written);
-    Ok(Some(String::from_utf8(bytes)?))
+    let bytes = (|| {
+        let mut bytes = Vec::new();
+        bytes.try_reserve_exact(len)?;
+        if len != 0 {
+            // SAFETY: format_alloc returned a readable `len`-byte allocation.
+            // Copy it because Ghostty and Rust may use different heaps on
+            // Windows; fallible reservation keeps the FFI buffer releasable if
+            // Rust cannot allocate the destination.
+            bytes.extend_from_slice(unsafe { std::slice::from_raw_parts(ptr, len) });
+        }
+        Ok::<_, anyhow::Error>(bytes)
+    })();
+    unsafe { ghostty_free(std::ptr::null(), ptr, len) };
+    Ok(Some(String::from_utf8(bytes?)?))
 }
 
 fn empty_snapshot(cols: u16, rows: u16, generation: u64) -> ScreenSnapshot {
@@ -5832,7 +5918,7 @@ mod tests {
         let baseline_generation = screen.generation();
 
         screen
-            .selection_press(test_selection_point(0, 0, 1.0), geometry)
+            .selection_press(test_selection_point(0, 0, 1.0), geometry, 1, false)
             .expect("press selection anchor");
         assert!(!screen.has_selection());
         assert_eq!(screen.generation(), baseline_generation);
@@ -5873,7 +5959,7 @@ mod tests {
         screen.acknowledge_snapshot(baseline.generation);
 
         screen
-            .selection_press(test_selection_point(2, 0, 1.0), geometry)
+            .selection_press(test_selection_point(2, 0, 1.0), geometry, 1, false)
             .expect("press selection anchor");
         screen
             .selection_drag(test_selection_point(3, 1, 9.0), geometry)
@@ -5919,7 +6005,7 @@ mod tests {
         let point = test_selection_point(1, 0, 5.0);
 
         screen
-            .selection_press(point, geometry)
+            .selection_press(point, geometry, 1, false)
             .expect("first click");
         screen
             .selection_release(Some((point.col, point.row)))
@@ -5927,7 +6013,7 @@ mod tests {
         assert_eq!(screen.selection_text(), None);
 
         screen
-            .selection_press(point, geometry)
+            .selection_press(point, geometry, 2, false)
             .expect("second click");
         assert_eq!(screen.selection_text().as_deref(), Some("alpha"));
         screen
@@ -5935,9 +6021,54 @@ mod tests {
             .expect("second release");
 
         screen
-            .selection_press(point, geometry)
+            .selection_press(point, geometry, 3, false)
             .expect("third click");
         assert_eq!(screen.selection_text().as_deref(), Some("alpha beta"));
+    }
+
+    #[test]
+    fn shifted_single_click_falls_back_to_a_fresh_press_after_gesture_reset() {
+        let screen = VtScreen::new(20, 2, None).expect("create vt screen");
+        screen.feed(b"alpha beta");
+        let geometry = test_selection_geometry(20, 2);
+
+        screen
+            .selection_press(test_selection_point(0, 0, 1.0), geometry, 1, false)
+            .expect("press initial anchor");
+        screen
+            .selection_drag(test_selection_point(4, 0, 9.0), geometry)
+            .expect("select alpha");
+        screen
+            .selection_release(Some((4, 0)))
+            .expect("release initial selection");
+        screen.selection_cancel_gesture();
+
+        screen
+            .selection_press(test_selection_point(6, 0, 1.0), geometry, 1, true)
+            .expect("shifted press after reset");
+        screen
+            .selection_drag(test_selection_point(9, 0, 9.0), geometry)
+            .expect("drag from fallback anchor");
+        assert_eq!(screen.selection_text().as_deref(), Some("beta"));
+    }
+
+    #[test]
+    fn shifted_repeat_click_keeps_platform_word_behavior() {
+        let screen = VtScreen::new(20, 2, None).expect("create vt screen");
+        screen.feed(b"alpha beta");
+        let geometry = test_selection_geometry(20, 2);
+
+        screen
+            .selection_press(test_selection_point(0, 0, 1.0), geometry, 1, false)
+            .expect("first click");
+        screen
+            .selection_release(Some((0, 0)))
+            .expect("first release");
+        screen
+            .selection_press(test_selection_point(7, 0, 5.0), geometry, 2, true)
+            .expect("shifted double click");
+
+        assert_eq!(screen.selection_text().as_deref(), Some("beta"));
     }
 
     #[test]
@@ -5948,7 +6079,7 @@ mod tests {
         let point = test_selection_point(1, 0, 5.0);
 
         screen
-            .selection_press(point, geometry)
+            .selection_press(point, geometry, 1, false)
             .expect("first click");
         screen
             .selection_release(Some((point.col, point.row)))
@@ -5956,7 +6087,7 @@ mod tests {
         assert!(!screen.clear_selection());
 
         screen
-            .selection_press(point, geometry)
+            .selection_press(point, geometry, 1, false)
             .expect("click after clear");
         assert_eq!(screen.selection_text(), None);
     }
@@ -5968,7 +6099,7 @@ mod tests {
         let geometry = test_selection_geometry(20, 2);
 
         screen
-            .selection_press(test_selection_point(0, 0, 1.0), geometry)
+            .selection_press(test_selection_point(0, 0, 1.0), geometry, 1, false)
             .expect("press selection anchor");
         screen
             .selection_drag(test_selection_point(4, 0, 9.0), geometry)
@@ -6009,7 +6140,7 @@ mod tests {
         screen.feed(b"alpha beta");
         let geometry = test_selection_geometry(20, 3);
         screen
-            .selection_press(test_selection_point(0, 0, 1.0), geometry)
+            .selection_press(test_selection_point(0, 0, 1.0), geometry, 1, false)
             .expect("press selection anchor");
         screen
             .selection_drag(test_selection_point(4, 0, 9.0), geometry)
@@ -6037,7 +6168,7 @@ mod tests {
         let geometry = test_selection_geometry(5, 3);
 
         screen
-            .selection_press(test_selection_point(0, 0, 1.0), geometry)
+            .selection_press(test_selection_point(0, 0, 1.0), geometry, 1, false)
             .expect("press selection anchor");
         screen
             .selection_drag(test_selection_point(0, 1, 9.0), geometry)
@@ -6053,7 +6184,7 @@ mod tests {
         let geometry = test_selection_geometry(10, 2);
 
         screen
-            .selection_press(test_selection_point(0, 0, 1.0), geometry)
+            .selection_press(test_selection_point(0, 0, 1.0), geometry, 1, false)
             .expect("press selection anchor");
         screen
             .selection_drag(test_selection_point(4, 0, 9.0), geometry)
@@ -6077,7 +6208,7 @@ mod tests {
         assert_eq!(screen.scrollbar().map(|state| state.offset), Some(1));
 
         screen
-            .selection_press(test_selection_point(4, 1, 9.0), geometry)
+            .selection_press(test_selection_point(4, 1, 9.0), geometry, 1, false)
             .expect("press selection anchor");
         assert_eq!(
             screen
@@ -6087,16 +6218,42 @@ mod tests {
         );
         let generation_before_tick = screen.generation();
 
-        assert_eq!(
-            screen
-                .selection_autoscroll_tick(point_above_viewport, geometry)
-                .expect("autoscroll selection"),
-            SelectionAutoscroll::Up
-        );
+        let update = screen
+            .selection_autoscroll_tick(point_above_viewport, geometry)
+            .expect("autoscroll selection");
+        assert_eq!(update.direction, SelectionAutoscroll::Up);
+        assert!(update.changed);
 
         assert!(screen.generation() > generation_before_tick);
         assert_eq!(screen.scrollbar().map(|state| state.offset), Some(0));
         assert_eq!(screen.selection_text().as_deref(), Some("one\ntwo\nthree"));
+
+        let generation_at_boundary = screen.generation();
+        let update = screen
+            .selection_autoscroll_tick(point_above_viewport, geometry)
+            .expect("clamped autoscroll selection");
+        assert_eq!(update.direction, SelectionAutoscroll::Up);
+        assert!(!update.changed);
+        assert_eq!(screen.generation(), generation_at_boundary);
+    }
+
+    #[test]
+    fn taking_selection_formats_and_clears_in_one_generation() {
+        let screen = VtScreen::new(20, 2, None).expect("create vt screen");
+        screen.feed(b"alpha beta");
+        let geometry = test_selection_geometry(20, 2);
+        screen
+            .selection_press(test_selection_point(0, 0, 1.0), geometry, 1, false)
+            .expect("press selection anchor");
+        screen
+            .selection_drag(test_selection_point(4, 0, 9.0), geometry)
+            .expect("select alpha");
+        let generation = screen.generation();
+
+        assert_eq!(screen.take_selection_text().as_deref(), Some("alpha"));
+        assert!(!screen.has_selection());
+        assert_eq!(screen.generation(), generation.wrapping_add(1));
+        assert_eq!(screen.take_selection_text(), None);
     }
 
     #[test]
@@ -6108,7 +6265,7 @@ mod tests {
 
         assert!(
             screen
-                .selection_press(point, test_selection_geometry(20, 2))
+                .selection_press(point, test_selection_geometry(20, 2), 1, false)
                 .is_err()
         );
         assert!(
@@ -6121,6 +6278,8 @@ mod tests {
                         padding_left_px: 0,
                         screen_height_px: 40,
                     },
+                    1,
+                    false,
                 )
                 .is_err()
         );

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -1076,6 +1076,12 @@ unsafe extern "C" {
         event: GhosttySelectionGestureEvent,
         out_selection: *mut GhosttySelection,
     ) -> GhosttyResult;
+    fn ghostty_terminal_selection_equal(
+        terminal: GhosttyTerminal,
+        a: *const GhosttySelection,
+        b: *const GhosttySelection,
+        out_equal: *mut bool,
+    ) -> GhosttyResult;
     fn ghostty_terminal_selection_format_buf(
         terminal: GhosttyTerminal,
         options: GhosttyTerminalSelectionFormatOptions,
@@ -2841,6 +2847,9 @@ impl VtScreen {
     /// present and successfully cleared.
     pub fn clear_selection(&self) -> bool {
         let mut inner = self.inner.lock();
+        if let Some(state) = inner.selection_gesture.as_ref() {
+            unsafe { ghostty_selection_gesture_reset(state.gesture, inner.terminal) };
+        }
         match set_selection_locked(&mut inner, None) {
             Ok(changed) => changed,
             Err(err) => {
@@ -3572,6 +3581,13 @@ impl VtScreen {
             || self.mode_active(MODE_BUTTON_MOUSE)
             || self.mode_active(MODE_ANY_MOUSE)
             || self.mode_active(MODE_X10_MOUSE)
+    }
+
+    /// Returns `true` when the application requested pointer motion reports.
+    /// Normal (1000) and X10 tracking only receive button events; button-motion
+    /// (1002) and any-motion (1003) receive drag updates.
+    pub fn mouse_motion_tracking_active(&self) -> bool {
+        self.mode_active(MODE_BUTTON_MOUSE) || self.mode_active(MODE_ANY_MOUSE)
     }
 
     /// SGR (1006) mouse format is the extended coord encoding.
@@ -4416,7 +4432,7 @@ fn selection_gesture_autoscroll(inner: &VtInner) -> anyhow::Result<SelectionAuto
     Ok(autoscroll.into())
 }
 
-fn has_selection_locked(inner: &VtInner) -> anyhow::Result<bool> {
+fn selection_locked(inner: &VtInner) -> anyhow::Result<Option<GhosttySelection>> {
     let mut selection = GhosttySelection::default();
     let rc = unsafe {
         ghostty_terminal_get(
@@ -4426,18 +4442,36 @@ fn has_selection_locked(inner: &VtInner) -> anyhow::Result<bool> {
         )
     };
     match rc {
-        GHOSTTY_SUCCESS => Ok(true),
-        GHOSTTY_NO_VALUE => Ok(false),
+        GHOSTTY_SUCCESS => Ok(Some(selection)),
+        GHOSTTY_NO_VALUE => Ok(None),
         _ => anyhow::bail!("ghostty_terminal_get(SELECTION) failed: rc={rc}"),
     }
+}
+
+fn has_selection_locked(inner: &VtInner) -> anyhow::Result<bool> {
+    Ok(selection_locked(inner)?.is_some())
 }
 
 fn set_selection_locked(
     inner: &mut VtInner,
     selection: Option<&GhosttySelection>,
 ) -> anyhow::Result<bool> {
-    if selection.is_none() && !has_selection_locked(inner)? {
-        return Ok(false);
+    let current = selection_locked(inner)?;
+    match (selection, current.as_ref()) {
+        (None, None) => return Ok(false),
+        (Some(selection), Some(current)) => {
+            let mut equal = false;
+            let rc = unsafe {
+                ghostty_terminal_selection_equal(inner.terminal, selection, current, &mut equal)
+            };
+            if rc != GHOSTTY_SUCCESS {
+                anyhow::bail!("ghostty_terminal_selection_equal failed: rc={rc}");
+            }
+            if equal {
+                return Ok(false);
+            }
+        }
+        _ => {}
     }
     let value = selection.map_or(std::ptr::null(), |selection| {
         selection as *const GhosttySelection as *const c_void
@@ -5810,6 +5844,12 @@ mod tests {
         assert_eq!(screen.selection_text().as_deref(), Some("alpha"));
         assert_eq!(screen.generation(), baseline_generation.wrapping_add(1));
 
+        let selected_generation = screen.generation();
+        screen
+            .selection_drag(test_selection_point(4, 0, 9.0), geometry)
+            .expect("repeat drag in selected cell");
+        assert_eq!(screen.generation(), selected_generation);
+
         screen
             .selection_release(Some((4, 0)))
             .expect("release selection");
@@ -5901,6 +5941,69 @@ mod tests {
     }
 
     #[test]
+    fn clearing_selection_resets_repeat_click_state() {
+        let screen = VtScreen::new(20, 2, None).expect("create vt screen");
+        screen.feed(b"alpha beta");
+        let geometry = test_selection_geometry(20, 2);
+        let point = test_selection_point(1, 0, 5.0);
+
+        screen
+            .selection_press(point, geometry)
+            .expect("first click");
+        screen
+            .selection_release(Some((point.col, point.row)))
+            .expect("first release");
+        assert!(!screen.clear_selection());
+
+        screen
+            .selection_press(point, geometry)
+            .expect("click after clear");
+        assert_eq!(screen.selection_text(), None);
+    }
+
+    #[test]
+    fn drag_after_release_extends_existing_selection() {
+        let screen = VtScreen::new(20, 2, None).expect("create vt screen");
+        screen.feed(b"alpha beta");
+        let geometry = test_selection_geometry(20, 2);
+
+        screen
+            .selection_press(test_selection_point(0, 0, 1.0), geometry)
+            .expect("press selection anchor");
+        screen
+            .selection_drag(test_selection_point(4, 0, 9.0), geometry)
+            .expect("drag initial selection");
+        screen
+            .selection_release(Some((4, 0)))
+            .expect("release initial selection");
+
+        screen
+            .selection_drag(test_selection_point(9, 0, 9.0), geometry)
+            .expect("extend released selection");
+        assert_eq!(screen.selection_text().as_deref(), Some("alpha beta"));
+    }
+
+    #[test]
+    fn mouse_motion_tracking_excludes_press_only_modes() {
+        let screen = VtScreen::new(20, 2, None).expect("create vt screen");
+        assert!(!screen.mouse_motion_tracking_active());
+
+        screen.feed(b"\x1b[?1000h");
+        assert!(screen.mouse_tracking_active());
+        assert!(!screen.mouse_motion_tracking_active());
+
+        screen.feed(b"\x1b[?1000l\x1b[?1002h");
+        assert!(screen.mouse_motion_tracking_active());
+
+        screen.feed(b"\x1b[?1002l\x1b[?1003h");
+        assert!(screen.mouse_motion_tracking_active());
+
+        screen.feed(b"\x1b[?1003l\x1b[?9h");
+        assert!(screen.mouse_tracking_active());
+        assert!(!screen.mouse_motion_tracking_active());
+    }
+
+    #[test]
     fn terminal_selection_survives_reflow_and_clears_across_screen_switches() {
         let screen = VtScreen::new(20, 3, None).expect("create vt screen");
         screen.feed(b"alpha beta");
@@ -5925,6 +6028,75 @@ mod tests {
         screen.feed(b"\x1b[?1049l");
         assert!(!screen.has_selection());
         assert_eq!(screen.selection_text(), None);
+    }
+
+    #[test]
+    fn terminal_selection_preserves_graphemes_across_soft_wraps() {
+        let screen = VtScreen::new(5, 3, None).expect("create vt screen");
+        screen.feed("cafe\u{301}xy".as_bytes());
+        let geometry = test_selection_geometry(5, 3);
+
+        screen
+            .selection_press(test_selection_point(0, 0, 1.0), geometry)
+            .expect("press selection anchor");
+        screen
+            .selection_drag(test_selection_point(0, 1, 9.0), geometry)
+            .expect("drag selection across soft wrap");
+
+        assert_eq!(screen.selection_text().as_deref(), Some("cafe\u{301}xy"));
+    }
+
+    #[test]
+    fn terminal_selection_tracks_text_into_scrollback() {
+        let screen = VtScreen::new(10, 2, None).expect("create vt screen");
+        screen.feed(b"alpha\r\nbeta");
+        let geometry = test_selection_geometry(10, 2);
+
+        screen
+            .selection_press(test_selection_point(0, 0, 1.0), geometry)
+            .expect("press selection anchor");
+        screen
+            .selection_drag(test_selection_point(4, 0, 9.0), geometry)
+            .expect("drag selection");
+        screen
+            .selection_release(Some((4, 0)))
+            .expect("release selection");
+
+        screen.feed(b"\r\ngamma");
+
+        assert_eq!(screen.selection_text().as_deref(), Some("alpha"));
+    }
+
+    #[test]
+    fn terminal_selection_autoscroll_tick_extends_into_scrollback() {
+        let screen = VtScreen::new(10, 2, None).expect("create vt screen");
+        screen.feed(b"one\r\ntwo\r\nthree");
+        let geometry = test_selection_geometry(10, 2);
+        let mut point_above_viewport = test_selection_point(0, 0, 1.0);
+        point_above_viewport.surface_y_px = -1.0;
+        assert_eq!(screen.scrollbar().map(|state| state.offset), Some(1));
+
+        screen
+            .selection_press(test_selection_point(4, 1, 9.0), geometry)
+            .expect("press selection anchor");
+        assert_eq!(
+            screen
+                .selection_drag(point_above_viewport, geometry)
+                .expect("drag above viewport"),
+            SelectionAutoscroll::Up
+        );
+        let generation_before_tick = screen.generation();
+
+        assert_eq!(
+            screen
+                .selection_autoscroll_tick(point_above_viewport, geometry)
+                .expect("autoscroll selection"),
+            SelectionAutoscroll::Up
+        );
+
+        assert!(screen.generation() > generation_before_tick);
+        assert_eq!(screen.scrollbar().map(|state| state.offset), Some(0));
+        assert_eq!(screen.selection_text().as_deref(), Some("one\ntwo\nthree"));
     }
 
     #[test]

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -607,6 +607,24 @@ impl Default for GhosttyRenderStateCursor {
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
+pub struct GhosttyRenderStateRowSelection {
+    pub size: usize,
+    pub start_x: u16,
+    pub end_x: u16,
+}
+
+impl Default for GhosttyRenderStateRowSelection {
+    fn default() -> Self {
+        Self {
+            size: std::mem::size_of::<Self>(),
+            start_x: 0,
+            end_x: 0,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
 pub struct GhosttyRenderStateColors {
     pub size: usize,
     pub background: GhosttyColorRgb,
@@ -1520,6 +1538,7 @@ pub struct ScreenSnapshot {
     pub cols: u16,
     pub rows: u16,
     pub cells: Vec<Cell>,
+    pub selection_ranges: Vec<Option<SelectionRange>>,
     pub kitty_placements: Arc<[KittyPlacement]>,
     pub dirty_rows: Vec<u16>,
     pub cursor: Cursor,
@@ -1527,6 +1546,19 @@ pub struct ScreenSnapshot {
     pub scrollbar: Option<GhosttyScrollbar>,
     pub title: Option<String>,
     pub generation: u64,
+}
+
+/// Inclusive visible-grid column range selected on one snapshot row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SelectionRange {
+    pub start: u16,
+    pub end: u16,
+}
+
+impl SelectionRange {
+    pub fn contains(self, col: u16) -> bool {
+        col >= self.start && col <= self.end
+    }
 }
 
 struct SnapshotMetadata {
@@ -1551,11 +1583,16 @@ struct SnapshotEpoch {
 }
 
 impl SnapshotMetadata {
-    fn snapshot(&self, cells: &[Cell]) -> ScreenSnapshot {
+    fn snapshot(
+        &self,
+        cells: &[Cell],
+        selection_ranges: &[Option<SelectionRange>],
+    ) -> ScreenSnapshot {
         ScreenSnapshot {
             cols: self.cols,
             rows: self.rows,
             cells: cells.to_vec(),
+            selection_ranges: selection_ranges.to_vec(),
             kitty_placements: self.kitty_placements.clone(),
             dirty_rows: self.dirty_rows.clone(),
             cursor: self.cursor,
@@ -1808,6 +1845,7 @@ struct VtRenderState {
     scratch_cols: u16,
     scratch_rows: u16,
     scratch: Vec<Cell>,
+    selection_ranges: Vec<Option<SelectionRange>>,
     last_cursor: Cursor,
     snapshot_metadata: Option<SnapshotMetadata>,
 }
@@ -2439,6 +2477,7 @@ impl VtScreen {
                 scratch_cols: cols,
                 scratch_rows: rows,
                 scratch: Vec::with_capacity(cols as usize * rows as usize),
+                selection_ranges: Vec::with_capacity(rows as usize),
                 last_cursor: Cursor::default(),
                 snapshot_metadata: None,
             }),
@@ -3199,7 +3238,7 @@ impl VtScreen {
                     .snapshot_metadata
                     .as_ref()
                     .expect("snapshot metadata checked above");
-                return Some(metadata.snapshot(&render.scratch));
+                return Some(metadata.snapshot(&render.scratch, &render.selection_ranges));
             }
 
             let mut active_screen = GhosttyTerminalScreen::Primary;
@@ -3314,6 +3353,8 @@ impl VtScreen {
         {
             render.scratch.clear();
             render.scratch.resize(total, Cell::default());
+            render.selection_ranges.clear();
+            render.selection_ranges.resize(rows as usize, None);
             render.scratch_cols = cols;
             render.scratch_rows = rows;
             full_redraw = true;
@@ -3361,6 +3402,41 @@ impl VtScreen {
                 render.force_full_snapshot = true;
                 return None;
             }
+
+            let mut row_selection = GhosttyRenderStateRowSelection::default();
+            let rc = unsafe {
+                ghostty_render_state_row_get(
+                    render.row_iter,
+                    GhosttyRenderStateRowData::Selection,
+                    &mut row_selection as *mut _ as *mut c_void,
+                )
+            };
+            render.selection_ranges[row_idx as usize] = match rc {
+                GHOSTTY_SUCCESS
+                    if row_selection.start_x <= row_selection.end_x
+                        && row_selection.end_x < cols =>
+                {
+                    Some(SelectionRange {
+                        start: row_selection.start_x,
+                        end: row_selection.end_x,
+                    })
+                }
+                GHOSTTY_NO_VALUE => None,
+                GHOSTTY_SUCCESS => {
+                    log::warn!(
+                        "invalid render selection range at row {row_idx}: {}..={} for {cols} cols",
+                        row_selection.start_x,
+                        row_selection.end_x
+                    );
+                    render.force_full_snapshot = true;
+                    return None;
+                }
+                _ => {
+                    log::warn!("ghostty_render_state_row_get(SELECTION) rc={rc} at row {row_idx}");
+                    render.force_full_snapshot = true;
+                    return None;
+                }
+            };
 
             let row_start = row_idx as usize * cols as usize;
             let mut col_idx: u16 = 0;
@@ -3437,7 +3513,7 @@ impl VtScreen {
             generation: epoch.generation,
         };
         let clone_started = perf_trace_enabled().then(Instant::now);
-        let snapshot = metadata.snapshot(&render.scratch);
+        let snapshot = metadata.snapshot(&render.scratch, &render.selection_ranges);
         let clone_elapsed_ms =
             clone_started.map(|started| started.elapsed().as_secs_f64() * 1000.0);
         render.snapshot_metadata = Some(metadata);
@@ -4424,6 +4500,7 @@ fn empty_snapshot(cols: u16, rows: u16, generation: u64) -> ScreenSnapshot {
         cols,
         rows,
         cells: Vec::new(),
+        selection_ranges: Vec::new(),
         kitty_placements: Arc::from([]),
         dirty_rows: Vec::new(),
         cursor: Cursor::default(),
@@ -5100,6 +5177,11 @@ mod tests {
                 std::mem::align_of::<GhosttyRenderStateCursor>(),
             ),
             (
+                "GhosttyRenderStateRowSelection",
+                std::mem::size_of::<GhosttyRenderStateRowSelection>(),
+                std::mem::align_of::<GhosttyRenderStateRowSelection>(),
+            ),
+            (
                 "GhosttyRenderStateColors",
                 std::mem::size_of::<GhosttyRenderStateColors>(),
                 std::mem::align_of::<GhosttyRenderStateColors>(),
@@ -5196,6 +5278,27 @@ mod tests {
                 cursor_fields[name]["offset"].as_u64(),
                 Some(offset as u64),
                 "GhosttyRenderStateCursor::{name} offset"
+            );
+        }
+        let row_selection_fields = &types["GhosttyRenderStateRowSelection"]["fields"];
+        for (name, offset) in [
+            (
+                "size",
+                std::mem::offset_of!(GhosttyRenderStateRowSelection, size),
+            ),
+            (
+                "start_x",
+                std::mem::offset_of!(GhosttyRenderStateRowSelection, start_x),
+            ),
+            (
+                "end_x",
+                std::mem::offset_of!(GhosttyRenderStateRowSelection, end_x),
+            ),
+        ] {
+            assert_eq!(
+                row_selection_fields[name]["offset"].as_u64(),
+                Some(offset as u64),
+                "GhosttyRenderStateRowSelection::{name} offset"
             );
         }
         let colors_fields = &types["GhosttyRenderStateColors"]["fields"];
@@ -5718,6 +5821,54 @@ mod tests {
         let cleared_generation = screen.generation();
         assert!(!screen.clear_selection());
         assert_eq!(screen.generation(), cleared_generation);
+    }
+
+    #[test]
+    fn snapshots_cache_terminal_selection_ranges_and_clear_stale_rows() {
+        let screen = VtScreen::new(6, 3, None).expect("create vt screen");
+        screen.feed(b"abcdef\r\nghijkl\x1b[?25l");
+        let geometry = test_selection_geometry(6, 3);
+        let baseline = screen.snapshot();
+        assert_eq!(baseline.selection_ranges, vec![None; 3]);
+        screen.acknowledge_snapshot(baseline.generation);
+
+        screen
+            .selection_press(test_selection_point(2, 0, 1.0), geometry)
+            .expect("press selection anchor");
+        screen
+            .selection_drag(test_selection_point(3, 1, 9.0), geometry)
+            .expect("drag selection across rows");
+
+        let selected = screen.snapshot();
+        assert_eq!(
+            selected.selection_ranges,
+            vec![
+                Some(SelectionRange { start: 2, end: 5 }),
+                Some(SelectionRange { start: 0, end: 3 }),
+                None,
+            ]
+        );
+        assert!(selected.generation > baseline.generation);
+        assert_eq!(selected.dirty_rows, vec![0, 1, 2]);
+        assert!(selected.selection_ranges[0].is_some_and(|range| range.contains(2)));
+        assert!(!selected.selection_ranges[0].is_some_and(|range| range.contains(1)));
+
+        let cached = screen.snapshot();
+        assert_eq!(cached.generation, selected.generation);
+        assert_eq!(cached.selection_ranges, selected.selection_ranges);
+        screen.acknowledge_snapshot(selected.generation);
+
+        screen.feed(b"\x1b[3;1HX");
+        let partial = screen.snapshot();
+        assert_eq!(partial.selection_ranges, selected.selection_ranges);
+        assert_eq!(partial.dirty_rows, vec![1, 2]);
+        screen.acknowledge_snapshot(partial.generation);
+
+        assert!(screen.clear_selection());
+        let cleared = screen.snapshot();
+        assert!(cleared.generation > partial.generation);
+        assert_eq!(cleared.selection_ranges, vec![None; 3]);
+        assert_eq!(cleared.dirty_rows, vec![0, 1, 2]);
     }
 
     #[test]

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -69,6 +69,8 @@ pub type GhosttyRowIterator = *mut c_void;
 pub type GhosttyRowCells = *mut c_void;
 pub type GhosttyKeyEncoder = *mut c_void;
 pub type GhosttyKeyEvent = *mut c_void;
+pub type GhosttySelectionGesture = *mut c_void;
+pub type GhosttySelectionGestureEvent = *mut c_void;
 pub type GhosttyKittyGraphics = *mut c_void;
 pub type GhosttyKittyGraphicsImage = *mut c_void;
 pub type GhosttyKittyGraphicsPlacementIterator = *mut c_void;
@@ -78,6 +80,7 @@ pub type GhosttyResult = c_int;
 const GHOSTTY_SUCCESS: GhosttyResult = 0;
 const GHOSTTY_INVALID_VALUE: GhosttyResult = -2;
 const GHOSTTY_OUT_OF_SPACE: GhosttyResult = -3;
+const GHOSTTY_NO_VALUE: GhosttyResult = -4;
 const GHOSTTY_IO_ERROR: GhosttyResult = -5;
 const GHOSTTY_REJECTED: GhosttyResult = -7;
 
@@ -117,6 +120,7 @@ const METADATA_DIRTY_PWD: u8 = 1 << 1;
 const UNKNOWN_SEQUENCE_LOG_TARGET: &str = "con_ghostty::vt::unknown_sequence";
 const UNKNOWN_SEQUENCE_MAX_BYTES: usize = 256;
 const UNKNOWN_SEQUENCE_LOG_LIMIT: u8 = 16;
+const SELECTION_REPEAT_INTERVAL_NS: u64 = 500_000_000;
 
 // ── Enums (keys) ───────────────────────────────────────────────────────
 //
@@ -141,6 +145,7 @@ pub enum GhosttyTerminalData {
     Pwd = 13,
     KittyImageStorageLimit = 26,
     KittyGraphics = 30,
+    Selection = 31,
     ScrollbackMaxLines = 35,
     Mode = 37,
     CursorAtPrompt = 39,
@@ -212,6 +217,7 @@ pub enum GhosttyTerminalOption {
     /// `GhosttyColorRgb[256]*` — full 256-entry palette.
     ColorPalette = 14,
     KittyImageStorageLimit = 15,
+    Selection = 21,
     PwdChanged = 25,
     ClipboardWrite = 26,
     ScrollbackMaxLines = 28,
@@ -221,6 +227,153 @@ pub enum GhosttyTerminalOption {
     UnknownMaxBytes = 36,
     ClipboardRead = 38,
     ClipboardWriteMaxBytes = 39,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GhosttyFormatterFormat {
+    Plain = 0,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GhosttyPointTag {
+    Viewport = 1,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+union GhosttyPointValue {
+    coordinate: GhosttyPointCoordinate,
+    _padding: [u64; 2],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct GhosttyPoint {
+    tag: GhosttyPointTag,
+    value: GhosttyPointValue,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
+struct GhosttyPointCoordinate {
+    x: u16,
+    y: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct GhosttyGridRef {
+    size: usize,
+    node: *mut c_void,
+    x: u16,
+    y: u16,
+}
+
+impl Default for GhosttyGridRef {
+    fn default() -> Self {
+        Self {
+            size: std::mem::size_of::<Self>(),
+            node: std::ptr::null_mut(),
+            x: 0,
+            y: 0,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct GhosttySelection {
+    size: usize,
+    start: GhosttyGridRef,
+    end: GhosttyGridRef,
+    rectangle: bool,
+}
+
+impl Default for GhosttySelection {
+    fn default() -> Self {
+        Self {
+            size: std::mem::size_of::<Self>(),
+            start: GhosttyGridRef::default(),
+            end: GhosttyGridRef::default(),
+            rectangle: false,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct GhosttyTerminalSelectionFormatOptions {
+    size: usize,
+    emit: GhosttyFormatterFormat,
+    unwrap: bool,
+    trim: bool,
+    selection: *const GhosttySelection,
+}
+
+impl Default for GhosttyTerminalSelectionFormatOptions {
+    fn default() -> Self {
+        Self {
+            size: std::mem::size_of::<Self>(),
+            emit: GhosttyFormatterFormat::Plain,
+            unwrap: true,
+            trim: true,
+            selection: std::ptr::null(),
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GhosttySelectionGestureData {
+    ClickCount = 0,
+    Autoscroll = 2,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GhosttySelectionGestureEventType {
+    Press = 0,
+    Release = 1,
+    Drag = 2,
+    AutoscrollTick = 3,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GhosttySelectionGestureEventOption {
+    Ref = 0,
+    Position = 1,
+    RepeatDistance = 2,
+    TimeNs = 3,
+    RepeatIntervalNs = 4,
+    Geometry = 8,
+    Viewport = 9,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct GhosttySurfacePosition {
+    x: f64,
+    y: f64,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct GhosttySelectionGestureGeometry {
+    columns: u32,
+    cell_width: u32,
+    padding_left: u32,
+    screen_height: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GhosttySelectionGestureAutoscroll {
+    None = 0,
+    Up = 1,
+    Down = 2,
 }
 
 /// `GHOSTTY_SYS_OPT_*` keys for process-global optional services.
@@ -862,10 +1015,55 @@ unsafe extern "C" {
         key: GhosttyTerminalData,
         out: *mut c_void,
     ) -> GhosttyResult;
+    fn ghostty_terminal_grid_ref(
+        terminal: GhosttyTerminal,
+        point: GhosttyPoint,
+        out_ref: *mut GhosttyGridRef,
+    ) -> GhosttyResult;
     pub fn ghostty_terminal_paste(
         terminal: GhosttyTerminal,
         paste: *const GhosttyPaste,
         out_written: *mut bool,
+    ) -> GhosttyResult;
+
+    // Selection gesture (`selection.h`). Handles and reusable events live
+    // under the same mutex as the terminal because the gesture owns tracked
+    // grid references into that terminal.
+    fn ghostty_selection_gesture_new(
+        allocator: *const GhosttyAllocator,
+        out_gesture: *mut GhosttySelectionGesture,
+    ) -> GhosttyResult;
+    fn ghostty_selection_gesture_free(gesture: GhosttySelectionGesture, terminal: GhosttyTerminal);
+    fn ghostty_selection_gesture_reset(gesture: GhosttySelectionGesture, terminal: GhosttyTerminal);
+    fn ghostty_selection_gesture_get(
+        gesture: GhosttySelectionGesture,
+        terminal: GhosttyTerminal,
+        data: GhosttySelectionGestureData,
+        value: *mut c_void,
+    ) -> GhosttyResult;
+    fn ghostty_selection_gesture_event_new(
+        allocator: *const GhosttyAllocator,
+        out_event: *mut GhosttySelectionGestureEvent,
+        event_type: GhosttySelectionGestureEventType,
+    ) -> GhosttyResult;
+    fn ghostty_selection_gesture_event_free(event: GhosttySelectionGestureEvent);
+    fn ghostty_selection_gesture_event_set(
+        event: GhosttySelectionGestureEvent,
+        option: GhosttySelectionGestureEventOption,
+        value: *const c_void,
+    ) -> GhosttyResult;
+    fn ghostty_selection_gesture_event(
+        gesture: GhosttySelectionGesture,
+        terminal: GhosttyTerminal,
+        event: GhosttySelectionGestureEvent,
+        out_selection: *mut GhosttySelection,
+    ) -> GhosttyResult;
+    fn ghostty_terminal_selection_format_buf(
+        terminal: GhosttyTerminal,
+        options: GhosttyTerminalSelectionFormatOptions,
+        buf: *mut u8,
+        buf_len: usize,
+        out_written: *mut usize,
     ) -> GhosttyResult;
 
     // Key encoder (`key/{encoder,event}.h`). The encoder and reusable
@@ -1237,6 +1435,58 @@ pub struct Cursor {
     pub visible: bool,
 }
 
+/// Pointer location for a selection gesture. Grid coordinates identify the
+/// viewport cell while surface coordinates preserve within-cell thresholds and
+/// allow drag autoscroll to detect positions outside the viewport.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SelectionPoint {
+    pub col: u16,
+    pub row: u16,
+    pub surface_x_px: f64,
+    pub surface_y_px: f64,
+}
+
+/// Physical geometry used by Ghostty's selection drag state machine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SelectionGeometry {
+    pub columns: u32,
+    pub cell_width_px: u32,
+    pub padding_left_px: u32,
+    pub screen_height_px: u32,
+}
+
+impl SelectionGeometry {
+    fn to_ffi(self) -> anyhow::Result<GhosttySelectionGestureGeometry> {
+        if self.columns == 0 || self.cell_width_px == 0 || self.screen_height_px == 0 {
+            anyhow::bail!("selection geometry dimensions must be non-zero");
+        }
+        Ok(GhosttySelectionGestureGeometry {
+            columns: self.columns,
+            cell_width: self.cell_width_px,
+            padding_left: self.padding_left_px,
+            screen_height: self.screen_height_px,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SelectionAutoscroll {
+    #[default]
+    None,
+    Up,
+    Down,
+}
+
+impl From<GhosttySelectionGestureAutoscroll> for SelectionAutoscroll {
+    fn from(value: GhosttySelectionGestureAutoscroll) -> Self {
+        match value {
+            GhosttySelectionGestureAutoscroll::None => Self::None,
+            GhosttySelectionGestureAutoscroll::Up => Self::Up,
+            GhosttySelectionGestureAutoscroll::Down => Self::Down,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct KittyImage {
     pub id: u32,
@@ -1448,6 +1698,7 @@ struct VtInner {
     terminal: GhosttyTerminal,
     key_encoder: GhosttyKeyEncoder,
     key_event: GhosttyKeyEvent,
+    selection_gesture: Option<SelectionGestureState>,
     kitty_placement_iter: GhosttyKittyGraphicsPlacementIterator,
     kitty_image_cache: HashMap<u32, Arc<KittyImage>>,
     kitty_placements: Arc<[KittyPlacement]>,
@@ -1461,6 +1712,91 @@ struct VtInner {
     generation: u64,
     output_generation: u64,
     required_full_snapshot_generation: u64,
+}
+
+struct SelectionGestureState {
+    gesture: GhosttySelectionGesture,
+    press: GhosttySelectionGestureEvent,
+    release: GhosttySelectionGestureEvent,
+    drag: GhosttySelectionGestureEvent,
+    autoscroll_tick: GhosttySelectionGestureEvent,
+    clock: Instant,
+}
+
+impl SelectionGestureState {
+    fn new() -> anyhow::Result<Self> {
+        let mut state = Self {
+            gesture: std::ptr::null_mut(),
+            press: std::ptr::null_mut(),
+            release: std::ptr::null_mut(),
+            drag: std::ptr::null_mut(),
+            autoscroll_tick: std::ptr::null_mut(),
+            clock: Instant::now(),
+        };
+
+        let rc = unsafe { ghostty_selection_gesture_new(std::ptr::null(), &mut state.gesture) };
+        if rc != GHOSTTY_SUCCESS || state.gesture.is_null() {
+            if !state.gesture.is_null() {
+                unsafe { state.free(std::ptr::null_mut()) };
+            }
+            anyhow::bail!("ghostty_selection_gesture_new failed: rc={rc}");
+        }
+
+        macro_rules! new_event {
+            ($field:ident, $event_type:expr, $label:literal) => {{
+                let rc = unsafe {
+                    ghostty_selection_gesture_event_new(
+                        std::ptr::null(),
+                        &mut state.$field,
+                        $event_type,
+                    )
+                };
+                if rc != GHOSTTY_SUCCESS || state.$field.is_null() {
+                    unsafe { state.free(std::ptr::null_mut()) };
+                    anyhow::bail!(
+                        "ghostty_selection_gesture_event_new({}) failed: rc={rc}",
+                        $label
+                    );
+                }
+            }};
+        }
+        new_event!(press, GhosttySelectionGestureEventType::Press, "PRESS");
+        new_event!(
+            release,
+            GhosttySelectionGestureEventType::Release,
+            "RELEASE"
+        );
+        new_event!(drag, GhosttySelectionGestureEventType::Drag, "DRAG");
+        new_event!(
+            autoscroll_tick,
+            GhosttySelectionGestureEventType::AutoscrollTick,
+            "AUTOSCROLL_TICK"
+        );
+
+        Ok(state)
+    }
+
+    unsafe fn free(&mut self, terminal: GhosttyTerminal) {
+        for event in [
+            &mut self.autoscroll_tick,
+            &mut self.drag,
+            &mut self.release,
+            &mut self.press,
+        ] {
+            if !event.is_null() {
+                unsafe { ghostty_selection_gesture_event_free(*event) };
+                *event = std::ptr::null_mut();
+            }
+        }
+        if !self.gesture.is_null() {
+            unsafe { ghostty_selection_gesture_free(self.gesture, terminal) };
+            self.gesture = std::ptr::null_mut();
+        }
+    }
+
+    fn time_ns(&self) -> u64 {
+        u64::try_from(self.clock.elapsed().as_nanos()).unwrap_or(u64::MAX)
+    }
 }
 
 struct VtRenderState {
@@ -2079,6 +2415,7 @@ impl VtScreen {
                 terminal,
                 key_encoder,
                 key_event,
+                selection_gesture: None,
                 kitty_placement_iter,
                 kitty_image_cache: HashMap::new(),
                 kitty_placements: Arc::from([]),
@@ -2238,6 +2575,240 @@ impl VtScreen {
 
     pub fn generation(&self) -> u64 {
         self.inner.lock().generation
+    }
+
+    /// Begin a local text-selection gesture at a viewport cell.
+    ///
+    /// A first click clears the previous active selection. Repeat clicks use
+    /// Ghostty's default cell/word/line behavior table.
+    pub fn selection_press(
+        &self,
+        point: SelectionPoint,
+        geometry: SelectionGeometry,
+    ) -> anyhow::Result<()> {
+        validate_selection_point(point)?;
+        let geometry = geometry.to_ffi()?;
+        let mut inner = self.inner.lock();
+        let terminal = inner.terminal;
+        let grid_ref = selection_grid_ref(terminal, point.col, point.row)?;
+
+        if inner.selection_gesture.is_none() {
+            inner.selection_gesture = Some(SelectionGestureState::new()?);
+        }
+        let state = inner
+            .selection_gesture
+            .as_mut()
+            .expect("selection gesture initialized");
+        let event = state.press;
+        let gesture = state.gesture;
+        let time_ns = state.time_ns();
+        let position = selection_surface_position(point);
+        let repeat_distance = f64::from(geometry.cell_width);
+
+        selection_event_set(event, GhosttySelectionGestureEventOption::Ref, &grid_ref)?;
+        selection_event_set(
+            event,
+            GhosttySelectionGestureEventOption::Position,
+            &position,
+        )?;
+        selection_event_set(
+            event,
+            GhosttySelectionGestureEventOption::RepeatDistance,
+            &repeat_distance,
+        )?;
+        selection_event_set(event, GhosttySelectionGestureEventOption::TimeNs, &time_ns)?;
+        selection_event_set(
+            event,
+            GhosttySelectionGestureEventOption::RepeatIntervalNs,
+            &SELECTION_REPEAT_INTERVAL_NS,
+        )?;
+
+        let selection = apply_selection_gesture_event(gesture, terminal, event)?;
+        if let Some(selection) = selection {
+            set_selection_locked(&mut inner, Some(&selection))?;
+        } else if selection_gesture_click_count(&inner)? == 1 {
+            set_selection_locked(&mut inner, None)?;
+        }
+        Ok(())
+    }
+
+    /// Continue the active selection gesture. The returned direction tells the
+    /// view whether it should run selection autoscroll ticks.
+    pub fn selection_drag(
+        &self,
+        point: SelectionPoint,
+        geometry: SelectionGeometry,
+    ) -> anyhow::Result<SelectionAutoscroll> {
+        validate_selection_point(point)?;
+        let geometry = geometry.to_ffi()?;
+        let mut inner = self.inner.lock();
+        let terminal = inner.terminal;
+        let grid_ref = selection_grid_ref(terminal, point.col, point.row)?;
+        let Some(state) = inner.selection_gesture.as_ref() else {
+            return Ok(SelectionAutoscroll::None);
+        };
+        let event = state.drag;
+        let gesture = state.gesture;
+        let position = selection_surface_position(point);
+
+        selection_event_set(event, GhosttySelectionGestureEventOption::Ref, &grid_ref)?;
+        selection_event_set(
+            event,
+            GhosttySelectionGestureEventOption::Position,
+            &position,
+        )?;
+        selection_event_set(
+            event,
+            GhosttySelectionGestureEventOption::Geometry,
+            &geometry,
+        )?;
+
+        let selection = apply_selection_gesture_event(gesture, terminal, event)?;
+        let click_count = selection_gesture_click_count(&inner)?;
+        if let Some(selection) = selection {
+            set_selection_locked(&mut inner, Some(&selection))?;
+        } else if click_count > 0 {
+            set_selection_locked(&mut inner, None)?;
+        }
+        selection_gesture_autoscroll(&inner)
+    }
+
+    /// Advance an active selection autoscroll gesture by one row.
+    pub fn selection_autoscroll_tick(
+        &self,
+        point: SelectionPoint,
+        geometry: SelectionGeometry,
+    ) -> anyhow::Result<SelectionAutoscroll> {
+        validate_selection_point(point)?;
+        let geometry = geometry.to_ffi()?;
+        let mut inner = self.inner.lock();
+        let terminal = inner.terminal;
+        let Some(state) = inner.selection_gesture.as_ref() else {
+            return Ok(SelectionAutoscroll::None);
+        };
+        let event = state.autoscroll_tick;
+        let gesture = state.gesture;
+        let viewport = GhosttyPointCoordinate {
+            x: point.col,
+            y: u32::from(point.row),
+        };
+        let position = selection_surface_position(point);
+        let autoscroll_before = selection_gesture_autoscroll(&inner)?;
+        if autoscroll_before == SelectionAutoscroll::None {
+            return Ok(SelectionAutoscroll::None);
+        }
+
+        selection_event_set(
+            event,
+            GhosttySelectionGestureEventOption::Viewport,
+            &viewport,
+        )?;
+        selection_event_set(
+            event,
+            GhosttySelectionGestureEventOption::Position,
+            &position,
+        )?;
+        selection_event_set(
+            event,
+            GhosttySelectionGestureEventOption::Geometry,
+            &geometry,
+        )?;
+
+        let selection = apply_selection_gesture_event(gesture, terminal, event)?;
+        // A successful AUTOSCROLL_TICK may scroll the viewport before any
+        // subsequent gesture query or selection install. Account for that
+        // mutation immediately so even a later FFI error cannot leave snapshot
+        // caching on the old generation.
+        inner.generation = inner.generation.wrapping_add(1);
+        let click_count = selection_gesture_click_count(&inner)?;
+        if let Some(selection) = selection {
+            set_selection_locked(&mut inner, Some(&selection))?;
+        } else if click_count > 0 {
+            set_selection_locked(&mut inner, None)?;
+        }
+        selection_gesture_autoscroll(&inner)
+    }
+
+    /// Finish a normal pointer gesture while retaining repeat-click state for
+    /// a possible double or triple click.
+    pub fn selection_release(&self, point: Option<(u16, u16)>) -> anyhow::Result<()> {
+        let inner = self.inner.lock();
+        let terminal = inner.terminal;
+        let Some(state) = inner.selection_gesture.as_ref() else {
+            return Ok(());
+        };
+        let event = state.release;
+        let gesture = state.gesture;
+
+        let grid_ref = point
+            .map(|(col, row)| selection_grid_ref(terminal, col, row))
+            .transpose()?;
+        let value = grid_ref.as_ref().map_or(std::ptr::null(), |grid_ref| {
+            grid_ref as *const _ as *const c_void
+        });
+        let rc = unsafe {
+            ghostty_selection_gesture_event_set(
+                event,
+                GhosttySelectionGestureEventOption::Ref,
+                value,
+            )
+        };
+        if rc != GHOSTTY_SUCCESS {
+            anyhow::bail!("ghostty_selection_gesture_event_set(RELEASE REF) failed: rc={rc}");
+        }
+        let rc = unsafe {
+            ghostty_selection_gesture_event(gesture, terminal, event, std::ptr::null_mut())
+        };
+        if rc != GHOSTTY_NO_VALUE && rc != GHOSTTY_SUCCESS {
+            anyhow::bail!("ghostty_selection_gesture_event(RELEASE) failed: rc={rc}");
+        }
+        Ok(())
+    }
+
+    /// Abandon the active pointer gesture without changing the installed
+    /// terminal selection.
+    pub fn selection_cancel_gesture(&self) {
+        let inner = self.inner.lock();
+        if let Some(state) = inner.selection_gesture.as_ref() {
+            unsafe { ghostty_selection_gesture_reset(state.gesture, inner.terminal) };
+        }
+    }
+
+    pub fn selection_autoscroll(&self) -> anyhow::Result<SelectionAutoscroll> {
+        selection_gesture_autoscroll(&self.inner.lock())
+    }
+
+    pub fn has_selection(&self) -> bool {
+        match has_selection_locked(&self.inner.lock()) {
+            Ok(has_selection) => has_selection,
+            Err(err) => {
+                log::warn!("failed to read terminal selection: {err:#}");
+                false
+            }
+        }
+    }
+
+    pub fn selection_text(&self) -> Option<String> {
+        match selection_text_locked(&self.inner.lock()) {
+            Ok(selection) => selection,
+            Err(err) => {
+                log::warn!("failed to format terminal selection: {err:#}");
+                None
+            }
+        }
+    }
+
+    /// Clear the terminal-owned selection. Returns whether a selection was
+    /// present and successfully cleared.
+    pub fn clear_selection(&self) -> bool {
+        let mut inner = self.inner.lock();
+        match set_selection_locked(&mut inner, None) {
+            Ok(changed) => changed,
+            Err(err) => {
+                log::warn!("failed to clear terminal selection: {err:#}");
+                false
+            }
+        }
     }
 
     pub(crate) fn acknowledge_snapshot(&self, generation: u64) {
@@ -3667,6 +4238,187 @@ unsafe extern "C" fn vt_xtversion_callback(
     }
 }
 
+fn validate_selection_point(point: SelectionPoint) -> anyhow::Result<()> {
+    if !point.surface_x_px.is_finite() || !point.surface_y_px.is_finite() {
+        anyhow::bail!("selection surface position must be finite");
+    }
+    Ok(())
+}
+
+fn selection_surface_position(point: SelectionPoint) -> GhosttySurfacePosition {
+    GhosttySurfacePosition {
+        x: point.surface_x_px,
+        y: point.surface_y_px,
+    }
+}
+
+fn selection_grid_ref(
+    terminal: GhosttyTerminal,
+    col: u16,
+    row: u16,
+) -> anyhow::Result<GhosttyGridRef> {
+    let point = GhosttyPoint {
+        tag: GhosttyPointTag::Viewport,
+        value: GhosttyPointValue {
+            coordinate: GhosttyPointCoordinate {
+                x: col,
+                y: u32::from(row),
+            },
+        },
+    };
+    let mut grid_ref = GhosttyGridRef::default();
+    let rc = unsafe { ghostty_terminal_grid_ref(terminal, point, &mut grid_ref) };
+    if rc != GHOSTTY_SUCCESS {
+        anyhow::bail!("ghostty_terminal_grid_ref(VIEWPORT {col},{row}) failed: rc={rc}");
+    }
+    Ok(grid_ref)
+}
+
+fn selection_event_set<T>(
+    event: GhosttySelectionGestureEvent,
+    option: GhosttySelectionGestureEventOption,
+    value: &T,
+) -> anyhow::Result<()> {
+    let rc = unsafe {
+        ghostty_selection_gesture_event_set(event, option, value as *const T as *const c_void)
+    };
+    if rc != GHOSTTY_SUCCESS {
+        anyhow::bail!("ghostty_selection_gesture_event_set({option:?}) failed: rc={rc}");
+    }
+    Ok(())
+}
+
+fn apply_selection_gesture_event(
+    gesture: GhosttySelectionGesture,
+    terminal: GhosttyTerminal,
+    event: GhosttySelectionGestureEvent,
+) -> anyhow::Result<Option<GhosttySelection>> {
+    let mut selection = GhosttySelection::default();
+    let rc = unsafe { ghostty_selection_gesture_event(gesture, terminal, event, &mut selection) };
+    match rc {
+        GHOSTTY_SUCCESS => Ok(Some(selection)),
+        GHOSTTY_NO_VALUE => Ok(None),
+        _ => anyhow::bail!("ghostty_selection_gesture_event failed: rc={rc}"),
+    }
+}
+
+fn selection_gesture_click_count(inner: &VtInner) -> anyhow::Result<u8> {
+    let Some(state) = inner.selection_gesture.as_ref() else {
+        return Ok(0);
+    };
+    let mut click_count = 0_u8;
+    let rc = unsafe {
+        ghostty_selection_gesture_get(
+            state.gesture,
+            inner.terminal,
+            GhosttySelectionGestureData::ClickCount,
+            &mut click_count as *mut _ as *mut c_void,
+        )
+    };
+    if rc != GHOSTTY_SUCCESS {
+        anyhow::bail!("ghostty_selection_gesture_get(CLICK_COUNT) failed: rc={rc}");
+    }
+    Ok(click_count)
+}
+
+fn selection_gesture_autoscroll(inner: &VtInner) -> anyhow::Result<SelectionAutoscroll> {
+    let Some(state) = inner.selection_gesture.as_ref() else {
+        return Ok(SelectionAutoscroll::None);
+    };
+    let mut autoscroll = GhosttySelectionGestureAutoscroll::None;
+    let rc = unsafe {
+        ghostty_selection_gesture_get(
+            state.gesture,
+            inner.terminal,
+            GhosttySelectionGestureData::Autoscroll,
+            &mut autoscroll as *mut _ as *mut c_void,
+        )
+    };
+    if rc != GHOSTTY_SUCCESS {
+        anyhow::bail!("ghostty_selection_gesture_get(AUTOSCROLL) failed: rc={rc}");
+    }
+    Ok(autoscroll.into())
+}
+
+fn has_selection_locked(inner: &VtInner) -> anyhow::Result<bool> {
+    let mut selection = GhosttySelection::default();
+    let rc = unsafe {
+        ghostty_terminal_get(
+            inner.terminal,
+            GhosttyTerminalData::Selection,
+            &mut selection as *mut _ as *mut c_void,
+        )
+    };
+    match rc {
+        GHOSTTY_SUCCESS => Ok(true),
+        GHOSTTY_NO_VALUE => Ok(false),
+        _ => anyhow::bail!("ghostty_terminal_get(SELECTION) failed: rc={rc}"),
+    }
+}
+
+fn set_selection_locked(
+    inner: &mut VtInner,
+    selection: Option<&GhosttySelection>,
+) -> anyhow::Result<bool> {
+    if selection.is_none() && !has_selection_locked(inner)? {
+        return Ok(false);
+    }
+    let value = selection.map_or(std::ptr::null(), |selection| {
+        selection as *const GhosttySelection as *const c_void
+    });
+    let rc =
+        unsafe { ghostty_terminal_set(inner.terminal, GhosttyTerminalOption::Selection, value) };
+    if rc != GHOSTTY_SUCCESS {
+        anyhow::bail!("ghostty_terminal_set(SELECTION) failed: rc={rc}");
+    }
+    inner.generation = inner.generation.wrapping_add(1);
+    Ok(true)
+}
+
+fn selection_text_locked(inner: &VtInner) -> anyhow::Result<Option<String>> {
+    let options = GhosttyTerminalSelectionFormatOptions::default();
+    let mut required = 0_usize;
+    let rc = unsafe {
+        ghostty_terminal_selection_format_buf(
+            inner.terminal,
+            options,
+            std::ptr::null_mut(),
+            0,
+            &mut required,
+        )
+    };
+    match rc {
+        GHOSTTY_NO_VALUE => return Ok(None),
+        GHOSTTY_OUT_OF_SPACE => {}
+        _ => anyhow::bail!("ghostty_terminal_selection_format_buf(size) failed: rc={rc}"),
+    }
+
+    let mut bytes = Vec::new();
+    bytes.try_reserve_exact(required)?;
+    bytes.resize(required, 0);
+    let mut written = 0_usize;
+    let rc = unsafe {
+        ghostty_terminal_selection_format_buf(
+            inner.terminal,
+            options,
+            bytes.as_mut_ptr(),
+            bytes.len(),
+            &mut written,
+        )
+    };
+    if rc != GHOSTTY_SUCCESS {
+        anyhow::bail!("ghostty_terminal_selection_format_buf(write) failed: rc={rc}");
+    }
+    if written > bytes.len() {
+        anyhow::bail!(
+            "ghostty_terminal_selection_format_buf wrote {written} bytes into {}-byte buffer",
+            bytes.len()
+        );
+    }
+    bytes.truncate(written);
+    Ok(Some(String::from_utf8(bytes)?))
+}
+
 fn empty_snapshot(cols: u16, rows: u16, generation: u64) -> ScreenSnapshot {
     ScreenSnapshot {
         cols,
@@ -4131,8 +4883,8 @@ impl Drop for VtScreen {
         if let Some(mutex) = Arc::get_mut(&mut self.inner) {
             let inner = mutex.get_mut();
             let render = self.render.get_mut();
-            // Free in reverse-creation order: key event/encoder, render
-            // helpers, then terminal.
+            // Free every object that can refer to the terminal before the
+            // terminal itself.
             // SAFETY: unique owner via Arc::get_mut.
             if !inner.key_event.is_null() {
                 unsafe { ghostty_key_event_free(inner.key_event) };
@@ -4159,6 +4911,9 @@ impl Drop for VtScreen {
             if !render.render_state.is_null() {
                 unsafe { ghostty_render_state_free(render.render_state) };
                 render.render_state = std::ptr::null_mut();
+            }
+            if let Some(mut selection_gesture) = inner.selection_gesture.take() {
+                unsafe { selection_gesture.free(inner.terminal) };
             }
             if !inner.terminal.is_null() {
                 unsafe { ghostty_terminal_free(inner.terminal) };
@@ -4214,6 +4969,10 @@ mod tests {
         assert_eq!(
             types["GhosttyTerminalOption"]["values"]["KITTY_IMAGE_STORAGE_LIMIT"].as_i64(),
             Some(GhosttyTerminalOption::KittyImageStorageLimit as i64)
+        );
+        assert_eq!(
+            types["GhosttyTerminalOption"]["values"]["SELECTION"].as_i64(),
+            Some(GhosttyTerminalOption::Selection as i64)
         );
         assert_eq!(
             types["GhosttyTerminalOption"]["values"]["CLIPBOARD_READ"].as_i64(),
@@ -4345,6 +5104,46 @@ mod tests {
                 std::mem::size_of::<GhosttyRenderStateColors>(),
                 std::mem::align_of::<GhosttyRenderStateColors>(),
             ),
+            (
+                "GhosttyPointValue",
+                std::mem::size_of::<GhosttyPointValue>(),
+                std::mem::align_of::<GhosttyPointValue>(),
+            ),
+            (
+                "GhosttyPoint",
+                std::mem::size_of::<GhosttyPoint>(),
+                std::mem::align_of::<GhosttyPoint>(),
+            ),
+            (
+                "GhosttyPointCoordinate",
+                std::mem::size_of::<GhosttyPointCoordinate>(),
+                std::mem::align_of::<GhosttyPointCoordinate>(),
+            ),
+            (
+                "GhosttyGridRef",
+                std::mem::size_of::<GhosttyGridRef>(),
+                std::mem::align_of::<GhosttyGridRef>(),
+            ),
+            (
+                "GhosttySelection",
+                std::mem::size_of::<GhosttySelection>(),
+                std::mem::align_of::<GhosttySelection>(),
+            ),
+            (
+                "GhosttyTerminalSelectionFormatOptions",
+                std::mem::size_of::<GhosttyTerminalSelectionFormatOptions>(),
+                std::mem::align_of::<GhosttyTerminalSelectionFormatOptions>(),
+            ),
+            (
+                "GhosttySurfacePosition",
+                std::mem::size_of::<GhosttySurfacePosition>(),
+                std::mem::align_of::<GhosttySurfacePosition>(),
+            ),
+            (
+                "GhosttySelectionGestureGeometry",
+                std::mem::size_of::<GhosttySelectionGestureGeometry>(),
+                std::mem::align_of::<GhosttySelectionGestureGeometry>(),
+            ),
         ] {
             assert_eq!(
                 types[name]["size"].as_u64(),
@@ -4429,6 +5228,169 @@ mod tests {
                 "GhosttyRenderStateColors::{name} offset"
             );
         }
+        for (type_name, fields) in [
+            (
+                "GhosttyPoint",
+                &[
+                    ("tag", std::mem::offset_of!(GhosttyPoint, tag)),
+                    ("value", std::mem::offset_of!(GhosttyPoint, value)),
+                ][..],
+            ),
+            (
+                "GhosttyPointCoordinate",
+                &[
+                    ("x", std::mem::offset_of!(GhosttyPointCoordinate, x)),
+                    ("y", std::mem::offset_of!(GhosttyPointCoordinate, y)),
+                ],
+            ),
+            (
+                "GhosttyGridRef",
+                &[
+                    ("size", std::mem::offset_of!(GhosttyGridRef, size)),
+                    ("node", std::mem::offset_of!(GhosttyGridRef, node)),
+                    ("x", std::mem::offset_of!(GhosttyGridRef, x)),
+                    ("y", std::mem::offset_of!(GhosttyGridRef, y)),
+                ],
+            ),
+            (
+                "GhosttySelection",
+                &[
+                    ("size", std::mem::offset_of!(GhosttySelection, size)),
+                    ("start", std::mem::offset_of!(GhosttySelection, start)),
+                    ("end", std::mem::offset_of!(GhosttySelection, end)),
+                    (
+                        "rectangle",
+                        std::mem::offset_of!(GhosttySelection, rectangle),
+                    ),
+                ],
+            ),
+            (
+                "GhosttyTerminalSelectionFormatOptions",
+                &[
+                    (
+                        "size",
+                        std::mem::offset_of!(GhosttyTerminalSelectionFormatOptions, size),
+                    ),
+                    (
+                        "emit",
+                        std::mem::offset_of!(GhosttyTerminalSelectionFormatOptions, emit),
+                    ),
+                    (
+                        "unwrap",
+                        std::mem::offset_of!(GhosttyTerminalSelectionFormatOptions, unwrap),
+                    ),
+                    (
+                        "trim",
+                        std::mem::offset_of!(GhosttyTerminalSelectionFormatOptions, trim),
+                    ),
+                    (
+                        "selection",
+                        std::mem::offset_of!(GhosttyTerminalSelectionFormatOptions, selection),
+                    ),
+                ],
+            ),
+            (
+                "GhosttySurfacePosition",
+                &[
+                    ("x", std::mem::offset_of!(GhosttySurfacePosition, x)),
+                    ("y", std::mem::offset_of!(GhosttySurfacePosition, y)),
+                ],
+            ),
+            (
+                "GhosttySelectionGestureGeometry",
+                &[
+                    (
+                        "columns",
+                        std::mem::offset_of!(GhosttySelectionGestureGeometry, columns),
+                    ),
+                    (
+                        "cell_width",
+                        std::mem::offset_of!(GhosttySelectionGestureGeometry, cell_width),
+                    ),
+                    (
+                        "padding_left",
+                        std::mem::offset_of!(GhosttySelectionGestureGeometry, padding_left),
+                    ),
+                    (
+                        "screen_height",
+                        std::mem::offset_of!(GhosttySelectionGestureGeometry, screen_height),
+                    ),
+                ],
+            ),
+        ] {
+            for (field_name, offset) in fields {
+                assert_eq!(
+                    types[type_name]["fields"][field_name]["offset"].as_u64(),
+                    Some(*offset as u64),
+                    "{type_name}::{field_name} offset"
+                );
+            }
+        }
+        for (name, value) in [
+            ("NONE", GhosttySelectionGestureAutoscroll::None),
+            ("UP", GhosttySelectionGestureAutoscroll::Up),
+            ("DOWN", GhosttySelectionGestureAutoscroll::Down),
+        ] {
+            assert_eq!(
+                types["GhosttySelectionGestureAutoscroll"]["values"][name].as_i64(),
+                Some(value as i64),
+                "GhosttySelectionGestureAutoscroll::{name}"
+            );
+        }
+        for (name, value) in [
+            ("CLICK_COUNT", GhosttySelectionGestureData::ClickCount),
+            ("AUTOSCROLL", GhosttySelectionGestureData::Autoscroll),
+        ] {
+            assert_eq!(
+                types["GhosttySelectionGestureData"]["values"][name].as_i64(),
+                Some(value as i64),
+                "GhosttySelectionGestureData::{name}"
+            );
+        }
+        for (name, value) in [
+            ("PRESS", GhosttySelectionGestureEventType::Press),
+            ("RELEASE", GhosttySelectionGestureEventType::Release),
+            ("DRAG", GhosttySelectionGestureEventType::Drag),
+            (
+                "AUTOSCROLL_TICK",
+                GhosttySelectionGestureEventType::AutoscrollTick,
+            ),
+        ] {
+            assert_eq!(
+                types["GhosttySelectionGestureEventType"]["values"][name].as_i64(),
+                Some(value as i64),
+                "GhosttySelectionGestureEventType::{name}"
+            );
+        }
+        for (name, value) in [
+            ("REF", GhosttySelectionGestureEventOption::Ref),
+            ("POSITION", GhosttySelectionGestureEventOption::Position),
+            (
+                "REPEAT_DISTANCE",
+                GhosttySelectionGestureEventOption::RepeatDistance,
+            ),
+            ("TIME_NS", GhosttySelectionGestureEventOption::TimeNs),
+            (
+                "REPEAT_INTERVAL_NS",
+                GhosttySelectionGestureEventOption::RepeatIntervalNs,
+            ),
+            ("GEOMETRY", GhosttySelectionGestureEventOption::Geometry),
+            ("VIEWPORT", GhosttySelectionGestureEventOption::Viewport),
+        ] {
+            assert_eq!(
+                types["GhosttySelectionGestureEventOption"]["values"][name].as_i64(),
+                Some(value as i64),
+                "GhosttySelectionGestureEventOption::{name}"
+            );
+        }
+        assert_eq!(
+            types["GhosttyFormatterFormat"]["values"]["PLAIN"].as_i64(),
+            Some(GhosttyFormatterFormat::Plain as i64)
+        );
+        assert_eq!(
+            types["GhosttyPointTag"]["values"]["VIEWPORT"].as_i64(),
+            Some(GhosttyPointTag::Viewport as i64)
+        );
         for (name, value) in [
             ("STANDARD", GhosttyClipboardLocation::Standard),
             ("SELECTION", GhosttyClipboardLocation::Selection),
@@ -4489,6 +5451,10 @@ mod tests {
             types["GhosttyResult"]["values"]["REJECTED"].as_i64(),
             Some(GHOSTTY_REJECTED as i64)
         );
+        assert_eq!(
+            types["GhosttyResult"]["values"]["NO_VALUE"].as_i64(),
+            Some(GHOSTTY_NO_VALUE as i64)
+        );
         for (name, value) in [
             ("CURSOR", GhosttyRenderStateData::Cursor),
             ("COLORS", GhosttyRenderStateData::Colors),
@@ -4542,6 +5508,10 @@ mod tests {
         assert_eq!(
             types["GhosttyTerminalData"]["values"]["KITTY_GRAPHICS"].as_i64(),
             Some(GhosttyTerminalData::KittyGraphics as i64)
+        );
+        assert_eq!(
+            types["GhosttyTerminalData"]["values"]["SELECTION"].as_i64(),
+            Some(GhosttyTerminalData::Selection as i64)
         );
         assert_eq!(
             types["GhosttySysOption"]["values"]["DECODE_PNG"].as_i64(),
@@ -4697,6 +5667,142 @@ mod tests {
         ] {
             assert_eq!(keys[name].as_i64(), Some(key as i64), "GhosttyKey::{key:?}");
         }
+    }
+
+    fn test_selection_geometry(columns: u32, rows: u32) -> SelectionGeometry {
+        SelectionGeometry {
+            columns,
+            cell_width_px: 10,
+            padding_left_px: 0,
+            screen_height_px: rows * 20,
+        }
+    }
+
+    fn test_selection_point(col: u16, row: u16, x_offset_px: f64) -> SelectionPoint {
+        SelectionPoint {
+            col,
+            row,
+            surface_x_px: f64::from(col) * 10.0 + x_offset_px,
+            surface_y_px: f64::from(row) * 20.0 + 10.0,
+        }
+    }
+
+    #[test]
+    fn terminal_selection_formats_text_and_advances_generation() {
+        let screen = VtScreen::new(20, 3, None).expect("create vt screen");
+        screen.feed(b"alpha beta\r\nsecond line");
+        let geometry = test_selection_geometry(20, 3);
+        let baseline_generation = screen.generation();
+
+        screen
+            .selection_press(test_selection_point(0, 0, 1.0), geometry)
+            .expect("press selection anchor");
+        assert!(!screen.has_selection());
+        assert_eq!(screen.generation(), baseline_generation);
+
+        screen
+            .selection_drag(test_selection_point(4, 0, 9.0), geometry)
+            .expect("drag selection");
+        assert!(screen.has_selection());
+        assert_eq!(screen.selection_text().as_deref(), Some("alpha"));
+        assert_eq!(screen.generation(), baseline_generation.wrapping_add(1));
+
+        screen
+            .selection_release(Some((4, 0)))
+            .expect("release selection");
+        assert!(screen.clear_selection());
+        assert!(!screen.has_selection());
+        assert_eq!(screen.selection_text(), None);
+        assert_eq!(screen.generation(), baseline_generation.wrapping_add(2));
+
+        let cleared_generation = screen.generation();
+        assert!(!screen.clear_selection());
+        assert_eq!(screen.generation(), cleared_generation);
+    }
+
+    #[test]
+    fn repeat_clicks_select_word_then_line() {
+        let screen = VtScreen::new(20, 2, None).expect("create vt screen");
+        screen.feed(b"alpha beta");
+        let geometry = test_selection_geometry(20, 2);
+        let point = test_selection_point(1, 0, 5.0);
+
+        screen
+            .selection_press(point, geometry)
+            .expect("first click");
+        screen
+            .selection_release(Some((point.col, point.row)))
+            .expect("first release");
+        assert_eq!(screen.selection_text(), None);
+
+        screen
+            .selection_press(point, geometry)
+            .expect("second click");
+        assert_eq!(screen.selection_text().as_deref(), Some("alpha"));
+        screen
+            .selection_release(Some((point.col, point.row)))
+            .expect("second release");
+
+        screen
+            .selection_press(point, geometry)
+            .expect("third click");
+        assert_eq!(screen.selection_text().as_deref(), Some("alpha beta"));
+    }
+
+    #[test]
+    fn terminal_selection_survives_reflow_and_clears_across_screen_switches() {
+        let screen = VtScreen::new(20, 3, None).expect("create vt screen");
+        screen.feed(b"alpha beta");
+        let geometry = test_selection_geometry(20, 3);
+        screen
+            .selection_press(test_selection_point(0, 0, 1.0), geometry)
+            .expect("press selection anchor");
+        screen
+            .selection_drag(test_selection_point(4, 0, 9.0), geometry)
+            .expect("drag selection");
+        screen
+            .selection_release(Some((4, 0)))
+            .expect("release selection");
+
+        screen.resize(8, 3, 10, 20).expect("reflow terminal");
+        assert_eq!(screen.selection_text().as_deref(), Some("alpha"));
+
+        screen.feed(b"\x1b[?1049h");
+        assert!(!screen.has_selection());
+        assert_eq!(screen.selection_text(), None);
+
+        screen.feed(b"\x1b[?1049l");
+        assert!(!screen.has_selection());
+        assert_eq!(screen.selection_text(), None);
+    }
+
+    #[test]
+    fn selection_rejects_invalid_view_geometry_without_mutation() {
+        let screen = VtScreen::new(20, 2, None).expect("create vt screen");
+        let generation = screen.generation();
+        let mut point = test_selection_point(0, 0, 1.0);
+        point.surface_x_px = f64::NAN;
+
+        assert!(
+            screen
+                .selection_press(point, test_selection_geometry(20, 2))
+                .is_err()
+        );
+        assert!(
+            screen
+                .selection_press(
+                    test_selection_point(0, 0, 1.0),
+                    SelectionGeometry {
+                        columns: 20,
+                        cell_width_px: 0,
+                        padding_left_px: 0,
+                        screen_height_px: 40,
+                    },
+                )
+                .is_err()
+        );
+        assert!(!screen.has_selection());
+        assert_eq!(screen.generation(), generation);
     }
 
     #[test]

--- a/crates/con-ghostty/src/windows/backend.rs
+++ b/crates/con-ghostty/src/windows/backend.rs
@@ -385,6 +385,12 @@ impl WindowsGhosttyTerminal {
     pub fn selection_text(&self) -> Option<String> {
         self.inner.lock().as_ref().and_then(|s| s.selection_text())
     }
+    pub fn take_selection_text(&self) -> Option<String> {
+        self.inner
+            .lock()
+            .as_ref()
+            .and_then(|s| s.take_selection_text())
+    }
     pub fn clear_selection(&self) {
         if let Some(session) = self.inner.lock().as_ref() {
             session.clear_selection();

--- a/crates/con-ghostty/src/windows/ghostty_vt_stub.c
+++ b/crates/con-ghostty/src/windows/ghostty_vt_stub.c
@@ -23,10 +23,49 @@ typedef void* GhosttyRowIterator;
 typedef void* GhosttyRowCells;
 typedef void* GhosttyKeyEncoder;
 typedef void* GhosttyKeyEvent;
+typedef void* GhosttySelectionGesture;
+typedef void* GhosttySelectionGestureEvent;
 typedef void* GhosttyKittyGraphics;
 typedef void* GhosttyKittyGraphicsImage;
 typedef void* GhosttyKittyGraphicsPlacementIterator;
 typedef int   GhosttyResult;
+
+struct GhosttyPointCoordinate {
+    uint16_t x;
+    uint32_t y;
+};
+
+union GhosttyPointValue {
+    struct GhosttyPointCoordinate coordinate;
+    uint64_t _padding[2];
+};
+
+struct GhosttyPoint {
+    int tag;
+    union GhosttyPointValue value;
+};
+
+struct GhosttyGridRef {
+    size_t size;
+    void* node;
+    uint16_t x;
+    uint16_t y;
+};
+
+struct GhosttySelection {
+    size_t size;
+    struct GhosttyGridRef start;
+    struct GhosttyGridRef end;
+    bool rectangle;
+};
+
+struct GhosttyTerminalSelectionFormatOptions {
+    size_t size;
+    int emit;
+    bool unwrap;
+    bool trim;
+    const struct GhosttySelection* selection;
+};
 
 union GhosttyTerminalScrollViewportValue {
     intptr_t delta;
@@ -48,6 +87,10 @@ const char* ghostty_type_json(void) { return NULL; }
 uint8_t* ghostty_alloc(const void* allocator, size_t len) {
     (void)allocator; (void)len;
     return NULL;
+}
+
+void ghostty_free(const void* allocator, uint8_t* ptr, size_t len) {
+    (void)allocator; (void)ptr; (void)len;
 }
 
 GhosttyResult ghostty_sys_set(int option, const void* value) {
@@ -110,6 +153,96 @@ GhosttyResult ghostty_terminal_paste(
     (void)terminal; (void)paste;
     if (out_written) { *out_written = false; }
     return 0;
+}
+
+GhosttyResult ghostty_terminal_grid_ref(
+    GhosttyTerminal terminal, struct GhosttyPoint point,
+    struct GhosttyGridRef* out_ref
+) {
+    (void)terminal; (void)point; (void)out_ref;
+    return -4;
+}
+
+/* ── Selection ─────────────────────────────────────────────────── */
+
+GhosttyResult ghostty_selection_gesture_new(
+    const void* allocator, GhosttySelectionGesture* out_gesture
+) {
+    (void)allocator;
+    if (out_gesture) { *out_gesture = (void*)(uintptr_t)8; }
+    return 0;
+}
+
+void ghostty_selection_gesture_free(
+    GhosttySelectionGesture gesture, GhosttyTerminal terminal
+) {
+    (void)gesture; (void)terminal;
+}
+
+void ghostty_selection_gesture_reset(
+    GhosttySelectionGesture gesture, GhosttyTerminal terminal
+) {
+    (void)gesture; (void)terminal;
+}
+
+GhosttyResult ghostty_selection_gesture_get(
+    GhosttySelectionGesture gesture, GhosttyTerminal terminal,
+    int data, void* out
+) {
+    (void)gesture; (void)terminal;
+    if (out) {
+        if (data == 0) { *(uint8_t*)out = 0; }
+        else { *(int*)out = 0; }
+    }
+    return 0;
+}
+
+GhosttyResult ghostty_selection_gesture_event_new(
+    const void* allocator, GhosttySelectionGestureEvent* out_event,
+    int event_type
+) {
+    (void)allocator; (void)event_type;
+    if (out_event) { *out_event = (void*)(uintptr_t)9; }
+    return 0;
+}
+
+void ghostty_selection_gesture_event_free(GhosttySelectionGestureEvent event) {
+    (void)event;
+}
+
+GhosttyResult ghostty_selection_gesture_event_set(
+    GhosttySelectionGestureEvent event, int option, const void* value
+) {
+    (void)event; (void)option; (void)value;
+    return 0;
+}
+
+GhosttyResult ghostty_selection_gesture_event(
+    GhosttySelectionGesture gesture, GhosttyTerminal terminal,
+    GhosttySelectionGestureEvent event, struct GhosttySelection* out_selection
+) {
+    (void)gesture; (void)terminal; (void)event; (void)out_selection;
+    return -4;
+}
+
+GhosttyResult ghostty_terminal_selection_equal(
+    GhosttyTerminal terminal, const struct GhosttySelection* a,
+    const struct GhosttySelection* b, bool* out_equal
+) {
+    (void)terminal; (void)a; (void)b;
+    if (out_equal) { *out_equal = true; }
+    return 0;
+}
+
+GhosttyResult ghostty_terminal_selection_format_alloc(
+    GhosttyTerminal terminal, const void* allocator,
+    struct GhosttyTerminalSelectionFormatOptions options,
+    uint8_t** out_ptr, size_t* out_len
+) {
+    (void)terminal; (void)allocator; (void)options;
+    if (out_ptr) { *out_ptr = NULL; }
+    if (out_len) { *out_len = 0; }
+    return -4;
 }
 
 /* ── Kitty graphics ────────────────────────────────────────────── */

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -30,8 +30,11 @@ use crate::{DesktopNotificationPolicy, clipboard_write_policy};
 
 use super::conpty::{ConPty, PtySize};
 use super::profile::{perf_trace_enabled, perf_trace_verbose};
-use super::render::{RenderOutcome, Renderer, RendererConfig, Selection, ThemeColors};
-use super::vt::{ScreenSnapshot, VtKeyEvent, VtKeyOutcome, VtPasteResult, VtPasteSource, VtScreen};
+use super::render::{RenderOutcome, Renderer, RendererConfig, ThemeColors};
+use super::vt::{
+    SelectionAutoscroll, SelectionGeometry, SelectionPoint, VtKeyEvent, VtKeyOutcome,
+    VtPasteResult, VtPasteSource, VtScreen,
+};
 
 use super::render::CellMetrics;
 
@@ -67,7 +70,6 @@ pub struct RenderSession {
     /// so fractional deltas accumulate here instead of turning every
     /// tiny touchpad event into a full-row jump.
     scroll_remainder: Mutex<ScrollRemainder>,
-    drag_anchor: Mutex<Option<(u16, u64)>>,
 }
 
 unsafe impl Send for RenderSession {}
@@ -118,6 +120,13 @@ pub struct MouseEventMods {
     pub shift: bool,
     pub alt: bool,
     pub control: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MouseDownRoute {
+    Ignored,
+    LocalSelection,
+    TerminalReport,
 }
 
 impl RenderSession {
@@ -249,7 +258,6 @@ impl RenderSession {
             low_latency_generation_target: AtomicU64::new(0),
             low_latency_burst_until: Mutex::new(None),
             scroll_remainder: Mutex::new(ScrollRemainder::default()),
-            drag_anchor: Mutex::new(None),
         })
     }
 
@@ -494,38 +502,43 @@ impl RenderSession {
     /// we emit an SGR button-press report and leave selection alone.
     /// Shift+click with an existing selection extends from the original
     /// anchor (matches every other terminal). `button` follows the SGR
-    /// button index (0=Left, 1=Middle, 2=Right). Returns `true` when the
-    /// event was consumed by the terminal app (an SGR report emitted) —
-    /// the view uses this to suppress its own context menu on
-    /// right-click.
-    pub fn mouse_down(&self, button: u8, col: u16, row: u16, mods: MouseEventMods) -> bool {
+    /// button index (0=Left, 1=Middle, 2=Right). The return value records
+    /// the chosen route so the view can preserve it through drag/release.
+    pub fn mouse_down(
+        &self,
+        button: u8,
+        point: SelectionPoint,
+        geometry: SelectionGeometry,
+        mods: MouseEventMods,
+    ) -> MouseDownRoute {
         if self.vt.mouse_tracking_active() && !mods.shift {
+            self.vt.selection_cancel_gesture();
             self.request_low_latency_after_next_generation();
-            return self.report_sgr_button(button, col, row, mods, true);
+            return if self.report_sgr_button(button, point.col, point.row, mods, true) {
+                MouseDownRoute::TerminalReport
+            } else {
+                MouseDownRoute::Ignored
+            };
         }
         if button != 0 {
             // Non-left buttons never drive local selection; when tracking
             // is off the click is simply not consumed by the terminal.
-            return false;
+            return MouseDownRoute::Ignored;
         }
         self.request_low_latency_present();
-        let point = self.selection_point(col, row);
-        if mods.shift {
-            let renderer = self.renderer.lock();
-            let existing_anchor = renderer.selection().map(|s| s.anchor).unwrap_or(point);
-            *self.drag_anchor.lock() = Some(existing_anchor);
-            renderer.set_selection(Some(Selection {
-                anchor: existing_anchor,
-                extent: point,
-            }));
-            return false;
+        let result = if mods.shift && self.vt.has_selection() {
+            self.vt.selection_drag(point, geometry).map(|_| ())
+        } else {
+            self.vt.selection_press(point, geometry)
+        };
+        match result {
+            Ok(()) => MouseDownRoute::LocalSelection,
+            Err(err) => {
+                log::debug!("windows terminal selection press failed: {err:#}");
+                self.vt.selection_cancel_gesture();
+                MouseDownRoute::Ignored
+            }
         }
-        *self.drag_anchor.lock() = Some(point);
-        self.renderer.lock().set_selection(Some(Selection {
-            anchor: point,
-            extent: point,
-        }));
-        false
     }
 
     /// Mouse-moved at the given cell while a button is held.
@@ -533,60 +546,86 @@ impl RenderSession {
     /// Emits an SGR motion-with-button report only when the shell
     /// requested motion reporting (DECSET 1002 button-event or 1003
     /// any-event); plain button-event tracking (1000) reports presses
-    /// and releases but no motion. When motion reporting is off or
-    /// Shift is held we extend the local left-button drag selection.
+    /// and releases but no motion. `local_selection` preserves the route
+    /// chosen for the matching press, even if the child changes mouse modes
+    /// while the button remains held.
     /// `button` follows the SGR button index (0=Left, 1=Middle,
     /// 2=Right); the motion bit (+32) is added inside.
-    pub fn mouse_drag(&self, button: u8, col: u16, row: u16, mods: MouseEventMods) {
-        let motion_reporting = self.mouse_motion_reporting_active();
-        if motion_reporting && !mods.shift {
-            self.request_low_latency_after_next_generation();
-            // Button + 32 = motion-with-button bit per SGR spec.
-            self.report_sgr_button(button.saturating_add(32), col, row, mods, true);
-            return;
+    pub fn mouse_drag(
+        &self,
+        button: u8,
+        point: SelectionPoint,
+        geometry: SelectionGeometry,
+        mods: MouseEventMods,
+        local_selection: bool,
+    ) -> SelectionAutoscroll {
+        if !local_selection {
+            if self.mouse_motion_reporting_active() {
+                self.request_low_latency_after_next_generation();
+                // Button + 32 = motion-with-button bit per SGR spec.
+                self.report_sgr_button(button.saturating_add(32), point.col, point.row, mods, true);
+            }
+            return SelectionAutoscroll::None;
         }
-        if !mouse_drag_updates_local_selection(button, motion_reporting, mods.shift) {
-            return;
+        if button != 0 {
+            return SelectionAutoscroll::None;
         }
         self.request_low_latency_present();
-        let anchor = *self.drag_anchor.lock();
-        if let Some(anchor) = anchor {
-            self.renderer.lock().set_selection(Some(Selection {
-                anchor,
-                extent: self.selection_point(col, row),
-            }));
+        match self.vt.selection_drag(point, geometry) {
+            Ok(autoscroll) => autoscroll,
+            Err(err) => {
+                log::debug!("windows terminal selection drag failed: {err:#}");
+                self.vt.selection_cancel_gesture();
+                SelectionAutoscroll::None
+            }
         }
     }
 
-    /// Mouse-up at the given cell.
-    ///
-    /// Emits an SGR release when mouse tracking is active (unless Shift
-    /// is held to keep selection). Otherwise clears a transient 1-cell
-    /// selection — a click without drag shouldn't leave a lone cell
-    /// highlighted. `button` follows the SGR button index (0=Left,
-    /// 1=Middle, 2=Right). Returns `true` when the release was consumed
-    /// by the terminal app (an SGR report was emitted).
-    pub fn mouse_up(&self, button: u8, col: u16, row: u16, mods: MouseEventMods) -> bool {
-        if self.mouse_release_reporting_active() && !mods.shift {
-            self.request_low_latency_after_next_generation();
-            return self.report_sgr_button(button, col, row, mods, false);
-        }
-        if button != 0 {
+    /// Finish the route chosen for a pointer press.
+    pub fn mouse_up(
+        &self,
+        button: u8,
+        point: Option<SelectionPoint>,
+        mods: MouseEventMods,
+        local_selection: bool,
+    ) -> bool {
+        if local_selection {
+            if button != 0 {
+                return false;
+            }
+            self.request_low_latency_present();
+            let point = point.map(|point| (point.col, point.row));
+            if let Err(err) = self.vt.selection_release(point) {
+                log::debug!("windows terminal selection release failed: {err:#}");
+                self.vt.selection_cancel_gesture();
+            }
             return false;
         }
-        self.request_low_latency_present();
-        let anchor = self.drag_anchor.lock().take();
-        if let Some(anchor) = anchor
-            && anchor == self.selection_point(col, row)
-        {
-            self.renderer.lock().set_selection(None);
+
+        let Some(point) = point else {
+            return false;
+        };
+        if self.mouse_release_reporting_active() {
+            self.request_low_latency_after_next_generation();
+            return self.report_sgr_button(button, point.col, point.row, mods, false);
         }
         false
     }
 
-    fn selection_point(&self, col: u16, row: u16) -> (u16, u64) {
-        let viewport_offset = self.vt.scrollbar().map_or(0, |scrollbar| scrollbar.offset);
-        (col, viewport_offset.saturating_add(row as u64))
+    pub fn selection_autoscroll_tick(
+        &self,
+        point: SelectionPoint,
+        geometry: SelectionGeometry,
+    ) -> SelectionAutoscroll {
+        self.request_low_latency_present();
+        match self.vt.selection_autoscroll_tick(point, geometry) {
+            Ok(autoscroll) => autoscroll,
+            Err(err) => {
+                log::debug!("windows terminal selection autoscroll failed: {err:#}");
+                self.vt.selection_cancel_gesture();
+                SelectionAutoscroll::None
+            }
+        }
     }
 
     fn report_sgr_button(
@@ -607,7 +646,7 @@ impl RenderSession {
 
     /// Cancel any in-flight drag (used on focus loss).
     pub fn cancel_drag(&self) {
-        *self.drag_anchor.lock() = None;
+        self.vt.selection_cancel_gesture();
     }
 
     /// SGR mouse-wheel report. Only used when the shell has enabled
@@ -741,15 +780,13 @@ impl RenderSession {
     }
 
     pub fn has_selection(&self) -> bool {
-        self.renderer.lock().selection().is_some()
+        self.vt.has_selection()
     }
 
     /// Extract the current selection as text. Returns `None` when
     /// nothing is selected.
     pub fn selection_text(&self) -> Option<String> {
-        let selection = self.renderer.lock().selection()?;
-        let snapshot = self.vt.snapshot();
-        Some(extract_selection_text(&snapshot, selection))
+        self.vt.selection_text()
     }
 
     pub fn read_screen_text(&self, max_lines: usize) -> Vec<String> {
@@ -797,7 +834,7 @@ impl RenderSession {
     }
 
     pub fn clear_selection(&self) {
-        self.renderer.lock().set_selection(None);
+        self.vt.clear_selection();
     }
 
     pub fn dimensions_px(&self) -> (u32, u32) {
@@ -906,10 +943,6 @@ fn mouse_motion_reporting_active_for_modes(button_tracking: bool, any_tracking: 
     button_tracking || any_tracking
 }
 
-fn mouse_drag_updates_local_selection(button: u8, motion_reporting: bool, shift: bool) -> bool {
-    button == 0 && (!motion_reporting || shift)
-}
-
 fn cursor_key_for_scroll_rows(rows: isize, decckm: bool) -> Option<&'static str> {
     match rows.cmp(&0) {
         std::cmp::Ordering::Greater => Some(if decckm { "\x1bOA" } else { "\x1b[A" }),
@@ -924,50 +957,6 @@ fn viewport_delta_for_scroll_rows(rows: isize) -> isize {
 
 fn scale_font_size(logical_px: f32, dpi: u32) -> f32 {
     logical_px * (dpi as f32) / 96.0
-}
-
-fn extract_selection_text(snapshot: &ScreenSnapshot, sel: Selection) -> String {
-    let cols = snapshot.cols;
-    if cols == 0 || snapshot.cells.is_empty() {
-        return String::new();
-    }
-    let viewport_offset = snapshot.scrollbar.map_or(0, |scrollbar| scrollbar.offset);
-    let mut out = String::new();
-    let rows = snapshot.rows;
-    for row in 0..rows {
-        let mut row_buf = String::new();
-        let mut row_has_cell = false;
-        let mut last_non_blank: i32 = -1;
-        for col in 0..cols {
-            if !sel.contains(col, row, cols, viewport_offset) {
-                continue;
-            }
-            row_has_cell = true;
-            let idx = row as usize * cols as usize + col as usize;
-            let cell = snapshot.cells.get(idx).copied().unwrap_or_default();
-            let ch = if cell.codepoint == 0 {
-                ' '
-            } else {
-                char::from_u32(cell.codepoint).unwrap_or(' ')
-            };
-            row_buf.push(ch);
-            if cell.codepoint != 0 && cell.codepoint != 0x20 {
-                last_non_blank = row_buf.chars().count() as i32 - 1;
-            }
-        }
-        if !row_has_cell {
-            continue;
-        }
-        if last_non_blank >= 0 {
-            let trimmed: String = row_buf.chars().take(last_non_blank as usize + 1).collect();
-            out.push_str(&trimmed);
-        }
-        out.push('\n');
-    }
-    if out.ends_with('\n') {
-        out.pop();
-    }
-    out
 }
 
 #[cfg(test)]
@@ -1038,14 +1027,5 @@ mod tests {
         assert!(!mouse_motion_reporting_active_for_modes(false, false));
         assert!(mouse_motion_reporting_active_for_modes(true, false));
         assert!(mouse_motion_reporting_active_for_modes(false, true));
-    }
-
-    #[test]
-    fn only_left_drag_updates_local_selection() {
-        assert!(mouse_drag_updates_local_selection(0, false, false));
-        assert!(mouse_drag_updates_local_selection(0, true, true));
-        assert!(!mouse_drag_updates_local_selection(0, true, false));
-        assert!(!mouse_drag_updates_local_selection(2, false, false));
-        assert!(!mouse_drag_updates_local_selection(2, true, true));
     }
 }

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -32,8 +32,8 @@ use super::conpty::{ConPty, PtySize};
 use super::profile::{perf_trace_enabled, perf_trace_verbose};
 use super::render::{RenderOutcome, Renderer, RendererConfig, ThemeColors};
 use super::vt::{
-    SelectionAutoscroll, SelectionGeometry, SelectionPoint, VtKeyEvent, VtKeyOutcome,
-    VtPasteResult, VtPasteSource, VtScreen,
+    SelectionAutoscroll, SelectionAutoscrollUpdate, SelectionGeometry, SelectionPoint, VtKeyEvent,
+    VtKeyOutcome, VtPasteResult, VtPasteSource, VtScreen,
 };
 
 use super::render::CellMetrics;
@@ -500,16 +500,18 @@ impl RenderSession {
     /// tracking is off or Shift is held, we drive local selection (left
     /// button only — non-left buttons never drive selection); otherwise
     /// we emit an SGR button-press report and leave selection alone.
-    /// Shift+click with an existing selection extends from the original
-    /// anchor (matches every other terminal). `button` follows the SGR
-    /// button index (0=Left, 1=Middle, 2=Right). The return value records
-    /// the chosen route so the view can preserve it through drag/release.
+    /// Shift+single-click with an existing selection extends from the original
+    /// anchor; repeated clicks retain the platform's word/line behavior.
+    /// `button` follows the SGR button index (0=Left, 1=Middle, 2=Right). The
+    /// return value records the chosen route so the view can preserve it
+    /// through drag/release.
     pub fn mouse_down(
         &self,
         button: u8,
         point: SelectionPoint,
         geometry: SelectionGeometry,
         mods: MouseEventMods,
+        click_count: u8,
     ) -> MouseDownRoute {
         if self.vt.mouse_tracking_active() && !mods.shift {
             self.vt.selection_cancel_gesture();
@@ -526,11 +528,9 @@ impl RenderSession {
             return MouseDownRoute::Ignored;
         }
         self.request_low_latency_present();
-        let result = if mods.shift && self.vt.has_selection() {
-            self.vt.selection_drag(point, geometry).map(|_| ())
-        } else {
-            self.vt.selection_press(point, geometry)
-        };
+        let result = self
+            .vt
+            .selection_press(point, geometry, click_count, mods.shift);
         match result {
             Ok(()) => MouseDownRoute::LocalSelection,
             Err(err) => {
@@ -616,14 +616,18 @@ impl RenderSession {
         &self,
         point: SelectionPoint,
         geometry: SelectionGeometry,
-    ) -> SelectionAutoscroll {
-        self.request_low_latency_present();
+    ) -> SelectionAutoscrollUpdate {
         match self.vt.selection_autoscroll_tick(point, geometry) {
-            Ok(autoscroll) => autoscroll,
+            Ok(update) => {
+                if update.changed {
+                    self.request_low_latency_present();
+                }
+                update
+            }
             Err(err) => {
                 log::debug!("windows terminal selection autoscroll failed: {err:#}");
                 self.vt.selection_cancel_gesture();
-                SelectionAutoscroll::None
+                SelectionAutoscrollUpdate::default()
             }
         }
     }
@@ -787,6 +791,10 @@ impl RenderSession {
     /// nothing is selected.
     pub fn selection_text(&self) -> Option<String> {
         self.vt.selection_text()
+    }
+
+    pub fn take_selection_text(&self) -> Option<String> {
+        self.vt.take_selection_text()
     }
 
     pub fn read_screen_text(&self, max_lines: usize) -> Vec<String> {

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -964,9 +964,13 @@ impl Renderer {
             let col = (i % snapshot.cols as usize) as u16;
             let row = (i / snapshot.cols as usize) as u16;
 
-            let in_sel = selection
-                .map(|s| s.contains(col, row, snapshot.cols, viewport_offset))
-                .unwrap_or(false);
+            let in_sel = snapshot
+                .selection_ranges
+                .get(row as usize)
+                .copied()
+                .flatten()
+                .is_some_and(|range| range.contains(col))
+                || selection.is_some_and(|s| s.contains(col, row, snapshot.cols, viewport_offset));
             let effective_attrs = if in_sel {
                 cell.attrs ^ 0x10
             } else {

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -124,14 +124,12 @@ pub struct Renderer {
     has_full_frame: Mutex<bool>,
     kitty_readback: Mutex<KittyReadbackState>,
     /// Generation fingerprint of the last frame we actually rendered.
-    /// It includes VT generation, selection state, and snapshot/view
-    /// geometry so resize catch-up frames are not mistaken for
-    /// unchanged content. Seeded with `u64::MAX` so the very first call
-    /// — which sees `generation = 0` on a quiet VT — still produces a
-    /// frame (the cleared background), giving the pane something to
-    /// show before the shell has printed anything.
+    /// It includes VT generation and snapshot/view geometry so resize
+    /// catch-up frames are not mistaken for unchanged content. Seeded
+    /// with `u64::MAX` so the very first call — which sees `generation =
+    /// 0` on a quiet VT — still produces a frame (the cleared background),
+    /// giving the pane something to show before the shell has printed anything.
     last_generation: Mutex<u64>,
-    selection: Mutex<Option<Selection>>,
     /// Wall-clock time of the last `Rendered` outcome. Drives the
     /// `MIN_FALLBACK_PRESENT_INTERVAL` cap that decouples presentation
     /// rate from the VT update rate, so continuous-output TUIs (issue
@@ -190,37 +188,6 @@ pub enum RenderOutcome {
     /// image and schedule another prepaint unless this frame was marked
     /// latency-critical.
     Pending,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct Selection {
-    pub anchor: (u16, u64),
-    pub extent: (u16, u64),
-}
-
-impl Selection {
-    pub fn contains(&self, col: u16, row: u16, cols: u16, viewport_offset: u64) -> bool {
-        let to_lin = |p: (u16, u64)| (p.1 as u128) * (cols as u128) + (p.0 as u128);
-        let a = to_lin(self.anchor);
-        let b = to_lin(self.extent);
-        let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
-        let here = to_lin((col, viewport_offset.saturating_add(row as u64)));
-        here >= lo && here <= hi
-    }
-
-    pub fn hash_u64(&self) -> u64 {
-        let mut hash = 0x9E37_79B9_7F4A_7C15u64;
-        for value in [
-            self.anchor.0 as u64,
-            self.anchor.1,
-            self.extent.0 as u64,
-            self.extent.1,
-        ] {
-            hash ^= value;
-            hash = hash.rotate_left(13).wrapping_mul(0xBF58_476D_1CE4_E5B9);
-        }
-        hash
-    }
 }
 
 unsafe impl Send for Renderer {}
@@ -291,7 +258,6 @@ impl Renderer {
             has_full_frame: Mutex::new(false),
             kitty_readback: Mutex::new(KittyReadbackState::default()),
             last_generation: Mutex::new(u64::MAX),
-            selection: Mutex::new(None),
             last_presented_at: Mutex::new(None),
             width_px: width,
             height_px: height,
@@ -338,23 +304,6 @@ impl Renderer {
             .metrics()
     }
 
-    /// Install / clear the current selection. The render-gate combines
-    /// `snapshot.generation` with the selection fingerprint, so setting
-    /// a new selection naturally invalidates the last frame.
-    pub fn set_selection(&self, selection: Option<Selection>) {
-        *self
-            .selection
-            .lock()
-            .expect("selection mutex poisoned in set_selection()") = selection;
-    }
-
-    pub fn selection(&self) -> Option<Selection> {
-        *self
-            .selection
-            .lock()
-            .expect("selection mutex poisoned in selection()")
-    }
-
     pub fn grid_for_dimensions(&self, _config: &RendererConfig) -> (u16, u16) {
         let m = self.metrics();
         let cols = (self.width_px / m.cell_width_px.max(1)).max(1) as u16;
@@ -388,7 +337,7 @@ impl Renderer {
     /// # State machine
     ///
     /// Inputs read each call:
-    /// * `snapshot.generation`, `selection`, viewport geometry —
+    /// * `snapshot.generation`, viewport geometry —
     ///   combined into a fingerprint that decides `needs_draw`.
     /// * Staging ring's `oldest_in_flight()` — the GPU copy queued by
     ///   a prior call that may now have completed.
@@ -456,17 +405,12 @@ impl Renderer {
         prefer_latest: bool,
     ) -> Result<RenderOutcome> {
         let prof_started = perf_trace_enabled().then(Instant::now);
-        let selection = *self
-            .selection
-            .lock()
-            .expect("selection mutex poisoned in render()");
-        let sel_hash = selection.map(|s| s.hash_u64()).unwrap_or(0);
         let geometry_hash =
             geometry_fingerprint(snapshot.cols, snapshot.rows, self.width_px, self.height_px);
         let combined = snapshot
             .generation
             .wrapping_mul(0x9E37_79B9_7F4A_7C15)
-            .wrapping_add(sel_hash ^ geometry_hash.rotate_left(13));
+            .wrapping_add(geometry_hash.rotate_left(13));
         let needs_draw = *self
             .last_generation
             .lock()
@@ -572,7 +516,7 @@ impl Renderer {
                 [cell_metrics.cell_width_px, cell_metrics.cell_height_px],
             );
             let readback_regions =
-                self.readback_regions(snapshot, sel_hash, can_partial_readback, &kitty_visuals);
+                self.readback_regions(snapshot, can_partial_readback, &kitty_visuals);
             submitted = Some(ring.submit_copy_mailbox(
                 &self.context,
                 &self.rt_texture,
@@ -789,12 +733,10 @@ impl Renderer {
     fn readback_regions(
         &self,
         snapshot: &ScreenSnapshot,
-        sel_hash: u64,
         allow_partial: bool,
         kitty_visuals: &KittyVisualState,
     ) -> Vec<ReadbackRegion> {
         if !allow_partial
-            || sel_hash != 0
             || snapshot.dirty_rows.is_empty()
             || snapshot.dirty_rows.len() >= snapshot.rows as usize
         {
@@ -911,10 +853,6 @@ impl Renderer {
         snapshot: &ScreenSnapshot,
         config: &RendererConfig,
     ) -> Result<CellMetrics> {
-        let selection = *self
-            .selection
-            .lock()
-            .expect("selection mutex poisoned in draw_terminal()");
         // Sentinel alpha=0 in cell.bg means "default theme background"
         // (set by the VT layer); rewrite it to the configured opacity
         // so the shader composes the cell over Mica with the right
@@ -957,7 +895,6 @@ impl Renderer {
         } else {
             None
         };
-        let viewport_offset = snapshot.scrollbar.map_or(0, |scrollbar| scrollbar.offset);
         let mut has_wide_glyph = false;
 
         for (i, cell) in snapshot.cells.iter().enumerate() {
@@ -969,8 +906,7 @@ impl Renderer {
                 .get(row as usize)
                 .copied()
                 .flatten()
-                .is_some_and(|range| range.contains(col))
-                || selection.is_some_and(|s| s.contains(col, row, snapshot.cols, viewport_offset));
+                .is_some_and(|range| range.contains(col));
             let effective_attrs = if in_sel {
                 cell.attrs ^ 0x10
             } else {


### PR DESCRIPTION
## Summary

Windows and Linux now use libghostty-vt as the source of truth for terminal selection. GPUI views still handle coordinate conversion and interaction policy. Ghostty owns the selection anchors, tracked grid references, word and line boundaries, text formatting, and per-row ranges.

- Route press, drag, release, and autoscroll through Ghostty's selection gesture API.
- Preserve platform click counts for cell, word, and line selection. Shift+single-click extends an existing gesture.
- Feed Ghostty's per-row selection ranges into the Windows and Linux render paths.
- Format copied text through Ghostty so graphemes and soft-wrapped lines are preserved.
- Remove both host-side selection stores and the snapshot-based text extraction path.
- Skip generation and render work when autoscroll is clamped at a scrollback boundary.
- Keep the fallback VT stub aligned with the selection FFI surface.

## Why

The old Windows selection stored `(col, absolute_row)` positions and copied text from the visible snapshot. Linux kept selection in the view, cleared it when snapshots changed, and reported no selection from the backend. Reflow, scrolling, and pruning could invalidate anchors, while the two platforms disagreed about selection ownership and formatting.

With this change, selection follows the same terminal state that owns the grid and scrollback.

## Design

- `VtScreen` owns FFI handles, serializes gesture operations with terminal mutation, updates snapshot generations, and formats selection text.
- Platform views retain pixel-to-cell conversion, mouse-report gating, link priority, Shift policy, and the autoscroll timer.
- Render snapshots carry Ghostty's per-row selection ranges instead of rebuilding ranges from host coordinates.
- Copy-and-clear runs under one VT lock, so a screen change cannot replace the selection between formatting and clearing.

## Testing

```sh
cargo test --workspace
cargo check -p con --tests --target x86_64-unknown-linux-gnu
cargo wcheck -p con --target x86_64-pc-windows-gnu --tests
```

The `con-ghostty` VT suite also ran on Ubuntu with 42 passing tests, including Shift extension after gesture reset, word and line clicks, bounded autoscroll, reflow, scrollback tracking, screen switching, graphemes, soft wraps, and atomic copy-and-clear. The fallback C stub passes `-Wall -Wextra -Werror`, and every Rust `ghostty_*` extern has a matching stub symbol.
