### PR TITLE
docs: finalize beta.95 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
-## `v0.1.0-beta.95` - unreleased
+## `v0.1.0-beta.95` - 2026-09-06
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
- record the published date for `v0.1.0-beta.95`

## Context
The release is public and all platform release gates have passed. This keeps the repository and docs-site changelog aligned with the shipped release.