### PR TITLE
fix(windows): apply terminal font changes to existing panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ con is still pre-release, so entries may group related beta work while the produ
 
 ### Fixed
 
+**Windows**
+
+- Changing the terminal font or its size now updates panes that are already
+  open, including their cell metrics and shell geometry. _(PR
+  [#346](https://github.com/nowledge-co/con-terminal/pull/346) by
+  [@batkiz](https://github.com/batkiz))_
+
 **macOS**
 
 - Selecting terminal text copies it to the clipboard again, without weakening

--- a/crates/con-app/src/windows_view.rs
+++ b/crates/con-app/src/windows_view.rs
@@ -641,7 +641,9 @@ impl GhosttyView {
         // Recompute the grid and mouse cell geometry after a DPI change even
         // when physical dimensions happen to be unchanged.
         let dpi_changed = dpi != self.last_dpi;
-        let resize_needed = dpi_changed || self.last_physical_size != Some((width_px, height_px));
+        let resize_needed = dpi_changed
+            || session.geometry_sync_pending()
+            || self.last_physical_size != Some((width_px, height_px));
         if resize_needed {
             let dpi_ready = if dpi_changed {
                 match session.set_dpi(dpi) {

--- a/crates/con-ghostty/src/windows/backend.rs
+++ b/crates/con-ghostty/src/windows/backend.rs
@@ -231,8 +231,8 @@ impl WindowsGhosttyTerminal {
     pub fn update_appearance(
         &self,
         colors: &TerminalColors,
-        _font_family: &str,
-        _font_size: f32,
+        font_family: &str,
+        font_size: f32,
         background_opacity: f32,
         _background_blur: bool,
         _cursor_style: &str,
@@ -244,6 +244,9 @@ impl WindowsGhosttyTerminal {
     ) -> Result<(), String> {
         if let Some(session) = self.inner.lock().as_ref() {
             let theme = theme_from_colors(colors);
+            session
+                .set_font(font_family, font_size)
+                .map_err(|err| err.to_string())?;
             session.set_appearance(Some(&theme), clamp_opacity(background_opacity));
         }
         Ok(())

--- a/crates/con-ghostty/src/windows/backend.rs
+++ b/crates/con-ghostty/src/windows/backend.rs
@@ -244,10 +244,12 @@ impl WindowsGhosttyTerminal {
     ) -> Result<(), String> {
         if let Some(session) = self.inner.lock().as_ref() {
             let theme = theme_from_colors(colors);
+            // Theme and opacity are independent of font resource creation;
+            // keep them live even if DirectWrite rejects a font update.
+            session.set_appearance(Some(&theme), clamp_opacity(background_opacity));
             session
                 .set_font(font_family, font_size)
                 .map_err(|err| err.to_string())?;
-            session.set_appearance(Some(&theme), clamp_opacity(background_opacity));
         }
         Ok(())
     }

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -49,7 +49,10 @@ pub struct RenderSession {
     conpty: Arc<ConPty>,
     shell_cwd: Option<PathBuf>,
     config: Mutex<RendererConfig>,
-    base_font_size_px: f32,
+    /// Logical (96-DPI) font size. Settings can update it while the pane is
+    /// alive; DPI changes use the latest value rather than the construction
+    /// time value.
+    base_font_size_px: Mutex<f32>,
     dpi: AtomicU32,
     /// When a local user action mutates terminal state (typing, paste,
     /// mouse selection), the next render should prefer the freshest
@@ -270,7 +273,7 @@ impl RenderSession {
             conpty,
             shell_cwd,
             config: Mutex::new(renderer_config),
-            base_font_size_px,
+            base_font_size_px: Mutex::new(base_font_size_px),
             dpi: AtomicU32::new(current_dpi),
             low_latency_requested: AtomicBool::new(false),
             low_latency_generation_target: AtomicU64::new(0),
@@ -414,6 +417,45 @@ impl RenderSession {
         }
     }
 
+    /// Apply a live font change, rebuild cell metrics, and resize both the VT
+    /// and ConPTY grid. The settings panel updates existing sessions, so only
+    /// changing the app-level template is not sufficient.
+    pub fn set_font(&self, font_family: &str, font_size_px: f32) -> Result<()> {
+        let logical_size = font_size_px.max(1.0);
+        let dpi = self.dpi.load(Ordering::Acquire).max(1);
+        let physical_size = scale_font_size(logical_size, dpi);
+        {
+            let config = self.config.lock();
+            if config.font_family == font_family
+                && (config.font_size_px - physical_size).abs() <= f32::EPSILON
+            {
+                return Ok(());
+            }
+        }
+
+        let (width, height) = {
+            let renderer = self.renderer.lock();
+            renderer
+                .rebuild_atlas(font_family, physical_size)
+                .context("rebuild_atlas on font change failed")?;
+            renderer.dimensions_px()
+        };
+        *self.base_font_size_px.lock() = logical_size;
+        {
+            let mut config = self.config.lock();
+            config.font_family = font_family.to_string();
+            config.font_size_px = physical_size;
+        }
+        // Renderer::resize is idempotent for unchanged pixel dimensions, but
+        // this method still re-derives the grid from the new atlas metrics.
+        self.resize(width, height)?;
+        self.vt.bump_generation();
+        log::info!(
+            "RenderSession::set_font family={font_family:?} logical_px={logical_size:.2} physical_px={physical_size:.2}"
+        );
+        Ok(())
+    }
+
     /// Notify of a DPI change. Rebuilds the glyph atlas at the new
     /// physical font size and re-derives the cell grid. Follow with a
     /// `resize` to match the new physical dimensions.
@@ -424,9 +466,10 @@ impl RenderSession {
         if prev == new_dpi {
             return Ok(());
         }
-        let new_font = scale_font_size(self.base_font_size_px, new_dpi);
+        let new_font = scale_font_size(*self.base_font_size_px.lock(), new_dpi);
+        let family = self.config.lock().font_family.clone();
         renderer
-            .rebuild_atlas(new_font)
+            .rebuild_atlas(&family, new_font)
             .context("rebuild_atlas on DPI change failed")?;
         let mut config = self.config.lock();
         config.font_size_px = new_font;

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -54,6 +54,10 @@ pub struct RenderSession {
     /// time value.
     base_font_size_px: Mutex<f32>,
     dpi: AtomicU32,
+    /// A live metrics change must be reconciled with VT and ConPTY geometry.
+    /// Kept explicit so a partial resize failure is retried by the next
+    /// prepaint instead of leaving the renderer and child process desynced.
+    geometry_sync_pending: AtomicBool,
     /// When a local user action mutates terminal state (typing, paste,
     /// mouse selection), the next render should prefer the freshest
     /// frame over the lowest-latency non-blocking staging drain. This
@@ -275,6 +279,7 @@ impl RenderSession {
             config: Mutex::new(renderer_config),
             base_font_size_px: Mutex::new(base_font_size_px),
             dpi: AtomicU32::new(current_dpi),
+            geometry_sync_pending: AtomicBool::new(false),
             low_latency_requested: AtomicBool::new(false),
             low_latency_generation_target: AtomicU64::new(0),
             low_latency_burst_until: Mutex::new(None),
@@ -365,6 +370,7 @@ impl RenderSession {
         self.conpty
             .resize(PtySize { cols, rows })
             .context("ConPty::resize failed")?;
+        self.geometry_sync_pending.store(false, Ordering::Release);
         log::debug!(
             "RenderSession::resize -> {width_px}x{height_px} grid={cols}x{rows} \
              cell={cell_width_px}x{cell_height_px}"
@@ -446,6 +452,7 @@ impl RenderSession {
             config.font_family = font_family.to_string();
             config.font_size_px = physical_size;
         }
+        self.geometry_sync_pending.store(true, Ordering::Release);
         // Renderer::resize is idempotent for unchanged pixel dimensions, but
         // this method still re-derives the grid from the new atlas metrics.
         self.resize(width, height)?;
@@ -454,6 +461,11 @@ impl RenderSession {
             "RenderSession::set_font family={font_family:?} logical_px={logical_size:.2} physical_px={physical_size:.2}"
         );
         Ok(())
+    }
+
+    /// Whether a metrics change still needs to reach VT and ConPTY.
+    pub fn geometry_sync_pending(&self) -> bool {
+        self.geometry_sync_pending.load(Ordering::Acquire)
     }
 
     /// Notify of a DPI change. Rebuilds the glyph atlas at the new

--- a/crates/con-ghostty/src/windows/render/atlas.rs
+++ b/crates/con-ghostty/src/windows/render/atlas.rs
@@ -130,9 +130,13 @@ pub struct GlyphCache {
     device: ID3D11Device,
     _context: ID3D11DeviceContext,
     dwrite: IDWriteFactory,
-    /// Font collection that owns `font_family`. `Some` only for our
-    /// bundled IoskeleyMono collection; `None` means DirectWrite should
-    /// resolve the family from the system collection.
+    /// The bundled collection remains available even when the currently
+    /// selected family comes from the system collection, so a live settings
+    /// change can switch back to IoskeleyMono without recreating the renderer.
+    bundled_font_collection: Option<IDWriteFontCollection>,
+    /// Font collection that owns `font_family`. `Some` only when the resolved
+    /// family comes from our bundled collection; `None` means DirectWrite
+    /// resolves it from the system collection.
     font_collection: Option<IDWriteFontCollection>,
     /// System font-fallback cascade. Attached to each
     /// `IDWriteTextFormat1` so DirectWrite transparently swaps in
@@ -445,6 +449,7 @@ impl GlyphCache {
             device: device.clone(),
             _context: context.clone(),
             dwrite: dwrite.clone(),
+            bundled_font_collection: bundled_collection,
             font_collection,
             font_fallback,
             _d2d_factory: d2d_factory,
@@ -833,70 +838,75 @@ impl GlyphCache {
         }
     }
 
-    pub fn rebuild(&mut self, font_size_px: f32) -> Result<()> {
-        // Build every fallible DirectWrite resource before replacing the live
-        // atlas state. A transient format or metrics failure must leave the old
-        // state usable so the caller can retry safely.
+    pub fn rebuild(&mut self, font_family: &str, font_size_px: f32) -> Result<()> {
+        // Resolve both values together. In particular, the collection must
+        // change when settings switch between a bundled and a system font.
+        let resolved = resolve_font_family(
+            &self.dwrite,
+            self.bundled_font_collection.as_ref(),
+            font_family,
+        )?;
+        let resolved_family = resolved.family;
+        let font_collection = resolved.collection.cloned();
+        let collection = font_collection.as_ref();
+
+        // Build every fallible DirectWrite object before mutating the cache,
+        // leaving the previous font fully usable if the requested font fails.
         let text_format_regular = make_text_format(
             &self.dwrite,
-            self.font_collection.as_ref(),
+            collection,
             self.font_fallback.as_ref(),
-            &self.font_family,
+            &resolved_family,
             font_size_px,
             false,
             false,
         )?;
         let text_format_bold = make_text_format(
             &self.dwrite,
-            self.font_collection.as_ref(),
+            collection,
             self.font_fallback.as_ref(),
-            &self.font_family,
+            &resolved_family,
             font_size_px,
             true,
             false,
         )?;
         let text_format_italic = make_text_format(
             &self.dwrite,
-            self.font_collection.as_ref(),
+            collection,
             self.font_fallback.as_ref(),
-            &self.font_family,
+            &resolved_family,
             font_size_px,
             false,
             true,
         )?;
         let text_format_bold_italic = make_text_format(
             &self.dwrite,
-            self.font_collection.as_ref(),
+            collection,
             self.font_fallback.as_ref(),
-            &self.font_family,
+            &resolved_family,
             font_size_px,
             true,
             true,
         )?;
         let text_format_cjk_regular = make_text_format_with_weight(
             &self.dwrite,
-            self.font_collection.as_ref(),
+            collection,
             self.font_fallback.as_ref(),
-            &self.font_family,
+            &resolved_family,
             font_size_px,
             DWRITE_FONT_WEIGHT_MEDIUM,
             false,
         )?;
         let text_format_cjk_italic = make_text_format_with_weight(
             &self.dwrite,
-            self.font_collection.as_ref(),
+            collection,
             self.font_fallback.as_ref(),
-            &self.font_family,
+            &resolved_family,
             font_size_px,
             DWRITE_FONT_WEIGHT_MEDIUM,
             true,
         )?;
-        let metrics = measure_cell(
-            &self.dwrite,
-            self.font_collection.as_ref(),
-            &self.font_family,
-            font_size_px,
-        )?;
+        let metrics = measure_cell(&self.dwrite, collection, &resolved_family, font_size_px)?;
         let layout_baselines = TextFormatBaselines::measure(
             &self.dwrite,
             metrics.baseline_px as f32,
@@ -909,26 +919,25 @@ impl GlyphCache {
         // works after a font-size change (the face itself doesn't
         // depend on size, but re-resolving keeps the field in lockstep
         // with the current collection / family).
-        let (primary_face, primary_upm) = match resolve_font_face(
-            &self.dwrite,
-            self.font_collection.as_ref(),
-            &self.font_family,
-        ) {
-            Ok((face, _src)) => {
-                let mut fm = DWRITE_FONT_METRICS::default();
-                // SAFETY: windows-rs writes through the out pointer.
-                unsafe { face.GetMetrics(&mut fm) };
-                (Some(face), fm.designUnitsPerEm as f32)
-            }
-            Err(err) => {
-                log::warn!(
-                    "GlyphCache::rebuild: primary face resolution failed ({err:?}); \
+        let (primary_face, primary_upm) =
+            match resolve_font_face(&self.dwrite, collection, &resolved_family) {
+                Ok((face, _src)) => {
+                    let mut fm = DWRITE_FONT_METRICS::default();
+                    // SAFETY: windows-rs writes through the out pointer.
+                    unsafe { face.GetMetrics(&mut fm) };
+                    (Some(face), fm.designUnitsPerEm as f32)
+                }
+                Err(err) => {
+                    log::warn!(
+                        "GlyphCache::rebuild: primary face resolution failed ({err:?}); \
                      wide Nerd-Font icons will render clipped at the cell edge"
-                );
-                (None, 1.0)
-            }
-        };
+                    );
+                    (None, 1.0)
+                }
+            };
 
+        self.font_family = resolved_family;
+        self.font_collection = font_collection;
         self.font_size_px = font_size_px;
         self.entries.clear();
         self.allocator = AtlasAllocator::new(size2(self.atlas_size as i32, self.atlas_size as i32));

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -315,11 +315,11 @@ impl Renderer {
         (self.width_px, self.height_px)
     }
 
-    pub fn rebuild_atlas(&self, font_size_px: f32) -> Result<()> {
+    pub fn rebuild_atlas(&self, font_family: &str, font_size_px: f32) -> Result<()> {
         self.atlas
             .lock()
             .expect("atlas mutex poisoned in rebuild_atlas()")
-            .rebuild(font_size_px)?;
+            .rebuild(font_family, font_size_px)?;
         *self
             .last_generation
             .lock()

--- a/postmortem/2026-07-21-windows-live-terminal-font-settings.md
+++ b/postmortem/2026-07-21-windows-live-terminal-font-settings.md
@@ -1,0 +1,21 @@
+# Windows terminal font settings did not update live panes
+
+## What happened
+
+Changing the terminal font family or size in Settings updated the saved/app-level renderer configuration, but text in terminal panes that were already open did not change on Windows. Newly created panes used the new values.
+
+## Root cause
+
+The Windows `WindowsGhosttyTerminal::update_appearance` implementation intentionally ignored its `font_family` and `font_size` arguments and only forwarded theme colors and background opacity to the live `RenderSession`. The renderer's atlas rebuild API also accepted only a size, and the glyph cache discarded access to the bundled font collection whenever its current font came from the system collection. That made a complete live family switch impossible.
+
+## Fix applied
+
+- Forward font family and size updates to every live Windows render session.
+- Re-resolve the requested family against bundled and system collections and rebuild all DirectWrite formats, metrics, primary face data, and glyph atlas state.
+- Retain the bundled collection so live switching between system fonts and IoskeleyMono works in both directions.
+- Recompute the VT/ConPTY grid after cell metrics change and force a repaint.
+- Keep the latest logical font size for subsequent DPI changes.
+
+## What we learned
+
+App-level renderer configuration is only a template for future panes. Every appearance setting advertised as a live preview must also have a per-session update path, and font updates must treat family, collection, metrics, grid size, and DPI-scaled size as one operation.

--- a/postmortem/2026-07-21-windows-live-terminal-font-settings.md
+++ b/postmortem/2026-07-21-windows-live-terminal-font-settings.md
@@ -15,7 +15,15 @@ The Windows `WindowsGhosttyTerminal::update_appearance` implementation intention
 - Retain the bundled collection so live switching between system fonts and IoskeleyMono works in both directions.
 - Recompute the VT/ConPTY grid after cell metrics change and force a repaint.
 - Keep the latest logical font size for subsequent DPI changes.
+- Track incomplete geometry synchronization explicitly, so a transient VT,
+  mouse-geometry, or ConPTY resize failure is retried on the next prepaint.
+- Apply independent theme and opacity changes even when DirectWrite rejects a
+  requested font update.
 
 ## What we learned
 
 App-level renderer configuration is only a template for future panes. Every appearance setting advertised as a live preview must also have a per-session update path, and font updates must treat family, collection, metrics, grid size, and DPI-scaled size as one operation.
+
+That operation also needs a durable retry boundary. Logging a partial geometry
+failure is not enough: the view must keep reconciling renderer metrics, VT
+geometry, and ConPTY dimensions until all three agree.


### PR DESCRIPTION
Changing the terminal font family or size currently leaves existing Windows panes using the old glyph atlas. This change makes font settings live for panes that are already open: it rebuilds DirectWrite resources, updates cell metrics, and synchronizes the VT and ConPTY grid.

The update is failure-safe. If geometry synchronization is interrupted, the next prepaint retries it instead of leaving the renderer and child process out of sync. Theme and opacity updates remain independent of font resource creation.

This is the first layer because ordered fallback builds on the live-font API. Original commit: `85da87f` by @batkiz; contributor authorship and the stacked review structure are preserved.

### Stack

Part 1/8 of https://github.com/nowledge-co/con-terminal/issues/273. This PR targets `main` and contains only the live-font layer. Later layers remain separate so each behavior and platform risk can be reviewed independently.

1. [Apply terminal font changes to existing panes](https://github.com/nowledge-co/con-terminal/pull/346)
2. [Support ordered font fallback and Windows CJK selection](https://github.com/batkiz/con-terminal/pull/1)
3. [Apply foreground-aware grayscale glyph correction](https://github.com/batkiz/con-terminal/pull/2)
4. [Configure the default shell command](https://github.com/batkiz/con-terminal/pull/3)
5. [Synchronize theme palette and margin background](https://github.com/batkiz/con-terminal/pull/4)
6. [Evaluate the terminal text restore default](https://github.com/batkiz/con-terminal/pull/5)
7. [Evaluate full readback on viewport changes](https://github.com/batkiz/con-terminal/pull/6)
8. [Scale icons with configured font sizes](https://github.com/batkiz/con-terminal/pull/7)

### Validation

- The original head passed native Windows and Ubuntu portable CI plus macOS E2E.
- `cargo fmt -p con-ghostty -- --check` passed; the Windows app file passes standalone `rustfmt --check`.
- `git diff --check` passed.
- The branch is rebased by merge onto the libghostty revision from #345; fresh native CI is required before merge.

The beta.96 changelog credits @batkiz for the user-visible fix.
