### PR TITLE
fix(macos): validate OSC 8 hyperlinks before opening them

### DIFF
--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -167,6 +167,26 @@ struct BlockedOsc8Url {
     copy_control_id: SharedString,
 }
 
+/// Surface color for the OSC 8 hover and blocked cards.
+///
+/// The cards float over live terminal output (the Ghostty view sits below the
+/// GPUI layer), so a bare tint such as `warning.opacity(0.12)` lets the
+/// terminal text bleed straight through the card. Start from the same
+/// near-opaque popover base the find overlay uses and blend the warning tint
+/// onto it, so the card reads as an elevated surface rather than a color wash.
+fn osc8_card_surface(theme: &gpui_component::Theme, warning: bool) -> Hsla {
+    let base = theme.popover.opacity(0.96);
+    if warning {
+        base.blend(
+            theme
+                .warning
+                .opacity(if theme.is_dark() { 0.18 } else { 0.12 }),
+        )
+    } else {
+        base
+    }
+}
+
 /// Hover card for an OSC 8 link: icon, the canonical target, and a status word.
 ///
 /// The card is sized by flex layout from its children and never from a
@@ -188,15 +208,7 @@ fn osc8_link_preview_card(
     } else {
         theme.warning
     };
-    let surface = if preview.will_open {
-        theme
-            .background
-            .opacity(if theme.is_dark() { 0.92 } else { 0.96 })
-    } else {
-        theme
-            .warning
-            .opacity(if theme.is_dark() { 0.18 } else { 0.12 })
-    };
+    let surface = osc8_card_surface(theme, !preview.will_open);
     let status = if preview.will_open {
         "Opens"
     } else {
@@ -607,7 +619,7 @@ impl GhosttyView {
                         .gap(px(8.0))
                         .p(px(10.0))
                         .rounded(px(8.0))
-                        .bg(warning.opacity(if theme.is_dark() { 0.18 } else { 0.12 }))
+                        .bg(osc8_card_surface(theme, true))
                         .on_mouse_down(
                             gpui::MouseButton::Left,
                             cx.listener(|_this, _event, _window, cx| {

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -26,8 +26,8 @@ use std::time::{Duration, Instant};
 use con_ghostty::GhosttyScrollbar;
 use con_ghostty::ffi;
 use con_ghostty::{
-    GhosttyApp, GhosttyOpenUrlKind, GhosttySplitDirection, GhosttySurfaceEvent, GhosttyTerminal,
-    MouseButton, TerminalProgress,
+    GhosttyApp, GhosttySplitDirection, GhosttySurfaceEvent, GhosttyTerminal, MouseButton,
+    TerminalProgress,
 };
 use gpui::{prelude::FluentBuilder as _, *};
 use gpui_component::button::{Button, ButtonVariants as _};
@@ -78,7 +78,7 @@ static NATIVE_TRANSITION_UNDERLAY_ASSOCIATION_KEY: u8 = 0;
 #[cfg(target_os = "macos")]
 static NATIVE_TRANSITION_UNDERLAY_OWNERS_ASSOCIATION_KEY: u8 = 0;
 #[cfg(target_os = "macos")]
-static NEXT_NATIVE_TRANSITION_OWNER_ID: AtomicU64 = AtomicU64::new(1);
+static NEXT_GHOSTTY_VIEW_ID: AtomicU64 = AtomicU64::new(1);
 
 #[cfg(target_os = "macos")]
 #[derive(Debug, Clone, Copy)]
@@ -231,7 +231,7 @@ pub struct GhosttyView {
     #[cfg(target_os = "macos")]
     native_transition_underlay_visible: Cell<bool>,
     #[cfg(target_os = "macos")]
-    native_transition_underlay_owner_id: u64,
+    view_id: u64,
     left_mouse_sequence: MouseButtonSequence<i32>,
     right_mouse_sequence: MouseButtonSequence<i32>,
     /// Whether the most recent right-button press was consumed by libghostty.
@@ -305,8 +305,7 @@ impl GhosttyView {
             #[cfg(target_os = "macos")]
             native_transition_underlay_visible: Cell::new(false),
             #[cfg(target_os = "macos")]
-            native_transition_underlay_owner_id: NEXT_NATIVE_TRANSITION_OWNER_ID
-                .fetch_add(1, Ordering::Relaxed),
+            view_id: NEXT_GHOSTTY_VIEW_ID.fetch_add(1, Ordering::Relaxed),
             left_mouse_sequence: MouseButtonSequence::default(),
             right_mouse_sequence: MouseButtonSequence::default(),
             right_click_consumed: Rc::new(Cell::new(false)),
@@ -460,6 +459,7 @@ impl GhosttyView {
         if self.blocked_osc8_url.take().is_none() {
             return false;
         }
+        self.hovered_osc8_url = None;
         window.focus(&self.focus_handle, cx);
         cx.notify();
         true
@@ -594,7 +594,7 @@ impl GhosttyView {
                         .child(
                             div()
                                 .flex()
-                                .items_start()
+                                .items_center()
                                 .gap(px(8.0))
                                 .child(
                                     Icon::default()
@@ -606,23 +606,10 @@ impl GhosttyView {
                                     div()
                                         .min_w_0()
                                         .flex_1()
-                                        .flex()
-                                        .flex_col()
-                                        .gap(px(2.0))
-                                        .child(
-                                            div()
-                                                .text_size(px(12.0))
-                                                .font_weight(FontWeight::MEDIUM)
-                                                .text_color(theme.foreground)
-                                                .child("Terminal link blocked"),
-                                        )
-                                        .child(
-                                            div()
-                                                .text_size(px(11.0))
-                                                .line_height(px(15.0))
-                                                .text_color(theme.foreground.opacity(0.72))
-                                                .child(target.reason.message()),
-                                        ),
+                                        .text_size(px(11.0))
+                                        .line_height(px(15.0))
+                                        .text_color(theme.foreground.opacity(0.78))
+                                        .child(target.reason.message()),
                                 )
                                 .child(
                                     Button::new("dismiss-blocked-osc8-url")
@@ -643,27 +630,22 @@ impl GhosttyView {
                         .child(
                             div()
                                 .min_w_0()
-                                .truncate()
+                                .flex()
+                                .items_center()
+                                .gap(px(6.0))
                                 .px(px(8.0))
                                 .py(px(6.0))
                                 .rounded(px(6.0))
                                 .bg(theme.foreground.opacity(0.06))
-                                .font_family(theme.mono_font_family.clone())
-                                .text_size(px(11.0))
-                                .text_color(theme.foreground.opacity(0.84))
-                                .child(target.display.clone()),
-                        )
-                        .child(
-                            div()
-                                .flex()
-                                .items_center()
-                                .justify_between()
-                                .gap(px(8.0))
                                 .child(
                                     div()
-                                        .text_size(px(10.0))
-                                        .text_color(theme.muted_foreground)
-                                        .child("Copy the displayed target only if you trust it."),
+                                        .min_w_0()
+                                        .flex_1()
+                                        .truncate()
+                                        .font_family(theme.mono_font_family.clone())
+                                        .text_size(px(11.0))
+                                        .text_color(theme.foreground.opacity(0.84))
+                                        .child(target.display.clone()),
                                 )
                                 .child(
                                     Clipboard::new(target.copy_control_id.clone())
@@ -754,25 +736,20 @@ impl GhosttyView {
                 GhosttySurfaceEvent::SplitRequest(direction) => {
                     cx.emit(GhosttySplitRequested(direction));
                 }
-                GhosttySurfaceEvent::OpenUrl { kind, url } => {
-                    if kind != GhosttyOpenUrlKind::Osc8 {
-                        cx.open_url(String::from_utf8_lossy(&url).as_ref());
-                        continue;
+                GhosttySurfaceEvent::OpenUrl(url) => cx.open_url(&url),
+                GhosttySurfaceEvent::OpenOsc8Url(url) => match evaluate_osc8_url(&url) {
+                    Osc8UrlDecision::Allow(url) => cx.open_url(&url),
+                    Osc8UrlDecision::Deny { display, reason } => {
+                        let id = self.next_blocked_osc8_url_id;
+                        self.next_blocked_osc8_url_id = id.wrapping_add(1);
+                        self.blocked_osc8_url = Some(BlockedOsc8Url {
+                            display: display.into(),
+                            reason,
+                            copy_control_id: format!("blocked-osc8-url-copy-{}-{id}", self.view_id)
+                                .into(),
+                        });
                     }
-
-                    match evaluate_osc8_url(&url) {
-                        Osc8UrlDecision::Allow(url) => cx.open_url(&url),
-                        Osc8UrlDecision::Deny { display, reason } => {
-                            let id = self.next_blocked_osc8_url_id;
-                            self.next_blocked_osc8_url_id = id.wrapping_add(1);
-                            self.blocked_osc8_url = Some(BlockedOsc8Url {
-                                display: display.into(),
-                                reason,
-                                copy_control_id: format!("blocked-osc8-url-copy-{id}").into(),
-                            });
-                        }
-                    }
-                }
+                },
                 GhosttySurfaceEvent::Osc8LinkHoverChanged(url) => {
                     self.hovered_osc8_url = url.map(|url| match evaluate_osc8_url(&url) {
                         Osc8UrlDecision::Allow(url) => Osc8LinkPreview {
@@ -994,11 +971,7 @@ impl GhosttyView {
     #[cfg(target_os = "macos")]
     fn detach_host_view(&mut self) {
         if let Some(underlay_view) = self.native_underlay_view {
-            Self::set_transition_underlay_owner_visible(
-                underlay_view,
-                self.native_transition_underlay_owner_id,
-                false,
-            );
+            Self::set_transition_underlay_owner_visible(underlay_view, self.view_id, false);
         }
         self.native_underlay_view = None;
         if let Some(nsview) = self.nsview {
@@ -1473,7 +1446,7 @@ impl GhosttyView {
         if let Some(underlay_view) = self.native_underlay_view {
             Self::set_transition_underlay_owner_visible(
                 underlay_view,
-                self.native_transition_underlay_owner_id,
+                self.view_id,
                 self.native_transition_underlay_visible.get(),
             );
         }

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -41,7 +41,7 @@ use crate::terminal_paste::{
     TerminalPastePayload, payload_from_clipboard, payload_from_external_paths,
 };
 use crate::terminal_restore::key_down_may_write_terminal;
-use crate::terminal_url::{Osc8UrlDecision, Osc8UrlDenialReason, evaluate_osc8_url};
+use crate::terminal_url::{Osc8UrlDecision, Osc8UrlDenial, evaluate_osc8_url};
 
 // Actions owned by the embedded terminal view.
 actions!(ghostty, [ConsumeTab, ConsumeTabPrev]);
@@ -78,7 +78,7 @@ static NATIVE_TRANSITION_UNDERLAY_ASSOCIATION_KEY: u8 = 0;
 #[cfg(target_os = "macos")]
 static NATIVE_TRANSITION_UNDERLAY_OWNERS_ASSOCIATION_KEY: u8 = 0;
 #[cfg(target_os = "macos")]
-static NEXT_GHOSTTY_VIEW_ID: AtomicU64 = AtomicU64::new(1);
+static NEXT_NATIVE_TRANSITION_OWNER_ID: AtomicU64 = AtomicU64::new(1);
 
 #[cfg(target_os = "macos")]
 #[derive(Debug, Clone, Copy)]
@@ -153,19 +153,8 @@ struct ScrollbarDrag {
     grab_offset: f32,
 }
 
-/// Distance between the OSC 8 hover card and the pane edges.
-const OSC8_LINK_PREVIEW_INSET_PX: f32 = 10.0;
-
-struct Osc8LinkPreview {
-    display: SharedString,
-    will_open: bool,
-}
-
-struct BlockedOsc8Url {
-    display: SharedString,
-    reason: Osc8UrlDenialReason,
-    copy_control_id: SharedString,
-}
+/// Distance between the OSC 8 hover / blocked cards and the pane edges.
+const OSC8_CARD_INSET_PX: f32 = 10.0;
 
 /// Surface color for the OSC 8 hover and blocked cards.
 ///
@@ -199,21 +188,20 @@ fn osc8_card_surface(theme: &gpui_component::Theme, warning: bool) -> Hsla {
 /// (and truncates) once the whole card reaches `max_width`, because the icon
 /// and status are `flex_none`.
 fn osc8_link_preview_card(
-    preview: &Osc8LinkPreview,
+    decision: &Osc8UrlDecision,
     theme: &gpui_component::Theme,
     max_width: Pixels,
 ) -> Div {
-    let accent = if preview.will_open {
+    let (display, will_open) = match decision {
+        Osc8UrlDecision::Allow(url) => (url, true),
+        Osc8UrlDecision::Deny(denial) => (&denial.display, false),
+    };
+    let accent = if will_open {
         theme.foreground.opacity(0.72)
     } else {
         theme.warning
     };
-    let surface = osc8_card_surface(theme, !preview.will_open);
-    let status = if preview.will_open {
-        "Opens"
-    } else {
-        "Blocked"
-    };
+    let status = if will_open { "Opens" } else { "Blocked" };
 
     div()
         .debug_selector(|| "osc8-link-preview-card".into())
@@ -226,10 +214,10 @@ fn osc8_link_preview_card(
         .px(px(8.0))
         .py(px(5.0))
         .rounded(px(6.0))
-        .bg(surface)
+        .bg(osc8_card_surface(theme, !will_open))
         .child(
             Icon::default()
-                .path(if preview.will_open {
+                .path(if will_open {
                     "phosphor/link.svg"
                 } else {
                     "phosphor/shield-warning-fill.svg"
@@ -248,7 +236,7 @@ fn osc8_link_preview_card(
                 .font_family(theme.mono_font_family.clone())
                 .text_size(px(11.0))
                 .text_color(theme.foreground.opacity(0.86))
-                .child(preview.display.clone()),
+                .child(display.clone()),
         )
         .child(
             div()
@@ -316,11 +304,10 @@ pub struct GhosttyView {
     /// mouse-move event when the pointer is stationary.
     #[cfg(target_os = "macos")]
     last_mouse_position: Option<Point<Pixels>>,
-    /// Transient preview for the OSC 8 target currently under the pointer.
-    hovered_osc8_url: Option<Osc8LinkPreview>,
-    /// Persistent explanation for the last OSC 8 target denied on click.
-    blocked_osc8_url: Option<BlockedOsc8Url>,
-    next_blocked_osc8_url_id: u64,
+    /// Decision for the OSC 8 target under the pointer; shown while hovering.
+    hovered_osc8_url: Option<Osc8UrlDecision>,
+    /// The last OSC 8 target denied on click; shown until dismissed.
+    blocked_osc8_url: Option<Osc8UrlDenial>,
     #[cfg(target_os = "macos")]
     scrollbar_drag: Option<ScrollbarDrag>,
     #[cfg(target_os = "macos")]
@@ -328,7 +315,7 @@ pub struct GhosttyView {
     #[cfg(target_os = "macos")]
     native_transition_underlay_visible: Cell<bool>,
     #[cfg(target_os = "macos")]
-    view_id: u64,
+    native_transition_underlay_owner_id: u64,
     left_mouse_sequence: MouseButtonSequence<i32>,
     right_mouse_sequence: MouseButtonSequence<i32>,
     /// Whether the most recent right-button press was consumed by libghostty.
@@ -394,7 +381,6 @@ impl GhosttyView {
             last_mouse_position: None,
             hovered_osc8_url: None,
             blocked_osc8_url: None,
-            next_blocked_osc8_url_id: 0,
             #[cfg(target_os = "macos")]
             scrollbar_drag: None,
             #[cfg(target_os = "macos")]
@@ -402,7 +388,8 @@ impl GhosttyView {
             #[cfg(target_os = "macos")]
             native_transition_underlay_visible: Cell::new(false),
             #[cfg(target_os = "macos")]
-            view_id: NEXT_GHOSTTY_VIEW_ID.fetch_add(1, Ordering::Relaxed),
+            native_transition_underlay_owner_id: NEXT_NATIVE_TRANSITION_OWNER_ID
+                .fetch_add(1, Ordering::Relaxed),
             left_mouse_sequence: MouseButtonSequence::default(),
             right_mouse_sequence: MouseButtonSequence::default(),
             right_click_consumed: Rc::new(Cell::new(false)),
@@ -566,17 +553,17 @@ impl GhosttyView {
         if self.blocked_osc8_url.is_some() {
             return None;
         }
-        let preview = self.hovered_osc8_url.as_ref()?;
+        let decision = self.hovered_osc8_url.as_ref()?;
         let theme = cx.theme();
         let bounds = self.last_bounds?;
         let align_right = self
             .last_mouse_position
             .is_some_and(|mouse| mouse.x < bounds.origin.x + bounds.size.width / 2.0);
 
-        // The card may use the whole overlay width (pane minus the 10px side
+        // The card may use the whole overlay width (pane minus the side
         // insets): the target is security-relevant text, so prefer showing it
         // in full over truncating it to a fraction of the pane.
-        let inset = px(OSC8_LINK_PREVIEW_INSET_PX);
+        let inset = px(OSC8_CARD_INSET_PX);
         let max_width = (bounds.size.width - inset * 2.0).max(px(0.0));
 
         let mut overlay = div()
@@ -591,22 +578,24 @@ impl GhosttyView {
 
         Some(
             overlay
-                .child(osc8_link_preview_card(preview, theme, max_width))
+                .child(osc8_link_preview_card(decision, theme, max_width))
                 .into_any_element(),
         )
     }
 
     fn render_blocked_osc8_url(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
-        let target = self.blocked_osc8_url.as_ref()?;
+        let denial = self.blocked_osc8_url.as_ref()?;
         let theme = cx.theme();
         let warning = theme.warning;
+        let display: SharedString = denial.display.clone().into();
+        let inset = px(OSC8_CARD_INSET_PX);
 
         Some(
             div()
                 .absolute()
-                .left(px(12.0))
-                .right(px(12.0))
-                .bottom(px(12.0))
+                .left(inset)
+                .right(inset)
+                .bottom(inset)
                 .flex()
                 .justify_center()
                 .child(
@@ -656,7 +645,7 @@ impl GhosttyView {
                                         .text_size(px(11.0))
                                         .line_height(px(15.0))
                                         .text_color(theme.foreground.opacity(0.78))
-                                        .child(target.reason.message()),
+                                        .child(denial.reason.message()),
                                 )
                                 .child(
                                     Button::new("dismiss-blocked-osc8-url")
@@ -692,11 +681,14 @@ impl GhosttyView {
                                         .font_family(theme.mono_font_family.clone())
                                         .text_size(px(11.0))
                                         .text_color(theme.foreground.opacity(0.84))
-                                        .child(target.display.clone()),
+                                        .child(display.clone()),
                                 )
                                 .child(
-                                    Clipboard::new(target.copy_control_id.clone())
-                                        .value(target.display.clone())
+                                    // Keyed by the displayed text so the
+                                    // "copied" state cannot carry over to a
+                                    // different blocked target.
+                                    Clipboard::new(display.clone())
+                                        .value(display)
                                         .tooltip("Copy displayed target"),
                                 ),
                         ),
@@ -786,28 +778,10 @@ impl GhosttyView {
                 GhosttySurfaceEvent::OpenUrl(url) => cx.open_url(&url),
                 GhosttySurfaceEvent::OpenOsc8Url(url) => match evaluate_osc8_url(&url) {
                     Osc8UrlDecision::Allow(url) => cx.open_url(&url),
-                    Osc8UrlDecision::Deny { display, reason } => {
-                        let id = self.next_blocked_osc8_url_id;
-                        self.next_blocked_osc8_url_id = id.wrapping_add(1);
-                        self.blocked_osc8_url = Some(BlockedOsc8Url {
-                            display: display.into(),
-                            reason,
-                            copy_control_id: format!("blocked-osc8-url-copy-{}-{id}", self.view_id)
-                                .into(),
-                        });
-                    }
+                    Osc8UrlDecision::Deny(denial) => self.blocked_osc8_url = Some(denial),
                 },
                 GhosttySurfaceEvent::Osc8LinkHoverChanged(url) => {
-                    self.hovered_osc8_url = url.map(|url| match evaluate_osc8_url(&url) {
-                        Osc8UrlDecision::Allow(url) => Osc8LinkPreview {
-                            display: url.into(),
-                            will_open: true,
-                        },
-                        Osc8UrlDecision::Deny { display, .. } => Osc8LinkPreview {
-                            display: display.into(),
-                            will_open: false,
-                        },
-                    });
+                    self.hovered_osc8_url = url.map(|url| evaluate_osc8_url(&url));
                 }
                 GhosttySurfaceEvent::PwdChanged(cwd) => {
                     self.last_cwd = Some(cwd.clone());
@@ -1018,7 +992,11 @@ impl GhosttyView {
     #[cfg(target_os = "macos")]
     fn detach_host_view(&mut self) {
         if let Some(underlay_view) = self.native_underlay_view {
-            Self::set_transition_underlay_owner_visible(underlay_view, self.view_id, false);
+            Self::set_transition_underlay_owner_visible(
+                underlay_view,
+                self.native_transition_underlay_owner_id,
+                false,
+            );
         }
         self.native_underlay_view = None;
         if let Some(nsview) = self.nsview {
@@ -1493,7 +1471,7 @@ impl GhosttyView {
         if let Some(underlay_view) = self.native_underlay_view {
             Self::set_transition_underlay_owner_visible(
                 underlay_view,
-                self.view_id,
+                self.native_transition_underlay_owner_id,
                 self.native_transition_underlay_visible.get(),
             );
         }
@@ -2816,7 +2794,7 @@ impl Render for GhosttyView {
 #[cfg(test)]
 mod tests {
     use super::{
-        Osc8LinkPreview, gpui_consumed_mods_to_ghostty, osc8_link_preview_card,
+        Osc8UrlDecision, gpui_consumed_mods_to_ghostty, osc8_link_preview_card,
         should_send_ime_insert_as_key_event,
     };
     use con_ghostty::ffi;
@@ -2859,12 +2837,9 @@ mod tests {
                     )
                     .width(),
             );
-            let preview = Osc8LinkPreview {
-                display: self.display.clone(),
-                will_open: true,
-            };
+            let decision = Osc8UrlDecision::Allow(self.display.to_string());
             div().w(px(1_000.0)).flex().child(osc8_link_preview_card(
-                &preview,
+                &decision,
                 &theme,
                 self.max_width,
             ))

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -153,6 +153,9 @@ struct ScrollbarDrag {
     grab_offset: f32,
 }
 
+/// Distance between the OSC 8 hover card and the pane edges.
+const OSC8_LINK_PREVIEW_INSET_PX: f32 = 10.0;
+
 struct Osc8LinkPreview {
     display: SharedString,
     will_open: bool,
@@ -162,6 +165,88 @@ struct BlockedOsc8Url {
     display: SharedString,
     reason: Osc8UrlDenialReason,
     copy_control_id: SharedString,
+}
+
+/// Hover card for an OSC 8 link: icon, the canonical target, and a status word.
+///
+/// The card is sized by flex layout from its children and never from a
+/// hand-measured text width. GPUI rounds every text element's measured width
+/// up to a whole pixel (`TextLayout::layout` → `.ceil()`), so any fixed width
+/// derived from unrounded shaping is short by up to 1px per text child, and
+/// `truncate()` turns even a 0.2px deficit into a dropped character plus an
+/// ellipsis. Letting the target keep its own content width as its flex basis
+/// guarantees it receives at least the width it measured; it only shrinks
+/// (and truncates) once the whole card reaches `max_width`, because the icon
+/// and status are `flex_none`.
+fn osc8_link_preview_card(
+    preview: &Osc8LinkPreview,
+    theme: &gpui_component::Theme,
+    max_width: Pixels,
+) -> Div {
+    let accent = if preview.will_open {
+        theme.foreground.opacity(0.72)
+    } else {
+        theme.warning
+    };
+    let surface = if preview.will_open {
+        theme
+            .background
+            .opacity(if theme.is_dark() { 0.92 } else { 0.96 })
+    } else {
+        theme
+            .warning
+            .opacity(if theme.is_dark() { 0.18 } else { 0.12 })
+    };
+    let status = if preview.will_open {
+        "Opens"
+    } else {
+        "Blocked"
+    };
+
+    div()
+        .debug_selector(|| "osc8-link-preview-card".into())
+        .max_w(max_width)
+        .min_w_0()
+        .flex()
+        .flex_none()
+        .items_center()
+        .gap(px(6.0))
+        .px(px(8.0))
+        .py(px(5.0))
+        .rounded(px(6.0))
+        .bg(surface)
+        .child(
+            Icon::default()
+                .path(if preview.will_open {
+                    "phosphor/link.svg"
+                } else {
+                    "phosphor/shield-warning-fill.svg"
+                })
+                .size(px(12.0))
+                .text_color(accent),
+        )
+        .child(
+            // No `flex_1` here: a zero flex basis would make this child absorb
+            // every sub-pixel rounding difference in the row. With the default
+            // `flex: 0 1 auto` its basis is its own (ceil-rounded) text width.
+            div()
+                .debug_selector(|| "osc8-link-preview-target".into())
+                .min_w_0()
+                .truncate()
+                .font_family(theme.mono_font_family.clone())
+                .text_size(px(11.0))
+                .text_color(theme.foreground.opacity(0.86))
+                .child(preview.display.clone()),
+        )
+        .child(
+            div()
+                .debug_selector(|| "osc8-link-preview-status".into())
+                .flex_none()
+                .text_size(px(10.0))
+                .font_weight(FontWeight::MEDIUM)
+                .text_color(accent)
+                .child(status),
+        )
 }
 
 /// GPUI view wrapping a ghostty terminal surface.
@@ -471,30 +556,22 @@ impl GhosttyView {
         }
         let preview = self.hovered_osc8_url.as_ref()?;
         let theme = cx.theme();
-        let accent = if preview.will_open {
-            theme.foreground.opacity(0.72)
-        } else {
-            theme.warning
-        };
-        let surface = if preview.will_open {
-            theme
-                .background
-                .opacity(if theme.is_dark() { 0.92 } else { 0.96 })
-        } else {
-            theme
-                .warning
-                .opacity(if theme.is_dark() { 0.18 } else { 0.12 })
-        };
+        let bounds = self.last_bounds?;
         let align_right = self
-            .last_bounds
-            .zip(self.last_mouse_position)
-            .is_some_and(|(bounds, mouse)| mouse.x < bounds.origin.x + bounds.size.width / 2.0);
+            .last_mouse_position
+            .is_some_and(|mouse| mouse.x < bounds.origin.x + bounds.size.width / 2.0);
+
+        // The card may use the whole overlay width (pane minus the 10px side
+        // insets): the target is security-relevant text, so prefer showing it
+        // in full over truncating it to a fraction of the pane.
+        let inset = px(OSC8_LINK_PREVIEW_INSET_PX);
+        let max_width = (bounds.size.width - inset * 2.0).max(px(0.0));
 
         let mut overlay = div()
             .absolute()
-            .left(px(10.0))
-            .right(px(10.0))
-            .bottom(px(10.0))
+            .left(inset)
+            .right(inset)
+            .bottom(inset)
             .flex();
         if align_right {
             overlay = overlay.justify_end();
@@ -502,49 +579,7 @@ impl GhosttyView {
 
         Some(
             overlay
-                .child(
-                    div()
-                        .max_w(relative(0.72))
-                        .min_w_0()
-                        .flex()
-                        .items_center()
-                        .gap(px(6.0))
-                        .px(px(8.0))
-                        .py(px(5.0))
-                        .rounded(px(6.0))
-                        .bg(surface)
-                        .child(
-                            Icon::default()
-                                .path(if preview.will_open {
-                                    "phosphor/link.svg"
-                                } else {
-                                    "phosphor/shield-warning-fill.svg"
-                                })
-                                .xsmall()
-                                .text_color(accent),
-                        )
-                        .child(
-                            div()
-                                .min_w_0()
-                                .truncate()
-                                .font_family(theme.mono_font_family.clone())
-                                .text_size(px(11.0))
-                                .text_color(theme.foreground.opacity(0.86))
-                                .child(preview.display.clone()),
-                        )
-                        .child(
-                            div()
-                                .flex_none()
-                                .text_size(px(10.0))
-                                .font_weight(FontWeight::MEDIUM)
-                                .text_color(accent)
-                                .child(if preview.will_open {
-                                    "Opens"
-                                } else {
-                                    "Blocked"
-                                }),
-                        ),
-                )
+                .child(osc8_link_preview_card(preview, theme, max_width))
                 .into_any_element(),
         )
     }
@@ -2768,9 +2803,138 @@ impl Render for GhosttyView {
 
 #[cfg(test)]
 mod tests {
-    use super::{gpui_consumed_mods_to_ghostty, should_send_ime_insert_as_key_event};
+    use super::{
+        Osc8LinkPreview, gpui_consumed_mods_to_ghostty, osc8_link_preview_card,
+        should_send_ime_insert_as_key_event,
+    };
     use con_ghostty::ffi;
-    use gpui::Modifiers;
+    use gpui::{
+        Modifiers, Pixels, Render, SharedString, TextRun, Window, div, font, prelude::*, px,
+    };
+    use gpui_component::Theme;
+
+    /// Renders the hover card inside a flex row, like the real overlay does.
+    /// (A block parent would stretch the card to the parent width and hide
+    /// content-sizing bugs.) Records the shaped width of the target text with
+    /// the same font and size the card uses so tests can check the contract
+    /// "the target element is at least as wide as its text".
+    struct Osc8LinkPreviewLayoutTestView {
+        display: SharedString,
+        max_width: Pixels,
+        shaped_target_width: Option<Pixels>,
+    }
+
+    impl Render for Osc8LinkPreviewLayoutTestView {
+        fn render(
+            &mut self,
+            window: &mut Window,
+            _cx: &mut gpui::Context<Self>,
+        ) -> impl IntoElement {
+            let theme = Theme::default();
+            self.shaped_target_width = Some(
+                window
+                    .text_system()
+                    .shape_line(
+                        self.display.clone(),
+                        px(11.0),
+                        &[TextRun {
+                            len: self.display.len(),
+                            font: font(theme.mono_font_family.clone()),
+                            color: theme.foreground,
+                            ..TextRun::default()
+                        }],
+                        None,
+                    )
+                    .width(),
+            );
+            let preview = Osc8LinkPreview {
+                display: self.display.clone(),
+                will_open: true,
+            };
+            div().w(px(1_000.0)).flex().child(osc8_link_preview_card(
+                &preview,
+                &theme,
+                self.max_width,
+            ))
+        }
+    }
+
+    #[gpui::test]
+    fn osc8_link_preview_keeps_target_visible_without_filling_the_pane(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let (view, cx) = cx.add_window_view(|_window, _cx| Osc8LinkPreviewLayoutTestView {
+            display: "https://example.com/osc8".into(),
+            max_width: px(720.0),
+            shaped_target_width: None,
+        });
+        let card = cx
+            .debug_bounds("osc8-link-preview-card")
+            .expect("preview card bounds");
+        let target = cx
+            .debug_bounds("osc8-link-preview-target")
+            .expect("preview target bounds");
+        let status = cx
+            .debug_bounds("osc8-link-preview-status")
+            .expect("preview status bounds");
+        let shaped = view
+            .read_with(cx, |view, _| view.shaped_target_width)
+            .expect("target text was shaped during render");
+
+        // `should_truncate_line` ellipsizes as soon as the element is narrower
+        // than the text, so this is the "no ellipsis for a short link" contract.
+        // Note: the test text system uses fixed integer glyph advances, so this
+        // cannot reproduce the real-font sub-pixel case; the runtime check for
+        // that lives in the commit message of the fix.
+        assert!(
+            target.size.width >= shaped,
+            "preview target narrower than its text (would ellipsize): target={target:?} shaped={shaped:?}"
+        );
+        assert!(
+            card.size.width < px(400.0),
+            "short preview filled most of the pane: {card:?}"
+        );
+        let gap: f32 = (status.left() - target.right()).into();
+        assert!(
+            gap <= 8.0,
+            "preview target and status are separated by an empty gap: target={target:?} status={status:?}"
+        );
+    }
+
+    #[gpui::test]
+    fn osc8_link_preview_caps_long_targets_without_clipping_status(cx: &mut gpui::TestAppContext) {
+        let (_view, cx) = cx.add_window_view(|_window, _cx| Osc8LinkPreviewLayoutTestView {
+            display: format!("https://example.com/{}", "a".repeat(300)).into(),
+            max_width: px(320.0),
+            shaped_target_width: None,
+        });
+        let card = cx
+            .debug_bounds("osc8-link-preview-card")
+            .expect("preview card bounds");
+        let target = cx
+            .debug_bounds("osc8-link-preview-target")
+            .expect("preview target bounds");
+        let status = cx
+            .debug_bounds("osc8-link-preview-status")
+            .expect("preview status bounds");
+
+        assert!(
+            card.size.width <= px(320.0),
+            "long preview exceeded its width cap: {card:?}"
+        );
+        assert!(
+            card.size.width > px(300.0),
+            "long preview did not use the available width: {card:?}"
+        );
+        assert!(
+            target.size.width > px(200.0),
+            "long target did not retain useful preview space: {target:?}"
+        );
+        assert!(
+            status.right() <= card.right(),
+            "preview status was clipped by the width cap: card={card:?} status={status:?}"
+        );
+    }
 
     #[test]
     fn direct_ascii_ime_commits_use_key_event_path() {

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -26,12 +26,14 @@ use std::time::{Duration, Instant};
 use con_ghostty::GhosttyScrollbar;
 use con_ghostty::ffi;
 use con_ghostty::{
-    GhosttyApp, GhosttySplitDirection, GhosttySurfaceEvent, GhosttyTerminal, MouseButton,
-    TerminalProgress,
+    GhosttyApp, GhosttyOpenUrlKind, GhosttySplitDirection, GhosttySurfaceEvent, GhosttyTerminal,
+    MouseButton, TerminalProgress,
 };
 use gpui::{prelude::FluentBuilder as _, *};
-use gpui_component::ActiveTheme;
+use gpui_component::button::{Button, ButtonVariants as _};
+use gpui_component::clipboard::Clipboard;
 use gpui_component::menu::ContextMenuExt;
+use gpui_component::{ActiveTheme, Icon, Sizable as _};
 
 use crate::mouse_sequence::MouseButtonSequence;
 use crate::terminal_find::{TerminalFind, TerminalFindDismissed};
@@ -39,6 +41,7 @@ use crate::terminal_paste::{
     TerminalPastePayload, payload_from_clipboard, payload_from_external_paths,
 };
 use crate::terminal_restore::key_down_may_write_terminal;
+use crate::terminal_url::{Osc8UrlDecision, Osc8UrlDenialReason, evaluate_osc8_url};
 
 // Actions owned by the embedded terminal view.
 actions!(ghostty, [ConsumeTab, ConsumeTabPrev]);
@@ -150,6 +153,17 @@ struct ScrollbarDrag {
     grab_offset: f32,
 }
 
+struct Osc8LinkPreview {
+    display: SharedString,
+    will_open: bool,
+}
+
+struct BlockedOsc8Url {
+    display: SharedString,
+    reason: Osc8UrlDenialReason,
+    copy_control_id: SharedString,
+}
+
 /// GPUI view wrapping a ghostty terminal surface.
 pub struct GhosttyView {
     app: Arc<GhosttyApp>,
@@ -205,6 +219,11 @@ pub struct GhosttyView {
     /// mouse-move event when the pointer is stationary.
     #[cfg(target_os = "macos")]
     last_mouse_position: Option<Point<Pixels>>,
+    /// Transient preview for the OSC 8 target currently under the pointer.
+    hovered_osc8_url: Option<Osc8LinkPreview>,
+    /// Persistent explanation for the last OSC 8 target denied on click.
+    blocked_osc8_url: Option<BlockedOsc8Url>,
+    next_blocked_osc8_url_id: u64,
     #[cfg(target_os = "macos")]
     scrollbar_drag: Option<ScrollbarDrag>,
     #[cfg(target_os = "macos")]
@@ -276,6 +295,9 @@ impl GhosttyView {
             next_surface_init_retry_at: None,
             #[cfg(target_os = "macos")]
             last_mouse_position: None,
+            hovered_osc8_url: None,
+            blocked_osc8_url: None,
+            next_blocked_osc8_url_id: 0,
             #[cfg(target_os = "macos")]
             scrollbar_drag: None,
             #[cfg(target_os = "macos")]
@@ -434,6 +456,226 @@ impl GhosttyView {
         )
     }
 
+    fn dismiss_blocked_osc8_url(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
+        if self.blocked_osc8_url.take().is_none() {
+            return false;
+        }
+        window.focus(&self.focus_handle, cx);
+        cx.notify();
+        true
+    }
+
+    fn render_osc8_link_preview(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
+        if self.blocked_osc8_url.is_some() {
+            return None;
+        }
+        let preview = self.hovered_osc8_url.as_ref()?;
+        let theme = cx.theme();
+        let accent = if preview.will_open {
+            theme.foreground.opacity(0.72)
+        } else {
+            theme.warning
+        };
+        let surface = if preview.will_open {
+            theme
+                .background
+                .opacity(if theme.is_dark() { 0.92 } else { 0.96 })
+        } else {
+            theme
+                .warning
+                .opacity(if theme.is_dark() { 0.18 } else { 0.12 })
+        };
+        let align_right = self
+            .last_bounds
+            .zip(self.last_mouse_position)
+            .is_some_and(|(bounds, mouse)| mouse.x < bounds.origin.x + bounds.size.width / 2.0);
+
+        let mut overlay = div()
+            .absolute()
+            .left(px(10.0))
+            .right(px(10.0))
+            .bottom(px(10.0))
+            .flex();
+        if align_right {
+            overlay = overlay.justify_end();
+        }
+
+        Some(
+            overlay
+                .child(
+                    div()
+                        .max_w(relative(0.72))
+                        .min_w_0()
+                        .flex()
+                        .items_center()
+                        .gap(px(6.0))
+                        .px(px(8.0))
+                        .py(px(5.0))
+                        .rounded(px(6.0))
+                        .bg(surface)
+                        .child(
+                            Icon::default()
+                                .path(if preview.will_open {
+                                    "phosphor/link.svg"
+                                } else {
+                                    "phosphor/shield-warning-fill.svg"
+                                })
+                                .xsmall()
+                                .text_color(accent),
+                        )
+                        .child(
+                            div()
+                                .min_w_0()
+                                .truncate()
+                                .font_family(theme.mono_font_family.clone())
+                                .text_size(px(11.0))
+                                .text_color(theme.foreground.opacity(0.86))
+                                .child(preview.display.clone()),
+                        )
+                        .child(
+                            div()
+                                .flex_none()
+                                .text_size(px(10.0))
+                                .font_weight(FontWeight::MEDIUM)
+                                .text_color(accent)
+                                .child(if preview.will_open {
+                                    "Opens"
+                                } else {
+                                    "Blocked"
+                                }),
+                        ),
+                )
+                .into_any_element(),
+        )
+    }
+
+    fn render_blocked_osc8_url(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
+        let target = self.blocked_osc8_url.as_ref()?;
+        let theme = cx.theme();
+        let warning = theme.warning;
+
+        Some(
+            div()
+                .absolute()
+                .left(px(12.0))
+                .right(px(12.0))
+                .bottom(px(12.0))
+                .flex()
+                .justify_center()
+                .child(
+                    div()
+                        .occlude()
+                        .w_full()
+                        .max_w(px(620.0))
+                        .flex()
+                        .flex_col()
+                        .gap(px(8.0))
+                        .p(px(10.0))
+                        .rounded(px(8.0))
+                        .bg(warning.opacity(if theme.is_dark() { 0.18 } else { 0.12 }))
+                        .on_mouse_down(
+                            gpui::MouseButton::Left,
+                            cx.listener(|_this, _event, _window, cx| {
+                                cx.stop_propagation();
+                            }),
+                        )
+                        .on_mouse_down(
+                            gpui::MouseButton::Right,
+                            cx.listener(|_this, _event, _window, cx| {
+                                cx.stop_propagation();
+                            }),
+                        )
+                        .on_mouse_move(cx.listener(|_this, _event, _window, cx| {
+                            cx.stop_propagation();
+                        }))
+                        .on_scroll_wheel(cx.listener(|_this, _event, _window, cx| {
+                            cx.stop_propagation();
+                        }))
+                        .child(
+                            div()
+                                .flex()
+                                .items_start()
+                                .gap(px(8.0))
+                                .child(
+                                    Icon::default()
+                                        .path("phosphor/shield-warning-fill.svg")
+                                        .small()
+                                        .text_color(warning),
+                                )
+                                .child(
+                                    div()
+                                        .min_w_0()
+                                        .flex_1()
+                                        .flex()
+                                        .flex_col()
+                                        .gap(px(2.0))
+                                        .child(
+                                            div()
+                                                .text_size(px(12.0))
+                                                .font_weight(FontWeight::MEDIUM)
+                                                .text_color(theme.foreground)
+                                                .child("Terminal link blocked"),
+                                        )
+                                        .child(
+                                            div()
+                                                .text_size(px(11.0))
+                                                .line_height(px(15.0))
+                                                .text_color(theme.foreground.opacity(0.72))
+                                                .child(target.reason.message()),
+                                        ),
+                                )
+                                .child(
+                                    Button::new("dismiss-blocked-osc8-url")
+                                        .icon(
+                                            Icon::default()
+                                                .path("phosphor/x.svg")
+                                                .text_color(theme.muted_foreground),
+                                        )
+                                        .ghost()
+                                        .xsmall()
+                                        .tooltip("Dismiss")
+                                        .on_click(cx.listener(|this, _event, window, cx| {
+                                            cx.stop_propagation();
+                                            this.dismiss_blocked_osc8_url(window, cx);
+                                        })),
+                                ),
+                        )
+                        .child(
+                            div()
+                                .min_w_0()
+                                .truncate()
+                                .px(px(8.0))
+                                .py(px(6.0))
+                                .rounded(px(6.0))
+                                .bg(theme.foreground.opacity(0.06))
+                                .font_family(theme.mono_font_family.clone())
+                                .text_size(px(11.0))
+                                .text_color(theme.foreground.opacity(0.84))
+                                .child(target.display.clone()),
+                        )
+                        .child(
+                            div()
+                                .flex()
+                                .items_center()
+                                .justify_between()
+                                .gap(px(8.0))
+                                .child(
+                                    div()
+                                        .text_size(px(10.0))
+                                        .text_color(theme.muted_foreground)
+                                        .child("Copy the displayed target only if you trust it."),
+                                )
+                                .child(
+                                    Clipboard::new(target.copy_control_id.clone())
+                                        .value(target.display.clone())
+                                        .tooltip("Copy displayed target"),
+                                ),
+                        ),
+                )
+                .into_any_element(),
+        )
+    }
+
     pub(crate) fn show_terminal_find(
         &mut self,
         needle: String,
@@ -512,8 +754,36 @@ impl GhosttyView {
                 GhosttySurfaceEvent::SplitRequest(direction) => {
                     cx.emit(GhosttySplitRequested(direction));
                 }
-                GhosttySurfaceEvent::OpenUrl(url) => {
-                    cx.open_url(&url);
+                GhosttySurfaceEvent::OpenUrl { kind, url } => {
+                    if kind != GhosttyOpenUrlKind::Osc8 {
+                        cx.open_url(String::from_utf8_lossy(&url).as_ref());
+                        continue;
+                    }
+
+                    match evaluate_osc8_url(&url) {
+                        Osc8UrlDecision::Allow(url) => cx.open_url(&url),
+                        Osc8UrlDecision::Deny { display, reason } => {
+                            let id = self.next_blocked_osc8_url_id;
+                            self.next_blocked_osc8_url_id = id.wrapping_add(1);
+                            self.blocked_osc8_url = Some(BlockedOsc8Url {
+                                display: display.into(),
+                                reason,
+                                copy_control_id: format!("blocked-osc8-url-copy-{id}").into(),
+                            });
+                        }
+                    }
+                }
+                GhosttySurfaceEvent::Osc8LinkHoverChanged(url) => {
+                    self.hovered_osc8_url = url.map(|url| match evaluate_osc8_url(&url) {
+                        Osc8UrlDecision::Allow(url) => Osc8LinkPreview {
+                            display: url.into(),
+                            will_open: true,
+                        },
+                        Osc8UrlDecision::Deny { display, .. } => Osc8LinkPreview {
+                            display: display.into(),
+                            will_open: false,
+                        },
+                    });
                 }
                 GhosttySurfaceEvent::PwdChanged(cwd) => {
                     self.last_cwd = Some(cwd.clone());
@@ -2451,6 +2721,11 @@ impl Render for GhosttyView {
                 }
             }))
             .on_key_down(cx.listener(|this, event: &KeyDownEvent, window, cx| {
+                if event.keystroke.key == "escape" && this.dismiss_blocked_osc8_url(window, cx) {
+                    window.prevent_default();
+                    cx.stop_propagation();
+                    return;
+                }
                 if !this.focus_handle.is_focused(window) {
                     return;
                 }
@@ -2499,6 +2774,8 @@ impl Render for GhosttyView {
                 .size_full(),
             )
             .children(self.render_terminal_scrollbar(cx))
+            .children(self.render_osc8_link_preview(cx))
+            .children(self.render_blocked_osc8_url(cx))
             .children(terminal_find)
             .context_menu(move |menu, window, cx| {
                 // An empty PopupMenu renders nothing (ContextMenu checks

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -85,6 +85,10 @@ mod terminal_pane;
 mod terminal_paste;
 mod terminal_restore;
 mod terminal_shortcuts;
+// OSC 8 link policy. Only the macOS view consumes it today; Windows and
+// Linux still detect links in `terminal_links` and will adopt it when they
+// read OSC 8 URIs from libghostty-vt.
+#[cfg(target_os = "macos")]
 mod terminal_url;
 mod theme;
 mod ui_scale;

--- a/crates/con-app/src/main.rs
+++ b/crates/con-app/src/main.rs
@@ -85,6 +85,7 @@ mod terminal_pane;
 mod terminal_paste;
 mod terminal_restore;
 mod terminal_shortcuts;
+mod terminal_url;
 mod theme;
 mod ui_scale;
 mod updater;

--- a/crates/con-app/src/terminal_url.rs
+++ b/crates/con-app/src/terminal_url.rs
@@ -1,0 +1,214 @@
+use std::fmt::Write as _;
+
+use url::Url;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Osc8UrlDenialReason {
+    Malformed,
+    UnsafeCharacters,
+    InvalidWebUrl,
+    EmptyEmailAddress,
+    LocalFile,
+    UnsupportedScheme,
+}
+
+impl Osc8UrlDenialReason {
+    pub(crate) fn message(self) -> &'static str {
+        match self {
+            Self::Malformed => "The target is not an absolute URL with a scheme.",
+            Self::UnsafeCharacters => "The target contains invisible or line-breaking characters.",
+            Self::InvalidWebUrl => {
+                "The web target must use http:// or https:// and contain a valid host."
+            }
+            Self::EmptyEmailAddress => "The email target does not contain an address.",
+            Self::LocalFile => "Opening local files from terminal links is blocked.",
+            Self::UnsupportedScheme => "Opening this URL scheme from terminal links is blocked.",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Osc8UrlDecision {
+    Allow(String),
+    Deny {
+        display: String,
+        reason: Osc8UrlDenialReason,
+    },
+}
+
+impl Osc8UrlDecision {
+    pub(crate) fn display(&self) -> &str {
+        match self {
+            Self::Allow(url) => url,
+            Self::Deny { display, .. } => display,
+        }
+    }
+}
+
+/// Classifies a URL supplied by terminal-controlled OSC 8 output.
+///
+/// Raw Unicode checks intentionally happen before URL parsing. The WHATWG
+/// parser removes tabs, newlines, and some zero-width host characters, which
+/// would otherwise erase the evidence needed to reject a deceptive target.
+pub(crate) fn evaluate_osc8_url(raw: &str) -> Osc8UrlDecision {
+    if raw.is_empty() {
+        return deny(raw, Osc8UrlDenialReason::Malformed);
+    }
+    if raw.chars().any(is_unsafe_url_character) {
+        return deny(raw, Osc8UrlDenialReason::UnsafeCharacters);
+    }
+
+    let Ok(url) = Url::parse(raw) else {
+        return deny(raw, Osc8UrlDenialReason::Malformed);
+    };
+
+    match url.scheme() {
+        "http" => {
+            if !has_explicit_web_authority(raw, "http://")
+                || !url.host_str().is_some_and(|host| !host.is_empty())
+            {
+                return deny(raw, Osc8UrlDenialReason::InvalidWebUrl);
+            }
+            Osc8UrlDecision::Allow(url.into())
+        }
+        "https" => {
+            if !has_explicit_web_authority(raw, "https://")
+                || !url.host_str().is_some_and(|host| !host.is_empty())
+            {
+                return deny(raw, Osc8UrlDenialReason::InvalidWebUrl);
+            }
+            Osc8UrlDecision::Allow(url.into())
+        }
+        "mailto" => {
+            if url.path().is_empty() {
+                return deny(raw, Osc8UrlDenialReason::EmptyEmailAddress);
+            }
+            Osc8UrlDecision::Allow(url.into())
+        }
+        "file" => deny(raw, Osc8UrlDenialReason::LocalFile),
+        _ => deny(raw, Osc8UrlDenialReason::UnsupportedScheme),
+    }
+}
+
+fn deny(raw: &str, reason: Osc8UrlDenialReason) -> Osc8UrlDecision {
+    Osc8UrlDecision::Deny {
+        display: escape_unsafe_url_characters(raw),
+        reason,
+    }
+}
+
+fn has_explicit_web_authority(raw: &str, prefix: &str) -> bool {
+    let bytes = raw.as_bytes();
+    bytes
+        .get(..prefix.len())
+        .is_some_and(|start| start.eq_ignore_ascii_case(prefix.as_bytes()))
+        && bytes
+            .get(prefix.len())
+            .is_some_and(|first| !matches!(first, b'/' | b'\\'))
+}
+
+fn escape_unsafe_url_characters(raw: &str) -> String {
+    let mut display = String::with_capacity(raw.len());
+    for character in raw.chars() {
+        if is_unsafe_url_character(character) {
+            write!(display, "\\u{{{:X}}}", character as u32)
+                .expect("writing to a String cannot fail");
+        } else {
+            display.push(character);
+        }
+    }
+    display
+}
+
+fn is_unsafe_url_character(character: char) -> bool {
+    matches!(
+        character as u32,
+        0x00..=0x1F
+            | 0x7F..=0x9F
+            | 0x061C
+            | 0x200B..=0x200F
+            | 0x2028..=0x2029
+            | 0x202A..=0x202E
+            | 0x2060
+            | 0x2066..=0x2069
+            | 0xFEFF
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Osc8UrlDecision, Osc8UrlDenialReason, evaluate_osc8_url};
+
+    #[test]
+    fn allows_supported_absolute_urls_using_their_serialized_target() {
+        let cases = [
+            ("https://example.com/path", "https://example.com/path"),
+            ("HTTP://EXAMPLE.COM", "http://example.com/"),
+            ("https://exаmple.com/x", "https://xn--exmple-4nf.com/x"),
+            ("mailto:user@example.com", "mailto:user@example.com"),
+        ];
+
+        for (raw, expected) in cases {
+            assert_eq!(
+                evaluate_osc8_url(raw),
+                Osc8UrlDecision::Allow(expected.to_string()),
+                "unexpected decision for {raw:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_unsupported_or_ambiguous_targets() {
+        let cases = [
+            ("", Osc8UrlDenialReason::Malformed),
+            ("example.com", Osc8UrlDenialReason::Malformed),
+            ("https:relative", Osc8UrlDenialReason::InvalidWebUrl),
+            (
+                "https:relative?next=a://b",
+                Osc8UrlDenialReason::InvalidWebUrl,
+            ),
+            (" https://example.com/ ", Osc8UrlDenialReason::InvalidWebUrl),
+            ("https:///path", Osc8UrlDenialReason::InvalidWebUrl),
+            ("https://\\example.com", Osc8UrlDenialReason::InvalidWebUrl),
+            ("mailto:", Osc8UrlDenialReason::EmptyEmailAddress),
+            ("file:///tmp/report.txt", Osc8UrlDenialReason::LocalFile),
+            (
+                "vscode://file/tmp/report.txt",
+                Osc8UrlDenialReason::UnsupportedScheme,
+            ),
+        ];
+
+        for (raw, expected_reason) in cases {
+            assert_eq!(
+                evaluate_osc8_url(raw),
+                Osc8UrlDecision::Deny {
+                    display: raw.to_string(),
+                    reason: expected_reason,
+                },
+                "unexpected decision for {raw:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_and_escapes_unsafe_characters_before_parsing() {
+        let unsafe_scalars = [
+            0x00, 0x09, 0x1F, 0x7F, 0x85, 0x9F, 0x061C, 0x200B, 0x200F, 0x2028, 0x2029, 0x202A,
+            0x202E, 0x2060, 0x2066, 0x2069, 0xFEFF,
+        ];
+
+        for scalar in unsafe_scalars {
+            let character = char::from_u32(scalar).expect("test scalar must be valid Unicode");
+            let raw = format!("https://example.com/a{character}b");
+            let expected_display = format!("https://example.com/a\\u{{{scalar:X}}}b");
+            assert_eq!(
+                evaluate_osc8_url(&raw),
+                Osc8UrlDecision::Deny {
+                    display: expected_display,
+                    reason: Osc8UrlDenialReason::UnsafeCharacters,
+                },
+                "unexpected decision for {raw:?}"
+            );
+        }
+    }
+}

--- a/crates/con-app/src/terminal_url.rs
+++ b/crates/con-app/src/terminal_url.rs
@@ -22,7 +22,7 @@ impl Osc8UrlDenialReason {
             Self::UnsafeCharacters => "The target contains invisible or line-breaking characters.",
             Self::SurroundingWhitespace => "The target contains leading or trailing whitespace.",
             Self::InvalidWebUrl => {
-                "The web target must use http:// or https:// and contain a valid host."
+                "The web target must contain a valid host and no embedded credentials."
             }
             Self::EmptyEmailAddress => "The email target does not contain an address.",
             Self::LocalFile => "Opening local files from terminal links is blocked.",
@@ -70,17 +70,16 @@ pub(crate) fn evaluate_osc8_url(raw: &[u8]) -> Osc8UrlDecision {
     };
 
     match url.scheme() {
-        "http" => {
-            if !has_explicit_web_authority(raw, "http://")
+        scheme @ ("http" | "https") => {
+            let prefix = if scheme == "http" {
+                "http://"
+            } else {
+                "https://"
+            };
+            if !has_explicit_web_authority(raw, prefix)
                 || !url.host_str().is_some_and(|host| !host.is_empty())
-            {
-                return deny(raw, Osc8UrlDenialReason::InvalidWebUrl);
-            }
-            Osc8UrlDecision::Allow(url.into())
-        }
-        "https" => {
-            if !has_explicit_web_authority(raw, "https://")
-                || !url.host_str().is_some_and(|host| !host.is_empty())
+                || !url.username().is_empty()
+                || url.password().is_some()
             {
                 return deny(raw, Osc8UrlDenialReason::InvalidWebUrl);
             }
@@ -220,6 +219,14 @@ mod tests {
             ),
             ("https:///path", Osc8UrlDenialReason::InvalidWebUrl),
             ("https://\\example.com", Osc8UrlDenialReason::InvalidWebUrl),
+            (
+                "https://trusted.example@evil.example/",
+                Osc8UrlDenialReason::InvalidWebUrl,
+            ),
+            (
+                "https://:secret@evil.example/",
+                Osc8UrlDenialReason::InvalidWebUrl,
+            ),
             ("mailto:", Osc8UrlDenialReason::EmptyEmailAddress),
             ("file:///tmp/report.txt", Osc8UrlDenialReason::LocalFile),
             (

--- a/crates/con-app/src/terminal_url.rs
+++ b/crates/con-app/src/terminal_url.rs
@@ -5,7 +5,9 @@ use url::Url;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Osc8UrlDenialReason {
     Malformed,
+    InvalidEncoding,
     UnsafeCharacters,
+    SurroundingWhitespace,
     InvalidWebUrl,
     EmptyEmailAddress,
     LocalFile,
@@ -16,7 +18,9 @@ impl Osc8UrlDenialReason {
     pub(crate) fn message(self) -> &'static str {
         match self {
             Self::Malformed => "The target is not an absolute URL with a scheme.",
+            Self::InvalidEncoding => "The target is not valid UTF-8.",
             Self::UnsafeCharacters => "The target contains invisible or line-breaking characters.",
+            Self::SurroundingWhitespace => "The target contains leading or trailing whitespace.",
             Self::InvalidWebUrl => {
                 "The web target must use http:// or https:// and contain a valid host."
             }
@@ -36,26 +40,29 @@ pub(crate) enum Osc8UrlDecision {
     },
 }
 
-impl Osc8UrlDecision {
-    pub(crate) fn display(&self) -> &str {
-        match self {
-            Self::Allow(url) => url,
-            Self::Deny { display, .. } => display,
-        }
-    }
-}
-
 /// Classifies a URL supplied by terminal-controlled OSC 8 output.
 ///
 /// Raw Unicode checks intentionally happen before URL parsing. The WHATWG
 /// parser removes tabs, newlines, and some zero-width host characters, which
 /// would otherwise erase the evidence needed to reject a deceptive target.
-pub(crate) fn evaluate_osc8_url(raw: &str) -> Osc8UrlDecision {
+pub(crate) fn evaluate_osc8_url(raw: &[u8]) -> Osc8UrlDecision {
+    let Ok(raw) = std::str::from_utf8(raw) else {
+        return Osc8UrlDecision::Deny {
+            display: escape_unsafe_url_bytes(raw),
+            reason: Osc8UrlDenialReason::InvalidEncoding,
+        };
+    };
     if raw.is_empty() {
         return deny(raw, Osc8UrlDenialReason::Malformed);
     }
     if raw.chars().any(is_unsafe_url_character) {
         return deny(raw, Osc8UrlDenialReason::UnsafeCharacters);
+    }
+    if raw.trim() != raw {
+        return Osc8UrlDecision::Deny {
+            display: escape_surrounding_whitespace(raw),
+            reason: Osc8UrlDenialReason::SurroundingWhitespace,
+        };
     }
 
     let Ok(url) = Url::parse(raw) else {
@@ -109,6 +116,51 @@ fn has_explicit_web_authority(raw: &str, prefix: &str) -> bool {
 
 fn escape_unsafe_url_characters(raw: &str) -> String {
     let mut display = String::with_capacity(raw.len());
+    append_escaped_url_characters(&mut display, raw);
+    display
+}
+
+fn escape_surrounding_whitespace(raw: &str) -> String {
+    let leading_end = raw.len() - raw.trim_start().len();
+    let trailing_start = raw.trim_end().len();
+    let mut display = String::with_capacity(raw.len());
+    for (offset, character) in raw.char_indices() {
+        if offset < leading_end || offset >= trailing_start {
+            write!(display, "\\u{{{:X}}}", character as u32)
+                .expect("writing to a String cannot fail");
+        } else {
+            display.push(character);
+        }
+    }
+    display
+}
+
+fn escape_unsafe_url_bytes(mut raw: &[u8]) -> String {
+    let mut display = String::with_capacity(raw.len());
+    while !raw.is_empty() {
+        match std::str::from_utf8(raw) {
+            Ok(valid) => {
+                append_escaped_url_characters(&mut display, valid);
+                break;
+            }
+            Err(error) => {
+                let (valid, invalid) = raw.split_at(error.valid_up_to());
+                append_escaped_url_characters(
+                    &mut display,
+                    std::str::from_utf8(valid).expect("prefix before UTF-8 error must be valid"),
+                );
+                let invalid_len = error.error_len().unwrap_or(invalid.len());
+                for byte in &invalid[..invalid_len] {
+                    write!(display, "\\x{{{byte:02X}}}").expect("writing to a String cannot fail");
+                }
+                raw = &invalid[invalid_len..];
+            }
+        }
+    }
+    display
+}
+
+fn append_escaped_url_characters(display: &mut String, raw: &str) {
     for character in raw.chars() {
         if is_unsafe_url_character(character) {
             write!(display, "\\u{{{:X}}}", character as u32)
@@ -117,7 +169,6 @@ fn escape_unsafe_url_characters(raw: &str) -> String {
             display.push(character);
         }
     }
-    display
 }
 
 fn is_unsafe_url_character(character: char) -> bool {
@@ -150,7 +201,7 @@ mod tests {
 
         for (raw, expected) in cases {
             assert_eq!(
-                evaluate_osc8_url(raw),
+                evaluate_osc8_url(raw.as_bytes()),
                 Osc8UrlDecision::Allow(expected.to_string()),
                 "unexpected decision for {raw:?}"
             );
@@ -167,7 +218,6 @@ mod tests {
                 "https:relative?next=a://b",
                 Osc8UrlDenialReason::InvalidWebUrl,
             ),
-            (" https://example.com/ ", Osc8UrlDenialReason::InvalidWebUrl),
             ("https:///path", Osc8UrlDenialReason::InvalidWebUrl),
             ("https://\\example.com", Osc8UrlDenialReason::InvalidWebUrl),
             ("mailto:", Osc8UrlDenialReason::EmptyEmailAddress),
@@ -180,10 +230,33 @@ mod tests {
 
         for (raw, expected_reason) in cases {
             assert_eq!(
-                evaluate_osc8_url(raw),
+                evaluate_osc8_url(raw.as_bytes()),
                 Osc8UrlDecision::Deny {
                     display: raw.to_string(),
                     reason: expected_reason,
+                },
+                "unexpected decision for {raw:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_and_escapes_surrounding_whitespace() {
+        let cases = [
+            (" https://example.com/", "\\u{20}https://example.com/"),
+            ("https://example.com/ ", "https://example.com/\\u{20}"),
+            (
+                "\u{2003}mailto:user@example.com\u{A0}",
+                "\\u{2003}mailto:user@example.com\\u{A0}",
+            ),
+        ];
+
+        for (raw, expected_display) in cases {
+            assert_eq!(
+                evaluate_osc8_url(raw.as_bytes()),
+                Osc8UrlDecision::Deny {
+                    display: expected_display.to_string(),
+                    reason: Osc8UrlDenialReason::SurroundingWhitespace,
                 },
                 "unexpected decision for {raw:?}"
             );
@@ -202,7 +275,7 @@ mod tests {
             let raw = format!("https://example.com/a{character}b");
             let expected_display = format!("https://example.com/a\\u{{{scalar:X}}}b");
             assert_eq!(
-                evaluate_osc8_url(&raw),
+                evaluate_osc8_url(raw.as_bytes()),
                 Osc8UrlDecision::Deny {
                     display: expected_display,
                     reason: Osc8UrlDenialReason::UnsafeCharacters,
@@ -210,5 +283,18 @@ mod tests {
                 "unexpected decision for {raw:?}"
             );
         }
+    }
+
+    #[test]
+    fn rejects_and_escapes_invalid_utf8_before_parsing() {
+        let raw = b"https://example.com/a\xF0\x28\x8C\x28b\xFF";
+
+        assert_eq!(
+            evaluate_osc8_url(raw),
+            Osc8UrlDecision::Deny {
+                display: "https://example.com/a\\x{F0}(\\x{8C}(b\\x{FF}".to_string(),
+                reason: Osc8UrlDenialReason::InvalidEncoding,
+            }
+        );
     }
 }

--- a/crates/con-app/src/terminal_url.rs
+++ b/crates/con-app/src/terminal_url.rs
@@ -5,9 +5,7 @@ use url::Url;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Osc8UrlDenialReason {
     Malformed,
-    InvalidEncoding,
     UnsafeCharacters,
-    SurroundingWhitespace,
     InvalidWebUrl,
     EmptyEmailAddress,
     LocalFile,
@@ -18,9 +16,9 @@ impl Osc8UrlDenialReason {
     pub(crate) fn message(self) -> &'static str {
         match self {
             Self::Malformed => "The target is not an absolute URL with a scheme.",
-            Self::InvalidEncoding => "The target is not valid UTF-8.",
-            Self::UnsafeCharacters => "The target contains invisible or line-breaking characters.",
-            Self::SurroundingWhitespace => "The target contains leading or trailing whitespace.",
+            Self::UnsafeCharacters => {
+                "The target contains whitespace, control, or invisible characters."
+            }
             Self::InvalidWebUrl => {
                 "The web target must contain a valid host and no embedded credentials."
             }
@@ -31,38 +29,33 @@ impl Osc8UrlDenialReason {
     }
 }
 
+/// A denied OSC 8 target: what to show the user, with unsafe characters made
+/// visible, and why it was denied.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Osc8UrlDenial {
+    pub(crate) display: String,
+    pub(crate) reason: Osc8UrlDenialReason,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Osc8UrlDecision {
+    /// Open, and display, exactly this serialized URL.
     Allow(String),
-    Deny {
-        display: String,
-        reason: Osc8UrlDenialReason,
-    },
+    Deny(Osc8UrlDenial),
 }
 
 /// Classifies a URL supplied by terminal-controlled OSC 8 output.
 ///
-/// Raw Unicode checks intentionally happen before URL parsing. The WHATWG
-/// parser removes tabs, newlines, and some zero-width host characters, which
-/// would otherwise erase the evidence needed to reject a deceptive target.
-pub(crate) fn evaluate_osc8_url(raw: &[u8]) -> Osc8UrlDecision {
-    let Ok(raw) = std::str::from_utf8(raw) else {
-        return Osc8UrlDecision::Deny {
-            display: escape_unsafe_url_bytes(raw),
-            reason: Osc8UrlDenialReason::InvalidEncoding,
-        };
-    };
+/// Raw character checks intentionally happen before URL parsing. The WHATWG
+/// parser strips tabs, newlines, and surrounding whitespace and drops some
+/// zero-width host characters, which would otherwise erase the evidence needed
+/// to reject a deceptive target.
+pub(crate) fn evaluate_osc8_url(raw: &str) -> Osc8UrlDecision {
     if raw.is_empty() {
         return deny(raw, Osc8UrlDenialReason::Malformed);
     }
     if raw.chars().any(is_unsafe_url_character) {
         return deny(raw, Osc8UrlDenialReason::UnsafeCharacters);
-    }
-    if raw.trim() != raw {
-        return Osc8UrlDecision::Deny {
-            display: escape_surrounding_whitespace(raw),
-            reason: Osc8UrlDenialReason::SurroundingWhitespace,
-        };
     }
 
     let Ok(url) = Url::parse(raw) else {
@@ -71,12 +64,7 @@ pub(crate) fn evaluate_osc8_url(raw: &[u8]) -> Osc8UrlDecision {
 
     match url.scheme() {
         scheme @ ("http" | "https") => {
-            let prefix = if scheme == "http" {
-                "http://"
-            } else {
-                "https://"
-            };
-            if !has_explicit_web_authority(raw, prefix)
+            if !has_explicit_web_authority(raw, scheme)
                 || !url.host_str().is_some_and(|host| !host.is_empty())
                 || !url.username().is_empty()
                 || url.password().is_some()
@@ -97,69 +85,31 @@ pub(crate) fn evaluate_osc8_url(raw: &[u8]) -> Osc8UrlDecision {
 }
 
 fn deny(raw: &str, reason: Osc8UrlDenialReason) -> Osc8UrlDecision {
-    Osc8UrlDecision::Deny {
-        display: escape_unsafe_url_characters(raw),
+    Osc8UrlDecision::Deny(Osc8UrlDenial {
+        display: escape_unsafe_characters(raw),
         reason,
-    }
+    })
 }
 
-fn has_explicit_web_authority(raw: &str, prefix: &str) -> bool {
+/// The WHATWG parser accepts `https:relative` (host `relative`) and
+/// `https:///host`. Require the literal `scheme://` spelling followed by a host
+/// character so the target means what it looks like.
+fn has_explicit_web_authority(raw: &str, scheme: &str) -> bool {
     let bytes = raw.as_bytes();
+    let authority_start = scheme.len() + "://".len();
     bytes
-        .get(..prefix.len())
-        .is_some_and(|start| start.eq_ignore_ascii_case(prefix.as_bytes()))
+        .get(..scheme.len())
+        .is_some_and(|start| start.eq_ignore_ascii_case(scheme.as_bytes()))
+        && bytes.get(scheme.len()..authority_start) == Some(b"://")
         && bytes
-            .get(prefix.len())
+            .get(authority_start)
             .is_some_and(|first| !matches!(first, b'/' | b'\\'))
 }
 
-fn escape_unsafe_url_characters(raw: &str) -> String {
+/// Renders unsafe characters as `\u{…}` so a denied target can be shown and
+/// copied without carrying whitespace, control, or invisible characters.
+fn escape_unsafe_characters(raw: &str) -> String {
     let mut display = String::with_capacity(raw.len());
-    append_escaped_url_characters(&mut display, raw);
-    display
-}
-
-fn escape_surrounding_whitespace(raw: &str) -> String {
-    let leading_end = raw.len() - raw.trim_start().len();
-    let trailing_start = raw.trim_end().len();
-    let mut display = String::with_capacity(raw.len());
-    for (offset, character) in raw.char_indices() {
-        if offset < leading_end || offset >= trailing_start {
-            write!(display, "\\u{{{:X}}}", character as u32)
-                .expect("writing to a String cannot fail");
-        } else {
-            display.push(character);
-        }
-    }
-    display
-}
-
-fn escape_unsafe_url_bytes(mut raw: &[u8]) -> String {
-    let mut display = String::with_capacity(raw.len());
-    while !raw.is_empty() {
-        match std::str::from_utf8(raw) {
-            Ok(valid) => {
-                append_escaped_url_characters(&mut display, valid);
-                break;
-            }
-            Err(error) => {
-                let (valid, invalid) = raw.split_at(error.valid_up_to());
-                append_escaped_url_characters(
-                    &mut display,
-                    std::str::from_utf8(valid).expect("prefix before UTF-8 error must be valid"),
-                );
-                let invalid_len = error.error_len().unwrap_or(invalid.len());
-                for byte in &invalid[..invalid_len] {
-                    write!(display, "\\x{{{byte:02X}}}").expect("writing to a String cannot fail");
-                }
-                raw = &invalid[invalid_len..];
-            }
-        }
-    }
-    display
-}
-
-fn append_escaped_url_characters(display: &mut String, raw: &str) {
     for character in raw.chars() {
         if is_unsafe_url_character(character) {
             write!(display, "\\u{{{:X}}}", character as u32)
@@ -168,26 +118,38 @@ fn append_escaped_url_characters(display: &mut String, raw: &str) {
             display.push(character);
         }
     }
+    display
 }
 
+/// Whitespace (never valid in a URI), C0/C1 controls, and the bidirectional,
+/// zero-width, and line-separator scalars that can reorder or conceal parts of
+/// a displayed URL.
 fn is_unsafe_url_character(character: char) -> bool {
-    matches!(
-        character as u32,
-        0x00..=0x1F
-            | 0x7F..=0x9F
-            | 0x061C
-            | 0x200B..=0x200F
-            | 0x2028..=0x2029
-            | 0x202A..=0x202E
-            | 0x2060
-            | 0x2066..=0x2069
-            | 0xFEFF
-    )
+    character.is_whitespace()
+        || matches!(
+            character as u32,
+            0x00..=0x1F
+                | 0x7F..=0x9F
+                | 0x061C
+                | 0x200B..=0x200F
+                | 0x2028..=0x2029
+                | 0x202A..=0x202E
+                | 0x2060
+                | 0x2066..=0x2069
+                | 0xFEFF
+        )
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Osc8UrlDecision, Osc8UrlDenialReason, evaluate_osc8_url};
+    use super::{Osc8UrlDecision, Osc8UrlDenial, Osc8UrlDenialReason, evaluate_osc8_url};
+
+    fn denied(display: &str, reason: Osc8UrlDenialReason) -> Osc8UrlDecision {
+        Osc8UrlDecision::Deny(Osc8UrlDenial {
+            display: display.to_string(),
+            reason,
+        })
+    }
 
     #[test]
     fn allows_supported_absolute_urls_using_their_serialized_target() {
@@ -200,7 +162,7 @@ mod tests {
 
         for (raw, expected) in cases {
             assert_eq!(
-                evaluate_osc8_url(raw.as_bytes()),
+                evaluate_osc8_url(raw),
                 Osc8UrlDecision::Allow(expected.to_string()),
                 "unexpected decision for {raw:?}"
             );
@@ -237,21 +199,21 @@ mod tests {
 
         for (raw, expected_reason) in cases {
             assert_eq!(
-                evaluate_osc8_url(raw.as_bytes()),
-                Osc8UrlDecision::Deny {
-                    display: raw.to_string(),
-                    reason: expected_reason,
-                },
+                evaluate_osc8_url(raw),
+                denied(raw, expected_reason),
                 "unexpected decision for {raw:?}"
             );
         }
     }
 
     #[test]
-    fn rejects_and_escapes_surrounding_whitespace() {
+    fn rejects_and_escapes_whitespace_wherever_it_appears() {
+        // The WHATWG parser would silently trim the outer cases and
+        // percent-encode the inner one; a URI with raw whitespace is malformed.
         let cases = [
             (" https://example.com/", "\\u{20}https://example.com/"),
             ("https://example.com/ ", "https://example.com/\\u{20}"),
+            ("https://example.com/a b", "https://example.com/a\\u{20}b"),
             (
                 "\u{2003}mailto:user@example.com\u{A0}",
                 "\\u{2003}mailto:user@example.com\\u{A0}",
@@ -260,11 +222,8 @@ mod tests {
 
         for (raw, expected_display) in cases {
             assert_eq!(
-                evaluate_osc8_url(raw.as_bytes()),
-                Osc8UrlDecision::Deny {
-                    display: expected_display.to_string(),
-                    reason: Osc8UrlDenialReason::SurroundingWhitespace,
-                },
+                evaluate_osc8_url(raw),
+                denied(expected_display, Osc8UrlDenialReason::UnsafeCharacters),
                 "unexpected decision for {raw:?}"
             );
         }
@@ -282,26 +241,10 @@ mod tests {
             let raw = format!("https://example.com/a{character}b");
             let expected_display = format!("https://example.com/a\\u{{{scalar:X}}}b");
             assert_eq!(
-                evaluate_osc8_url(raw.as_bytes()),
-                Osc8UrlDecision::Deny {
-                    display: expected_display,
-                    reason: Osc8UrlDenialReason::UnsafeCharacters,
-                },
+                evaluate_osc8_url(&raw),
+                denied(&expected_display, Osc8UrlDenialReason::UnsafeCharacters),
                 "unexpected decision for {raw:?}"
             );
         }
-    }
-
-    #[test]
-    fn rejects_and_escapes_invalid_utf8_before_parsing() {
-        let raw = b"https://example.com/a\xF0\x28\x8C\x28b\xFF";
-
-        assert_eq!(
-            evaluate_osc8_url(raw),
-            Osc8UrlDecision::Deny {
-                display: "https://example.com/a\\x{F0}(\\x{8C}(b\\x{FF}".to_string(),
-                reason: Osc8UrlDenialReason::InvalidEncoding,
-            }
-        );
     }
 }

--- a/crates/con-ghostty/src/ffi.rs
+++ b/crates/con-ghostty/src/ffi.rs
@@ -421,6 +421,14 @@ pub struct ghostty_action_scrollbar_s {
     pub len: u64,
 }
 
+/// Action payload for MOUSE_OVER_LINK.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct ghostty_action_mouse_over_link_s {
+    pub url: *const c_char,
+    pub len: usize,
+}
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[allow(clippy::upper_case_acronyms)]
@@ -464,6 +472,7 @@ pub union ghostty_action_u {
     pub start_search: ghostty_action_start_search_s,
     pub search_total: ghostty_action_search_total_s,
     pub search_selected: ghostty_action_search_selected_s,
+    pub mouse_over_link: ghostty_action_mouse_over_link_s,
     pub open_url: ghostty_action_open_url_s,
     pub child_exited: ghostty_surface_message_childexited_s,
 }
@@ -482,6 +491,8 @@ const _: [(); 8] = [(); std::mem::size_of::<ghostty_action_progress_report_s>()]
 const _: [(); 8] = [(); std::mem::size_of::<ghostty_action_start_search_s>()];
 const _: [(); 8] = [(); std::mem::size_of::<ghostty_action_search_total_s>()];
 const _: [(); 8] = [(); std::mem::size_of::<ghostty_action_search_selected_s>()];
+const _: [(); 16] = [(); std::mem::size_of::<ghostty_action_mouse_over_link_s>()];
+const _: [(); 24] = [(); std::mem::size_of::<ghostty_action_open_url_s>()];
 const _: [(); 24] = [(); std::mem::size_of::<ghostty_action_u>()];
 const _: [(); 32] = [(); std::mem::size_of::<ghostty_action_s>()];
 

--- a/crates/con-ghostty/src/ffi.rs
+++ b/crates/con-ghostty/src/ffi.rs
@@ -429,15 +429,8 @@ pub struct ghostty_action_mouse_over_link_s {
     pub len: usize,
 }
 
-#[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(clippy::upper_case_acronyms)]
-pub enum ghostty_action_open_url_kind_e {
-    GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN = 0,
-    GHOSTTY_ACTION_OPEN_URL_KIND_TEXT = 1,
-    GHOSTTY_ACTION_OPEN_URL_KIND_HTML = 2,
-    GHOSTTY_ACTION_OPEN_URL_KIND_OSC8 = 3,
-}
+pub type ghostty_action_open_url_kind_e = c_int;
+pub const GHOSTTY_ACTION_OPEN_URL_KIND_OSC8: ghostty_action_open_url_kind_e = 3;
 
 /// Action payload for OPEN_URL.
 #[repr(C)]

--- a/crates/con-ghostty/src/ffi_abi.c
+++ b/crates/con-ghostty/src/ffi_abi.c
@@ -107,6 +107,28 @@ _Static_assert(sizeof(ghostty_action_search_total_s) == sizeof(ssize_t),
                "ghostty search-total payload changed layout");
 _Static_assert(sizeof(ghostty_action_search_selected_s) == sizeof(ssize_t),
                "ghostty search-selected payload changed layout");
+_Static_assert(sizeof(ghostty_action_mouse_over_link_s) == 16,
+               "ghostty mouse-over-link payload changed layout");
+_Static_assert(offsetof(ghostty_action_mouse_over_link_s, url) == 0,
+               "ghostty mouse-over-link pointer changed offset");
+_Static_assert(offsetof(ghostty_action_mouse_over_link_s, len) == 8,
+               "ghostty mouse-over-link length changed offset");
+_Static_assert(GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN == 0,
+               "ghostty unknown open-url kind changed value");
+_Static_assert(GHOSTTY_ACTION_OPEN_URL_KIND_TEXT == 1,
+               "ghostty text open-url kind changed value");
+_Static_assert(GHOSTTY_ACTION_OPEN_URL_KIND_HTML == 2,
+               "ghostty HTML open-url kind changed value");
+_Static_assert(GHOSTTY_ACTION_OPEN_URL_KIND_OSC8 == 3,
+               "ghostty OSC 8 open-url kind changed value");
+_Static_assert(sizeof(ghostty_action_open_url_s) == 24,
+               "ghostty open-url payload changed layout");
+_Static_assert(offsetof(ghostty_action_open_url_s, kind) == 0,
+               "ghostty open-url kind changed offset");
+_Static_assert(offsetof(ghostty_action_open_url_s, url) == 8,
+               "ghostty open-url pointer changed offset");
+_Static_assert(offsetof(ghostty_action_open_url_s, len) == 16,
+               "ghostty open-url length changed offset");
 
 _Static_assert(GHOSTTY_CLIPBOARD_STANDARD == 0,
                "ghostty standard clipboard changed value");

--- a/crates/con-ghostty/src/ffi_abi.c
+++ b/crates/con-ghostty/src/ffi_abi.c
@@ -113,12 +113,6 @@ _Static_assert(offsetof(ghostty_action_mouse_over_link_s, url) == 0,
                "ghostty mouse-over-link pointer changed offset");
 _Static_assert(offsetof(ghostty_action_mouse_over_link_s, len) == 8,
                "ghostty mouse-over-link length changed offset");
-_Static_assert(GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN == 0,
-               "ghostty unknown open-url kind changed value");
-_Static_assert(GHOSTTY_ACTION_OPEN_URL_KIND_TEXT == 1,
-               "ghostty text open-url kind changed value");
-_Static_assert(GHOSTTY_ACTION_OPEN_URL_KIND_HTML == 2,
-               "ghostty HTML open-url kind changed value");
 _Static_assert(GHOSTTY_ACTION_OPEN_URL_KIND_OSC8 == 3,
                "ghostty OSC 8 open-url kind changed value");
 _Static_assert(sizeof(ghostty_action_open_url_s) == 24,

--- a/crates/con-ghostty/src/lib.rs
+++ b/crates/con-ghostty/src/lib.rs
@@ -264,9 +264,9 @@ pub mod windows;
 
 #[cfg(target_os = "macos")]
 pub use terminal::{
-    CommandFinishedSignal, CommandRecord, GhosttyApp, GhosttyConfigPatch, GhosttyOpenUrlKind,
-    GhosttyScrollbar, GhosttySplitDirection, GhosttySurfaceEvent, GhosttyTerminal, MouseButton,
-    SurfaceSize, TerminalColors, TerminalState,
+    CommandFinishedSignal, CommandRecord, GhosttyApp, GhosttyConfigPatch, GhosttyScrollbar,
+    GhosttySplitDirection, GhosttySurfaceEvent, GhosttyTerminal, MouseButton, SurfaceSize,
+    TerminalColors, TerminalState,
 };
 
 #[cfg(target_os = "windows")]

--- a/crates/con-ghostty/src/lib.rs
+++ b/crates/con-ghostty/src/lib.rs
@@ -264,9 +264,9 @@ pub mod windows;
 
 #[cfg(target_os = "macos")]
 pub use terminal::{
-    CommandFinishedSignal, CommandRecord, GhosttyApp, GhosttyConfigPatch, GhosttyScrollbar,
-    GhosttySplitDirection, GhosttySurfaceEvent, GhosttyTerminal, MouseButton, SurfaceSize,
-    TerminalColors, TerminalState,
+    CommandFinishedSignal, CommandRecord, GhosttyApp, GhosttyConfigPatch, GhosttyOpenUrlKind,
+    GhosttyScrollbar, GhosttySplitDirection, GhosttySurfaceEvent, GhosttyTerminal, MouseButton,
+    SurfaceSize, TerminalColors, TerminalState,
 };
 
 #[cfg(target_os = "windows")]

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -291,34 +291,11 @@ pub enum GhosttySplitDirection {
     Up,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum GhosttyOpenUrlKind {
-    Unknown,
-    Text,
-    Html,
-    Osc8,
-}
-
-impl From<ffi::ghostty_action_open_url_kind_e> for GhosttyOpenUrlKind {
-    fn from(kind: ffi::ghostty_action_open_url_kind_e) -> Self {
-        match kind {
-            ffi::ghostty_action_open_url_kind_e::GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN => {
-                Self::Unknown
-            }
-            ffi::ghostty_action_open_url_kind_e::GHOSTTY_ACTION_OPEN_URL_KIND_TEXT => Self::Text,
-            ffi::ghostty_action_open_url_kind_e::GHOSTTY_ACTION_OPEN_URL_KIND_HTML => Self::Html,
-            ffi::ghostty_action_open_url_kind_e::GHOSTTY_ACTION_OPEN_URL_KIND_OSC8 => Self::Osc8,
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GhosttySurfaceEvent {
     SplitRequest(GhosttySplitDirection),
-    OpenUrl {
-        kind: GhosttyOpenUrlKind,
-        url: Vec<u8>,
-    },
+    OpenUrl(String),
+    OpenOsc8Url(Vec<u8>),
     Osc8LinkHoverChanged(Option<Arc<[u8]>>),
     PwdChanged(String),
     StartSearch(String),
@@ -1667,13 +1644,12 @@ unsafe extern "C" fn action_callback(
                 }
 
                 let bytes = std::slice::from_raw_parts(open_url.url as *const u8, open_url.len);
-                state
-                    .lock()
-                    .pending_events
-                    .push_back(GhosttySurfaceEvent::OpenUrl {
-                        kind: open_url.kind.into(),
-                        url: bytes.to_vec(),
-                    });
+                let event = if open_url.kind == ffi::GHOSTTY_ACTION_OPEN_URL_KIND_OSC8 {
+                    GhosttySurfaceEvent::OpenOsc8Url(bytes.to_vec())
+                } else {
+                    GhosttySurfaceEvent::OpenUrl(String::from_utf8_lossy(bytes).into_owned())
+                };
+                state.lock().pending_events.push_back(event);
                 true
             }
             ffi::ghostty_action_tag_e::GHOSTTY_ACTION_MOUSE_OVER_LINK => {

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -174,6 +174,10 @@ impl GhosttyConfigPatch {
         s.push_str("shell-integration-features = ");
         s.push_str(CON_SHELL_INTEGRATION_FEATURES);
         s.push('\n');
+        // Plain links already display their target as terminal text. Restrict
+        // host-side previews to OSC 8, whose visible label can differ from the
+        // producer-controlled URI and therefore needs an explicit preview.
+        s.push_str("link-previews = osc8\n");
         let clipboard_write = self.clipboard_write.unwrap_or(false);
         s.push_str(if clipboard_write {
             "clipboard-write = allow\n"
@@ -287,10 +291,35 @@ pub enum GhosttySplitDirection {
     Up,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GhosttyOpenUrlKind {
+    Unknown,
+    Text,
+    Html,
+    Osc8,
+}
+
+impl From<ffi::ghostty_action_open_url_kind_e> for GhosttyOpenUrlKind {
+    fn from(kind: ffi::ghostty_action_open_url_kind_e) -> Self {
+        match kind {
+            ffi::ghostty_action_open_url_kind_e::GHOSTTY_ACTION_OPEN_URL_KIND_UNKNOWN => {
+                Self::Unknown
+            }
+            ffi::ghostty_action_open_url_kind_e::GHOSTTY_ACTION_OPEN_URL_KIND_TEXT => Self::Text,
+            ffi::ghostty_action_open_url_kind_e::GHOSTTY_ACTION_OPEN_URL_KIND_HTML => Self::Html,
+            ffi::ghostty_action_open_url_kind_e::GHOSTTY_ACTION_OPEN_URL_KIND_OSC8 => Self::Osc8,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GhosttySurfaceEvent {
     SplitRequest(GhosttySplitDirection),
-    OpenUrl(String),
+    OpenUrl {
+        kind: GhosttyOpenUrlKind,
+        url: Vec<u8>,
+    },
+    Osc8LinkHoverChanged(Option<Arc<[u8]>>),
     PwdChanged(String),
     StartSearch(String),
     EndSearch,
@@ -329,6 +358,10 @@ pub struct TerminalState {
     clipboard_write_policy: Arc<ClipboardWritePolicy>,
     /// Pending host-side events emitted by Ghostty actions for this surface.
     pub pending_events: VecDeque<GhosttySurfaceEvent>,
+    /// Latest OSC 8 URI under the pointer. Hover is level-triggered UI state,
+    /// so only the final value needs to survive until the next host drain.
+    hovered_osc8_link_url: Option<Arc<[u8]>>,
+    osc8_link_hover_changed: bool,
     /// Latest viewport scrollbar state emitted by Ghostty.
     pub scrollbar: Option<GhosttyScrollbar>,
 }
@@ -355,8 +388,30 @@ impl Default for TerminalState {
             surface: std::ptr::null_mut(),
             clipboard_write_policy: Arc::new(ClipboardWritePolicy::new(false)),
             pending_events: VecDeque::new(),
+            hovered_osc8_link_url: None,
+            osc8_link_hover_changed: false,
             scrollbar: None,
         }
+    }
+}
+
+impl TerminalState {
+    fn update_osc8_link_hover(&mut self, url: Option<Arc<[u8]>>) {
+        if self.hovered_osc8_link_url == url {
+            return;
+        }
+        self.hovered_osc8_link_url = url;
+        self.osc8_link_hover_changed = true;
+    }
+
+    fn drain_pending_events(&mut self) -> Vec<GhosttySurfaceEvent> {
+        let mut events: Vec<_> = self.pending_events.drain(..).collect();
+        if std::mem::take(&mut self.osc8_link_hover_changed) {
+            events.push(GhosttySurfaceEvent::Osc8LinkHoverChanged(
+                self.hovered_osc8_link_url.clone(),
+            ));
+        }
+        events
     }
 }
 
@@ -1388,8 +1443,7 @@ impl GhosttyTerminal {
     }
 
     pub fn take_pending_events(&self) -> Vec<GhosttySurfaceEvent> {
-        let mut state = self.state.lock();
-        state.pending_events.drain(..).collect()
+        self.state.lock().drain_pending_events()
     }
 }
 
@@ -1613,11 +1667,35 @@ unsafe extern "C" fn action_callback(
                 }
 
                 let bytes = std::slice::from_raw_parts(open_url.url as *const u8, open_url.len);
-                let url = String::from_utf8_lossy(bytes).into_owned();
                 state
                     .lock()
                     .pending_events
-                    .push_back(GhosttySurfaceEvent::OpenUrl(url));
+                    .push_back(GhosttySurfaceEvent::OpenUrl {
+                        kind: open_url.kind.into(),
+                        url: bytes.to_vec(),
+                    });
+                true
+            }
+            ffi::ghostty_action_tag_e::GHOSTTY_ACTION_MOUSE_OVER_LINK => {
+                let mouse_over_link = action.action.mouse_over_link;
+                let mut state = state.lock();
+                if mouse_over_link.len == 0 {
+                    state.update_osc8_link_hover(None);
+                    return true;
+                }
+                if mouse_over_link.url.is_null() {
+                    return false;
+                }
+
+                let bytes = std::slice::from_raw_parts(
+                    mouse_over_link.url as *const u8,
+                    mouse_over_link.len,
+                );
+                if state.hovered_osc8_link_url.as_deref() == Some(bytes) {
+                    return true;
+                }
+                let url = Arc::<[u8]>::from(bytes);
+                state.update_osc8_link_hover(Some(url));
                 true
             }
             ffi::ghostty_action_tag_e::GHOSTTY_ACTION_COMMAND_FINISHED => {
@@ -1947,7 +2025,7 @@ mod tests {
     use parking_lot::Mutex;
 
     use super::{
-        GhosttyConfigPatch, TerminalColors, TerminalState,
+        GhosttyConfigPatch, GhosttySurfaceEvent, TerminalColors, TerminalState,
         installed_app_ghostty_resources_dir_for_exe, mark_child_exited_state,
     };
 
@@ -1979,6 +2057,30 @@ mod tests {
         assert!(state.needs_render);
         assert!(!state.is_busy);
         assert_eq!(state.last_command_finished_input_generation, 7);
+    }
+
+    #[test]
+    fn osc8_hover_updates_coalesce_to_the_latest_state() {
+        let mut state = TerminalState::default();
+        let latest: Arc<[u8]> = Arc::from(&b"https://two.example"[..]);
+
+        state.update_osc8_link_hover(Some(Arc::from(&b"https://one.example"[..])));
+        state.update_osc8_link_hover(Some(Arc::clone(&latest)));
+        assert_eq!(
+            state.drain_pending_events(),
+            vec![GhosttySurfaceEvent::Osc8LinkHoverChanged(Some(Arc::clone(
+                &latest
+            )))]
+        );
+        assert!(state.drain_pending_events().is_empty());
+        state.update_osc8_link_hover(Some(latest));
+        assert!(state.drain_pending_events().is_empty());
+
+        state.update_osc8_link_hover(None);
+        assert_eq!(
+            state.drain_pending_events(),
+            vec![GhosttySurfaceEvent::Osc8LinkHoverChanged(None)]
+        );
     }
 
     #[test]
@@ -2051,6 +2153,13 @@ mod tests {
 
         assert!(config.contains("shell-integration-features = no-cursor,ssh-env\n"));
         assert!(!config.contains("ssh-terminfo"));
+    }
+
+    #[test]
+    fn ghostty_config_only_previews_osc8_links() {
+        let config = GhosttyConfigPatch::default().to_config_string();
+
+        assert!(config.contains("link-previews = osc8\n"));
     }
 
     #[test]

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -295,8 +295,11 @@ pub enum GhosttySplitDirection {
 pub enum GhosttySurfaceEvent {
     SplitRequest(GhosttySplitDirection),
     OpenUrl(String),
-    OpenOsc8Url(Vec<u8>),
-    Osc8LinkHoverChanged(Option<Arc<[u8]>>),
+    /// An OSC 8 hyperlink was clicked. The URL is terminal-authored and must
+    /// be validated before it is opened.
+    OpenOsc8Url(String),
+    /// The OSC 8 hyperlink under the pointer changed (`None` = no link).
+    Osc8LinkHoverChanged(Option<String>),
     PwdChanged(String),
     StartSearch(String),
     EndSearch,
@@ -335,10 +338,9 @@ pub struct TerminalState {
     clipboard_write_policy: Arc<ClipboardWritePolicy>,
     /// Pending host-side events emitted by Ghostty actions for this surface.
     pub pending_events: VecDeque<GhosttySurfaceEvent>,
-    /// Latest OSC 8 URI under the pointer. Hover is level-triggered UI state,
-    /// so only the final value needs to survive until the next host drain.
-    hovered_osc8_link_url: Option<Arc<[u8]>>,
-    osc8_link_hover_changed: bool,
+    /// OSC 8 URI under the pointer. Ghostty reports it on every mouse move
+    /// while hovering; this lets us emit an event only when it changes.
+    hovered_osc8_link_url: Option<String>,
     /// Latest viewport scrollbar state emitted by Ghostty.
     pub scrollbar: Option<GhosttyScrollbar>,
 }
@@ -366,29 +368,23 @@ impl Default for TerminalState {
             clipboard_write_policy: Arc::new(ClipboardWritePolicy::new(false)),
             pending_events: VecDeque::new(),
             hovered_osc8_link_url: None,
-            osc8_link_hover_changed: false,
             scrollbar: None,
         }
     }
 }
 
 impl TerminalState {
-    fn update_osc8_link_hover(&mut self, url: Option<Arc<[u8]>>) {
-        if self.hovered_osc8_link_url == url {
+    /// Records the OSC 8 link under the pointer and queues a hover event if
+    /// it differs from the previous one.
+    fn set_hovered_osc8_link(&mut self, url: Option<&str>) {
+        if self.hovered_osc8_link_url.as_deref() == url {
             return;
         }
-        self.hovered_osc8_link_url = url;
-        self.osc8_link_hover_changed = true;
-    }
-
-    fn drain_pending_events(&mut self) -> Vec<GhosttySurfaceEvent> {
-        let mut events: Vec<_> = self.pending_events.drain(..).collect();
-        if std::mem::take(&mut self.osc8_link_hover_changed) {
-            events.push(GhosttySurfaceEvent::Osc8LinkHoverChanged(
+        self.hovered_osc8_link_url = url.map(str::to_owned);
+        self.pending_events
+            .push_back(GhosttySurfaceEvent::Osc8LinkHoverChanged(
                 self.hovered_osc8_link_url.clone(),
             ));
-        }
-        events
     }
 }
 
@@ -1420,7 +1416,7 @@ impl GhosttyTerminal {
     }
 
     pub fn take_pending_events(&self) -> Vec<GhosttySurfaceEvent> {
-        self.state.lock().drain_pending_events()
+        self.state.lock().pending_events.drain(..).collect()
     }
 }
 
@@ -1644,19 +1640,20 @@ unsafe extern "C" fn action_callback(
                 }
 
                 let bytes = std::slice::from_raw_parts(open_url.url as *const u8, open_url.len);
+                let url = String::from_utf8_lossy(bytes).into_owned();
                 let event = if open_url.kind == ffi::GHOSTTY_ACTION_OPEN_URL_KIND_OSC8 {
-                    GhosttySurfaceEvent::OpenOsc8Url(bytes.to_vec())
+                    GhosttySurfaceEvent::OpenOsc8Url(url)
                 } else {
-                    GhosttySurfaceEvent::OpenUrl(String::from_utf8_lossy(bytes).into_owned())
+                    GhosttySurfaceEvent::OpenUrl(url)
                 };
                 state.lock().pending_events.push_back(event);
                 true
             }
             ffi::ghostty_action_tag_e::GHOSTTY_ACTION_MOUSE_OVER_LINK => {
+                // Ghostty sends an empty URL when the pointer leaves a link.
                 let mouse_over_link = action.action.mouse_over_link;
-                let mut state = state.lock();
                 if mouse_over_link.len == 0 {
-                    state.update_osc8_link_hover(None);
+                    state.lock().set_hovered_osc8_link(None);
                     return true;
                 }
                 if mouse_over_link.url.is_null() {
@@ -1667,11 +1664,8 @@ unsafe extern "C" fn action_callback(
                     mouse_over_link.url as *const u8,
                     mouse_over_link.len,
                 );
-                if state.hovered_osc8_link_url.as_deref() == Some(bytes) {
-                    return true;
-                }
-                let url = Arc::<[u8]>::from(bytes);
-                state.update_osc8_link_hover(Some(url));
+                let url = String::from_utf8_lossy(bytes);
+                state.lock().set_hovered_osc8_link(Some(&url));
                 true
             }
             ffi::ghostty_action_tag_e::GHOSTTY_ACTION_COMMAND_FINISHED => {
@@ -2036,26 +2030,21 @@ mod tests {
     }
 
     #[test]
-    fn osc8_hover_updates_coalesce_to_the_latest_state() {
+    fn osc8_hover_only_queues_an_event_when_the_link_changes() {
         let mut state = TerminalState::default();
-        let latest: Arc<[u8]> = Arc::from(&b"https://two.example"[..]);
 
-        state.update_osc8_link_hover(Some(Arc::from(&b"https://one.example"[..])));
-        state.update_osc8_link_hover(Some(Arc::clone(&latest)));
-        assert_eq!(
-            state.drain_pending_events(),
-            vec![GhosttySurfaceEvent::Osc8LinkHoverChanged(Some(Arc::clone(
-                &latest
-            )))]
-        );
-        assert!(state.drain_pending_events().is_empty());
-        state.update_osc8_link_hover(Some(latest));
-        assert!(state.drain_pending_events().is_empty());
+        // Ghostty repeats MOUSE_OVER_LINK on every pointer move over a link.
+        state.set_hovered_osc8_link(Some("https://one.example"));
+        state.set_hovered_osc8_link(Some("https://one.example"));
+        state.set_hovered_osc8_link(None);
+        state.set_hovered_osc8_link(None);
 
-        state.update_osc8_link_hover(None);
         assert_eq!(
-            state.drain_pending_events(),
-            vec![GhosttySurfaceEvent::Osc8LinkHoverChanged(None)]
+            state.pending_events.drain(..).collect::<Vec<_>>(),
+            vec![
+                GhosttySurfaceEvent::Osc8LinkHoverChanged(Some("https://one.example".into())),
+                GhosttySurfaceEvent::Osc8LinkHoverChanged(None),
+            ]
         );
     }
 

--- a/postmortem/2026-09-02-macos-osc8-url-validation.md
+++ b/postmortem/2026-09-02-macos-osc8-url-validation.md
@@ -16,18 +16,18 @@ show the terminal-controlled URI before a click.
 
 ## Fix applied
 
-The macOS transport now separates OSC 8 opens from ordinary URL opens and
-copies their raw payload bytes while they are valid. Con asks Ghostty to emit
-previews only for OSC 8 links, deduplicates repeated hover targets, and shows
-the canonical target in a non-interactive preview.
+The macOS transport now separates OSC 8 opens from ordinary URL opens. Con asks
+Ghostty to emit previews only for OSC 8 links, emits a hover event only when
+the link under the pointer changes, and shows the canonical target in a
+non-interactive preview.
 
-OSC 8 clicks now scan the raw input for control, bidirectional, zero-width, and
-line-separator characters before URL parsing. Invalid UTF-8 and surrounding
-whitespace are also rejected before parsing can replace or remove them. Con
-opens only explicit HTTP(S) URLs with a host and no embedded credentials, plus
-non-empty email URLs, using the same serialized value shown to the user. Other
-targets enter a persistent blocked state rather than reaching the platform
-opener. The user may explicitly copy only the escaped display value.
+OSC 8 clicks now scan the raw input for whitespace, control, bidirectional,
+zero-width, and line-separator characters before URL parsing, since the parser
+would otherwise strip or encode them. Con opens only explicit HTTP(S) URLs with
+a host and no embedded credentials, plus non-empty email URLs, using the same
+serialized value shown to the user. Other targets enter a persistent blocked
+state rather than reaching the platform opener. The user may explicitly copy
+only the escaped display value.
 
 ## What we learned
 

--- a/postmortem/2026-09-02-macos-osc8-url-validation.md
+++ b/postmortem/2026-09-02-macos-osc8-url-validation.md
@@ -16,18 +16,18 @@ show the terminal-controlled URI before a click.
 
 ## Fix applied
 
-The macOS transport now preserves the open-URL kind and copies raw URL payload
-bytes while they are valid. Con asks Ghostty to emit previews only for OSC 8
-links, deduplicates repeated hover targets, and shows the canonical target in
-a non-interactive preview.
+The macOS transport now separates OSC 8 opens from ordinary URL opens and
+copies their raw payload bytes while they are valid. Con asks Ghostty to emit
+previews only for OSC 8 links, deduplicates repeated hover targets, and shows
+the canonical target in a non-interactive preview.
 
 OSC 8 clicks now scan the raw input for control, bidirectional, zero-width, and
 line-separator characters before URL parsing. Invalid UTF-8 and surrounding
 whitespace are also rejected before parsing can replace or remove them. Con
-opens only explicit HTTP(S) URLs with a host and non-empty email URLs, using
-the same serialized value shown to the user. Other targets enter a persistent
-blocked state rather than reaching the platform opener. The user may
-explicitly copy only the escaped display value.
+opens only explicit HTTP(S) URLs with a host and no embedded credentials, plus
+non-empty email URLs, using the same serialized value shown to the user. Other
+targets enter a persistent blocked state rather than reaching the platform
+opener. The user may explicitly copy only the escaped display value.
 
 ## What we learned
 

--- a/postmortem/2026-09-02-macos-osc8-url-validation.md
+++ b/postmortem/2026-09-02-macos-osc8-url-validation.md
@@ -1,0 +1,42 @@
+# macOS opened terminal-provided OSC 8 targets without validation
+
+## What happened
+
+The macOS terminal backend forwarded every Ghostty `OPEN_URL` action directly
+to the operating system. OSC 8 output could therefore show a trusted-looking
+label while opening a different target, including local files or custom URL
+schemes, without Con exposing or validating the real destination.
+
+## Root cause
+
+Con reduced Ghostty's open-URL action to a `String` and discarded the action
+kind that distinguishes untrusted OSC 8 output from ordinary detected links.
+It also did not bind Ghostty's `MOUSE_OVER_LINK` action, so the app could not
+show the terminal-controlled URI before a click.
+
+## Fix applied
+
+The macOS transport now preserves the open-URL kind and copies raw URL payload
+bytes while they are valid. Con asks Ghostty to emit previews only for OSC 8
+links, deduplicates repeated hover targets, and shows the canonical target in
+a non-interactive preview.
+
+OSC 8 clicks now scan the raw input for control, bidirectional, zero-width, and
+line-separator characters before URL parsing. Invalid UTF-8 and surrounding
+whitespace are also rejected before parsing can replace or remove them. Con
+opens only explicit HTTP(S) URLs with a host and non-empty email URLs, using
+the same serialized value shown to the user. Other targets enter a persistent
+blocked state rather than reaching the platform opener. The user may
+explicitly copy only the escaped display value.
+
+## What we learned
+
+- URL safety checks must inspect raw input before WHATWG parsing because the
+  parser removes tabs, newlines, and some zero-width host characters.
+- Link provenance is part of the security boundary. Ordinary detected URLs
+  keep their existing behavior; terminal-authored OSC 8 targets require a
+  separate policy.
+- Ghostty's hover payload has no link kind. Setting `link-previews = osc8`
+  makes hover provenance unambiguous without changing click handling.
+- Safe local-file opening requires more than executable mode bits or filename
+  extensions. Denying OSC 8 `file:` targets is the conservative first policy.


### PR DESCRIPTION
## Summary

- Validate OSC 8 hyperlinks on macOS before opening them. Ghostty's `OPEN_URL` action now keeps its `kind`, so terminal-authored OSC 8 targets go through a separate policy while plain detected links keep their current behavior.
- Allow only explicit `http://` / `https://` URLs with a host and no embedded credentials, plus non-empty `mailto:`. Deny `file:`, custom schemes, scheme-less targets, and anything containing whitespace, control, bidirectional, zero-width, or line-separator characters.
- Bind Ghostty's `MOUSE_OVER_LINK` action and set `link-previews = osc8`, so hovering an OSC 8 link shows the real target (with punycode for IDN hosts) and whether a click will open or be blocked.
- Show a persistent blocked card for denied targets with the reason, an escaped copy of the target, a copy button, and dismissal via the × button or Escape.

## Why

The macOS backend forwarded every Ghostty `OPEN_URL` straight to `cx.open_url`, discarding the action kind. An OSC 8 link can display any label while pointing anywhere, including a local executable or a custom-scheme handler, and Con neither showed nor checked the real destination. Ghostty itself marks `osc8` opens as untrusted and applies a safe-open policy in its macOS app; Con had none.

Character checks run on the raw string before `Url::parse`. Verified against the workspace's `url` 2.5.8: the parser silently strips tabs and newlines, drops zero-width characters from hosts, and turns `https:relative` into `https://relative/`, so checking after parsing would let those through. For allowed links, the displayed string and the opened string are the same serialized URL.

This is a deliberate behavior change: OSC 8 `file:` links (for example from `eza --hyperlink`) no longer open on macOS. They show the target and can be copied. Reopening them behind a confirmation flow is left for later.

Two UI fixes are included because they surfaced while testing the cards:

- The hover card ellipsized short targets. It sized itself from unrounded `shape_line` widths while GPUI rounds each text child up to a whole pixel; the `flex_1` target absorbed the sub-pixel deficit and `truncate()` dropped characters. The card is now content-sized by flex and may use the full pane width.
- The blocked card used a 12% warning tint as its only background, so terminal text showed through it. Both cards now share the find overlay's near-opaque popover base.

Windows and Linux are unaffected; their link handling stays in `terminal_links.rs` and will get OSC 8 support in a follow-up.

## Tests

- `terminal_url`: table-driven unit tests for allowed targets (including IDN hosts serialized as punycode), denied schemes, `https:relative` / `https:///` / embedded credentials, whitespace anywhere in the input, and each unsafe scalar class. Expected values follow the `url` crate's actual behavior rather than a spec reading.
- `ghostty_view`: GPUI layout tests render the hover card in a flex row and assert the target element is at least as wide as its shaped text, and that long targets cap without clipping the status. The test text system uses integer glyph advances, so the real-font sub-pixel case is documented in the commit message of `c36279c1` instead.
- `con-ghostty`: hover events are queued only when the link under the pointer changes; the generated Ghostty config contains `link-previews = osc8`.
- `ffi_abi.c`: `_Static_assert`s for the `mouse_over_link` and `open_url` payload layouts and the OSC 8 kind value.
- `cargo test -p con --bin con`, `cargo test -p con-ghostty`, `cargo build -p con`, `rustfmt --check` on changed files.
- Manual: built `con Dev.app` and exercised allowed, punycode, scheme-less, `file:`, custom-scheme, zero-width, and plain-URL cases.

## Follow-ups

- Windows / Linux: read OSC 8 URIs through `ghostty_grid_ref_hyperlink_uri` (already exported at the pinned revision), prefer them over the plain-text scanner, and reuse this policy and the cards.


<img width="1211" height="214" alt="con Dev 2026-09-03 16 10 11" src="https://github.com/user-attachments/assets/cd945156-2915-4a5a-8284-c8ab9b2f9741" />
<img width="1202" height="206" alt="con Dev 2026-09-03 16 10 41" src="https://github.com/user-attachments/assets/f26064c0-a706-4d50-8b1d-a34176f919c3" />
<img width="1177" height="218" alt="image" src="https://github.com/user-attachments/assets/6c6c68f0-a7da-4067-adf0-207a76bb5c5a" />
