### PR TITLE
fix(windows): use Ghostty's mouse encoder for terminal reporting

### DIFF
--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -44,7 +44,7 @@ use std::time::{Duration, Instant};
 
 use con_ghostty::vt::{
     SelectionAutoscroll, SelectionAutoscrollUpdate, SelectionGeometry, SelectionPoint, VtKeyAction,
-    VtKeyEvent, VtKeyModifiers, VtPasteResult, VtPasteSource,
+    VtKeyEvent, VtKeyModifiers, VtMouseButton, VtPasteResult, VtPasteSource,
 };
 use con_ghostty::{DesktopNotification, TerminalProgress};
 use con_ghostty::{GhosttyApp, GhosttyScrollbar, GhosttySplitDirection, GhosttyTerminal};
@@ -152,8 +152,8 @@ pub struct GhosttyView {
     /// resize churn when the logical bounds round to the same physical
     /// size frame-to-frame.
     last_physical_size: Option<(u32, u32)>,
-    /// Last scale factor handed to `session.set_dpi`.
-    last_scale_factor: f32,
+    /// Last physical DPI handed to `session.set_dpi`.
+    last_dpi: u32,
     /// The most recently rendered frame, wrapped as a GPUI image.
     cached_image: Option<Arc<RenderImage>>,
     /// CPU-side copy of the current BGRA frame. Dirty-row readbacks
@@ -175,10 +175,11 @@ pub struct GhosttyView {
     images_to_drop: Vec<Arc<RenderImage>>,
     scrollbar_drag: Option<ScrollbarDrag>,
     terminal_left_mouse_sequence: MouseButtonSequence<MousePressRoute>,
+    terminal_middle_mouse_sequence: MouseButtonSequence<MousePressRoute>,
     terminal_right_mouse_sequence: MouseButtonSequence<MousePressRoute>,
-    /// Whether the most recent right-button press was consumed by the
-    /// terminal app (an SGR report emitted). The context-menu builder
-    /// suppresses con's menu only when this is true.
+    /// Whether the most recent right-button press was captured by terminal
+    /// mouse tracking. The context-menu builder suppresses Con's menu even
+    /// when the active protocol legitimately emits no bytes for that press.
     terminal_mouse_right_consumed: Option<bool>,
     mouse_down_link: Option<TerminalLink>,
     suppress_link_mouse_up: bool,
@@ -259,7 +260,7 @@ impl GhosttyView {
             ime_marked_text: None,
             ime_selected_range: None,
             last_physical_size: None,
-            last_scale_factor: 0.0,
+            last_dpi: 0,
             cached_image: None,
             cached_image_size: None,
             cached_frame: None,
@@ -268,6 +269,7 @@ impl GhosttyView {
             images_to_drop: Vec::new(),
             scrollbar_drag: None,
             terminal_left_mouse_sequence: MouseButtonSequence::default(),
+            terminal_middle_mouse_sequence: MouseButtonSequence::default(),
             terminal_right_mouse_sequence: MouseButtonSequence::default(),
             terminal_mouse_right_consumed: None,
             mouse_down_link: None,
@@ -330,7 +332,7 @@ impl GhosttyView {
             return;
         };
         if self.finish_terminal_mouse_sequence(
-            0,
+            VtMouseButton::Left,
             position,
             MouseEventMods {
                 shift: false,
@@ -359,6 +361,7 @@ impl GhosttyView {
         self.scrollbar_cache = None;
         self.scrollbar_drag = None;
         self.terminal_left_mouse_sequence = MouseButtonSequence::default();
+        self.terminal_middle_mouse_sequence = MouseButtonSequence::default();
         self.terminal_right_mouse_sequence = MouseButtonSequence::default();
         self.terminal_mouse_right_consumed = None;
         self.ime_marked_text = None;
@@ -548,7 +551,7 @@ impl GhosttyView {
                 self.last_title = self.terminal.as_ref().and_then(|t| t.title());
                 self.last_cwd = self.terminal.as_ref().and_then(|t| t.current_dir());
                 self.last_physical_size = Some((width_px, height_px));
-                self.last_scale_factor = dpi as f32 / 96.0;
+                self.last_dpi = dpi;
                 self.scrollbar_cache = None;
             }
             Err(err) => {
@@ -607,14 +610,17 @@ impl GhosttyView {
             return SyncRenderResult::Unchanged;
         };
 
-        if (scale_factor - self.last_scale_factor).abs() > f32::EPSILON {
+        let dpi_changed = dpi != self.last_dpi;
+        if dpi_changed {
             if let Err(err) = session.set_dpi(dpi) {
                 log::warn!("RenderSession::set_dpi failed: {err:#}");
             }
-            self.last_scale_factor = scale_factor;
+            self.last_dpi = dpi;
         }
 
-        if self.last_physical_size != Some((width_px, height_px)) {
+        // Recompute the grid and mouse cell geometry after a DPI change even
+        // when physical dimensions happen to be unchanged.
+        if dpi_changed || self.last_physical_size != Some((width_px, height_px)) {
             if let Err(err) = session.resize(width_px, height_px) {
                 log::warn!("RenderSession::resize failed: {err:#}");
             }
@@ -880,11 +886,20 @@ impl GhosttyView {
         pos: Point<Pixels>,
         clamp_to_grid: bool,
     ) -> Option<(SelectionPoint, SelectionGeometry)> {
-        let bounds = self.pane_bounds?;
         let terminal = self.terminal.as_ref()?;
         let inner = terminal.inner();
         let guard = inner.lock();
         let session = guard.as_ref()?;
+        self.selection_input_for_session(session, pos, clamp_to_grid)
+    }
+
+    fn selection_input_for_session(
+        &self,
+        session: &RenderSession,
+        pos: Point<Pixels>,
+        clamp_to_grid: bool,
+    ) -> Option<(SelectionPoint, SelectionGeometry)> {
+        let bounds = self.pane_bounds?;
         let metrics = session.metrics();
         if metrics.cell_width_px == 0 || metrics.cell_height_px == 0 {
             return None;
@@ -958,6 +973,7 @@ impl GhosttyView {
     fn clear_hovered_link(&mut self) -> bool {
         let changed = self.hovered_link.take().is_some();
         if !self.terminal_left_mouse_sequence.is_active()
+            && !self.terminal_middle_mouse_sequence.is_active()
             && !self.terminal_right_mouse_sequence.is_active()
         {
             self.last_mouse_position = None;
@@ -992,7 +1008,7 @@ impl GhosttyView {
 
     fn forward_mouse_down(
         &self,
-        button: u8,
+        button: VtMouseButton,
         pos: Point<Pixels>,
         mods: MouseEventMods,
         click_count: usize,
@@ -1016,7 +1032,7 @@ impl GhosttyView {
 
     fn forward_mouse_drag(
         &self,
-        button: u8,
+        button: VtMouseButton,
         pos: Point<Pixels>,
         mods: MouseEventMods,
         clamp: bool,
@@ -1035,7 +1051,7 @@ impl GhosttyView {
 
     fn forward_mouse_up(
         &self,
-        button: u8,
+        button: VtMouseButton,
         pos: Point<Pixels>,
         mods: MouseEventMods,
         clamp: bool,
@@ -1052,18 +1068,39 @@ impl GhosttyView {
         }
     }
 
+    fn forward_mouse_hover(&self, pos: Point<Pixels>, mods: MouseEventMods) -> bool {
+        let Some(terminal) = &self.terminal else {
+            return false;
+        };
+        let inner = terminal.inner();
+        let guard = inner.lock();
+        let Some(session) = guard.as_ref() else {
+            return false;
+        };
+        // Avoid renderer metrics and coordinate conversion on the common shell
+        // path where no application has enabled terminal mouse tracking.
+        if !session.mouse_tracking_active() {
+            return false;
+        }
+        let Some((point, _)) = self.selection_input_for_session(session, pos, false) else {
+            return false;
+        };
+        session.mouse_hover(point, mods)
+    }
+
     fn finish_terminal_mouse_sequence(
         &mut self,
-        button: u8,
+        button: VtMouseButton,
         pos: Point<Pixels>,
         mut mods: MouseEventMods,
     ) -> bool {
-        if button == 0 {
+        if button == VtMouseButton::Left {
             self.stop_selection_autoscroll();
         }
         let route = match button {
-            0 => self.terminal_left_mouse_sequence.finish(),
-            2 => self.terminal_right_mouse_sequence.finish(),
+            VtMouseButton::Left => self.terminal_left_mouse_sequence.finish(),
+            VtMouseButton::Middle => self.terminal_middle_mouse_sequence.finish(),
+            VtMouseButton::Right => self.terminal_right_mouse_sequence.finish(),
             _ => None,
         };
         let Some(route) = route else {
@@ -1159,14 +1196,27 @@ impl GhosttyView {
         self.scrollbar_drag = None;
         self.mouse_down_link = None;
         self.suppress_link_mouse_up = false;
-        self.finish_terminal_mouse_sequence(0, position, MouseEventMods::default());
+        self.finish_terminal_mouse_sequence(
+            VtMouseButton::Left,
+            position,
+            MouseEventMods::default(),
+        );
     }
 
     fn cancel_pointer_interactions(&mut self) {
         self.stop_selection_autoscroll();
         if let Some(position) = self.last_mouse_position {
             self.cancel_left_pointer_interactions(position);
-            self.finish_terminal_mouse_sequence(2, position, MouseEventMods::default());
+            self.finish_terminal_mouse_sequence(
+                VtMouseButton::Middle,
+                position,
+                MouseEventMods::default(),
+            );
+            self.finish_terminal_mouse_sequence(
+                VtMouseButton::Right,
+                position,
+                MouseEventMods::default(),
+            );
         } else {
             self.scrollbar_drag = None;
             self.mouse_down_link = None;
@@ -1180,6 +1230,7 @@ impl GhosttyView {
             {
                 session.cancel_drag();
             }
+            self.terminal_middle_mouse_sequence.finish();
             self.terminal_right_mouse_sequence.finish();
         }
     }
@@ -1205,7 +1256,7 @@ impl GhosttyView {
         }
 
         // Only report wheel to the shell when it has explicitly enabled
-        // mouse tracking (SGR). Otherwise scroll Con's own viewport via
+        // mouse tracking. Otherwise scroll Con's own viewport via
         // libghostty-vt. Shift bypasses reporting per xterm convention
         // so the user can scroll Con's scrollback even when a TUI has
         // `set mouse=a`.
@@ -1214,11 +1265,10 @@ impl GhosttyView {
             return true;
         }
 
-        let Some((col0, row0)) = self.cell_from_event_position(pos) else {
+        let Some((point, _)) = self.selection_input_from_event_position(pos, false) else {
             return false;
         };
-        // `forward_wheel` expects 1-based SGR coordinates.
-        session.forward_wheel(col0 + 1, row0 + 1, delta_y_px, mods);
+        session.forward_wheel(point, delta_y_px, mods);
         false
     }
 
@@ -1885,6 +1935,7 @@ impl Render for GhosttyView {
         let focus = self.focus_handle.clone();
         let input_focus = focus.clone();
         let context_focus = focus.clone();
+        let middle_focus = focus.clone();
         let menu_focus = focus.clone();
         let ui_font = cx.theme().font_family.clone();
 
@@ -1970,22 +2021,49 @@ impl Render for GhosttyView {
                     window.focus(&context_focus, cx);
                     this.last_mouse_position = Some(event.position);
                     this.finish_terminal_mouse_sequence(
-                        2,
+                        VtMouseButton::Right,
                         event.position,
                         MouseEventMods::default(),
                     );
                     let _ = this.update_hovered_link(&event.modifiers);
-                    // SGR button 2 = right; unconsumed when tracking is off.
                     let consumed = this.forward_mouse_down(
-                        2,
+                        VtMouseButton::Right,
                         event.position,
                         mouse_mods_from(&event.modifiers),
                         event.click_count,
-                    ) == MouseDownRoute::TerminalReport;
+                    ) == MouseDownRoute::TerminalCapture;
                     this.terminal_mouse_right_consumed = Some(consumed);
                     if consumed {
                         this.terminal_right_mouse_sequence.begin(MousePressRoute {
                             shift: event.modifiers.shift,
+                            local_selection: false,
+                        });
+                    }
+                    cx.emit(GhosttyFocusChanged);
+                    cx.notify();
+                }),
+            )
+            .on_mouse_down(
+                MouseButton::Middle,
+                cx.listener(move |this, event: &MouseDownEvent, window, cx| {
+                    window.focus(&middle_focus, cx);
+                    this.last_mouse_position = Some(event.position);
+                    this.finish_terminal_mouse_sequence(
+                        VtMouseButton::Middle,
+                        event.position,
+                        MouseEventMods::default(),
+                    );
+                    let _ = this.update_hovered_link(&event.modifiers);
+                    let mods = mouse_mods_from(&event.modifiers);
+                    if this.forward_mouse_down(
+                        VtMouseButton::Middle,
+                        event.position,
+                        mods,
+                        event.click_count,
+                    ) == MouseDownRoute::TerminalCapture
+                    {
+                        this.terminal_middle_mouse_sequence.begin(MousePressRoute {
+                            shift: mods.shift,
                             local_selection: false,
                         });
                     }
@@ -2013,22 +2091,26 @@ impl Render for GhosttyView {
                     }
                     // Left button has two valid continuation modes: local
                     // selection when mouse tracking is off/Shift-bypassed, or
-                    // terminal SGR reporting when the press was actually
-                    // written. Do not continue an SGR sequence after a failed
-                    // PTY write.
+                    // terminal reporting when tracking captures the press.
+                    // Zero-byte protocol outcomes remain captured; only an
+                    // actual PTY write failure abandons the sequence.
                     let mods = mouse_mods_from(&event.modifiers);
-                    let route =
-                        match this.forward_mouse_down(0, event.position, mods, event.click_count) {
-                            MouseDownRoute::TerminalReport => Some(MousePressRoute {
-                                shift: mods.shift,
-                                local_selection: false,
-                            }),
-                            MouseDownRoute::LocalSelection => Some(MousePressRoute {
-                                shift: mods.shift,
-                                local_selection: true,
-                            }),
-                            MouseDownRoute::Ignored => None,
-                        };
+                    let route = match this.forward_mouse_down(
+                        VtMouseButton::Left,
+                        event.position,
+                        mods,
+                        event.click_count,
+                    ) {
+                        MouseDownRoute::TerminalCapture => Some(MousePressRoute {
+                            shift: mods.shift,
+                            local_selection: false,
+                        }),
+                        MouseDownRoute::LocalSelection => Some(MousePressRoute {
+                            shift: mods.shift,
+                            local_selection: true,
+                        }),
+                        MouseDownRoute::Ignored => None,
+                    };
                     if let Some(route) = route {
                         this.terminal_left_mouse_sequence.begin(route);
                     }
@@ -2081,7 +2163,7 @@ impl Render for GhosttyView {
                 if event.pressed_button == Some(MouseButton::Left) {
                     if let Some(route) = this.terminal_left_mouse_sequence.payload().copied() {
                         let autoscroll = this.forward_mouse_drag(
-                            0,
+                            VtMouseButton::Left,
                             event.position,
                             MouseEventMods {
                                 shift: route.shift,
@@ -2097,14 +2179,25 @@ impl Render for GhosttyView {
                     } else if hover_changed {
                         cx.notify();
                     }
+                } else if event.pressed_button == Some(MouseButton::Middle)
+                    && let Some(route) = this.terminal_middle_mouse_sequence.payload().copied()
+                {
+                    let _ = this.forward_mouse_drag(
+                        VtMouseButton::Middle,
+                        event.position,
+                        MouseEventMods {
+                            shift: route.shift,
+                            ..mouse_mods_from(&event.modifiers)
+                        },
+                        true,
+                        false,
+                    );
+                    cx.notify();
                 } else if event.pressed_button == Some(MouseButton::Right)
                     && let Some(route) = this.terminal_right_mouse_sequence.payload().copied()
                 {
-                    // Right button is held and the sequence is active: keep
-                    // reporting motion (button 2 + 32) instead of treating
-                    // this as a release.
                     let _ = this.forward_mouse_drag(
-                        2,
+                        VtMouseButton::Right,
                         event.position,
                         MouseEventMods {
                             shift: route.shift,
@@ -2116,14 +2209,33 @@ impl Render for GhosttyView {
                     cx.notify();
                 } else if event.pressed_button.is_none()
                     && (this.terminal_left_mouse_sequence.is_active()
+                        || this.terminal_middle_mouse_sequence.is_active()
                         || this.terminal_right_mouse_sequence.is_active())
                 {
                     let release_mods = mouse_mods_from(&event.modifiers);
-                    this.finish_terminal_mouse_sequence(0, event.position, release_mods);
-                    this.finish_terminal_mouse_sequence(2, event.position, release_mods);
+                    this.finish_terminal_mouse_sequence(
+                        VtMouseButton::Left,
+                        event.position,
+                        release_mods,
+                    );
+                    this.finish_terminal_mouse_sequence(
+                        VtMouseButton::Middle,
+                        event.position,
+                        release_mods,
+                    );
+                    this.finish_terminal_mouse_sequence(
+                        VtMouseButton::Right,
+                        event.position,
+                        release_mods,
+                    );
                     cx.notify();
-                } else if hover_changed {
-                    cx.notify();
+                } else {
+                    let mouse_reported = event.pressed_button.is_none()
+                        && this
+                            .forward_mouse_hover(event.position, mouse_mods_from(&event.modifiers));
+                    if hover_changed || mouse_reported {
+                        cx.notify();
+                    }
                 }
             }))
             .on_mouse_up(
@@ -2150,7 +2262,7 @@ impl Render for GhosttyView {
                         return;
                     }
                     this.finish_terminal_mouse_sequence(
-                        0,
+                        VtMouseButton::Left,
                         event.position,
                         mouse_mods_from(&event.modifiers),
                     );
@@ -2172,7 +2284,36 @@ impl Render for GhosttyView {
                     this.mouse_down_link = None;
                     this.suppress_link_mouse_up = false;
                     this.finish_terminal_mouse_sequence(
-                        0,
+                        VtMouseButton::Left,
+                        event.position,
+                        mouse_mods_from(&event.modifiers),
+                    );
+                    let _ = this.update_hovered_link(&event.modifiers);
+                    cx.notify();
+                }),
+            )
+            .on_mouse_up(
+                MouseButton::Middle,
+                cx.listener(|this, event: &MouseUpEvent, _window, cx| {
+                    this.last_mouse_position = Some(event.position);
+                    this.finish_terminal_mouse_sequence(
+                        VtMouseButton::Middle,
+                        event.position,
+                        mouse_mods_from(&event.modifiers),
+                    );
+                    let _ = this.update_hovered_link(&event.modifiers);
+                    cx.notify();
+                }),
+            )
+            .on_mouse_up_out(
+                MouseButton::Middle,
+                cx.listener(|this, event: &MouseUpEvent, _window, cx| {
+                    if !this.terminal_middle_mouse_sequence.is_active() {
+                        return;
+                    }
+                    this.last_mouse_position = Some(event.position);
+                    this.finish_terminal_mouse_sequence(
+                        VtMouseButton::Middle,
                         event.position,
                         mouse_mods_from(&event.modifiers),
                     );
@@ -2185,7 +2326,7 @@ impl Render for GhosttyView {
                 cx.listener(|this, event: &MouseUpEvent, _window, cx| {
                     this.last_mouse_position = Some(event.position);
                     this.finish_terminal_mouse_sequence(
-                        2,
+                        VtMouseButton::Right,
                         event.position,
                         mouse_mods_from(&event.modifiers),
                     );
@@ -2201,7 +2342,7 @@ impl Render for GhosttyView {
                     }
                     this.last_mouse_position = Some(event.position);
                     this.finish_terminal_mouse_sequence(
-                        2,
+                        VtMouseButton::Right,
                         event.position,
                         mouse_mods_from(&event.modifiers),
                     );
@@ -2221,7 +2362,7 @@ impl Render for GhosttyView {
                     && let Some(route) = this.terminal_left_mouse_sequence.payload().copied()
                 {
                     let autoscroll = this.forward_mouse_drag(
-                        0,
+                        VtMouseButton::Left,
                         event.position,
                         MouseEventMods {
                             shift: route.shift,

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -154,6 +154,9 @@ pub struct GhosttyView {
     last_physical_size: Option<(u32, u32)>,
     /// Last physical DPI successfully applied by `session.set_dpi`.
     last_dpi: u32,
+    /// Current geometry synchronization failure, retained so a retry loop
+    /// reports each failing stage once instead of warning every prepaint.
+    geometry_sync_failure: Option<GeometrySyncFailure>,
     /// The most recently rendered frame, wrapped as a GPUI image.
     cached_image: Option<Arc<RenderImage>>,
     /// CPU-side copy of the current BGRA frame. Dirty-row readbacks
@@ -203,6 +206,12 @@ enum SyncRenderResult {
     Unchanged,
     Rendered { needs_followup_prepaint: bool },
     Pending,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum GeometrySyncFailure {
+    SetDpi,
+    Resize,
 }
 
 pub fn init(cx: &mut App) {
@@ -261,6 +270,7 @@ impl GhosttyView {
             ime_selected_range: None,
             last_physical_size: None,
             last_dpi: 0,
+            geometry_sync_failure: None,
             cached_image: None,
             cached_image_size: None,
             cached_frame: None,
@@ -375,6 +385,7 @@ impl GhosttyView {
         self.pending_unsafe_paste = None;
         self.images_to_drop.clear();
         self.last_physical_size = None;
+        self.geometry_sync_failure = None;
     }
 
     pub fn set_surface_focus_state(&mut self, focused: bool) {
@@ -552,6 +563,7 @@ impl GhosttyView {
                 self.last_cwd = self.terminal.as_ref().and_then(|t| t.current_dir());
                 self.last_physical_size = Some((width_px, height_px));
                 self.last_dpi = dpi;
+                self.geometry_sync_failure = None;
                 self.scrollbar_cache = None;
             }
             Err(err) => {
@@ -567,6 +579,22 @@ impl GhosttyView {
         self.pane_bounds = Some(bounds);
         self.scale_factor = scale_factor;
         bounds_changed || scale_changed
+    }
+
+    fn report_geometry_sync_failure(
+        &mut self,
+        failure: GeometrySyncFailure,
+        error: &anyhow::Error,
+    ) {
+        if self.geometry_sync_failure == Some(failure) {
+            return;
+        }
+        self.geometry_sync_failure = Some(failure);
+        let operation = match failure {
+            GeometrySyncFailure::SetDpi => "set_dpi",
+            GeometrySyncFailure::Resize => "resize",
+        };
+        log::warn!("RenderSession::{operation} failed: {error:#}");
     }
 
     /// Drives session lifecycle (init/resize/DPI) and pumps one render
@@ -622,7 +650,7 @@ impl GhosttyView {
                         true
                     }
                     Err(err) => {
-                        log::warn!("RenderSession::set_dpi failed: {err:#}");
+                        self.report_geometry_sync_failure(GeometrySyncFailure::SetDpi, &err);
                         false
                     }
                 }
@@ -632,16 +660,23 @@ impl GhosttyView {
 
             if dpi_ready {
                 match session.resize(width_px, height_px) {
-                    Ok(()) => self.last_physical_size = Some((width_px, height_px)),
+                    Ok(()) => {
+                        self.last_physical_size = Some((width_px, height_px));
+                        self.geometry_sync_failure = None;
+                    }
                     Err(err) => {
                         // A resize may have updated an earlier subsystem before
                         // a later one failed. Force the full idempotent sequence
                         // to run again on the next prepaint.
                         self.last_physical_size = None;
-                        log::warn!("RenderSession::resize failed: {err:#}");
+                        self.report_geometry_sync_failure(GeometrySyncFailure::Resize, &err);
                     }
                 }
             }
+        } else {
+            // Returning to the last applied geometry also ends a failed DPI
+            // transition, even though no synchronization call was required.
+            self.geometry_sync_failure = None;
         }
 
         let render_started = perf_trace_enabled().then(Instant::now);

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -148,11 +148,11 @@ pub struct GhosttyView {
     scale_factor: f32,
     ime_marked_text: Option<String>,
     ime_selected_range: Option<Range<usize>>,
-    /// Last physical-pixel size we sent to `session.resize`. Avoids
-    /// resize churn when the logical bounds round to the same physical
-    /// size frame-to-frame.
+    /// Last physical-pixel size successfully applied by `session.resize`.
+    /// Avoids resize churn when the logical bounds round to the same
+    /// physical size frame-to-frame.
     last_physical_size: Option<(u32, u32)>,
-    /// Last physical DPI handed to `session.set_dpi`.
+    /// Last physical DPI successfully applied by `session.set_dpi`.
     last_dpi: u32,
     /// The most recently rendered frame, wrapped as a GPUI image.
     cached_image: Option<Arc<RenderImage>>,
@@ -610,21 +610,38 @@ impl GhosttyView {
             return SyncRenderResult::Unchanged;
         };
 
-        let dpi_changed = dpi != self.last_dpi;
-        if dpi_changed {
-            if let Err(err) = session.set_dpi(dpi) {
-                log::warn!("RenderSession::set_dpi failed: {err:#}");
-            }
-            self.last_dpi = dpi;
-        }
-
         // Recompute the grid and mouse cell geometry after a DPI change even
         // when physical dimensions happen to be unchanged.
-        if dpi_changed || self.last_physical_size != Some((width_px, height_px)) {
-            if let Err(err) = session.resize(width_px, height_px) {
-                log::warn!("RenderSession::resize failed: {err:#}");
+        let dpi_changed = dpi != self.last_dpi;
+        let resize_needed = dpi_changed || self.last_physical_size != Some((width_px, height_px));
+        if resize_needed {
+            let dpi_ready = if dpi_changed {
+                match session.set_dpi(dpi) {
+                    Ok(()) => {
+                        self.last_dpi = dpi;
+                        true
+                    }
+                    Err(err) => {
+                        log::warn!("RenderSession::set_dpi failed: {err:#}");
+                        false
+                    }
+                }
+            } else {
+                true
+            };
+
+            if dpi_ready {
+                match session.resize(width_px, height_px) {
+                    Ok(()) => self.last_physical_size = Some((width_px, height_px)),
+                    Err(err) => {
+                        // A resize may have updated an earlier subsystem before
+                        // a later one failed. Force the full idempotent sequence
+                        // to run again on the next prepaint.
+                        self.last_physical_size = None;
+                        log::warn!("RenderSession::resize failed: {err:#}");
+                    }
+                }
             }
-            self.last_physical_size = Some((width_px, height_px));
         }
 
         let render_started = perf_trace_enabled().then(Instant::now);

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -1884,7 +1884,7 @@ struct MouseEncoderState {
 }
 
 impl MouseEncoderState {
-    fn new(terminal: GhosttyTerminal, cols: u16, rows: u16) -> anyhow::Result<Self> {
+    fn new(terminal: GhosttyTerminal, geometry: GhosttyMouseEncoderSize) -> anyhow::Result<Self> {
         let mut encoder = std::ptr::null_mut();
         let rc = unsafe { ghostty_mouse_encoder_new(std::ptr::null(), &mut encoder) };
         if rc != GHOSTTY_SUCCESS || encoder.is_null() {
@@ -1898,7 +1898,6 @@ impl MouseEncoderState {
             anyhow::bail!("ghostty_mouse_event_new failed: rc={rc}");
         }
 
-        let geometry = GhosttyMouseEncoderSize::new(u32::from(cols), u32::from(rows), 1, 1);
         let track_last_cell = true;
         unsafe {
             ghostty_mouse_encoder_setopt(
@@ -1937,7 +1936,7 @@ struct VtInner {
     terminal: GhosttyTerminal,
     key_encoder: GhosttyKeyEncoder,
     key_event: GhosttyKeyEvent,
-    mouse: MouseEncoderState,
+    mouse: Option<MouseEncoderState>,
     selection_gesture: Option<SelectionGestureState>,
     kitty_placement_iter: GhosttyKittyGraphicsPlacementIterator,
     kitty_image_cache: HashMap<u32, Arc<KittyImage>>,
@@ -2673,28 +2672,6 @@ impl VtScreen {
             anyhow::bail!("ghostty_key_event_new failed: rc={rc}");
         }
 
-        let mouse = match MouseEncoderState::new(terminal, cols, rows) {
-            Ok(mouse) => mouse,
-            Err(err) => {
-                unsafe {
-                    ghostty_key_event_free(key_event);
-                    ghostty_key_encoder_free(key_encoder);
-                    ghostty_kitty_graphics_placement_iterator_free(kitty_placement_iter);
-                    if !row_cells.is_null() {
-                        ghostty_render_state_row_cells_free(row_cells);
-                    }
-                    if !row_iter.is_null() {
-                        ghostty_render_state_row_iterator_free(row_iter);
-                    }
-                    if !render_state.is_null() {
-                        ghostty_render_state_free(render_state);
-                    }
-                    ghostty_terminal_free(terminal);
-                }
-                return Err(err);
-            }
-        };
-
         if let Some(theme) = theme {
             unsafe { apply_theme_to_terminal(terminal, theme) };
         }
@@ -2704,7 +2681,7 @@ impl VtScreen {
                 terminal,
                 key_encoder,
                 key_event,
-                mouse,
+                mouse: None,
                 selection_gesture: None,
                 kitty_placement_iter,
                 kitty_image_cache: HashMap::new(),
@@ -3293,7 +3270,9 @@ impl VtScreen {
         // not a pure function of the DEC mode bitset. Synchronize from the
         // terminal after every parsed output chunk so repeated DECSET/DECRST
         // sequences cannot leave the encoder on a stale protocol.
-        unsafe { ghostty_mouse_encoder_setopt_from_terminal(inner.mouse.encoder, inner.terminal) };
+        if let Some(mouse) = &inner.mouse {
+            unsafe { ghostty_mouse_encoder_setopt_from_terminal(mouse.encoder, inner.terminal) };
+        }
         refresh_terminal_metadata(&mut inner);
         inner.output_generation = inner.output_generation.wrapping_add(1);
         inner.generation = inner.generation.wrapping_add(1);
@@ -3308,7 +3287,7 @@ impl VtScreen {
         screen_height_px: u32,
         cell_width_px: u32,
         cell_height_px: u32,
-    ) {
+    ) -> anyhow::Result<()> {
         let geometry = GhosttyMouseEncoderSize::new(
             screen_width_px,
             screen_height_px,
@@ -3316,17 +3295,23 @@ impl VtScreen {
             cell_height_px,
         );
         let mut inner = self.inner.lock();
-        if inner.mouse.geometry == geometry {
-            return;
+        if let Some(mouse) = inner.mouse.as_mut() {
+            if mouse.geometry == geometry {
+                return Ok(());
+            }
+            unsafe {
+                ghostty_mouse_encoder_setopt(
+                    mouse.encoder,
+                    GhosttyMouseEncoderOption::Size,
+                    &geometry as *const _ as *const c_void,
+                )
+            };
+            mouse.geometry = geometry;
+            return Ok(());
         }
-        unsafe {
-            ghostty_mouse_encoder_setopt(
-                inner.mouse.encoder,
-                GhosttyMouseEncoderOption::Size,
-                &geometry as *const _ as *const c_void,
-            )
-        };
-        inner.mouse.geometry = geometry;
+        let terminal = inner.terminal;
+        inner.mouse = Some(MouseEncoderState::new(terminal, geometry)?);
+        Ok(())
     }
 
     /// Encode one normalized pointer event with Ghostty's effective terminal
@@ -3340,6 +3325,10 @@ impl VtScreen {
         }
 
         let inner = self.inner.lock();
+        let mouse = inner
+            .mouse
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("terminal mouse geometry is not initialized"))?;
         let callback_state = &inner.callback_state;
         let Some(write_pty) = callback_state.write_pty.clone() else {
             anyhow::bail!("terminal mouse encoding requires a WRITE_PTY callback");
@@ -3351,22 +3340,19 @@ impl VtScreen {
 
         unsafe {
             ghostty_mouse_encoder_setopt(
-                inner.mouse.encoder,
+                mouse.encoder,
                 GhosttyMouseEncoderOption::AnyButtonPressed,
                 &any_button_pressed as *const _ as *const c_void,
             );
-            ghostty_mouse_event_set_action(inner.mouse.event, ghostty_mouse_action(event.action));
+            ghostty_mouse_event_set_action(mouse.event, ghostty_mouse_action(event.action));
             if let Some(button) = event.button {
-                ghostty_mouse_event_set_button(inner.mouse.event, ghostty_mouse_button(button));
+                ghostty_mouse_event_set_button(mouse.event, ghostty_mouse_button(button));
             } else {
-                ghostty_mouse_event_clear_button(inner.mouse.event);
+                ghostty_mouse_event_clear_button(mouse.event);
             }
-            ghostty_mouse_event_set_mods(
-                inner.mouse.event,
-                ghostty_mouse_modifiers(event.modifiers),
-            );
+            ghostty_mouse_event_set_mods(mouse.event, ghostty_mouse_modifiers(event.modifiers));
             ghostty_mouse_event_set_position(
-                inner.mouse.event,
+                mouse.event,
                 GhosttyMousePosition {
                     x: event.surface_x_px,
                     y: event.surface_y_px,
@@ -3378,8 +3364,8 @@ impl VtScreen {
         let mut len = 0_usize;
         let mut rc = unsafe {
             ghostty_mouse_encoder_encode(
-                inner.mouse.encoder,
-                inner.mouse.event,
+                mouse.encoder,
+                mouse.event,
                 inline.as_mut_ptr().cast(),
                 inline.len(),
                 &mut len,
@@ -3391,8 +3377,8 @@ impl VtScreen {
             overflow.resize(len, 0);
             rc = unsafe {
                 ghostty_mouse_encoder_encode(
-                    inner.mouse.encoder,
-                    inner.mouse.event,
+                    mouse.encoder,
+                    mouse.event,
                     overflow.as_mut_ptr().cast(),
                     overflow.len(),
                     &mut len,
@@ -5481,7 +5467,9 @@ impl Drop for VtScreen {
             // Free every object that can refer to the terminal before the
             // terminal itself.
             // SAFETY: unique owner via Arc::get_mut.
-            unsafe { inner.mouse.free() };
+            if let Some(mut mouse) = inner.mouse.take() {
+                unsafe { mouse.free() };
+            }
             if !inner.key_event.is_null() {
                 unsafe { ghostty_key_event_free(inner.key_event) };
                 inner.key_event = std::ptr::null_mut();
@@ -6881,7 +6869,9 @@ mod tests {
             })),
         )
         .expect("create mouse test screen");
-        screen.set_mouse_geometry(u32::from(cols) * 10, u32::from(rows) * 20, 10, 20);
+        screen
+            .set_mouse_geometry(u32::from(cols) * 10, u32::from(rows) * 20, 10, 20)
+            .expect("initialize mouse geometry");
         (screen, writes)
     }
 
@@ -7014,19 +7004,6 @@ mod tests {
                 format!("\x1b[<{code};1;1M").into_bytes()
             );
         }
-
-        screen
-            .send_mouse_event(test_mouse_event(
-                VtMouseAction::Release,
-                Some(VtMouseButton::Left),
-                5.0,
-                5.0,
-            ))
-            .expect("encode release");
-        assert_eq!(
-            writes.lock().last().expect("captured release").1,
-            PtyWriteClass::ReservedControl
-        );
     }
 
     #[test]
@@ -7087,21 +7064,44 @@ mod tests {
     }
 
     #[test]
-    fn mouse_encoder_deduplicates_motion_until_terminal_output_resynchronizes() {
+    fn mouse_encoder_deduplicates_motion_across_equal_geometry_updates() {
         let (screen, writes) = mouse_test_screen(80, 24);
         screen.feed(b"\x1b[?1002h\x1b[?1006h");
         let drag = test_mouse_event(VtMouseAction::Motion, Some(VtMouseButton::Left), 5.0, 5.0);
 
         assert!(screen.send_mouse_event(drag).unwrap().output_written);
         assert!(!screen.send_mouse_event(drag).unwrap().output_written);
-        screen.set_mouse_geometry(800, 480, 10, 20);
+        screen
+            .set_mouse_geometry(800, 480, 10, 20)
+            .expect("keep equal mouse geometry");
         assert!(!screen.send_mouse_event(drag).unwrap().output_written);
+        assert_eq!(writes.lock().len(), 1);
+    }
 
-        // The pinned setopt_from_terminal implementation clears last-cell
-        // state on each feed, even when the parsed bytes do not change modes.
-        screen.feed(b"x");
-        assert!(screen.send_mouse_event(drag).unwrap().output_written);
-        assert_eq!(writes.lock().len(), 2);
+    #[test]
+    fn mouse_encoder_reports_only_pressed_motion_outside_the_viewport() {
+        let cases = [
+            (
+                b"\x1b[?1002h\x1b[?1006h".as_slice(),
+                Some(VtMouseButton::Left),
+                Some(b"\x1b[<32;1;1M".as_slice()),
+            ),
+            (b"\x1b[?1003h\x1b[?1006h".as_slice(), None, None),
+        ];
+
+        for (modes, button, expected) in cases {
+            let (screen, writes) = mouse_test_screen(80, 24);
+            screen.feed(modes);
+            let outcome = screen
+                .send_mouse_event(test_mouse_event(VtMouseAction::Motion, button, -5.0, -5.0))
+                .expect("encode out-of-viewport motion");
+            assert_eq!(outcome.output_written, expected.is_some());
+            let writes = writes.lock();
+            assert_eq!(writes.len(), usize::from(expected.is_some()));
+            if let Some(expected) = expected {
+                assert_eq!(writes[0].0.as_slice(), expected);
+            }
+        }
     }
 
     #[test]

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -69,6 +69,8 @@ pub type GhosttyRowIterator = *mut c_void;
 pub type GhosttyRowCells = *mut c_void;
 pub type GhosttyKeyEncoder = *mut c_void;
 pub type GhosttyKeyEvent = *mut c_void;
+pub type GhosttyMouseEncoder = *mut c_void;
+pub type GhosttyMouseEvent = *mut c_void;
 pub type GhosttySelectionGesture = *mut c_void;
 pub type GhosttySelectionGestureEvent = *mut c_void;
 pub type GhosttyKittyGraphics = *mut c_void;
@@ -373,6 +375,71 @@ enum GhosttySelectionGestureAutoscroll {
     None = 0,
     Up = 1,
     Down = 2,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GhosttyMouseAction {
+    Press = 0,
+    Release = 1,
+    Motion = 2,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GhosttyMouseButton {
+    Left = 1,
+    Right = 2,
+    Middle = 3,
+    Four = 4,
+    Five = 5,
+    Six = 6,
+    Seven = 7,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GhosttyMouseEncoderOption {
+    Size = 2,
+    AnyButtonPressed = 3,
+    TrackLastCell = 4,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct GhosttyMousePosition {
+    x: f32,
+    y: f32,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GhosttyMouseEncoderSize {
+    size: usize,
+    screen_width: u32,
+    screen_height: u32,
+    cell_width: u32,
+    cell_height: u32,
+    padding_top: u32,
+    padding_bottom: u32,
+    padding_right: u32,
+    padding_left: u32,
+}
+
+impl GhosttyMouseEncoderSize {
+    fn new(screen_width: u32, screen_height: u32, cell_width: u32, cell_height: u32) -> Self {
+        Self {
+            size: std::mem::size_of::<Self>(),
+            screen_width: screen_width.max(1),
+            screen_height: screen_height.max(1),
+            cell_width: cell_width.max(1),
+            cell_height: cell_height.max(1),
+            padding_top: 0,
+            padding_bottom: 0,
+            padding_right: 0,
+            padding_left: 0,
+        }
+    }
 }
 
 /// `GHOSTTY_SYS_OPT_*` keys for process-global optional services.
@@ -1122,6 +1189,40 @@ unsafe extern "C" {
     pub fn ghostty_key_event_set_utf8(event: GhosttyKeyEvent, utf8: *const c_char, len: usize);
     pub fn ghostty_key_event_set_unshifted_codepoint(event: GhosttyKeyEvent, codepoint: u32);
 
+    // Mouse input (`mouse/{encoder,event}.h`). The encoder and reusable event
+    // share `VtInner`'s mutex with the terminal mode state they encode against.
+    fn ghostty_mouse_encoder_new(
+        allocator: *const GhosttyAllocator,
+        out_encoder: *mut GhosttyMouseEncoder,
+    ) -> GhosttyResult;
+    fn ghostty_mouse_encoder_free(encoder: GhosttyMouseEncoder);
+    fn ghostty_mouse_encoder_setopt(
+        encoder: GhosttyMouseEncoder,
+        option: GhosttyMouseEncoderOption,
+        value: *const c_void,
+    );
+    fn ghostty_mouse_encoder_setopt_from_terminal(
+        encoder: GhosttyMouseEncoder,
+        terminal: GhosttyTerminal,
+    );
+    fn ghostty_mouse_encoder_encode(
+        encoder: GhosttyMouseEncoder,
+        event: GhosttyMouseEvent,
+        out_buf: *mut c_char,
+        out_buf_size: usize,
+        out_len: *mut usize,
+    ) -> GhosttyResult;
+    fn ghostty_mouse_event_new(
+        allocator: *const GhosttyAllocator,
+        out_event: *mut GhosttyMouseEvent,
+    ) -> GhosttyResult;
+    fn ghostty_mouse_event_free(event: GhosttyMouseEvent);
+    fn ghostty_mouse_event_set_action(event: GhosttyMouseEvent, action: GhosttyMouseAction);
+    fn ghostty_mouse_event_set_button(event: GhosttyMouseEvent, button: GhosttyMouseButton);
+    fn ghostty_mouse_event_clear_button(event: GhosttyMouseEvent);
+    fn ghostty_mouse_event_set_mods(event: GhosttyMouseEvent, mods: u16);
+    fn ghostty_mouse_event_set_position(event: GhosttyMouseEvent, position: GhosttyMousePosition);
+
     // Kitty graphics storage (`kitty_graphics.h`). Handles are borrowed from
     // the terminal and remain valid only while its mutex is held.
     fn ghostty_kitty_graphics_get(
@@ -1658,6 +1759,49 @@ pub struct VtKeyOutcome {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VtMouseAction {
+    Press,
+    Release,
+    Motion,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VtMouseButton {
+    Left,
+    Middle,
+    Right,
+    Button4,
+    Button5,
+    Button6,
+    Button7,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct VtMouseModifiers {
+    pub shift: bool,
+    pub control: bool,
+    pub alt: bool,
+}
+
+/// Normalized mouse input in physical surface pixels. Ghostty converts this
+/// position to cells or terminal-space pixels according to the active format.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct VtMouseEvent {
+    pub action: VtMouseAction,
+    pub button: Option<VtMouseButton>,
+    pub modifiers: VtMouseModifiers,
+    pub surface_x_px: f32,
+    pub surface_y_px: f32,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct VtMouseOutcome {
+    /// True only when the active protocol encoded bytes and the PTY callback
+    /// accepted them. A captured terminal event may legitimately produce none.
+    pub output_written: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VtPasteResult {
     Empty,
     Accepted,
@@ -1699,9 +1843,9 @@ impl PendingPasteWrite {
 
 struct VtCallbackState {
     write_pty: Option<PtyWriteCallback>,
-    /// Serializes host callback entry. `send_key` acquires this while it still
-    /// owns the VT mutex, then releases the VT mutex before invoking the host;
-    /// a parser reply therefore cannot overtake the already-encoded key.
+    /// Serializes host callback entry. Encoded input acquires this while it
+    /// still owns the VT mutex, then releases the VT mutex before invoking the
+    /// host; a parser reply therefore cannot overtake that input.
     write_order: Arc<Mutex<()>>,
     enquiry_response: Box<[u8]>,
     /// Last clipboard text the user explicitly chose to paste. Kitty grants
@@ -1733,10 +1877,67 @@ struct VtCallbackState {
     unknown_sequence_log_count: AtomicU8,
 }
 
+struct MouseEncoderState {
+    encoder: GhosttyMouseEncoder,
+    event: GhosttyMouseEvent,
+    geometry: GhosttyMouseEncoderSize,
+}
+
+impl MouseEncoderState {
+    fn new(terminal: GhosttyTerminal, cols: u16, rows: u16) -> anyhow::Result<Self> {
+        let mut encoder = std::ptr::null_mut();
+        let rc = unsafe { ghostty_mouse_encoder_new(std::ptr::null(), &mut encoder) };
+        if rc != GHOSTTY_SUCCESS || encoder.is_null() {
+            anyhow::bail!("ghostty_mouse_encoder_new failed: rc={rc}");
+        }
+
+        let mut event = std::ptr::null_mut();
+        let rc = unsafe { ghostty_mouse_event_new(std::ptr::null(), &mut event) };
+        if rc != GHOSTTY_SUCCESS || event.is_null() {
+            unsafe { ghostty_mouse_encoder_free(encoder) };
+            anyhow::bail!("ghostty_mouse_event_new failed: rc={rc}");
+        }
+
+        let geometry = GhosttyMouseEncoderSize::new(u32::from(cols), u32::from(rows), 1, 1);
+        let track_last_cell = true;
+        unsafe {
+            ghostty_mouse_encoder_setopt(
+                encoder,
+                GhosttyMouseEncoderOption::Size,
+                &geometry as *const _ as *const c_void,
+            );
+            ghostty_mouse_encoder_setopt(
+                encoder,
+                GhosttyMouseEncoderOption::TrackLastCell,
+                &track_last_cell as *const _ as *const c_void,
+            );
+            ghostty_mouse_encoder_setopt_from_terminal(encoder, terminal);
+        }
+
+        Ok(Self {
+            encoder,
+            event,
+            geometry,
+        })
+    }
+
+    unsafe fn free(&mut self) {
+        if !self.event.is_null() {
+            unsafe { ghostty_mouse_event_free(self.event) };
+            self.event = std::ptr::null_mut();
+        }
+        if !self.encoder.is_null() {
+            unsafe { ghostty_mouse_encoder_free(self.encoder) };
+            self.encoder = std::ptr::null_mut();
+        }
+    }
+}
+
 struct VtInner {
     terminal: GhosttyTerminal,
     key_encoder: GhosttyKeyEncoder,
     key_event: GhosttyKeyEvent,
+    mouse: MouseEncoderState,
     selection_gesture: Option<SelectionGestureState>,
     kitty_placement_iter: GhosttyKittyGraphicsPlacementIterator,
     kitty_image_cache: HashMap<u32, Arc<KittyImage>>,
@@ -1961,6 +2162,32 @@ fn ghostty_modifiers(modifiers: VtKeyModifiers) -> u16 {
         | (u16::from(modifiers.control) * GHOSTTY_MODS_CTRL)
         | (u16::from(modifiers.alt) * GHOSTTY_MODS_ALT)
         | (u16::from(modifiers.platform) * GHOSTTY_MODS_SUPER)
+}
+
+fn ghostty_mouse_action(action: VtMouseAction) -> GhosttyMouseAction {
+    match action {
+        VtMouseAction::Press => GhosttyMouseAction::Press,
+        VtMouseAction::Release => GhosttyMouseAction::Release,
+        VtMouseAction::Motion => GhosttyMouseAction::Motion,
+    }
+}
+
+fn ghostty_mouse_button(button: VtMouseButton) -> GhosttyMouseButton {
+    match button {
+        VtMouseButton::Left => GhosttyMouseButton::Left,
+        VtMouseButton::Middle => GhosttyMouseButton::Middle,
+        VtMouseButton::Right => GhosttyMouseButton::Right,
+        VtMouseButton::Button4 => GhosttyMouseButton::Four,
+        VtMouseButton::Button5 => GhosttyMouseButton::Five,
+        VtMouseButton::Button6 => GhosttyMouseButton::Six,
+        VtMouseButton::Button7 => GhosttyMouseButton::Seven,
+    }
+}
+
+fn ghostty_mouse_modifiers(modifiers: VtMouseModifiers) -> u16 {
+    (u16::from(modifiers.shift) * GHOSTTY_MODS_SHIFT)
+        | (u16::from(modifiers.control) * GHOSTTY_MODS_CTRL)
+        | (u16::from(modifiers.alt) * GHOSTTY_MODS_ALT)
 }
 
 /// Map only key names whose physical identity is unambiguous in GPUI's
@@ -2446,6 +2673,28 @@ impl VtScreen {
             anyhow::bail!("ghostty_key_event_new failed: rc={rc}");
         }
 
+        let mouse = match MouseEncoderState::new(terminal, cols, rows) {
+            Ok(mouse) => mouse,
+            Err(err) => {
+                unsafe {
+                    ghostty_key_event_free(key_event);
+                    ghostty_key_encoder_free(key_encoder);
+                    ghostty_kitty_graphics_placement_iterator_free(kitty_placement_iter);
+                    if !row_cells.is_null() {
+                        ghostty_render_state_row_cells_free(row_cells);
+                    }
+                    if !row_iter.is_null() {
+                        ghostty_render_state_row_iterator_free(row_iter);
+                    }
+                    if !render_state.is_null() {
+                        ghostty_render_state_free(render_state);
+                    }
+                    ghostty_terminal_free(terminal);
+                }
+                return Err(err);
+            }
+        };
+
         if let Some(theme) = theme {
             unsafe { apply_theme_to_terminal(terminal, theme) };
         }
@@ -2455,6 +2704,7 @@ impl VtScreen {
                 terminal,
                 key_encoder,
                 key_event,
+                mouse,
                 selection_gesture: None,
                 kitty_placement_iter,
                 kitty_image_cache: HashMap::new(),
@@ -3039,9 +3289,157 @@ impl VtScreen {
         let mut inner = self.inner.lock();
         // SAFETY: terminal valid; bytes live for the call.
         unsafe { ghostty_terminal_vt_write(inner.terminal, bytes.as_ptr(), bytes.len()) };
+        // Tracking event and output format are last-write-wins terminal flags,
+        // not a pure function of the DEC mode bitset. Synchronize from the
+        // terminal after every parsed output chunk so repeated DECSET/DECRST
+        // sequences cannot leave the encoder on a stale protocol.
+        unsafe { ghostty_mouse_encoder_setopt_from_terminal(inner.mouse.encoder, inner.terminal) };
         refresh_terminal_metadata(&mut inner);
         inner.output_generation = inner.output_generation.wrapping_add(1);
         inner.generation = inner.generation.wrapping_add(1);
+    }
+
+    /// Update the renderer geometry used for cell and SGR-pixel mouse formats.
+    /// Ghostty clears motion deduplication whenever this option is set, so
+    /// compare the complete geometry before crossing the FFI boundary.
+    pub fn set_mouse_geometry(
+        &self,
+        screen_width_px: u32,
+        screen_height_px: u32,
+        cell_width_px: u32,
+        cell_height_px: u32,
+    ) {
+        let geometry = GhosttyMouseEncoderSize::new(
+            screen_width_px,
+            screen_height_px,
+            cell_width_px,
+            cell_height_px,
+        );
+        let mut inner = self.inner.lock();
+        if inner.mouse.geometry == geometry {
+            return;
+        }
+        unsafe {
+            ghostty_mouse_encoder_setopt(
+                inner.mouse.encoder,
+                GhosttyMouseEncoderOption::Size,
+                &geometry as *const _ as *const c_void,
+            )
+        };
+        inner.mouse.geometry = geometry;
+    }
+
+    /// Encode one normalized pointer event with Ghostty's effective terminal
+    /// mouse mode and synchronously write any resulting protocol bytes.
+    pub fn send_mouse_event(&self, event: VtMouseEvent) -> anyhow::Result<VtMouseOutcome> {
+        if !event.surface_x_px.is_finite() || !event.surface_y_px.is_finite() {
+            anyhow::bail!("terminal mouse position must be finite");
+        }
+        if event.action != VtMouseAction::Motion && event.button.is_none() {
+            anyhow::bail!("terminal mouse press and release events require a button");
+        }
+
+        let inner = self.inner.lock();
+        let callback_state = &inner.callback_state;
+        let Some(write_pty) = callback_state.write_pty.clone() else {
+            anyhow::bail!("terminal mouse encoding requires a WRITE_PTY callback");
+        };
+        let write_failed = callback_state.write_failed.clone();
+        let write_order = callback_state.write_order.clone();
+        let any_button_pressed = event.action == VtMouseAction::Press
+            || (event.action == VtMouseAction::Motion && event.button.is_some());
+
+        unsafe {
+            ghostty_mouse_encoder_setopt(
+                inner.mouse.encoder,
+                GhosttyMouseEncoderOption::AnyButtonPressed,
+                &any_button_pressed as *const _ as *const c_void,
+            );
+            ghostty_mouse_event_set_action(inner.mouse.event, ghostty_mouse_action(event.action));
+            if let Some(button) = event.button {
+                ghostty_mouse_event_set_button(inner.mouse.event, ghostty_mouse_button(button));
+            } else {
+                ghostty_mouse_event_clear_button(inner.mouse.event);
+            }
+            ghostty_mouse_event_set_mods(
+                inner.mouse.event,
+                ghostty_mouse_modifiers(event.modifiers),
+            );
+            ghostty_mouse_event_set_position(
+                inner.mouse.event,
+                GhosttyMousePosition {
+                    x: event.surface_x_px,
+                    y: event.surface_y_px,
+                },
+            );
+        }
+
+        let mut inline = [0_u8; 128];
+        let mut len = 0_usize;
+        let mut rc = unsafe {
+            ghostty_mouse_encoder_encode(
+                inner.mouse.encoder,
+                inner.mouse.event,
+                inline.as_mut_ptr().cast(),
+                inline.len(),
+                &mut len,
+            )
+        };
+
+        let mut overflow = Vec::new();
+        let bytes = if rc == GHOSTTY_OUT_OF_SPACE {
+            overflow.resize(len, 0);
+            rc = unsafe {
+                ghostty_mouse_encoder_encode(
+                    inner.mouse.encoder,
+                    inner.mouse.event,
+                    overflow.as_mut_ptr().cast(),
+                    overflow.len(),
+                    &mut len,
+                )
+            };
+            if rc != GHOSTTY_SUCCESS {
+                anyhow::bail!("ghostty_mouse_encoder_encode retry failed: rc={rc}");
+            }
+            if len > overflow.len() {
+                anyhow::bail!("ghostty mouse encoder exceeded its requested output size");
+            }
+            &overflow[..len]
+        } else {
+            if rc != GHOSTTY_SUCCESS {
+                anyhow::bail!("ghostty_mouse_encoder_encode failed: rc={rc}");
+            }
+            if len > inline.len() {
+                anyhow::bail!("ghostty mouse encoder returned an invalid output size");
+            }
+            &inline[..len]
+        };
+
+        if bytes.is_empty() {
+            return Ok(VtMouseOutcome::default());
+        }
+
+        // Reserve this host-write position before releasing the mode snapshot.
+        // Parser-generated replies cannot then overtake the encoded event.
+        let write_guard = write_order.lock();
+        drop(inner);
+        let class = if event.action == VtMouseAction::Release {
+            PtyWriteClass::ReservedControl
+        } else {
+            PtyWriteClass::Regular
+        };
+        let result = write_pty(bytes, class);
+        if let Err(err) = &result
+            && class == PtyWriteClass::ReservedControl
+        {
+            mark_control_write_failed(&write_failed, err);
+        }
+        drop(write_guard);
+        result.map_err(|err| anyhow::anyhow!("failed to write encoded mouse event: {err}"))?;
+
+        Ok(VtMouseOutcome {
+            output_written: true,
+        })
     }
 
     /// Encode one platform key event against the terminal's current modes
@@ -5083,6 +5481,7 @@ impl Drop for VtScreen {
             // Free every object that can refer to the terminal before the
             // terminal itself.
             // SAFETY: unique owner via Arc::get_mut.
+            unsafe { inner.mouse.free() };
             if !inner.key_event.is_null() {
                 unsafe { ghostty_key_event_free(inner.key_event) };
                 inner.key_event = std::ptr::null_mut();
@@ -5216,6 +5615,16 @@ mod tests {
             Some(GhosttyTerminalData::ClipboardWriteMaxBytes as i64)
         );
         for (name, size, align) in [
+            (
+                "GhosttyMousePosition",
+                std::mem::size_of::<GhosttyMousePosition>(),
+                std::mem::align_of::<GhosttyMousePosition>(),
+            ),
+            (
+                "GhosttyMouseEncoderSize",
+                std::mem::size_of::<GhosttyMouseEncoderSize>(),
+                std::mem::align_of::<GhosttyMouseEncoderSize>(),
+            ),
             (
                 "GhosttyWriter",
                 std::mem::size_of::<GhosttyWriter>(),
@@ -5830,6 +6239,98 @@ mod tests {
             Some(ghostty_key_action(VtKeyAction::Repeat) as i64)
         );
 
+        for (name, action) in [
+            ("PRESS", GhosttyMouseAction::Press),
+            ("RELEASE", GhosttyMouseAction::Release),
+            ("MOTION", GhosttyMouseAction::Motion),
+        ] {
+            assert_eq!(
+                types["GhosttyMouseAction"]["values"][name].as_i64(),
+                Some(action as i64),
+                "GhosttyMouseAction::{name}"
+            );
+        }
+        for (name, button) in [
+            ("LEFT", GhosttyMouseButton::Left),
+            ("RIGHT", GhosttyMouseButton::Right),
+            ("MIDDLE", GhosttyMouseButton::Middle),
+            ("FOUR", GhosttyMouseButton::Four),
+            ("FIVE", GhosttyMouseButton::Five),
+            ("SIX", GhosttyMouseButton::Six),
+            ("SEVEN", GhosttyMouseButton::Seven),
+        ] {
+            assert_eq!(
+                types["GhosttyMouseButton"]["values"][name].as_i64(),
+                Some(button as i64),
+                "GhosttyMouseButton::{name}"
+            );
+        }
+        for (name, option) in [
+            ("SIZE", GhosttyMouseEncoderOption::Size),
+            (
+                "ANY_BUTTON_PRESSED",
+                GhosttyMouseEncoderOption::AnyButtonPressed,
+            ),
+            ("TRACK_LAST_CELL", GhosttyMouseEncoderOption::TrackLastCell),
+        ] {
+            assert_eq!(
+                types["GhosttyMouseEncoderOption"]["values"][name].as_i64(),
+                Some(option as i64),
+                "GhosttyMouseEncoderOption::{name}"
+            );
+        }
+        for (name, offset) in [
+            ("x", std::mem::offset_of!(GhosttyMousePosition, x)),
+            ("y", std::mem::offset_of!(GhosttyMousePosition, y)),
+        ] {
+            assert_eq!(
+                types["GhosttyMousePosition"]["fields"][name]["offset"].as_u64(),
+                Some(offset as u64),
+                "GhosttyMousePosition::{name} offset"
+            );
+        }
+        for (name, offset) in [
+            ("size", std::mem::offset_of!(GhosttyMouseEncoderSize, size)),
+            (
+                "screen_width",
+                std::mem::offset_of!(GhosttyMouseEncoderSize, screen_width),
+            ),
+            (
+                "screen_height",
+                std::mem::offset_of!(GhosttyMouseEncoderSize, screen_height),
+            ),
+            (
+                "cell_width",
+                std::mem::offset_of!(GhosttyMouseEncoderSize, cell_width),
+            ),
+            (
+                "cell_height",
+                std::mem::offset_of!(GhosttyMouseEncoderSize, cell_height),
+            ),
+            (
+                "padding_top",
+                std::mem::offset_of!(GhosttyMouseEncoderSize, padding_top),
+            ),
+            (
+                "padding_bottom",
+                std::mem::offset_of!(GhosttyMouseEncoderSize, padding_bottom),
+            ),
+            (
+                "padding_right",
+                std::mem::offset_of!(GhosttyMouseEncoderSize, padding_right),
+            ),
+            (
+                "padding_left",
+                std::mem::offset_of!(GhosttyMouseEncoderSize, padding_left),
+            ),
+        ] {
+            assert_eq!(
+                types["GhosttyMouseEncoderSize"]["fields"][name]["offset"].as_u64(),
+                Some(offset as u64),
+                "GhosttyMouseEncoderSize::{name} offset"
+            );
+        }
+
         let keys = &types["GhosttyKey"]["values"];
         for (name, key) in [
             ("UNIDENTIFIED", GhosttyKey::Unidentified),
@@ -6363,6 +6864,258 @@ mod tests {
         let second = screen.snapshot();
         assert_eq!(second.kitty_placements.len(), 1);
         assert!(Arc::ptr_eq(&pixels, &second.kitty_placements[0].image));
+    }
+
+    type MouseWrites = Arc<Mutex<Vec<(Vec<u8>, PtyWriteClass)>>>;
+
+    fn mouse_test_screen(cols: u16, rows: u16) -> (VtScreen, MouseWrites) {
+        let writes = Arc::new(Mutex::new(Vec::new()));
+        let callback_writes = writes.clone();
+        let screen = VtScreen::new_with_write_pty(
+            cols,
+            rows,
+            None,
+            Some(Arc::new(move |bytes, class| {
+                callback_writes.lock().push((bytes.to_vec(), class));
+                Ok(())
+            })),
+        )
+        .expect("create mouse test screen");
+        screen.set_mouse_geometry(u32::from(cols) * 10, u32::from(rows) * 20, 10, 20);
+        (screen, writes)
+    }
+
+    fn test_mouse_event(
+        action: VtMouseAction,
+        button: Option<VtMouseButton>,
+        x: f32,
+        y: f32,
+    ) -> VtMouseEvent {
+        VtMouseEvent {
+            action,
+            button,
+            modifiers: VtMouseModifiers::default(),
+            surface_x_px: x,
+            surface_y_px: y,
+        }
+    }
+
+    #[test]
+    fn mouse_encoder_emits_legacy_utf8_sgr_urxvt_and_pixel_formats() {
+        let cases = [
+            (
+                b"\x1b[?1000h".as_slice(),
+                test_mouse_event(VtMouseAction::Press, Some(VtMouseButton::Left), 15.0, 10.0),
+                b"\x1b[M \"!".as_slice(),
+                80,
+            ),
+            (
+                b"\x1b[?1000h\x1b[?1005h".as_slice(),
+                test_mouse_event(
+                    VtMouseAction::Press,
+                    Some(VtMouseButton::Left),
+                    2235.0,
+                    10.0,
+                ),
+                b"\x1b[M \xc4\x80!".as_slice(),
+                300,
+            ),
+            (
+                b"\x1b[?1000h\x1b[?1006h".as_slice(),
+                VtMouseEvent {
+                    modifiers: VtMouseModifiers {
+                        shift: true,
+                        control: true,
+                        alt: true,
+                    },
+                    ..test_mouse_event(
+                        VtMouseAction::Release,
+                        Some(VtMouseButton::Right),
+                        15.0,
+                        10.0,
+                    )
+                },
+                b"\x1b[<30;2;1m".as_slice(),
+                80,
+            ),
+            (
+                b"\x1b[?1000h\x1b[?1015h".as_slice(),
+                test_mouse_event(
+                    VtMouseAction::Release,
+                    Some(VtMouseButton::Right),
+                    15.0,
+                    10.0,
+                ),
+                b"\x1b[35;2;1M".as_slice(),
+                80,
+            ),
+            (
+                b"\x1b[?1000h\x1b[?1016h".as_slice(),
+                test_mouse_event(
+                    VtMouseAction::Press,
+                    Some(VtMouseButton::Left),
+                    15.25,
+                    10.75,
+                ),
+                b"\x1b[<0;15;11M".as_slice(),
+                80,
+            ),
+        ];
+
+        for (modes, event, expected, cols) in cases {
+            let (screen, writes) = mouse_test_screen(cols, 24);
+            screen.feed(modes);
+            let outcome = screen.send_mouse_event(event).expect("encode mouse event");
+            assert!(outcome.output_written, "modes={modes:?}");
+            let writes = writes.lock();
+            assert_eq!(writes.len(), 1, "modes={modes:?}");
+            assert_eq!(writes[0].0.as_slice(), expected, "modes={modes:?}");
+            assert_eq!(
+                writes[0].1,
+                if event.action == VtMouseAction::Release {
+                    PtyWriteClass::ReservedControl
+                } else {
+                    PtyWriteClass::Regular
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn mouse_encoder_maps_buttons_without_swapping_middle_and_right() {
+        let (screen, writes) = mouse_test_screen(80, 24);
+        screen.feed(b"\x1b[?1000h\x1b[?1006h");
+
+        for (button, code) in [
+            (VtMouseButton::Left, 0),
+            (VtMouseButton::Middle, 1),
+            (VtMouseButton::Right, 2),
+            (VtMouseButton::Button4, 64),
+            (VtMouseButton::Button5, 65),
+        ] {
+            assert!(
+                screen
+                    .send_mouse_event(test_mouse_event(
+                        VtMouseAction::Press,
+                        Some(button),
+                        5.0,
+                        5.0,
+                    ))
+                    .expect("encode button press")
+                    .output_written
+            );
+            assert_eq!(
+                writes
+                    .lock()
+                    .last()
+                    .expect("captured button press")
+                    .0
+                    .as_slice(),
+                format!("\x1b[<{code};1;1M").into_bytes()
+            );
+        }
+
+        screen
+            .send_mouse_event(test_mouse_event(
+                VtMouseAction::Release,
+                Some(VtMouseButton::Left),
+                5.0,
+                5.0,
+            ))
+            .expect("encode release");
+        assert_eq!(
+            writes.lock().last().expect("captured release").1,
+            PtyWriteClass::ReservedControl
+        );
+    }
+
+    #[test]
+    fn mouse_encoder_applies_x10_gating_and_effective_terminal_state() {
+        let (screen, writes) = mouse_test_screen(300, 24);
+        screen.feed(b"\x1b[?9h");
+        let event = VtMouseEvent {
+            modifiers: VtMouseModifiers {
+                shift: true,
+                control: true,
+                alt: true,
+            },
+            ..test_mouse_event(VtMouseAction::Press, Some(VtMouseButton::Left), 15.0, 10.0)
+        };
+        assert!(screen.send_mouse_event(event).unwrap().output_written);
+        assert_eq!(writes.lock()[0].0.as_slice(), b"\x1b[M \"!");
+
+        assert!(
+            !screen
+                .send_mouse_event(test_mouse_event(
+                    VtMouseAction::Release,
+                    Some(VtMouseButton::Left),
+                    15.0,
+                    10.0,
+                ))
+                .unwrap()
+                .output_written
+        );
+        assert!(
+            !screen
+                .send_mouse_event(test_mouse_event(
+                    VtMouseAction::Press,
+                    Some(VtMouseButton::Left),
+                    2235.0,
+                    10.0,
+                ))
+                .unwrap()
+                .output_written
+        );
+        assert_eq!(writes.lock().len(), 1);
+
+        // The public bitset route still sees 1002, but DECRST 1000 made the
+        // terminal's last-write-wins effective event mode `none`.
+        screen.feed(b"\x1b[?9l\x1b[?1000h\x1b[?1002h\x1b[?1000l");
+        assert!(screen.mouse_tracking_active());
+        assert!(
+            !screen
+                .send_mouse_event(test_mouse_event(
+                    VtMouseAction::Press,
+                    Some(VtMouseButton::Left),
+                    5.0,
+                    5.0,
+                ))
+                .unwrap()
+                .output_written
+        );
+        assert_eq!(writes.lock().len(), 1);
+    }
+
+    #[test]
+    fn mouse_encoder_deduplicates_motion_until_terminal_output_resynchronizes() {
+        let (screen, writes) = mouse_test_screen(80, 24);
+        screen.feed(b"\x1b[?1002h\x1b[?1006h");
+        let drag = test_mouse_event(VtMouseAction::Motion, Some(VtMouseButton::Left), 5.0, 5.0);
+
+        assert!(screen.send_mouse_event(drag).unwrap().output_written);
+        assert!(!screen.send_mouse_event(drag).unwrap().output_written);
+        screen.set_mouse_geometry(800, 480, 10, 20);
+        assert!(!screen.send_mouse_event(drag).unwrap().output_written);
+
+        // The pinned setopt_from_terminal implementation clears last-cell
+        // state on each feed, even when the parsed bytes do not change modes.
+        screen.feed(b"x");
+        assert!(screen.send_mouse_event(drag).unwrap().output_written);
+        assert_eq!(writes.lock().len(), 2);
+    }
+
+    #[test]
+    fn mouse_encoder_reports_no_button_motion_in_any_event_mode() {
+        let (screen, writes) = mouse_test_screen(80, 24);
+        screen.feed(b"\x1b[?1003h\x1b[?1006h");
+
+        assert!(
+            screen
+                .send_mouse_event(test_mouse_event(VtMouseAction::Motion, None, 5.0, 5.0))
+                .unwrap()
+                .output_written
+        );
+        assert_eq!(writes.lock()[0].0.as_slice(), b"\x1b[<35;1;1M");
     }
 
     #[test]

--- a/crates/con-ghostty/src/windows/ghostty_vt_stub.c
+++ b/crates/con-ghostty/src/windows/ghostty_vt_stub.c
@@ -23,6 +23,8 @@ typedef void* GhosttyRowIterator;
 typedef void* GhosttyRowCells;
 typedef void* GhosttyKeyEncoder;
 typedef void* GhosttyKeyEvent;
+typedef void* GhosttyMouseEncoder;
+typedef void* GhosttyMouseEvent;
 typedef void* GhosttySelectionGesture;
 typedef void* GhosttySelectionGestureEvent;
 typedef void* GhosttyKittyGraphics;
@@ -75,6 +77,11 @@ union GhosttyTerminalScrollViewportValue {
 struct GhosttyTerminalScrollViewport {
     int tag;
     union GhosttyTerminalScrollViewportValue value;
+};
+
+struct GhosttyMousePosition {
+    float x;
+    float y;
 };
 
 /* The stub has no real ABI manifest. Returning NULL keeps ordinary stub
@@ -373,6 +380,64 @@ void ghostty_key_event_set_unshifted_codepoint(
     GhosttyKeyEvent event, uint32_t codepoint
 ) {
     (void)event; (void)codepoint;
+}
+
+/* ── Mouse encoder ──────────────────────────────────────────────── */
+
+GhosttyResult ghostty_mouse_encoder_new(
+    const void* allocator, GhosttyMouseEncoder* out_encoder
+) {
+    (void)allocator;
+    if (out_encoder) { *out_encoder = (void*)(uintptr_t)10; }
+    return 0;
+}
+
+void ghostty_mouse_encoder_free(GhosttyMouseEncoder encoder) { (void)encoder; }
+
+void ghostty_mouse_encoder_setopt(
+    GhosttyMouseEncoder encoder, int option, const void* value
+) {
+    (void)encoder; (void)option; (void)value;
+}
+
+void ghostty_mouse_encoder_setopt_from_terminal(
+    GhosttyMouseEncoder encoder, GhosttyTerminal terminal
+) {
+    (void)encoder; (void)terminal;
+}
+
+GhosttyResult ghostty_mouse_encoder_encode(
+    GhosttyMouseEncoder encoder, GhosttyMouseEvent event,
+    char* out_buf, size_t out_buf_size, size_t* out_len
+) {
+    (void)encoder; (void)event; (void)out_buf; (void)out_buf_size;
+    if (out_len) { *out_len = 0; }
+    return 0;
+}
+
+GhosttyResult ghostty_mouse_event_new(
+    const void* allocator, GhosttyMouseEvent* out_event
+) {
+    (void)allocator;
+    if (out_event) { *out_event = (void*)(uintptr_t)11; }
+    return 0;
+}
+
+void ghostty_mouse_event_free(GhosttyMouseEvent event) { (void)event; }
+void ghostty_mouse_event_set_action(GhosttyMouseEvent event, int action) {
+    (void)event; (void)action;
+}
+void ghostty_mouse_event_set_button(GhosttyMouseEvent event, int button) {
+    (void)event; (void)button;
+}
+void ghostty_mouse_event_clear_button(GhosttyMouseEvent event) { (void)event; }
+void ghostty_mouse_event_set_mods(GhosttyMouseEvent event, uint16_t mods) {
+    (void)event; (void)mods;
+}
+void ghostty_mouse_event_set_position(
+    GhosttyMouseEvent event, struct GhosttyMousePosition position
+) {
+    (void)event; (void)position;
 }
 
 /* ── Cell accessor ──────────────────────────────────────────────── */

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -33,7 +33,8 @@ use super::profile::{perf_trace_enabled, perf_trace_verbose};
 use super::render::{RenderOutcome, Renderer, RendererConfig, ThemeColors};
 use super::vt::{
     SelectionAutoscroll, SelectionAutoscrollUpdate, SelectionGeometry, SelectionPoint, VtKeyEvent,
-    VtKeyOutcome, VtPasteResult, VtPasteSource, VtScreen,
+    VtKeyOutcome, VtMouseAction, VtMouseButton, VtMouseEvent, VtMouseModifiers, VtPasteResult,
+    VtPasteSource, VtScreen,
 };
 
 use super::render::CellMetrics;
@@ -112,9 +113,9 @@ impl ScrollRemainder {
 /// We don't import GPUI's `Modifiers` here because `con-ghostty` must
 /// stay independent of the UI crate on Windows. The view layer copies
 /// the three bits we care about (shift/alt/control) into this struct.
-/// `platform` (the Win key / cmd key) is not reported in SGR and not
-/// meaningful for xterm shift-bypass semantics, so it's deliberately
-/// omitted.
+/// `platform` (the Win key / cmd key) is not part of terminal mouse
+/// protocols or meaningful for xterm shift-bypass semantics, so it's
+/// deliberately omitted.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct MouseEventMods {
     pub shift: bool,
@@ -122,11 +123,21 @@ pub struct MouseEventMods {
     pub control: bool,
 }
 
+impl From<MouseEventMods> for VtMouseModifiers {
+    fn from(modifiers: MouseEventMods) -> Self {
+        Self {
+            shift: modifiers.shift,
+            control: modifiers.control,
+            alt: modifiers.alt,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum MouseDownRoute {
     Ignored,
     LocalSelection,
-    TerminalReport,
+    TerminalCapture,
 }
 
 impl RenderSession {
@@ -207,6 +218,12 @@ impl RenderSession {
         // indefinitely when the pane opens at its final dimensions.
         vt.resize(cols, rows, cell_width_px, cell_height_px)
             .context("initial VtScreen::resize failed")?;
+        vt.set_mouse_geometry(
+            renderer_config.initial_width,
+            renderer_config.initial_height,
+            cell_width_px,
+            cell_height_px,
+        );
         let transcript = Arc::new(Mutex::new(TranscriptBuffer::default()));
         if let Some(output) = initial_output
             .as_deref()
@@ -338,6 +355,8 @@ impl RenderSession {
         self.vt
             .resize(cols, rows, cell_width_px, cell_height_px)
             .context("VtScreen::resize failed")?;
+        self.vt
+            .set_mouse_geometry(width_px, height_px, cell_width_px, cell_height_px);
         self.conpty
             .resize(PtySize { cols, rows })
             .context("ConPty::resize failed")?;
@@ -435,21 +454,6 @@ impl RenderSession {
         self.vt.mouse_tracking_active()
     }
 
-    fn mouse_release_reporting_active(&self) -> bool {
-        mouse_release_reporting_active_for_modes(
-            self.vt.mode_active(crate::vt::MODE_NORMAL_MOUSE),
-            self.vt.mode_active(crate::vt::MODE_BUTTON_MOUSE),
-            self.vt.mode_active(crate::vt::MODE_ANY_MOUSE),
-        )
-    }
-
-    fn mouse_motion_reporting_active(&self) -> bool {
-        mouse_motion_reporting_active_for_modes(
-            self.vt.mode_active(crate::vt::MODE_BUTTON_MOUSE),
-            self.vt.mode_active(crate::vt::MODE_ANY_MOUSE),
-        )
-    }
-
     /// Send UTF-8 text to the child shell. Handles the ConPTY Enter
     /// quirk (shell expects CR, not LF).
     pub fn write_input(&self, text: &str) -> Result<()> {
@@ -493,21 +497,21 @@ impl RenderSession {
         self.request_low_latency_present();
     }
 
-    /// Mouse-down at the given cell.
+    /// Mouse-down at the given surface position.
     ///
     /// Xterm convention: Shift bypasses mouse tracking so the user can
     /// always select text, even when a TUI has `set mouse=a` on. When
     /// tracking is off or Shift is held, we drive local selection (left
     /// button only — non-left buttons never drive selection); otherwise
-    /// we emit an SGR button-press report and leave selection alone.
+    /// Ghostty encodes the press using the terminal's active mouse protocol.
     /// Shift+single-click with an existing selection extends from the original
     /// anchor; repeated clicks retain the platform's word/line behavior.
-    /// `button` follows the SGR button index (0=Left, 1=Middle, 2=Right). The
-    /// return value records the chosen route so the view can preserve it
-    /// through drag/release.
+    /// The return value records the chosen route so the view can preserve it
+    /// through drag/release. A captured event stays on the terminal route even
+    /// when the active protocol legitimately emits zero bytes.
     pub fn mouse_down(
         &self,
-        button: u8,
+        button: VtMouseButton,
         point: SelectionPoint,
         geometry: SelectionGeometry,
         mods: MouseEventMods,
@@ -515,14 +519,25 @@ impl RenderSession {
     ) -> MouseDownRoute {
         if self.vt.mouse_tracking_active() && !mods.shift {
             self.vt.selection_cancel_gesture();
-            self.request_low_latency_after_next_generation();
-            return if self.report_sgr_button(button, point.col, point.row, mods, true) {
-                MouseDownRoute::TerminalReport
-            } else {
-                MouseDownRoute::Ignored
+            return match self.send_terminal_mouse_event(
+                VtMouseAction::Press,
+                Some(button),
+                point,
+                mods,
+            ) {
+                Ok(output_written) => {
+                    if output_written {
+                        self.request_low_latency_after_next_generation();
+                    }
+                    MouseDownRoute::TerminalCapture
+                }
+                Err(err) => {
+                    log::debug!("windows terminal mouse press failed: {err:#}");
+                    MouseDownRoute::Ignored
+                }
             };
         }
-        if button != 0 {
+        if button != VtMouseButton::Left {
             // Non-left buttons never drive local selection; when tracking
             // is off the click is simply not consumed by the terminal.
             return MouseDownRoute::Ignored;
@@ -541,33 +556,28 @@ impl RenderSession {
         }
     }
 
-    /// Mouse-moved at the given cell while a button is held.
+    /// Mouse-moved at the given surface position while a button is held.
     ///
-    /// Emits an SGR motion-with-button report only when the shell
-    /// requested motion reporting (DECSET 1002 button-event or 1003
-    /// any-event); plain button-event tracking (1000) reports presses
-    /// and releases but no motion. `local_selection` preserves the route
-    /// chosen for the matching press, even if the child changes mouse modes
-    /// while the button remains held.
-    /// `button` follows the SGR button index (0=Left, 1=Middle,
-    /// 2=Right); the motion bit (+32) is added inside.
+    /// Ghostty applies the active mode's motion gate and same-cell deduplication.
+    /// `local_selection` preserves the route chosen for the matching press,
+    /// even if the child changes mouse modes while the button remains held.
     pub fn mouse_drag(
         &self,
-        button: u8,
+        button: VtMouseButton,
         point: SelectionPoint,
         geometry: SelectionGeometry,
         mods: MouseEventMods,
         local_selection: bool,
     ) -> SelectionAutoscroll {
         if !local_selection {
-            if self.mouse_motion_reporting_active() {
-                self.request_low_latency_after_next_generation();
-                // Button + 32 = motion-with-button bit per SGR spec.
-                self.report_sgr_button(button.saturating_add(32), point.col, point.row, mods, true);
+            match self.send_terminal_mouse_event(VtMouseAction::Motion, Some(button), point, mods) {
+                Ok(true) => self.request_low_latency_after_next_generation(),
+                Ok(false) => {}
+                Err(err) => log::debug!("windows terminal mouse drag failed: {err:#}"),
             }
             return SelectionAutoscroll::None;
         }
-        if button != 0 {
+        if button != VtMouseButton::Left {
             return SelectionAutoscroll::None;
         }
         self.request_low_latency_present();
@@ -584,13 +594,13 @@ impl RenderSession {
     /// Finish the route chosen for a pointer press.
     pub fn mouse_up(
         &self,
-        button: u8,
+        button: VtMouseButton,
         point: Option<SelectionPoint>,
         mods: MouseEventMods,
         local_selection: bool,
     ) -> bool {
         if local_selection {
-            if button != 0 {
+            if button != VtMouseButton::Left {
                 return false;
             }
             self.request_low_latency_present();
@@ -605,11 +615,18 @@ impl RenderSession {
         let Some(point) = point else {
             return false;
         };
-        if self.mouse_release_reporting_active() {
-            self.request_low_latency_after_next_generation();
-            return self.report_sgr_button(button, point.col, point.row, mods, false);
+        match self.send_terminal_mouse_event(VtMouseAction::Release, Some(button), point, mods) {
+            Ok(output_written) => {
+                if output_written {
+                    self.request_low_latency_after_next_generation();
+                }
+                output_written
+            }
+            Err(err) => {
+                log::debug!("windows terminal mouse release failed: {err:#}");
+                false
+            }
         }
-        false
     }
 
     pub fn selection_autoscroll_tick(
@@ -632,20 +649,42 @@ impl RenderSession {
         }
     }
 
-    fn report_sgr_button(
-        &self,
-        base_button: u8,
-        col: u16,
-        row: u16,
-        mods: MouseEventMods,
-        pressed: bool,
-    ) -> bool {
-        let seq = sgr_button_sequence(base_button, col, row, mods, pressed);
-        if pressed {
-            self.vt.write_input(seq.as_bytes()).is_ok()
-        } else {
-            self.vt.write_control(seq.as_bytes()).is_ok()
+    /// Report pointer motion with no button held. Ghostty emits this only for
+    /// DECSET 1003 and deduplicates cell formats internally.
+    pub fn mouse_hover(&self, point: SelectionPoint, mods: MouseEventMods) -> bool {
+        if !self.vt.mouse_tracking_active() {
+            return false;
         }
+        match self.send_terminal_mouse_event(VtMouseAction::Motion, None, point, mods) {
+            Ok(output_written) => {
+                if output_written {
+                    self.request_low_latency_after_next_generation();
+                }
+                output_written
+            }
+            Err(err) => {
+                log::debug!("windows terminal mouse hover failed: {err:#}");
+                false
+            }
+        }
+    }
+
+    fn send_terminal_mouse_event(
+        &self,
+        action: VtMouseAction,
+        button: Option<VtMouseButton>,
+        point: SelectionPoint,
+        mods: MouseEventMods,
+    ) -> Result<bool> {
+        self.vt
+            .send_mouse_event(VtMouseEvent {
+                action,
+                button,
+                modifiers: mods.into(),
+                surface_x_px: point.surface_x_px as f32,
+                surface_y_px: point.surface_y_px as f32,
+            })
+            .map(|outcome| outcome.output_written)
     }
 
     /// Cancel any in-flight drag (used on focus loss).
@@ -653,29 +692,21 @@ impl RenderSession {
         self.vt.selection_cancel_gesture();
     }
 
-    /// SGR mouse-wheel report. Only used when the shell has enabled
-    /// mouse tracking — see `mouse_tracking_active`. `col`/`row` are
-    /// 1-based cell coordinates per the SGR spec. Alt/Ctrl are encoded
-    /// into the button byte; Shift is handled upstream by the view,
-    /// which bypasses reporting entirely when Shift is held so the user
-    /// can scroll Con's own scrollback without the TUI seeing it.
-    pub fn forward_wheel(&self, col: u16, row: u16, delta_y: f32, mods: MouseEventMods) {
+    /// Mouse-wheel report using the terminal's active protocol. Shift bypass is
+    /// handled by the view so users can still scroll Con's own scrollback.
+    pub fn forward_wheel(&self, point: SelectionPoint, delta_y: f32, mods: MouseEventMods) {
         if delta_y.abs() < f32::EPSILON {
             return;
         }
-        self.request_low_latency_after_next_generation();
-        let mut button = sgr_wheel_button_for_delta(delta_y);
-        if mods.alt {
-            button |= 0x08;
-        }
-        if mods.control {
-            button |= 0x10;
-        }
-        let col = col.max(1);
-        let row = row.max(1);
-        let seq = format!("\x1b[<{button};{col};{row}M");
-        if let Err(err) = self.vt.write_input(seq.as_bytes()) {
-            log::debug!("windows terminal mouse wheel write failed: {err}");
+        let button = if delta_y > 0.0 {
+            VtMouseButton::Button4
+        } else {
+            VtMouseButton::Button5
+        };
+        match self.send_terminal_mouse_event(VtMouseAction::Press, Some(button), point, mods) {
+            Ok(true) => self.request_low_latency_after_next_generation(),
+            Ok(false) => {}
+            Err(err) => log::debug!("windows terminal mouse wheel failed: {err:#}"),
         }
     }
 
@@ -911,46 +942,6 @@ fn is_valid_shell_cwd(path: &Path) -> bool {
     path.is_absolute() && path.is_dir()
 }
 
-fn sgr_wheel_button_for_delta(delta_y: f32) -> u8 {
-    if delta_y > 0.0 { 64 } else { 65 }
-}
-
-/// Build an SGR (1006) mouse button report escape sequence for the
-/// given 0-based cell coordinates. Alt (0x08) and Ctrl (0x10) bits are
-/// folded into the button byte per the SGR spec; `pressed` selects the
-/// press (`M`) or release (`m`) terminator.
-fn sgr_button_sequence(
-    base_button: u8,
-    col: u16,
-    row: u16,
-    mods: MouseEventMods,
-    pressed: bool,
-) -> String {
-    let col = col.saturating_add(1);
-    let row = row.saturating_add(1);
-    let mut cb = base_button;
-    if mods.alt {
-        cb |= 0x08;
-    }
-    if mods.control {
-        cb |= 0x10;
-    }
-    let terminator = if pressed { 'M' } else { 'm' };
-    format!("\x1b[<{cb};{col};{row}{terminator}")
-}
-
-fn mouse_release_reporting_active_for_modes(
-    normal_tracking: bool,
-    button_tracking: bool,
-    any_tracking: bool,
-) -> bool {
-    normal_tracking || button_tracking || any_tracking
-}
-
-fn mouse_motion_reporting_active_for_modes(button_tracking: bool, any_tracking: bool) -> bool {
-    button_tracking || any_tracking
-}
-
 fn cursor_key_for_scroll_rows(rows: isize, decckm: bool) -> Option<&'static str> {
     match rows.cmp(&0) {
         std::cmp::Ordering::Greater => Some(if decckm { "\x1bOA" } else { "\x1b[A" }),
@@ -972,12 +963,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn sgr_wheel_delta_matches_gpui_scroll_direction() {
-        assert_eq!(sgr_wheel_button_for_delta(1.0), 64);
-        assert_eq!(sgr_wheel_button_for_delta(-1.0), 65);
-    }
-
-    #[test]
     fn alt_scroll_rows_match_cursor_direction() {
         assert_eq!(cursor_key_for_scroll_rows(2, false), Some("\x1b[A"));
         assert_eq!(cursor_key_for_scroll_rows(-2, false), Some("\x1b[B"));
@@ -991,49 +976,5 @@ mod tests {
         assert_eq!(viewport_delta_for_scroll_rows(3), -3);
         assert_eq!(viewport_delta_for_scroll_rows(-3), 3);
         assert_eq!(viewport_delta_for_scroll_rows(0), 0);
-    }
-
-    #[test]
-    fn sgr_right_button_press_and_release() {
-        let mods = MouseEventMods::default();
-        assert_eq!(sgr_button_sequence(2, 0, 0, mods, true), "\x1b[<2;1;1M");
-        assert_eq!(sgr_button_sequence(2, 5, 9, mods, false), "\x1b[<2;6;10m");
-    }
-
-    #[test]
-    fn sgr_button_sequence_folds_alt_and_ctrl_bits() {
-        let mods = MouseEventMods {
-            alt: true,
-            control: true,
-            shift: false,
-        };
-        // base 0 (left) | alt 0x08 | ctrl 0x10 = 0x18
-        assert_eq!(sgr_button_sequence(0, 3, 7, mods, true), "\x1b[<24;4;8M");
-    }
-
-    #[test]
-    fn sgr_drag_motion_uses_button_plus_32() {
-        // Right-button drag: 2 + 32 = 34.
-        let mods = MouseEventMods::default();
-        assert_eq!(sgr_button_sequence(34, 1, 2, mods, true), "\x1b[<34;2;3M");
-        // Left-button drag: 0 + 32 = 32.
-        assert_eq!(sgr_button_sequence(32, 1, 2, mods, true), "\x1b[<32;2;3M");
-    }
-
-    #[test]
-    fn release_reporting_excludes_x10_press_only_mode() {
-        assert!(!mouse_release_reporting_active_for_modes(
-            false, false, false
-        ));
-        assert!(mouse_release_reporting_active_for_modes(true, false, false));
-        assert!(mouse_release_reporting_active_for_modes(false, true, false));
-        assert!(mouse_release_reporting_active_for_modes(false, false, true));
-    }
-
-    #[test]
-    fn motion_reporting_requires_button_or_any_mode() {
-        assert!(!mouse_motion_reporting_active_for_modes(false, false));
-        assert!(mouse_motion_reporting_active_for_modes(true, false));
-        assert!(mouse_motion_reporting_active_for_modes(false, true));
     }
 }

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -419,17 +419,18 @@ impl RenderSession {
     /// `resize` to match the new physical dimensions.
     pub fn set_dpi(&self, dpi: u32) -> Result<()> {
         let new_dpi = dpi.max(1);
-        let prev = self.dpi.swap(new_dpi, Ordering::AcqRel);
+        let renderer = self.renderer.lock();
+        let prev = self.dpi.load(Ordering::Acquire);
         if prev == new_dpi {
             return Ok(());
         }
         let new_font = scale_font_size(self.base_font_size_px, new_dpi);
-        let renderer = self.renderer.lock();
         renderer
             .rebuild_atlas(new_font)
             .context("rebuild_atlas on DPI change failed")?;
         let mut config = self.config.lock();
         config.font_size_px = new_font;
+        self.dpi.store(new_dpi, Ordering::Release);
         log::info!("RenderSession::set_dpi {prev} -> {new_dpi} font_px={new_font:.2}");
         Ok(())
     }

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -223,7 +223,8 @@ impl RenderSession {
             renderer_config.initial_height,
             cell_width_px,
             cell_height_px,
-        );
+        )
+        .context("initial mouse geometry failed")?;
         let transcript = Arc::new(Mutex::new(TranscriptBuffer::default()));
         if let Some(output) = initial_output
             .as_deref()
@@ -356,7 +357,8 @@ impl RenderSession {
             .resize(cols, rows, cell_width_px, cell_height_px)
             .context("VtScreen::resize failed")?;
         self.vt
-            .set_mouse_geometry(width_px, height_px, cell_width_px, cell_height_px);
+            .set_mouse_geometry(width_px, height_px, cell_width_px, cell_height_px)
+            .context("mouse geometry resize failed")?;
         self.conpty
             .resize(PtySize { cols, rows })
             .context("ConPty::resize failed")?;

--- a/crates/con-ghostty/src/windows/render/atlas.rs
+++ b/crates/con-ghostty/src/windows/render/atlas.rs
@@ -834,9 +834,9 @@ impl GlyphCache {
     }
 
     pub fn rebuild(&mut self, font_size_px: f32) -> Result<()> {
-        // Build every fallible resource before replacing the live atlas
-        // state. A transient DirectWrite failure must leave the old formats,
-        // metrics, and cached glyphs usable so the caller can retry safely.
+        // Build every fallible DirectWrite resource before replacing the live
+        // atlas state. A transient format or metrics failure must leave the old
+        // state usable so the caller can retry safely.
         let text_format_regular = make_text_format(
             &self.dwrite,
             self.font_collection.as_ref(),

--- a/crates/con-ghostty/src/windows/render/atlas.rs
+++ b/crates/con-ghostty/src/windows/render/atlas.rs
@@ -834,10 +834,10 @@ impl GlyphCache {
     }
 
     pub fn rebuild(&mut self, font_size_px: f32) -> Result<()> {
-        self.font_size_px = font_size_px;
-        self.entries.clear();
-        self.allocator = AtlasAllocator::new(size2(self.atlas_size as i32, self.atlas_size as i32));
-        self.text_format_regular = make_text_format(
+        // Build every fallible resource before replacing the live atlas
+        // state. A transient DirectWrite failure must leave the old formats,
+        // metrics, and cached glyphs usable so the caller can retry safely.
+        let text_format_regular = make_text_format(
             &self.dwrite,
             self.font_collection.as_ref(),
             self.font_fallback.as_ref(),
@@ -846,7 +846,7 @@ impl GlyphCache {
             false,
             false,
         )?;
-        self.text_format_bold = make_text_format(
+        let text_format_bold = make_text_format(
             &self.dwrite,
             self.font_collection.as_ref(),
             self.font_fallback.as_ref(),
@@ -855,7 +855,7 @@ impl GlyphCache {
             true,
             false,
         )?;
-        self.text_format_italic = make_text_format(
+        let text_format_italic = make_text_format(
             &self.dwrite,
             self.font_collection.as_ref(),
             self.font_fallback.as_ref(),
@@ -864,7 +864,7 @@ impl GlyphCache {
             false,
             true,
         )?;
-        self.text_format_bold_italic = make_text_format(
+        let text_format_bold_italic = make_text_format(
             &self.dwrite,
             self.font_collection.as_ref(),
             self.font_fallback.as_ref(),
@@ -873,7 +873,7 @@ impl GlyphCache {
             true,
             true,
         )?;
-        self.text_format_cjk_regular = make_text_format_with_weight(
+        let text_format_cjk_regular = make_text_format_with_weight(
             &self.dwrite,
             self.font_collection.as_ref(),
             self.font_fallback.as_ref(),
@@ -882,7 +882,7 @@ impl GlyphCache {
             DWRITE_FONT_WEIGHT_MEDIUM,
             false,
         )?;
-        self.text_format_cjk_italic = make_text_format_with_weight(
+        let text_format_cjk_italic = make_text_format_with_weight(
             &self.dwrite,
             self.font_collection.as_ref(),
             self.font_fallback.as_ref(),
@@ -891,25 +891,25 @@ impl GlyphCache {
             DWRITE_FONT_WEIGHT_MEDIUM,
             true,
         )?;
-        self.metrics = measure_cell(
+        let metrics = measure_cell(
             &self.dwrite,
             self.font_collection.as_ref(),
             &self.font_family,
             font_size_px,
         )?;
-        self.layout_baselines = TextFormatBaselines::measure(
+        let layout_baselines = TextFormatBaselines::measure(
             &self.dwrite,
-            self.metrics.baseline_px as f32,
-            &self.text_format_regular,
-            &self.text_format_bold,
-            &self.text_format_italic,
-            &self.text_format_bold_italic,
+            metrics.baseline_px as f32,
+            &text_format_regular,
+            &text_format_bold,
+            &text_format_italic,
+            &text_format_bold_italic,
         );
         // Refresh the primary face + upm so per-glyph scale-to-fit
         // works after a font-size change (the face itself doesn't
         // depend on size, but re-resolving keeps the field in lockstep
         // with the current collection / family).
-        match resolve_font_face(
+        let (primary_face, primary_upm) = match resolve_font_face(
             &self.dwrite,
             self.font_collection.as_ref(),
             &self.font_family,
@@ -918,18 +918,31 @@ impl GlyphCache {
                 let mut fm = DWRITE_FONT_METRICS::default();
                 // SAFETY: windows-rs writes through the out pointer.
                 unsafe { face.GetMetrics(&mut fm) };
-                self.primary_upm = fm.designUnitsPerEm as f32;
-                self.primary_face = Some(face);
+                (Some(face), fm.designUnitsPerEm as f32)
             }
             Err(err) => {
                 log::warn!(
                     "GlyphCache::rebuild: primary face resolution failed ({err:?}); \
                      wide Nerd-Font icons will render clipped at the cell edge"
                 );
-                self.primary_face = None;
-                self.primary_upm = 1.0;
+                (None, 1.0)
             }
-        }
+        };
+
+        self.font_size_px = font_size_px;
+        self.entries.clear();
+        self.allocator = AtlasAllocator::new(size2(self.atlas_size as i32, self.atlas_size as i32));
+        self.text_format_regular = text_format_regular;
+        self.text_format_bold = text_format_bold;
+        self.text_format_italic = text_format_italic;
+        self.text_format_bold_italic = text_format_bold_italic;
+        self.text_format_cjk_regular = text_format_cjk_regular;
+        self.text_format_cjk_italic = text_format_cjk_italic;
+        self.metrics = metrics;
+        self.layout_baselines = layout_baselines;
+        self.primary_face = primary_face;
+        self.primary_upm = primary_upm;
+
         // Clear the atlas texture so fresh rasterization doesn't blend
         // with stale pixels from the previous size. BeginDraw/Clear/End
         // is a single D2D op — the DXGI-backed RT aliases the same

--- a/postmortem/2026-09-01-windows-mouse-protocol-encoding.md
+++ b/postmortem/2026-09-01-windows-mouse-protocol-encoding.md
@@ -38,9 +38,9 @@ gates instead of incorrectly falling back to local selection or scrolling.
   Ghostty revision, so geometry updates must be cached. PTY output still resets
   deduplication until Ghostty can preserve it when effective state is unchanged.
 - The current public tracking query exposes requested mode bits, not effective
-  flags. A conflicting DECSET/DECRST sequence can therefore consume one event
-  after effective reporting has stopped, but the encoder now prevents stale
-  bytes from reaching the child. An effective-state getter is the clean
-  upstream follow-up.
+  flags. A conflicting DECSET/DECRST sequence can therefore keep consuming
+  pointer input after effective reporting has stopped, but the encoder now
+  prevents stale bytes from reaching the child. An effective-state getter is
+  the clean upstream follow-up.
 - Linux still has a separate handwritten SGR path and should reuse the shared
   encoder in a follow-up change.

--- a/postmortem/2026-09-01-windows-mouse-protocol-encoding.md
+++ b/postmortem/2026-09-01-windows-mouse-protocol-encoding.md
@@ -1,0 +1,46 @@
+# Windows mouse reports ignored the terminal's active protocol
+
+## What happened
+
+The Windows backend formatted every captured mouse event as an SGR report.
+Applications using legacy X10, UTF-8, URXVT, or SGR-pixel reporting therefore
+received the wrong bytes. The view also omitted no-button motion in any-event
+mode and middle-button input, and repeated motion events were not deduplicated.
+
+## Root cause
+
+Con routed mouse input from libghostty-vt's DEC mode bitset but encoded the
+result independently in the Windows host. That duplicated only one part of
+Ghostty's mouse protocol state machine and bypassed the mouse encoder already
+exported by the pinned libghostty-vt ABI.
+
+## Fix applied
+
+The shared VT layer now owns a reusable Ghostty mouse encoder and event. It
+synchronizes effective tracking and format state after terminal output is
+parsed, updates physical geometry only when it changes, enables same-cell
+motion deduplication, and serializes encoded writes with key input and parser
+replies. Windows passes physical pointer positions and typed button identities
+through that path for presses, releases, drags, hover motion, and wheel input.
+The view now forwards middle-button sequences and any-event hover motion.
+
+Terminal-captured events remain consumed when the active protocol legitimately
+emits no bytes. This preserves X10 coordinate limits and Ghostty's other event
+gates instead of incorrectly falling back to local selection or scrolling.
+
+## What we learned
+
+- Protocol routing and encoding must use the same effective terminal state;
+  mode bits alone cannot reconstruct Ghostty's last-write-wins flags.
+- Mouse button identities need a typed boundary because Ghostty's ABI orders
+  right and middle differently from SGR button codes.
+- Encoder geometry and mode synchronization reset deduplication in the pinned
+  Ghostty revision, so geometry updates must be cached. PTY output still resets
+  deduplication until Ghostty can preserve it when effective state is unchanged.
+- The current public tracking query exposes requested mode bits, not effective
+  flags. A conflicting DECSET/DECRST sequence can therefore consume one event
+  after effective reporting has stopped, but the encoder now prevents stale
+  bytes from reaching the child. An effective-state getter is the clean
+  upstream follow-up.
+- Linux still has a separate handwritten SGR path and should reuse the shared
+  encoder in a follow-up change.


### PR DESCRIPTION
## Summary

- Replace the Windows backend's handwritten SGR mouse reports with the mouse encoder exported by the pinned libghostty-vt ABI.
- Support X10, UTF-8, SGR, URXVT, and SGR-pixel formats from the terminal's active mode. Forward physical coordinates, middle-button input, and no-button motion for mode 1003.
- Keep encoder state synchronized after VT parsing, cache geometry updates, enable same-cell motion deduplication, and preserve PTY write ordering.
- Retry failed DPI and resize synchronization safely, and log each continuous failure stage once instead of warning every prepaint.

## Why

Windows previously emitted SGR bytes for every captured mouse event, even when the child requested another protocol. That produced invalid input for applications using X10, UTF-8, URXVT, or pixel reporting. It also bypassed Ghostty's protocol gates, pressed-button state, and motion deduplication.

The pinned Ghostty revision already exports the complete mouse encoder ABI, so this change does not require a dependency bump.

## Tests

- Added coverage for protocol formats, tracking modes, button mapping, release write ordering, motion deduplication, effective-mode edge cases, out-of-viewport motion, and FFI layout.
- `CON_SKIP_GHOSTTY_VT=1 cargo check -p con-ghostty --tests --target aarch64-pc-windows-msvc`
- `cc -std=c11 -Wall -Wextra -Werror -fsyntax-only crates/con-ghostty/src/windows/ghostty_vt_stub.c`
- `rustfmt --edition 2024 --check` on the changed Rust files
- `git diff --check`

## Follow-ups

- The pinned Ghostty encoder resets motion deduplication whenever terminal output resynchronizes its options. Preserving deduplication across unchanged effective modes needs an upstream Ghostty change.
- Ghostty's public tracking query exposes requested mode bits rather than effective tracking flags. Conflicting DECSET and DECRST sequences can still cause Con to consume pointer input after reporting becomes inactive, although the encoder prevents stale bytes from reaching the child.
- Linux still has a separate handwritten SGR path and should reuse the shared VT encoder.
