### PR TITLE
build(ghostty): bump libghostty to 492300ca and restore macOS copy-on-select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,8 @@ con is still pre-release, so entries may group related beta work while the produ
 
 **Terminal runtime**
 
-- Updated libghostty to its September 4 revision, bringing current terminal
-  memory, keyboard encoding, and renderer improvements while keeping Con's
-  platform contracts pinned and tested. _(PR
+- Updated libghostty to its September 4 revision, improving extended-key
+  compatibility, terminal memory use, and idle renderer efficiency. _(PR
   [#345](https://github.com/nowledge-co/con-terminal/pull/345) by
   [@yyhhyyyyyy](https://github.com/yyhhyyyyyy))_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## `v0.1.0-beta.96` - unreleased
+
+### Changed
+
+**Terminal runtime**
+
+- Updated libghostty to its September 4 revision, bringing current terminal
+  memory, keyboard encoding, and renderer improvements while keeping Con's
+  platform contracts pinned and tested. _(PR
+  [#345](https://github.com/nowledge-co/con-terminal/pull/345) by
+  [@yyhhyyyyyy](https://github.com/yyhhyyyyyy))_
+
+### Fixed
+
+**macOS**
+
+- Selecting terminal text copies it to the clipboard again, without weakening
+  the permission gate for clipboard writes initiated by terminal programs.
+  _(PR [#345](https://github.com/nowledge-co/con-terminal/pull/345) by
+  [@yyhhyyyyyy](https://github.com/yyhhyyyyyy))_
+
+---
+
 ## `v0.1.0-beta.95` - 2026-09-06
 
 ### Fixed

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -984,7 +984,7 @@ impl GhosttyView {
         let Some(position) = self.last_mouse_position else {
             return;
         };
-        if self.finish_mouse_sequence(MouseButton::Left, position, None) {
+        if self.release_left_mouse_sequence(position, None, cx) {
             self.drain_surface_state(true, cx);
             cx.notify();
         }
@@ -1990,6 +1990,39 @@ impl GhosttyView {
         true
     }
 
+    /// Deliver a left-button release and run Con's copy-on-select. Returns
+    /// whether a release was actually delivered so callers can drain the
+    /// surface state afterwards.
+    ///
+    /// Con owns copy-on-select for the macOS Ghostty backend. Ghostty's own
+    /// variant is disabled in the runtime config (`copy-on-select = none`)
+    /// because Ghostty would route it through the same `write_clipboard`
+    /// callback as OSC 52 application writes, and con-ghostty deliberately
+    /// gates that callback by the user's clipboard-write setting. A user
+    /// gesture must not depend on that setting, so the copy happens here, on
+    /// the GPUI clipboard path that Cmd+C already uses. Mirroring Ghostty,
+    /// only a left-button release copies: Ghostty clears the selection on a
+    /// plain left press, so a click to focus never republishes stale text.
+    fn release_left_mouse_sequence(
+        &mut self,
+        position: Point<Pixels>,
+        mods: Option<i32>,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if !self.finish_mouse_sequence(MouseButton::Left, position, mods) {
+            return false;
+        }
+        if let Some(selection) = self
+            .terminal
+            .as_ref()
+            .filter(|terminal| terminal.has_selection())
+            .and_then(|terminal| terminal.selection_text())
+        {
+            cx.write_to_clipboard(ClipboardItem::new_string(selection));
+        }
+        true
+    }
+
     fn finish_active_mouse_sequences(&mut self) {
         if let Some(position) = self.last_mouse_position {
             self.finish_mouse_sequence(MouseButton::Left, position, None);
@@ -2630,7 +2663,7 @@ impl Render for GhosttyView {
                     this.scrollbar_drag = None;
                     this.last_mouse_position = Some(event.position);
                     let mods = gpui_mods_to_ghostty(&event.modifiers);
-                    if this.finish_mouse_sequence(MouseButton::Left, event.position, Some(mods))
+                    if this.release_left_mouse_sequence(event.position, Some(mods), cx)
                         && this.drain_surface_state(true, cx)
                     {
                         cx.notify();
@@ -2646,7 +2679,7 @@ impl Render for GhosttyView {
                     }
                     this.last_mouse_position = Some(event.position);
                     let mods = gpui_mods_to_ghostty(&event.modifiers);
-                    if this.finish_mouse_sequence(MouseButton::Left, event.position, Some(mods))
+                    if this.release_left_mouse_sequence(event.position, Some(mods), cx)
                         && this.drain_surface_state(true, cx)
                     {
                         cx.notify();
@@ -2688,7 +2721,7 @@ impl Render for GhosttyView {
                 let mods = gpui_mods_to_ghostty(&event.modifiers);
                 if event.pressed_button.is_none() {
                     let released_left =
-                        this.finish_mouse_sequence(MouseButton::Left, event.position, Some(mods));
+                        this.release_left_mouse_sequence(event.position, Some(mods), cx);
                     this.finish_mouse_sequence(MouseButton::Right, event.position, Some(mods));
                     if released_left && this.drain_surface_state(true, cx) {
                         cx.notify();

--- a/crates/con-app/src/ghostty_view.rs
+++ b/crates/con-app/src/ghostty_view.rs
@@ -1990,19 +1990,11 @@ impl GhosttyView {
         true
     }
 
-    /// Deliver a left-button release and run Con's copy-on-select. Returns
-    /// whether a release was actually delivered so callers can drain the
-    /// surface state afterwards.
-    ///
-    /// Con owns copy-on-select for the macOS Ghostty backend. Ghostty's own
-    /// variant is disabled in the runtime config (`copy-on-select = none`)
-    /// because Ghostty would route it through the same `write_clipboard`
-    /// callback as OSC 52 application writes, and con-ghostty deliberately
-    /// gates that callback by the user's clipboard-write setting. A user
-    /// gesture must not depend on that setting, so the copy happens here, on
-    /// the GPUI clipboard path that Cmd+C already uses. Mirroring Ghostty,
-    /// only a left-button release copies: Ghostty clears the selection on a
-    /// plain left press, so a click to focus never republishes stale text.
+    /// Left-button release plus copy-on-select: Ghostty's own copy-on-select
+    /// is disabled in con-ghostty's runtime config (see `to_config_string`),
+    /// so the selection is copied here on the same path as Cmd+C. Like
+    /// Ghostty, only a left release copies; a plain left press clears the
+    /// selection, so clicking to focus never republishes stale text.
     fn release_left_mouse_sequence(
         &mut self,
         position: Point<Pixels>,
@@ -2012,12 +2004,7 @@ impl GhosttyView {
         if !self.finish_mouse_sequence(MouseButton::Left, position, mods) {
             return false;
         }
-        if let Some(selection) = self
-            .terminal
-            .as_ref()
-            .filter(|terminal| terminal.has_selection())
-            .and_then(|terminal| terminal.selection_text())
-        {
+        if let Some(selection) = self.terminal.as_ref().and_then(|t| t.selection_text()) {
             cx.write_to_clipboard(ClipboardItem::new_string(selection));
         }
         true

--- a/crates/con-ghostty/build.rs
+++ b/crates/con-ghostty/build.rs
@@ -16,15 +16,9 @@ const GHOSTTY_REPO: &str = "https://github.com/ghostty-org/ghostty.git";
 /// against Con's private embedding patch and portable VT bindings.
 ///
 /// 2026-09-06 bump: from `5f5b988c52...` to `492300cad1...` (186 upstream
-/// commits). `include/ghostty.h` is byte-identical; `include/ghostty/vt/`
-/// only gained the search API and `GhosttySelectionBuffer`. All embedding
-/// patch anchors still match, `ffi_abi.c` compiles against the new header,
-/// and the macOS archive built and passed `cargo test -p con-ghostty`.
-/// Behavior changes that needed Con-side handling: Ghostty 1.4 redefined
-/// `copy-on-select` / `middle-click-action` defaults (see
-/// `to_config_string` in `src/terminal.rs`), and the renderer now parks its
-/// CVDisplayLink whenever a surface is idle (`6688aa072`, `97f57edcc`),
-/// which overlaps with Con's sleep/wake visibility handling from #342.
+/// commits). `include/ghostty.h` unchanged, vt headers additive only, patch
+/// anchors intact. Ghostty 1.4 redefined `copy-on-select` /
+/// `middle-click-action`; Con pins both in `src/terminal.rs`.
 ///
 /// Ghostty's internal macOS embedding API and libghostty-vt API are not
 /// stable. Future bumps must update the handwritten FFI bindings, compile

--- a/crates/con-ghostty/build.rs
+++ b/crates/con-ghostty/build.rs
@@ -15,11 +15,22 @@ const GHOSTTY_REPO: &str = "https://github.com/ghostty-org/ghostty.git";
 /// commits were audited with unchanged public C headers and revalidated
 /// against Con's private embedding patch and portable VT bindings.
 ///
+/// 2026-09-06 bump: from `5f5b988c52...` to `492300cad1...` (186 upstream
+/// commits). `include/ghostty.h` is byte-identical; `include/ghostty/vt/`
+/// only gained the search API and `GhosttySelectionBuffer`. All embedding
+/// patch anchors still match, `ffi_abi.c` compiles against the new header,
+/// and the macOS archive built and passed `cargo test -p con-ghostty`.
+/// Behavior changes that needed Con-side handling: Ghostty 1.4 redefined
+/// `copy-on-select` / `middle-click-action` defaults (see
+/// `to_config_string` in `src/terminal.rs`), and the renderer now parks its
+/// CVDisplayLink whenever a surface is idle (`6688aa072`, `97f57edcc`),
+/// which overlaps with Con's sleep/wake visibility handling from #342.
+///
 /// Ghostty's internal macOS embedding API and libghostty-vt API are not
 /// stable. Future bumps must update the handwritten FFI bindings, compile
 /// the ABI assertions, and run real build/link/runtime checks on all three
 /// platforms rather than treating this as a source-only dependency bump.
-const GHOSTTY_REV: &str = "5f5b988c5236facfe8d2439203d9ee9d5b636cf8";
+const GHOSTTY_REV: &str = "492300cad104195411d12217dd22f1cd05f31376";
 const GHOSTTY_ENV: &str = "CON_GHOSTTY_SOURCE_DIR";
 const GHOSTTY_INITIAL_OUTPUT_REQUIRE_ENV: &str = "CON_REQUIRE_GHOSTTY_INITIAL_OUTPUT";
 const GHOSTTY_VT_TARGET_ENV: &str = "CON_GHOSTTY_VT_TARGET";
@@ -283,13 +294,15 @@ fn build_vt_backend(target_os: &str) {
     // Windows, so default it on regardless of cargo profile and let
     // `CON_GHOSTTY_OPTIMIZE=Debug` opt back in for VT-debugging.
     //
-    // `-Dsimd`: the pinned Ghostty revision must build Linux libghostty-vt
-    // with libc enabled. Its non-libc Wuffs module exports hidden weak
+    // `-Dsimd`: Linux libghostty-vt must be built with libc enabled. Ghostty's
+    // non-libc Wuffs module (`pkg/wuffs/src/main.zig`) exports hidden weak
     // `calloc`/`free` fallbacks; when that archive is linked into a Rust
     // executable, the hidden fallbacks capture the process-wide symbols and
     // make every zeroed Rust allocation fail. Enabling SIMD also enables libc
-    // on Ghostty's root module, suppressing those fallbacks, and the current
-    // Linux archive contains the required simdutf/highway objects.
+    // on Ghostty's root module (`src/build/GhosttyZig.zig`), suppressing
+    // those fallbacks, and the Linux archive contains the required
+    // simdutf/highway objects. Re-check both files on every GHOSTTY_REV bump;
+    // the coupling is an upstream implementation detail, not a contract.
     //
     // Windows keeps the conservative non-SIMD default because its static
     // archive has a different C++ link surface. The override remains useful

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -178,6 +178,25 @@ impl GhosttyConfigPatch {
         // host-side previews to OSC 8, whose visible label can differ from the
         // producer-controlled URI and therefore needs an explicit preview.
         s.push_str("link-previews = osc8\n");
+        // Pin clipboard routing instead of inheriting Ghostty's platform
+        // defaults; Ghostty 1.4 (ghostty-org/ghostty#12604) redefined both.
+        //
+        // `copy-on-select = none`: Ghostty delivers its own copy-on-select
+        // through the same `write_clipboard` callback as OSC 52 application
+        // writes, and `write_clipboard_callback` below deliberately gates that
+        // callback by the user's clipboard-write setting. User gestures must
+        // not depend on that setting, so selection copying is owned by the
+        // GPUI layer (`ghostty_view.rs`) and Ghostty's variant stays off.
+        //
+        // `middle-click-action = clipboard-paste`: Con reports
+        // `supports_selection_clipboard = false`, and since 1.4 the default
+        // `primary-paste` is a no-op on such hosts instead of falling back to
+        // the system clipboard. `clipboard-paste` only exists from that
+        // revision on; an older Ghostty (stale `CON_GHOSTTY_SOURCE_DIR`)
+        // records a config diagnostic and keeps `primary-paste`, which there
+        // still fell back to the system clipboard.
+        s.push_str("copy-on-select = none\n");
+        s.push_str("middle-click-action = clipboard-paste\n");
         let clipboard_write = self.clipboard_write.unwrap_or(false);
         s.push_str(if clipboard_write {
             "clipboard-write = allow\n"
@@ -1908,6 +1927,13 @@ unsafe extern "C" fn confirm_read_clipboard_callback(
 }
 
 /// Clipboard write — ghostty wants to copy plain text to the macOS pasteboard.
+///
+/// Ghostty routes every clipboard write through this callback: OSC 52 and
+/// Kitty application writes, but also its own copy-on-select and
+/// `copy_to_clipboard` keybinds, which arrive as multi-item
+/// (`text/plain` + `text/html`) payloads. The gate below treats everything as
+/// an application write, so Con's runtime config keeps Ghostty's
+/// copy-on-select off and copies user selections from the GPUI layer instead.
 unsafe extern "C" fn write_clipboard_callback(
     userdata: *mut c_void,
     clipboard: ffi::ghostty_clipboard_e,
@@ -2125,6 +2151,21 @@ mod tests {
         let config = GhosttyConfigPatch::default().to_config_string();
 
         assert!(config.contains("link-previews = osc8\n"));
+    }
+
+    #[test]
+    fn ghostty_config_pins_clipboard_routing_independent_of_ghostty_defaults() {
+        // Selection copying is owned by the GPUI layer, so Ghostty's own
+        // copy-on-select must stay off; otherwise it would be routed through
+        // `write_clipboard_callback` and silently gated by the OSC 52 setting.
+        // Middle-click must paste from the system clipboard even though Con
+        // has no selection clipboard, which Ghostty 1.4's `primary-paste`
+        // default no longer does. Both hold without any appearance patch.
+        let config = GhosttyConfigPatch::default().to_config_string();
+
+        assert!(config.contains("copy-on-select = none\n"));
+        assert!(config.contains("middle-click-action = clipboard-paste\n"));
+        assert!(!config.contains("primary-paste"));
     }
 
     #[test]

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -178,24 +178,14 @@ impl GhosttyConfigPatch {
         // host-side previews to OSC 8, whose visible label can differ from the
         // producer-controlled URI and therefore needs an explicit preview.
         s.push_str("link-previews = osc8\n");
-        // Pin clipboard routing instead of inheriting Ghostty's platform
-        // defaults; Ghostty 1.4 (ghostty-org/ghostty#12604) redefined both.
-        //
-        // `copy-on-select = none`: Ghostty delivers its own copy-on-select
-        // through the same `write_clipboard` callback as OSC 52 application
-        // writes, and `write_clipboard_callback` below deliberately gates that
-        // callback by the user's clipboard-write setting. User gestures must
-        // not depend on that setting, so selection copying is owned by the
-        // GPUI layer (`ghostty_view.rs`) and Ghostty's variant stays off.
-        //
-        // `middle-click-action = ignore`: the GPUI host view only forwards
-        // left and right buttons to Ghostty (`ghostty_view.rs` registers no
-        // middle-button listeners and the Ghostty NSView sits below GPUI's),
-        // so Ghostty never sees a middle click today and no Con platform
-        // pastes on middle click. Pin `ignore` so that forwarding the middle
-        // button later, e.g. for mouse-reporting parity with Windows, cannot
-        // start pasting the system clipboard as a side effect; Ghostty's
-        // default flipped between fallback-paste and no-op across 1.3/1.4.
+        // Ghostty routes its own copy-on-select through the same
+        // `write_clipboard` callback as OSC 52, and `write_clipboard_callback`
+        // gates that callback by the clipboard-write setting. A user gesture
+        // must not depend on that setting, so `ghostty_view.rs` copies the
+        // selection on left release and Ghostty's variant stays off. Middle
+        // clicks are never forwarded to Ghostty (the host view only wires
+        // left/right), so pin `ignore` rather than inherit a default that
+        // Ghostty 1.4 (ghostty-org/ghostty#12604) already flipped once.
         s.push_str("copy-on-select = none\n");
         s.push_str("middle-click-action = ignore\n");
         let clipboard_write = self.clipboard_write.unwrap_or(false);
@@ -1929,12 +1919,9 @@ unsafe extern "C" fn confirm_read_clipboard_callback(
 
 /// Clipboard write — ghostty wants to copy plain text to the macOS pasteboard.
 ///
-/// Ghostty routes every clipboard write through this callback: OSC 52 and
-/// Kitty application writes, but also its own copy-on-select and
-/// `copy_to_clipboard` keybinds, which arrive as multi-item
-/// (`text/plain` + `text/html`) payloads. The gate below treats everything as
-/// an application write, so Con's runtime config keeps Ghostty's
-/// copy-on-select off and copies user selections from the GPUI layer instead.
+/// Ghostty also sends user-gesture copies (copy-on-select, `copy_to_clipboard`)
+/// through here as multi-item payloads; the gate below would drop them, which
+/// is why `to_config_string` keeps `copy-on-select = none`.
 unsafe extern "C" fn write_clipboard_callback(
     userdata: *mut c_void,
     clipboard: ffi::ghostty_clipboard_e,
@@ -2155,20 +2142,11 @@ mod tests {
     }
 
     #[test]
-    fn ghostty_config_pins_clipboard_routing_independent_of_ghostty_defaults() {
-        // Selection copying is owned by the GPUI layer, so Ghostty's own
-        // copy-on-select must stay off; otherwise it would be routed through
-        // `write_clipboard_callback` and silently gated by the OSC 52 setting.
-        // Middle clicks are not forwarded to Ghostty on macOS, so the
-        // middle-click action is pinned to `ignore` rather than left to an
-        // upstream default that has already flipped once. Both hold without
-        // any appearance patch.
+    fn ghostty_config_pins_clipboard_routing() {
         let config = GhosttyConfigPatch::default().to_config_string();
 
         assert!(config.contains("copy-on-select = none\n"));
         assert!(config.contains("middle-click-action = ignore\n"));
-        assert!(!config.contains("primary-paste"));
-        assert!(!config.contains("clipboard-paste"));
     }
 
     #[test]

--- a/crates/con-ghostty/src/terminal.rs
+++ b/crates/con-ghostty/src/terminal.rs
@@ -188,15 +188,16 @@ impl GhosttyConfigPatch {
         // not depend on that setting, so selection copying is owned by the
         // GPUI layer (`ghostty_view.rs`) and Ghostty's variant stays off.
         //
-        // `middle-click-action = clipboard-paste`: Con reports
-        // `supports_selection_clipboard = false`, and since 1.4 the default
-        // `primary-paste` is a no-op on such hosts instead of falling back to
-        // the system clipboard. `clipboard-paste` only exists from that
-        // revision on; an older Ghostty (stale `CON_GHOSTTY_SOURCE_DIR`)
-        // records a config diagnostic and keeps `primary-paste`, which there
-        // still fell back to the system clipboard.
+        // `middle-click-action = ignore`: the GPUI host view only forwards
+        // left and right buttons to Ghostty (`ghostty_view.rs` registers no
+        // middle-button listeners and the Ghostty NSView sits below GPUI's),
+        // so Ghostty never sees a middle click today and no Con platform
+        // pastes on middle click. Pin `ignore` so that forwarding the middle
+        // button later, e.g. for mouse-reporting parity with Windows, cannot
+        // start pasting the system clipboard as a side effect; Ghostty's
+        // default flipped between fallback-paste and no-op across 1.3/1.4.
         s.push_str("copy-on-select = none\n");
-        s.push_str("middle-click-action = clipboard-paste\n");
+        s.push_str("middle-click-action = ignore\n");
         let clipboard_write = self.clipboard_write.unwrap_or(false);
         s.push_str(if clipboard_write {
             "clipboard-write = allow\n"
@@ -2158,14 +2159,16 @@ mod tests {
         // Selection copying is owned by the GPUI layer, so Ghostty's own
         // copy-on-select must stay off; otherwise it would be routed through
         // `write_clipboard_callback` and silently gated by the OSC 52 setting.
-        // Middle-click must paste from the system clipboard even though Con
-        // has no selection clipboard, which Ghostty 1.4's `primary-paste`
-        // default no longer does. Both hold without any appearance patch.
+        // Middle clicks are not forwarded to Ghostty on macOS, so the
+        // middle-click action is pinned to `ignore` rather than left to an
+        // upstream default that has already flipped once. Both hold without
+        // any appearance patch.
         let config = GhosttyConfigPatch::default().to_config_string();
 
         assert!(config.contains("copy-on-select = none\n"));
-        assert!(config.contains("middle-click-action = clipboard-paste\n"));
+        assert!(config.contains("middle-click-action = ignore\n"));
         assert!(!config.contains("primary-paste"));
+        assert!(!config.contains("clipboard-paste"));
     }
 
     #[test]

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -7238,6 +7238,118 @@ mod tests {
         assert_eq!(output.lock().as_slice(), b"\x00");
     }
 
+    /// Pins encoder behavior that Ghostty `492300ca` changed or added:
+    /// modifyOtherKeys=2 (`CSI > 4;2 m`, enabled by vim/neovim/tmux with
+    /// `extended-keys`) now covers Ctrl+letter, Ctrl+Space, and Alt+Escape,
+    /// F13-F25 and Help gained sequences, and Alt with non-ASCII text
+    /// prefixes the whole UTF-8 sequence. None of these depend on Con-side
+    /// code, so a regression here means the pinned Ghostty revision moved.
+    #[test]
+    fn key_encoder_tracks_modify_other_keys_and_extended_function_keys() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let output_for_callback = output.clone();
+        let screen = VtScreen::new_with_write_pty(
+            80,
+            24,
+            None,
+            Some(Arc::new(move |bytes, _| {
+                output_for_callback.lock().extend_from_slice(bytes);
+                Ok(())
+            })),
+        )
+        .expect("create vt screen");
+
+        let encode = |event: &VtKeyEvent<'_>, what: &str| {
+            output.lock().clear();
+            assert!(
+                screen
+                    .send_key(event)
+                    .unwrap_or_else(|err| panic!("encode {what}: {err}"))
+                    .output_accepted,
+                "{what} produced no output"
+            );
+            output.lock().clone()
+        };
+
+        let ctrl_p = VtKeyEvent {
+            key: "p",
+            text: "p",
+            unshifted_codepoint: Some('p'),
+            action: VtKeyAction::Press,
+            modifiers: VtKeyModifiers {
+                control: true,
+                ..VtKeyModifiers::default()
+            },
+            consumed_modifiers: VtKeyModifiers::default(),
+        };
+        let ctrl_space = VtKeyEvent {
+            key: "space",
+            text: " ",
+            unshifted_codepoint: Some(' '),
+            action: VtKeyAction::Press,
+            modifiers: VtKeyModifiers {
+                control: true,
+                ..VtKeyModifiers::default()
+            },
+            consumed_modifiers: VtKeyModifiers::default(),
+        };
+        let alt_escape = VtKeyEvent {
+            key: "escape",
+            text: "",
+            unshifted_codepoint: None,
+            action: VtKeyAction::Press,
+            modifiers: VtKeyModifiers {
+                alt: true,
+                ..VtKeyModifiers::default()
+            },
+            consumed_modifiers: VtKeyModifiers::default(),
+        };
+
+        // Legacy mode keeps the C0 bytes tmux relies on for its prefix.
+        assert_eq!(encode(&ctrl_p, "legacy Ctrl-P"), b"\x10");
+        assert_eq!(encode(&ctrl_space, "legacy Ctrl-Space"), b"\x00");
+        assert_eq!(encode(&alt_escape, "legacy Alt-Escape"), b"\x1b\x1b");
+
+        // modifyOtherKeys=2 switches the same chords to CSI 27 ; mods ; key ~.
+        screen.feed(b"\x1b[>4;2m");
+        assert_eq!(encode(&ctrl_p, "MOK2 Ctrl-P"), b"\x1b[27;5;112~");
+        assert_eq!(encode(&ctrl_space, "MOK2 Ctrl-Space"), b"\x1b[27;5;32~");
+        assert_eq!(encode(&alt_escape, "MOK2 Alt-Escape"), b"\x1b[27;3;27~");
+
+        // Resetting the mode restores the legacy bytes.
+        screen.feed(b"\x1b[>4;0m");
+        assert_eq!(encode(&ctrl_p, "reset Ctrl-P"), b"\x10");
+
+        // F13-F25 and Help were unmapped upstream before this revision, so
+        // Con's `ghostty_key` mappings for them produced no output at all.
+        let function_key = |key: &'static str| VtKeyEvent {
+            key,
+            text: "",
+            unshifted_codepoint: None,
+            action: VtKeyAction::Press,
+            modifiers: VtKeyModifiers::default(),
+            consumed_modifiers: VtKeyModifiers::default(),
+        };
+        assert_eq!(encode(&function_key("f13"), "F13"), b"\x1b[25~");
+        assert_eq!(encode(&function_key("f25"), "F25"), b"\x1b[46~");
+        assert_eq!(encode(&function_key("help"), "Help"), b"\x1b[28~");
+
+        // Alt with a non-ASCII layout character now prefixes the complete
+        // UTF-8 text instead of dropping the key.
+        let alt_cyrillic = VtKeyEvent {
+            key: "ф",
+            text: "ф",
+            unshifted_codepoint: Some('ф'),
+            action: VtKeyAction::Press,
+            modifiers: VtKeyModifiers {
+                alt: true,
+                ..VtKeyModifiers::default()
+            },
+            consumed_modifiers: VtKeyModifiers::default(),
+        };
+        assert_eq!(encode(&alt_cyrillic, "Alt-ф"), "\x1bф".as_bytes());
+    }
+
     #[test]
     fn key_encoder_handles_kitty_press_repeat_and_release() {
         let output = Arc::new(Mutex::new(Vec::new()));

--- a/crates/con-ghostty/src/vt.rs
+++ b/crates/con-ghostty/src/vt.rs
@@ -7238,12 +7238,9 @@ mod tests {
         assert_eq!(output.lock().as_slice(), b"\x00");
     }
 
-    /// Pins encoder behavior that Ghostty `492300ca` changed or added:
-    /// modifyOtherKeys=2 (`CSI > 4;2 m`, enabled by vim/neovim/tmux with
-    /// `extended-keys`) now covers Ctrl+letter, Ctrl+Space, and Alt+Escape,
-    /// F13-F25 and Help gained sequences, and Alt with non-ASCII text
-    /// prefixes the whole UTF-8 sequence. None of these depend on Con-side
-    /// code, so a regression here means the pinned Ghostty revision moved.
+    /// Encoder behavior that changed in Ghostty `492300ca`: modifyOtherKeys=2
+    /// now covers Ctrl chords and Alt+Escape, F13-F25/Help gained sequences,
+    /// and Alt with non-ASCII text prefixes the whole UTF-8 sequence.
     #[test]
     fn key_encoder_tracks_modify_other_keys_and_extended_function_keys() {
         let output = Arc::new(Mutex::new(Vec::new()));
@@ -7259,95 +7256,47 @@ mod tests {
         )
         .expect("create vt screen");
 
-        let encode = |event: &VtKeyEvent<'_>, what: &str| {
+        let key = |key, text, unshifted_codepoint, modifiers| VtKeyEvent {
+            key,
+            text,
+            unshifted_codepoint,
+            action: VtKeyAction::Press,
+            modifiers,
+            consumed_modifiers: VtKeyModifiers::default(),
+        };
+        let ctrl = VtKeyModifiers {
+            control: true,
+            ..VtKeyModifiers::default()
+        };
+        let alt = VtKeyModifiers {
+            alt: true,
+            ..VtKeyModifiers::default()
+        };
+        let none = VtKeyModifiers::default();
+        let encode = |event: &VtKeyEvent<'_>| {
             output.lock().clear();
-            assert!(
-                screen
-                    .send_key(event)
-                    .unwrap_or_else(|err| panic!("encode {what}: {err}"))
-                    .output_accepted,
-                "{what} produced no output"
-            );
+            assert!(screen.send_key(event).expect("encode key").output_accepted);
             output.lock().clone()
         };
 
-        let ctrl_p = VtKeyEvent {
-            key: "p",
-            text: "p",
-            unshifted_codepoint: Some('p'),
-            action: VtKeyAction::Press,
-            modifiers: VtKeyModifiers {
-                control: true,
-                ..VtKeyModifiers::default()
-            },
-            consumed_modifiers: VtKeyModifiers::default(),
-        };
-        let ctrl_space = VtKeyEvent {
-            key: "space",
-            text: " ",
-            unshifted_codepoint: Some(' '),
-            action: VtKeyAction::Press,
-            modifiers: VtKeyModifiers {
-                control: true,
-                ..VtKeyModifiers::default()
-            },
-            consumed_modifiers: VtKeyModifiers::default(),
-        };
-        let alt_escape = VtKeyEvent {
-            key: "escape",
-            text: "",
-            unshifted_codepoint: None,
-            action: VtKeyAction::Press,
-            modifiers: VtKeyModifiers {
-                alt: true,
-                ..VtKeyModifiers::default()
-            },
-            consumed_modifiers: VtKeyModifiers::default(),
-        };
+        let ctrl_p = key("p", "p", Some('p'), ctrl);
+        let ctrl_space = key("space", " ", Some(' '), ctrl);
+        let alt_escape = key("escape", "", None, alt);
 
-        // Legacy mode keeps the C0 bytes tmux relies on for its prefix.
-        assert_eq!(encode(&ctrl_p, "legacy Ctrl-P"), b"\x10");
-        assert_eq!(encode(&ctrl_space, "legacy Ctrl-Space"), b"\x00");
-        assert_eq!(encode(&alt_escape, "legacy Alt-Escape"), b"\x1b\x1b");
+        assert_eq!(encode(&ctrl_p), b"\x10");
+        assert_eq!(encode(&alt_escape), b"\x1b\x1b");
 
-        // modifyOtherKeys=2 switches the same chords to CSI 27 ; mods ; key ~.
         screen.feed(b"\x1b[>4;2m");
-        assert_eq!(encode(&ctrl_p, "MOK2 Ctrl-P"), b"\x1b[27;5;112~");
-        assert_eq!(encode(&ctrl_space, "MOK2 Ctrl-Space"), b"\x1b[27;5;32~");
-        assert_eq!(encode(&alt_escape, "MOK2 Alt-Escape"), b"\x1b[27;3;27~");
+        assert_eq!(encode(&ctrl_p), b"\x1b[27;5;112~");
+        assert_eq!(encode(&ctrl_space), b"\x1b[27;5;32~");
+        assert_eq!(encode(&alt_escape), b"\x1b[27;3;27~");
 
-        // Resetting the mode restores the legacy bytes.
         screen.feed(b"\x1b[>4;0m");
-        assert_eq!(encode(&ctrl_p, "reset Ctrl-P"), b"\x10");
+        assert_eq!(encode(&ctrl_p), b"\x10");
 
-        // F13-F25 and Help were unmapped upstream before this revision, so
-        // Con's `ghostty_key` mappings for them produced no output at all.
-        let function_key = |key: &'static str| VtKeyEvent {
-            key,
-            text: "",
-            unshifted_codepoint: None,
-            action: VtKeyAction::Press,
-            modifiers: VtKeyModifiers::default(),
-            consumed_modifiers: VtKeyModifiers::default(),
-        };
-        assert_eq!(encode(&function_key("f13"), "F13"), b"\x1b[25~");
-        assert_eq!(encode(&function_key("f25"), "F25"), b"\x1b[46~");
-        assert_eq!(encode(&function_key("help"), "Help"), b"\x1b[28~");
-
-        // Alt with a non-ASCII layout character now prefixes the complete
-        // UTF-8 text instead of dropping the key.
-        let alt_cyrillic = VtKeyEvent {
-            key: "ф",
-            text: "ф",
-            unshifted_codepoint: Some('ф'),
-            action: VtKeyAction::Press,
-            modifiers: VtKeyModifiers {
-                alt: true,
-                ..VtKeyModifiers::default()
-            },
-            consumed_modifiers: VtKeyModifiers::default(),
-        };
-        assert_eq!(encode(&alt_cyrillic, "Alt-ф"), "\x1bф".as_bytes());
+        assert_eq!(encode(&key("f13", "", None, none)), b"\x1b[25~");
+        assert_eq!(encode(&key("help", "", None, none)), b"\x1b[28~");
+        assert_eq!(encode(&key("ф", "ф", Some('ф'), alt)), "\x1bф".as_bytes());
     }
 
     #[test]

--- a/postmortem/2026-05-07-windows-tmux-ctrl-punctuation-prefix.md
+++ b/postmortem/2026-05-07-windows-tmux-ctrl-punctuation-prefix.md
@@ -85,13 +85,9 @@ Ghostty's VT key encoder.
 
 The long-term answer above landed in `07783391` (2026-08-26): Windows and
 Linux key presses now go through libghostty-vt's `ghostty_key_encoder_*`
-(`crates/con-ghostty/src/vt.rs`, `VtScreen::send_key`), so the Rust C0 table
-described here no longer sits on the keyboard path. `ctrl_key_to_c0` survives
-only for the control plane's `keys.send`, which writes raw bytes to the PTY.
-
-One consequence worth knowing: the Ghostty bump to `492300ca` made the
-encoder emit xterm `CSI 27 ; mods ; key ~` for Ctrl chords while an
-application has enabled modifyOtherKeys=2 (`CSI > 4;2 m`). tmux only does
-that with `extended-keys on`, so the default `C-]` prefix flow from #148 is
-unchanged; the `key_encoder_tracks_modify_other_keys_and_extended_function_keys`
-test in `vt.rs` pins both behaviors.
+(`VtScreen::send_key` in `crates/con-ghostty/src/vt.rs`). The Rust C0 table
+described here survives only for the control plane's `keys.send`, which
+writes raw bytes to the PTY. Since Ghostty `492300ca` the encoder emits xterm
+`CSI 27;mods;key~` for Ctrl chords once an application enables
+modifyOtherKeys=2; tmux only does that with `extended-keys on`, so the `C-]`
+prefix flow from #148 is unchanged.

--- a/postmortem/2026-05-07-windows-tmux-ctrl-punctuation-prefix.md
+++ b/postmortem/2026-05-07-windows-tmux-ctrl-punctuation-prefix.md
@@ -80,3 +80,18 @@ a platform, it must implement the complete legacy C0 control-byte layer and keep
 those semantics shared with the control-plane surface API. For anything beyond
 that layer, the long-term answer is not a larger Rust table; it is reusing
 Ghostty's VT key encoder.
+
+## Follow-Up (2026-09-06)
+
+The long-term answer above landed in `07783391` (2026-08-26): Windows and
+Linux key presses now go through libghostty-vt's `ghostty_key_encoder_*`
+(`crates/con-ghostty/src/vt.rs`, `VtScreen::send_key`), so the Rust C0 table
+described here no longer sits on the keyboard path. `ctrl_key_to_c0` survives
+only for the control plane's `keys.send`, which writes raw bytes to the PTY.
+
+One consequence worth knowing: the Ghostty bump to `492300ca` made the
+encoder emit xterm `CSI 27 ; mods ; key ~` for Ctrl chords while an
+application has enabled modifyOtherKeys=2 (`CSI > 4;2 m`). tmux only does
+that with `extended-keys on`, so the default `C-]` prefix flow from #148 is
+unchanged; the `key_encoder_tracks_modify_other_keys_and_extended_function_keys`
+test in `vt.rs` pins both behaviors.

--- a/postmortem/2026-09-06-macos-copy-on-select-lost-behind-clipboard-gate.md
+++ b/postmortem/2026-09-06-macos-copy-on-select-lost-behind-clipboard-gate.md
@@ -1,0 +1,63 @@
+# macOS Copy-On-Select Lost Behind the Clipboard-Write Gate
+
+## What Happened
+
+Since `v0.1.0-beta.93`, selecting text in a macOS terminal pane no longer
+copied it to the clipboard. Cmd+C still worked, so the regression looked like
+a preference change rather than a bug and went unreported. It surfaced while
+auditing the libghostty bump to `492300ca`, whose upstream `copy-on-select`
+redefinition (ghostty-org/ghostty#12604) prompted a check of what Con actually
+did with Ghostty's selection copies.
+
+## Root Cause
+
+Con has relied on Ghostty's macOS default `copy-on-select = true` since the
+libghostty backend landed. Ghostty implements that by calling the embedder's
+`write_clipboard` callback on left-button release with a two-item payload
+(`text/plain` plus `text/html`) for the standard clipboard.
+
+PR #331 hardened the same callback so that terminal programs cannot write the
+clipboard through OSC 52 or the Kitty clipboard protocol unless the user opts
+in. The new guard returns early when the clipboard-write policy is disabled
+(the default) or when `content_count > 1`. Ghostty uses one callback for
+application writes and for user-gesture copies and gives the embedder no way
+to tell them apart, so the guard also discarded every copy-on-select payload.
+Ghostty had already enforced `clipboard-write = deny` for OSC 52 before ever
+calling the callback, which is why the Rust-side gate only ever rejected the
+user's own selections in practice.
+
+Nothing failed loudly: the callback's early return is silent, no test covered
+copy-on-select, and the callback comment was rewritten from "selection, OSC 52"
+to "plain text", hiding the dropped case.
+
+## Fix Applied
+
+- Ghostty's own copy-on-select is now disabled explicitly
+  (`copy-on-select = none` in con-ghostty's runtime config) so the clipboard
+  callback receives only application-initiated writes and can keep its strict
+  gate. The same change pins `middle-click-action = clipboard-paste`, because
+  the bumped Ghostty turns the default `primary-paste` into a no-op on hosts
+  without a selection clipboard.
+- Copy-on-select is implemented in Con's GPUI layer: when a left-button
+  release ends a selection gesture with text selected, the view reads the
+  selection through `ghostty_surface_read_selection` and writes it with the
+  same `cx.write_to_clipboard` path Cmd+C uses. Only left releases copy, the
+  behavior Ghostty itself uses, and Ghostty clears the selection on a plain
+  left press, so clicking a pane to focus it never republishes stale text.
+- A unit test pins the two config lines so a future Ghostty default change or
+  callback edit cannot silently reintroduce the coupling.
+
+## What We Learned
+
+Ghostty's embedder callbacks carry more than one trust level over one wire.
+Any gate added for application-initiated traffic on `write_clipboard` also
+applies to user gestures unless the runtime config stops Ghostty from routing
+those gestures through the callback in the first place. Own the user-gesture
+path on the GPUI side, keep the callback for application writes, and state the
+split in the config that enforces it.
+
+Behavior inherited from an upstream default is unowned behavior. It cannot be
+tested without noticing it exists, and it changes when upstream changes. Every
+Ghostty default Con depends on for user-visible behavior should be written into
+the runtime config with a test, as `shell-integration-features` and
+`link-previews` already were.

--- a/postmortem/2026-09-06-macos-copy-on-select-lost-behind-clipboard-gate.md
+++ b/postmortem/2026-09-06-macos-copy-on-select-lost-behind-clipboard-gate.md
@@ -35,9 +35,10 @@ to "plain text", hiding the dropped case.
 - Ghostty's own copy-on-select is now disabled explicitly
   (`copy-on-select = none` in con-ghostty's runtime config) so the clipboard
   callback receives only application-initiated writes and can keep its strict
-  gate. The same change pins `middle-click-action = clipboard-paste`, because
-  the bumped Ghostty turns the default `primary-paste` into a no-op on hosts
-  without a selection clipboard.
+  gate. The same change pins `middle-click-action = ignore`: the GPUI host
+  view never forwards middle clicks to Ghostty, so the setting is inert today,
+  and pinning it keeps a future middle-button forwarding change from pasting
+  as a side effect of an upstream default.
 - Copy-on-select is implemented in Con's GPUI layer: when a left-button
   release ends a selection gesture with text selected, the view reads the
   selection through `ghostty_surface_read_selection` and writes it with the


### PR DESCRIPTION
## Summary

- Bump `GHOSTTY_REV` from `5f5b988c` (2026-08-26) to `492300ca` (2026-09-04), 186 upstream commits.
- Pin `copy-on-select = none` and `middle-click-action = ignore` in the Ghostty runtime config instead of inheriting defaults that Ghostty 1.4 redefined.
- Restore macOS copy-on-select, which has been silently broken since beta.93, by copying the selection from the GPUI layer on left-button release.
- Add a `vt.rs` test that pins the key encoder behavior the new revision changed on Windows and Linux.

## Upstream delta

`include/ghostty.h` is byte-identical. The libghostty-vt headers only gained the search API, `GhosttySelectionBuffer`, and a `GhosttySearch` typedef; every function and `repr(C)` type declared in `vt.rs` matches the new headers. The seven embedding patch anchors in `build.rs` still match, `ffi_abi.c` compiles against the new header with and without the `initial_output` patch, and Zig stays at 0.16.0.

Behavior that moved upstream and matters to Con:

- `copy-on-select` went from `true/false/clipboard` to `none/primary/clipboard/both`, with the macOS default now `none`. `middle-click-action = primary-paste` is a no-op on hosts without a selection clipboard (ghostty-org/ghostty#12604).
- The renderer parks its CVDisplayLink whenever a surface is idle and restarts it when cells change (`6688aa072`, `97f57edcc`). This overlaps with the sleep/wake handling from #342.
- The key encoder emits `CSI 27;mods;key~` for Ctrl chords and Alt+Escape once an application enables modifyOtherKeys=2, F13-F25 and Help gained sequences, and Alt with non-ASCII text prefixes the whole UTF-8 sequence. Legacy output is unchanged, so tmux prefixes keep working. macOS shares this encoder.

## Root cause of the copy-on-select regression

Con relied on Ghostty's macOS default `copy-on-select = true`. Ghostty delivers that through the embedder's `write_clipboard` callback as a two-item text/plain + text/html payload. #331 hardened the same callback against OSC 52 and Kitty clipboard writes: it returns early unless the clipboard-write setting is enabled and exactly one item is present. Ghostty gives the embedder no way to tell an application write from the user's own selection copy, so every copy-on-select payload was dropped. Cmd+C kept working, which hid it.

The fix keeps the callback strict and owns the user gesture in `ghostty_view.rs`: a left-button release that ends with a selection reads it through `ghostty_surface_read_selection` and writes it with the same `cx.write_to_clipboard` path Cmd+C uses. Only left releases copy, matching Ghostty, and a plain left press clears the selection, so clicking a pane to focus it never republishes stale text. Postmortem: `postmortem/2026-09-06-macos-copy-on-select-lost-behind-clipboard-gate.md`.

`middle-click-action` is pinned to `ignore` because the host view only forwards left and right buttons; Ghostty has never seen a middle click from Con, and the pin keeps a future middle-button forwarding change from pasting because of an upstream default.

## Verification

- `cargo test --workspace` on macOS: con 356, con-agent 130, con-core 99, con-ghostty 15, con-cli 16, con-test 18 passed.
- Fresh clone, patch, and `zig build` of the new revision through the normal `build.rs` path, in debug and in `--release --target aarch64-apple-darwin`; `scripts/macos/build-app.sh` produced a launchable `con Dev.app` embedding `492300ca`.
- `cc -fsyntax-only` of `ffi_abi.c` against the new header, patched and unpatched.
- `CON_SKIP_GHOSTTY_VT=1 cargo check -p con-ghostty --tests --target aarch64-pc-windows-msvc` for the new `vt.rs` test. It has not run on a Windows or Linux host from this checkout; CI is its first real run.
- `cargo fmt --check` on the touched crates and `git diff --check`.