### PR TITLE
docs: run build commands through mise

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -50,10 +50,14 @@ If you use [mise](https://mise.jdx.dev/), the repo root `mise.toml`
 pins the exact Zig version. Run:
 
 ```bash
-mise install   # installs zig 0.16.0
+mise install              # installs the pinned toolchain
+mise exec -- just build   # runs with Zig 0.16.0 on PATH
 ```
 
-Then use `just` for all build / run / test tasks (see below).
+Run the `just` commands below through `mise exec --` so the pinned tools are
+available even when mise shell activation is not configured. For example,
+`mise exec -- just test` runs the platform-appropriate test set. If your shell
+already activates mise, you can use `just` directly.
 
 ### Manual setup
 

--- a/mise.toml
+++ b/mise.toml
@@ -2,9 +2,9 @@
 # https://mise.jdx.dev/
 #
 # Usage:
-#   mise install    # Install pinned tool versions
-#   just build      # Build the project
-#   just run        # Run from source
+#   mise install              # Install pinned tool versions
+#   mise exec -- just build   # Build with pinned tools on PATH
+#   mise exec -- just run     # Run with pinned tools on PATH
 #
 # Note: mise manages tool versions only. Task running is delegated to
 # the justfile to keep a single source of truth for build commands.


### PR DESCRIPTION
Fixes #267.

The mise setup now runs `just` through `mise exec --`, ensuring the pinned Zig 0.16.0 is on `PATH` even when shell activation is not configured. The guide also explains when direct `just` commands are valid.

Validation: parsed `mise.toml` with Python `tomllib`, checked all mise/build references, and ran `git diff --check`.
