### PR TITLE
docs: finalize beta.96 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
-## `v0.1.0-beta.96` - unreleased
+## `v0.1.0-beta.96` - 2026-09-07
 
 ### Changed
 


### PR DESCRIPTION
## Summary
- record the published date for `v0.1.0-beta.96`

## Context
The release is public and all platform release gates have passed. This keeps the repository and docs-site changelog aligned with the shipped release.