### PR TITLE
fix(macos): prevent display-link hangs after wake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,49 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
-## `v0.1.0-beta.93` - unreleased
+## `v0.1.0-beta.95` - unreleased
+
+### Fixed
+
+**macOS**
+
+- Terminal links now reject unsafe OSC 8 targets before opening a browser,
+  while preserving supported web, mail, file, and SSH links. _(PR
+  [#340](https://github.com/nowledge-co/con-terminal/pull/340) by
+  [@yyhhyyyyyy](https://github.com/yyhhyyyyyy))_
+- Terminal surfaces now pause before system sleep and resume only after the
+  display topology has settled, avoiding the CoreVideo display-link hang
+  observed when waking a Mac onto an external display. _(PR
+  [#342](https://github.com/nowledge-co/con-terminal/pull/342) by
+  [@wey-gu](https://github.com/wey-gu))_
+
+---
+
+## `v0.1.0-beta.94` - 2026-09-02
+
+### Changed
+
+**Windows and Linux**
+
+- Terminal selection now uses libghostty-vt's canonical selection model,
+  keeping drag, word, line, and scrollback selection behavior consistent with
+  terminal state. _(PR
+  [#338](https://github.com/nowledge-co/con-terminal/pull/338) by
+  [@yyhhyyyyyy](https://github.com/yyhhyyyyyy))_
+
+### Fixed
+
+**Windows**
+
+- Mouse reporting now uses Ghostty's protocol encoder, improving wheel,
+  button, modifier, coordinate, and alternate-scroll handling in terminal
+  applications. _(PR
+  [#339](https://github.com/nowledge-co/con-terminal/pull/339) by
+  [@yyhhyyyyyy](https://github.com/yyhhyyyyyy))_
+
+---
+
+## `v0.1.0-beta.93` - 2026-09-01
 
 ### Added
 

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -93,6 +93,7 @@ unsafe extern "C" {
     fn objc_setAssociatedObject(object: id, key: *const c_void, value: id, policy: usize);
     fn con_ghostty_surface_install_backing_observer(view: *mut c_void, surface: *mut c_void);
     fn con_ghostty_surface_remove_backing_observer(view: *mut c_void);
+    fn con_ghostty_surface_sync_occlusion(view: *mut c_void);
     fn con_ghostty_surface_sync_backing(
         view: *mut c_void,
         surface: *mut c_void,
@@ -1126,7 +1127,7 @@ impl GhosttyView {
 
         if let Some(ref terminal) = self.terminal {
             terminal.set_focus(false);
-            terminal.set_occlusion(true);
+            terminal.set_visible(false);
         }
 
         self.detach_host_view();
@@ -1878,6 +1879,11 @@ impl GhosttyView {
     pub fn set_visible(&self, visible: bool) {
         self.native_view_visible.set(visible);
         self.apply_native_visibility();
+        if let Some(nsview) = self.nsview {
+            unsafe {
+                con_ghostty_surface_sync_occlusion(nsview as *mut c_void);
+            }
+        }
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/con-app/src/objc/ghostty_surface_trampoline.m
+++ b/crates/con-app/src/objc/ghostty_surface_trampoline.m
@@ -7,9 +7,12 @@
 
 extern void ghostty_surface_set_content_scale(void *surface, double x, double y);
 extern void ghostty_surface_set_display_id(void *surface, uint32_t display_id);
+// Ghostty's API name is historical; the boolean is true when the surface is visible.
+extern void ghostty_surface_set_occlusion(void *surface, bool visible);
 extern void ghostty_surface_set_size(void *surface, uint32_t width, uint32_t height);
 
 static char kConGhosttySurfaceBackingObserverKey;
+static const int64_t kConDisplayWakeQuietPeriodMilliseconds = 250;
 
 static double con_valid_scale(double scale, double fallback) {
     if (!isfinite(scale) || scale <= 0.0) {
@@ -99,9 +102,20 @@ bool con_ghostty_surface_sync_backing(
 @property(nonatomic, weak) NSWindow *window;
 @property(nonatomic, strong) id screenObserver;
 @property(nonatomic, strong) id backingObserver;
+@property(nonatomic, strong) id occlusionObserver;
+@property(nonatomic, strong) id displayObserver;
+@property(nonatomic, strong) id willSleepObserver;
+@property(nonatomic, strong) id didWakeObserver;
+@property(nonatomic, assign) BOOL suspendedForSleep;
+@property(nonatomic, assign) NSUInteger wakeGeneration;
+@property(nonatomic, assign) BOOL surfaceVisibilityKnown;
+@property(nonatomic, assign) BOOL lastSurfaceVisible;
 - (void)installForView:(NSView *)view surface:(void *)surface;
 - (void)invalidate;
+- (void)scheduleWakeSettle;
+- (void)setSurfaceVisible:(BOOL)visible;
 - (void)sync;
+- (void)syncOcclusion;
 @end
 
 @implementation ConGhosttySurfaceBackingObserver
@@ -112,7 +126,10 @@ bool con_ghostty_surface_sync_backing(
 
 - (void)installForView:(NSView *)view surface:(void *)surface {
     NSWindow *window = view.window;
-    if (_window == window && _surface == surface && _screenObserver != nil && _backingObserver != nil) {
+    if (_window == window && _surface == surface && _screenObserver != nil &&
+        _backingObserver != nil && _occlusionObserver != nil &&
+        _displayObserver != nil && _willSleepObserver != nil &&
+        _didWakeObserver != nil) {
         return;
     }
 
@@ -120,6 +137,9 @@ bool con_ghostty_surface_sync_backing(
     _view = view;
     _surface = surface;
     _window = window;
+    _suspendedForSleep = NO;
+    _wakeGeneration += 1;
+    _surfaceVisibilityKnown = NO;
 
     if (window == nil || surface == NULL) {
         return;
@@ -132,6 +152,10 @@ bool con_ghostty_surface_sync_backing(
                                            queue:NSOperationQueue.mainQueue
                                       usingBlock:^(__unused NSNotification *notification) {
         ConGhosttySurfaceBackingObserver *observer = weakSelf;
+        if (observer.suspendedForSleep) {
+            [observer scheduleWakeSettle];
+            return;
+        }
         [observer sync];
         dispatch_async(dispatch_get_main_queue(), ^{
             [observer sync];
@@ -141,9 +165,56 @@ bool con_ghostty_surface_sync_backing(
                                            object:window
                                             queue:NSOperationQueue.mainQueue
                                        usingBlock:^(__unused NSNotification *notification) {
-        [weakSelf sync];
+        ConGhosttySurfaceBackingObserver *observer = weakSelf;
+        if (observer.suspendedForSleep) {
+            [observer scheduleWakeSettle];
+        } else {
+            [observer sync];
+        }
+    }];
+    _occlusionObserver = [center addObserverForName:NSWindowDidChangeOcclusionStateNotification
+                                             object:window
+                                              queue:NSOperationQueue.mainQueue
+                                         usingBlock:^(__unused NSNotification *notification) {
+        [weakSelf syncOcclusion];
+    }];
+    _displayObserver = [center addObserverForName:NSApplicationDidChangeScreenParametersNotification
+                                           object:nil
+                                            queue:NSOperationQueue.mainQueue
+                                       usingBlock:^(__unused NSNotification *notification) {
+        ConGhosttySurfaceBackingObserver *observer = weakSelf;
+        if (observer.suspendedForSleep) {
+            [observer scheduleWakeSettle];
+        }
     }];
 
+    NSNotificationCenter *workspaceCenter = NSWorkspace.sharedWorkspace.notificationCenter;
+    _willSleepObserver = [workspaceCenter addObserverForName:NSWorkspaceWillSleepNotification
+                                                       object:nil
+                                                        queue:NSOperationQueue.mainQueue
+                                                   usingBlock:^(__unused NSNotification *notification) {
+        ConGhosttySurfaceBackingObserver *observer = weakSelf;
+        if (observer == nil || observer->_surface == NULL) {
+            return;
+        }
+
+        observer.suspendedForSleep = YES;
+        observer.wakeGeneration += 1;
+        [observer setSurfaceVisible:NO];
+    }];
+    _didWakeObserver = [workspaceCenter addObserverForName:NSWorkspaceDidWakeNotification
+                                                     object:nil
+                                                      queue:NSOperationQueue.mainQueue
+                                                 usingBlock:^(__unused NSNotification *notification) {
+        ConGhosttySurfaceBackingObserver *observer = weakSelf;
+        if (observer == nil) {
+            return;
+        }
+
+        [observer scheduleWakeSettle];
+    }];
+
+    [self syncOcclusion];
 }
 
 - (void)invalidate {
@@ -156,13 +227,64 @@ bool con_ghostty_surface_sync_backing(
         [center removeObserver:_backingObserver];
         _backingObserver = nil;
     }
+    if (_occlusionObserver != nil) {
+        [center removeObserver:_occlusionObserver];
+        _occlusionObserver = nil;
+    }
+    if (_displayObserver != nil) {
+        [center removeObserver:_displayObserver];
+        _displayObserver = nil;
+    }
+
+    NSNotificationCenter *workspaceCenter = NSWorkspace.sharedWorkspace.notificationCenter;
+    if (_willSleepObserver != nil) {
+        [workspaceCenter removeObserver:_willSleepObserver];
+        _willSleepObserver = nil;
+    }
+    if (_didWakeObserver != nil) {
+        [workspaceCenter removeObserver:_didWakeObserver];
+        _didWakeObserver = nil;
+    }
+    _wakeGeneration += 1;
+    _suspendedForSleep = NO;
+    _surfaceVisibilityKnown = NO;
     _window = nil;
     _surface = NULL;
 }
 
+- (void)scheduleWakeSettle {
+    if (!_suspendedForSleep || _surface == NULL) {
+        return;
+    }
+
+    NSUInteger generation = ++_wakeGeneration;
+    __weak ConGhosttySurfaceBackingObserver *weakSelf = self;
+    // Screen and backing notifications can arrive in bursts while WindowServer
+    // rebuilds the topology. Resume only after a quiet interval; every newer
+    // notification invalidates this block through wakeGeneration.
+    dispatch_after(
+        dispatch_time(
+            DISPATCH_TIME_NOW,
+            kConDisplayWakeQuietPeriodMilliseconds * NSEC_PER_MSEC
+        ),
+        dispatch_get_main_queue(),
+        ^{
+            ConGhosttySurfaceBackingObserver *observer = weakSelf;
+            if (observer == nil || observer.wakeGeneration != generation ||
+                observer->_surface == NULL) {
+                return;
+            }
+
+            observer.suspendedForSleep = NO;
+            [observer sync];
+            [observer syncOcclusion];
+        }
+    );
+}
+
 - (void)sync {
     NSView *view = _view;
-    if (view == nil || _surface == NULL) {
+    if (view == nil || _surface == NULL || _suspendedForSleep) {
         return;
     }
 
@@ -179,6 +301,28 @@ bool con_ghostty_surface_sync_backing(
         NULL,
         NULL
     );
+}
+
+- (void)setSurfaceVisible:(BOOL)visible {
+    if (_surface == NULL || (_surfaceVisibilityKnown && _lastSurfaceVisible == visible)) {
+        return;
+    }
+
+    _surfaceVisibilityKnown = YES;
+    _lastSurfaceVisible = visible;
+    ghostty_surface_set_occlusion(_surface, visible);
+}
+
+- (void)syncOcclusion {
+    NSView *view = _view;
+    NSWindow *window = _window;
+    if (view == nil || window == nil || _surface == NULL) {
+        return;
+    }
+
+    BOOL visible = !_suspendedForSleep && !view.isHiddenOrHasHiddenAncestor &&
+        (window.occlusionState & NSWindowOcclusionStateVisible) != 0;
+    [self setSurfaceVisible:visible];
 }
 
 @end
@@ -202,6 +346,17 @@ void con_ghostty_surface_install_backing_observer(void *view_ptr, void *surface_
     }
 
     [observer installForView:view surface:surface_ptr];
+}
+
+void con_ghostty_surface_sync_occlusion(void *view_ptr) {
+    NSView *view = (__bridge NSView *)view_ptr;
+    if (view == nil) {
+        return;
+    }
+
+    ConGhosttySurfaceBackingObserver *observer =
+        objc_getAssociatedObject(view, &kConGhosttySurfaceBackingObserverKey);
+    [observer syncOcclusion];
 }
 
 void con_ghostty_surface_remove_backing_observer(void *view_ptr) {

--- a/crates/con-ghostty/src/ffi.rs
+++ b/crates/con-ghostty/src/ffi.rs
@@ -665,7 +665,8 @@ unsafe extern "C" {
 
     // Surface focus / state
     pub fn ghostty_surface_set_focus(surface: ghostty_surface_t, focused: bool);
-    pub fn ghostty_surface_set_occlusion(surface: ghostty_surface_t, occluded: bool);
+    // Despite the C API name, this parameter is true when the surface is visible.
+    pub fn ghostty_surface_set_occlusion(surface: ghostty_surface_t, visible: bool);
     pub fn ghostty_surface_set_color_scheme(
         surface: ghostty_surface_t,
         scheme: ghostty_color_scheme_e,

--- a/crates/con-ghostty/src/linux/backend.rs
+++ b/crates/con-ghostty/src/linux/backend.rs
@@ -298,7 +298,7 @@ impl LinuxGhosttyTerminal {
 
     pub fn set_content_scale(&self, _scale: f64) {}
     pub fn set_focus(&self, _focused: bool) {}
-    pub fn set_occlusion(&self, _occluded: bool) {}
+    pub fn set_visible(&self, _visible: bool) {}
     pub fn set_color_scheme(&self, dark: bool) {
         if let Some(session) = self.inner.lock().as_ref() {
             session.set_dark_mode(dark);

--- a/crates/con-ghostty/src/stub.rs
+++ b/crates/con-ghostty/src/stub.rs
@@ -196,7 +196,7 @@ impl GhosttyTerminal {
     }
     pub fn set_content_scale(&self, _scale: f64) {}
     pub fn set_focus(&self, _focused: bool) {}
-    pub fn set_occlusion(&self, _occluded: bool) {}
+    pub fn set_visible(&self, _visible: bool) {}
     pub fn set_color_scheme(&self, _dark: bool) {}
     pub fn set_clipboard_write_enabled(&self, _enabled: bool) -> Result<(), String> {
         Ok(())

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -874,9 +874,9 @@ impl GhosttyTerminal {
         unsafe { ffi::ghostty_surface_set_focus(self.surface, focused) }
     }
 
-    /// Set occlusion state (hidden behind other windows).
-    pub fn set_occlusion(&self, occluded: bool) {
-        unsafe { ffi::ghostty_surface_set_occlusion(self.surface, occluded) }
+    /// Tell the renderer whether the native surface is currently visible.
+    pub fn set_visible(&self, visible: bool) {
+        unsafe { ffi::ghostty_surface_set_occlusion(self.surface, visible) }
     }
 
     /// Set color scheme (light/dark).

--- a/crates/con-ghostty/src/windows/backend.rs
+++ b/crates/con-ghostty/src/windows/backend.rs
@@ -211,7 +211,7 @@ impl WindowsGhosttyTerminal {
 
     pub fn set_content_scale(&self, _scale: f64) {}
     pub fn set_focus(&self, _focused: bool) {}
-    pub fn set_occlusion(&self, _occluded: bool) {}
+    pub fn set_visible(&self, _visible: bool) {}
     pub fn set_color_scheme(&self, _dark: bool) {}
     pub fn perform_binding_action(&self, _action: &str) -> Result<bool, String> {
         Ok(false)

--- a/docs/impl/terminal-rendering.md
+++ b/docs/impl/terminal-rendering.md
@@ -21,6 +21,27 @@ That is not a temporary compromise. It matches Ghostty's own host-side architect
 
 That split is intentional. Terminal correctness stays in Ghostty. Product intelligence stays in con.
 
+## macOS display lifecycle
+
+Each embedded macOS surface owns a Ghostty renderer and therefore participates
+in CoreVideo frame pacing independently from the GPUI window around it. Con
+keeps those native renderers aligned with AppKit's lifecycle:
+
+- `NSWindowDidChangeOcclusionStateNotification` is mirrored to
+  `ghostty_surface_set_occlusion`, so hidden or covered windows do not keep a
+  surface display link active.
+- `NSWorkspaceWillSleepNotification` occludes every live surface before the
+  display server starts tearing down the current topology.
+- After `NSWorkspaceDidWakeNotification`, screen and backing notifications are
+  coalesced until WindowServer's display changes become quiet. Backing scale,
+  display id, and pixel size are then synchronized before only actually visible
+  surfaces are unoccluded.
+
+This ordering is deliberate. Display identity, backing scale, renderer
+visibility, and framebuffer size are one lifecycle transaction on macOS; they
+must not be updated independently while the system is rebuilding its display
+configuration.
+
 Pane zoom follows the same boundary. Zooming a pane is a Con layout state,
 not a terminal mutation: every split surface stays alive, but the active
 tab renders and shows only the focused pane until the zoom shortcut is

--- a/postmortem/2026-09-05-macos-wake-display-link-hang.md
+++ b/postmortem/2026-09-05-macos-wake-display-link-hang.md
@@ -1,0 +1,71 @@
+# macOS Wake and External Display Hang
+
+## What Happened
+
+Con became permanently unresponsive after the Mac woke while reconnecting to
+an external 4K display. The problem occurred twice on the same machine. Force
+quit was the only recovery.
+
+Both system hang reports captured the same main-thread stack. The first sample
+started six seconds after wake; the second remained blocked for more than an
+hour. In both cases AppKit was processing a finalized display configuration
+when CoreVideo blocked in `CVDisplayLink::stop()`.
+
+## Root Cause
+
+Ghostty's historically named `ghostty_surface_set_occlusion` API accepts a
+`visible` boolean, not an `occluded` boolean. Con's Rust wrapper documented and
+forwarded that value as `occluded`. Its only call passed `true` during final
+teardown, which actually kept or restarted the renderer instead of pausing it.
+
+The macOS host also did not mirror system sleep or ordinary window occlusion
+into embedded Ghostty surfaces. Consequently, every visible or previously
+visible pane could retain an active per-surface `CVDisplayLink` while
+WindowServer removed and rebuilt displays during wake.
+
+CoreVideo stops display links synchronously as part of that system display
+reconfiguration. The two diagnostic reports show the main dispatch queue
+waiting in that stop path, while three `CVDisplayLink` threads remained in the
+process. This was a display-link lifecycle failure, not terminal parsing,
+layout computation, Metal drawing, or a Rust mutex deadlock.
+
+Con also allowed its ordinary GPUI layout pass to synchronize Ghostty's display
+id, backing scale, and size during this unstable interval. That did not create
+the sampled wait, but it made the display transition less deterministic.
+
+## Fix Applied
+
+- Replace Con's ambiguous `set_occlusion` wrapper with an explicit
+  `set_visible` API, including the no-op Windows, Linux, and stub backends.
+- Observe the AppKit window's occlusion state and mirror visibility to the
+  embedded Ghostty surface.
+- Observe workspace sleep and mark every surface invisible before display
+  teardown.
+- Keep each renderer paused after wake while coalescing AppKit screen and
+  backing-property notifications. Every new display event restarts the quiet
+  interval instead of relying on the first post-wake geometry.
+- Once display changes become quiet, synchronize display id, scale, and size,
+  then resume only surfaces whose native view and window are actually visible.
+- Invalidate both window and workspace observers before releasing the raw
+  Ghostty surface pointer; delayed wake callbacks carry a generation guard.
+
+The change is compiled only into the macOS Objective-C bridge. Windows and
+Linux terminal lifecycle and rendering paths are unchanged.
+
+## What We Learned
+
+Embedding a renderer means owning its power and display lifecycle, not only its
+view geometry. AppKit hiding a child view is not sufficient evidence that the
+embedded renderer has stopped its frame source.
+
+A cross-display fix must treat sleep, occlusion, display identity, backing
+scale, and framebuffer size as one ordered state transition. Reacting only to
+`NSWindowDidChangeScreenNotification` is too late for display teardown and too
+early for stable wake geometry.
+
+Zed later replaced GPUI's per-window `CVDisplayLink` teardown with a
+per-display registry upstream. Con cannot consume that single commit in
+isolation because the corresponding GPUI API generation is incompatible with
+the currently pinned gpui-component release. That coordinated dependency
+migration remains worthwhile, but it is separate from this targeted lifecycle
+fix and must pass full cross-platform UI regression testing.


### PR DESCRIPTION
## Summary

- correct Con's inverted interpretation of Ghostty's surface visibility API
- pause embedded terminal renderers when their AppKit view is occluded and before system sleep
- coalesce post-wake display, backing-scale, and geometry changes before resuming visible surfaces
- invalidate native observers and delayed callbacks before releasing a Ghostty surface

## Root cause

Two macOS hang reports from the same machine captured the main thread permanently blocked in `CVDisplayLink::stop()` while SkyLight finalized a display reconfiguration. One began six seconds after wake. Both processes retained three CoreVideo display-link threads.

Ghostty's historically named `ghostty_surface_set_occlusion` API takes `visible`, but Con wrapped it as `set_occlusion(occluded)`. The teardown path passed `true`, which told Ghostty that the renderer was visible instead of pausing it. Con also did not forward normal AppKit occlusion or system sleep/wake state to embedded surfaces.

This change follows Ghostty's native macOS host behavior for window visibility and adds an explicit sleep/wake transaction so display identity, backing scale, pixel size, and renderer visibility are not updated independently while WindowServer is rebuilding the display topology.

The Objective-C lifecycle implementation is macOS-only. Windows and Linux keep no-op visibility methods; their behavior is unchanged.

## Verification

- `CON_ZIG_BIN=/opt/homebrew/bin/zig cargo check -p con --all-targets`
- `CON_ZIG_BIN=/opt/homebrew/bin/zig cargo test -p con --all-targets` (356 passed)
- `CON_ZIG_BIN=/opt/homebrew/bin/zig cargo test -p con-ghostty`
- `xcrun clang -fsyntax-only -fobjc-arc -fmodules -Wall -Wextra crates/con-app/src/objc/ghostty_surface_trampoline.m`
- `git diff --check`

A physical sleep/wake cycle while reconnecting the external 4K display remains the final hardware validation.
