### PR TITLE
fix(core): preserve existing control socket directory permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ con is still pre-release, so entries may group related beta work while the produ
 
 **macOS**
 
+- Restored `con-cli` and local automation connectivity by leaving shared
+  control-socket parent directories such as `/tmp` untouched, while keeping
+  Con-created runtime directories private. _(PR
+  [#341](https://github.com/nowledge-co/con-terminal/pull/341) by
+  [@Job28703](https://github.com/Job28703))_
 - Terminal links now reject unsafe OSC 8 targets before opening a browser,
   while preserving supported web, mail, file, and SSH links. _(PR
   [#340](https://github.com/nowledge-co/con-terminal/pull/340) by

--- a/crates/con-core/src/control.rs
+++ b/crates/con-core/src/control.rs
@@ -1280,10 +1280,19 @@ fn prepare_socket_path(path: &Path) -> Result<()> {
         }
         if !parent.exists() {
             std::fs::create_dir_all(parent)?;
+            // Harden only directories we created ourselves. Chmod-ing a
+            // pre-existing parent (e.g. /tmp for the default socket path)
+            // fails with EPERM for non-root owners on macOS and aborts the
+            // socket bind entirely.
+            use std::os::unix::fs::PermissionsExt;
+            let permissions = std::fs::Permissions::from_mode(0o700);
+            std::fs::set_permissions(parent, permissions).with_context(|| {
+                format!(
+                    "failed to set permissions on control socket directory {}",
+                    parent.display()
+                )
+            })?;
         }
-        use std::os::unix::fs::PermissionsExt;
-        let permissions = std::fs::Permissions::from_mode(0o700);
-        std::fs::set_permissions(parent, permissions)?;
     }
 
     if path.exists() {
@@ -1718,6 +1727,62 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(unix)]
+    fn unique_scratch_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "con-control-test-{}-{}-{}",
+            tag,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("clock")
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("create scratch dir");
+        dir
+    }
+
+    /// Regression: a pre-existing parent directory must be left untouched.
+    /// chmod-ing a foreign parent (e.g. /tmp, root-owned 1777) fails with
+    /// EPERM for non-root users and previously aborted the socket bind.
+    #[cfg(unix)]
+    #[test]
+    fn prepare_socket_path_preserves_existing_parent_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = unique_scratch_dir("existing-parent");
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755))
+            .expect("set scratch permissions");
+        let socket = dir.join("con.sock");
+
+        prepare_socket_path(&socket).expect("prepare with existing parent");
+
+        let mode = std::fs::metadata(&dir).expect("metadata").permissions().mode() & 0o777;
+        assert_eq!(mode, 0o755, "existing parent permissions must be untouched");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    /// The Flatpak hardening this code was added for: a parent we create
+    /// ourselves still gets 0700.
+    #[cfg(unix)]
+    #[test]
+    fn prepare_socket_path_hardens_newly_created_parent() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let base = unique_scratch_dir("new-parent");
+        let socket = base.join("fresh").join("con.sock");
+
+        prepare_socket_path(&socket).expect("prepare with new parent");
+
+        let mode = std::fs::metadata(socket.parent().expect("parent"))
+            .expect("metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o700, "newly created parent must be hardened");
+        std::fs::remove_dir_all(&base).ok();
+    }
 
     #[test]
     fn control_command_round_trips_from_rpc() {

--- a/crates/con-core/src/control.rs
+++ b/crates/con-core/src/control.rs
@@ -1278,21 +1278,20 @@ fn prepare_socket_path(path: &Path) -> Result<()> {
                 parent.display()
             );
         }
-        if !parent.exists() {
-            std::fs::create_dir_all(parent)?;
-            // Harden only directories we created ourselves. Chmod-ing a
-            // pre-existing parent (e.g. /tmp for the default socket path)
-            // fails with EPERM for non-root owners on macOS and aborts the
-            // socket bind entirely.
-            use std::os::unix::fs::PermissionsExt;
-            let permissions = std::fs::Permissions::from_mode(0o700);
-            std::fs::set_permissions(parent, permissions).with_context(|| {
-                format!(
-                    "failed to set permissions on control socket directory {}",
-                    parent.display()
-                )
-            })?;
-        }
+
+        // Apply private permissions atomically to directories we create while
+        // leaving existing parents such as /tmp or XDG_RUNTIME_DIR untouched.
+        // A post-create chmod has both an ownership failure mode and a window
+        // where a newly created directory can be more permissive than intended.
+        use std::os::unix::fs::DirBuilderExt;
+        let mut builder = std::fs::DirBuilder::new();
+        builder.recursive(true).mode(0o700);
+        builder.create(parent).with_context(|| {
+            format!(
+                "failed to create control socket directory {}",
+                parent.display()
+            )
+        })?;
     }
 
     if path.exists() {
@@ -1758,13 +1757,17 @@ mod tests {
 
         prepare_socket_path(&socket).expect("prepare with existing parent");
 
-        let mode = std::fs::metadata(&dir).expect("metadata").permissions().mode() & 0o777;
+        let mode = std::fs::metadata(&dir)
+            .expect("metadata")
+            .permissions()
+            .mode()
+            & 0o777;
         assert_eq!(mode, 0o755, "existing parent permissions must be untouched");
         std::fs::remove_dir_all(&dir).ok();
     }
 
-    /// The Flatpak hardening this code was added for: a parent we create
-    /// ourselves still gets 0700.
+    /// The Flatpak hardening this code was added for: a parent created by Con
+    /// starts with private permissions.
     #[cfg(unix)]
     #[test]
     fn prepare_socket_path_hardens_newly_created_parent() {

--- a/docs/impl/socket-api.md
+++ b/docs/impl/socket-api.md
@@ -33,9 +33,13 @@ The result in con is a hybrid:
 - CLI override: `con-cli --socket /custom/path ...`
 
 The app removes stale socket files on startup and creates the live socket with
-user-only permissions. Debug builds intentionally use a separate default
-endpoint so `cargo run -p con` can run beside an installed Con without making
-startup treat the dev process as another window for the production app.
+user-only permissions. When Con must create the socket's parent directory, it
+creates that directory with mode `0700`. Existing parents such as `/tmp`,
+`XDG_RUNTIME_DIR`, or a directory supplied through `CON_SOCKET_PATH` retain
+their ownership and permissions; the socket itself is restricted to mode
+`0600`. Debug builds intentionally use a separate default endpoint so
+`cargo run -p con` can run beside an installed Con without making startup
+treat the dev process as another window for the production app.
 
 ## Protocol
 

--- a/postmortem/2026-09-06-control-socket-parent-permissions.md
+++ b/postmortem/2026-09-06-control-socket-parent-permissions.md
@@ -1,0 +1,46 @@
+# Control Socket Parent Permission Regression
+
+## What Happened
+
+Con could start normally on macOS without exposing its local control socket.
+The UI remained usable, but `con-cli`, second-instance forwarding, and external
+automation could not connect.
+
+The failure appeared after Flatpak support added private permissions for its
+runtime socket directory. The same preparation path also handles the macOS
+default at `/tmp/con.sock`.
+
+## Root Cause
+
+Socket preparation unconditionally applied mode `0700` to the socket's parent.
+For `/tmp/con.sock`, that attempted to change the root-owned `/tmp` directory.
+A normal macOS process receives `EPERM`, so preparation returned before the
+Unix socket could bind.
+
+The security boundary was modeled at the wrong ownership level. Con owns its
+socket and directories it creates, but it does not own every directory in
+which a user chooses to place that socket.
+
+## Fix Applied
+
+- Create missing parent directories with mode `0700` through Unix
+  `DirBuilderExt`, so private permissions apply at creation time.
+- Leave every existing parent directory unchanged.
+- Continue setting the bound socket itself to mode `0600`.
+- Add regression tests for both an existing shared parent and a newly created
+  private parent.
+- Preserve path context in directory creation errors.
+
+The implementation is Unix-only. Windows continues to use Named Pipes and is
+not affected by filesystem socket permissions.
+
+## What We Learned
+
+Hardening must follow ownership. Changing permissions on a caller- or
+system-owned directory is both unsafe and unreliable, even when the intended
+permission is more restrictive.
+
+Creation-time permissions are preferable to creating and then calling
+`chmod`: they avoid both ownership races and a temporary overly permissive
+state. Tests for security-sensitive filesystem setup must cover resources that
+already exist as well as resources the application creates.


### PR DESCRIPTION
## Problem

`prepare_socket_path` unconditionally changed the control socket parent to mode `0700`. With the macOS default `/tmp/con.sock`, that meant attempting to chmod the root-owned `/tmp` directory. The operation fails with `EPERM`, aborting startup before the control socket binds while the Con UI otherwise appears healthy.

This regressed `con-cli`, external automation, and second-instance forwarding after the Flatpak runtime-directory hardening landed.

## Fix

- Create missing Unix socket parent directories with `DirBuilderExt::mode(0o700)`, applying private permissions in the creation syscall.
- Leave existing system-, runtime-, and user-owned parent directories unchanged.
- Keep the bound socket itself at mode `0600`.
- Preserve contextual path errors.
- Document the ownership boundary and add a regression postmortem.

This retains the Flatpak hardening without mutating `/tmp`, `XDG_RUNTIME_DIR`, or a custom existing parent. Windows uses Named Pipes and does not execute this code.

## Tests

- `prepare_socket_path_preserves_existing_parent_permissions`
- `prepare_socket_path_hardens_newly_created_parent`
- `cargo test -p con-core` (99 passed)
- `CON_ZIG_BIN=/opt/homebrew/bin/zig cargo check -p con --all-targets`
- `cargo fmt -p con-core -- --check`
- `git diff --check`

## Release notes

The beta.95 changelog credits @Job28703 for the report, root-cause investigation, initial fix, and regression tests.
