### PR TITLE
fix(windows): apply foreground-aware grayscale glyph correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
+## `v0.1.0-beta.98` - unreleased
+
+### Fixed
+
+**Windows**
+
+- Terminal text now uses foreground-aware DirectWrite grayscale correction,
+  improving edge weight on both light and dark backgrounds without restoring
+  ClearType color fringes. CJK text retains its tuned contrast profile. _(PR
+  [#349](https://github.com/nowledge-co/con-terminal/pull/349) by
+  [@batkiz](https://github.com/batkiz))_
+
+---
+
 ## `v0.1.0-beta.97` - 2026-09-09
 
 ### Added

--- a/crates/con-ghostty/src/windows/render/atlas.rs
+++ b/crates/con-ghostty/src/windows/render/atlas.rs
@@ -37,17 +37,14 @@ use windows::Win32::Graphics::DirectWrite::{
     DWRITE_FONT_STYLE_NORMAL, DWRITE_FONT_WEIGHT, DWRITE_FONT_WEIGHT_BOLD,
     DWRITE_FONT_WEIGHT_MEDIUM, DWRITE_FONT_WEIGHT_NORMAL, DWRITE_GLYPH_METRICS,
     DWRITE_LINE_METRICS, DWRITE_MEASURING_MODE_NATURAL, DWRITE_PIXEL_GEOMETRY_FLAT,
-    DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC, IDWriteFactory, IDWriteFontCollection,
-    IDWriteFontFace, IDWriteFontFallback, IDWriteRenderingParams, IDWriteTextFormat,
-    IDWriteTextFormat1,
+    DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC, IDWriteFactory, IDWriteFactory1,
+    IDWriteFontCollection, IDWriteFontFace, IDWriteFontFallback, IDWriteRenderingParams,
+    IDWriteTextFormat, IDWriteTextFormat1,
 };
 use windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT_B8G8R8A8_UNORM, DXGI_SAMPLE_DESC};
 use windows::Win32::Graphics::Dxgi::IDXGISurface;
 use windows::core::Interface;
 use windows_numerics::Matrix3x2;
-
-const TEXT_ENHANCED_CONTRAST: f32 = 1.15;
-const CJK_TEXT_ENHANCED_CONTRAST: f32 = 1.45;
 
 const LOCALE_NAME_BUFFER_LENGTH: usize = 85;
 const FALLBACK_LOCALE_NAME: &str = "en-US";
@@ -176,8 +173,10 @@ pub struct GlyphCache {
     _atlas_texture: ID3D11Texture2D,
     atlas_srv: ID3D11ShaderResourceView,
     d2d_rt: ID2D1RenderTarget,
-    text_rendering_params: Option<IDWriteRenderingParams>,
-    cjk_text_rendering_params: Option<IDWriteRenderingParams>,
+    /// Linear grayscale rasterization parameters. The atlas stores neutral
+    /// coverage; foreground-aware gamma and contrast correction happens in
+    /// the pixel shader when the actual text color is known.
+    _linear_text_rendering_params: IDWriteRenderingParams,
     white_brush: ID2D1SolidColorBrush,
     /// Opaque-black brush. Used to clear each slot before `DrawText` so
     /// any stale pixels — from a neighbouring scaled-PUA glyph that bled
@@ -406,34 +405,19 @@ impl GlyphCache {
         let d2d_rt = unsafe { d2d_factory.CreateDxgiSurfaceRenderTarget(&dxgi_surface, &rt_props) }
             .context("CreateDxgiSurfaceRenderTarget failed")?;
 
-        // Custom rendering params give us consistent grayscale output
-        // across machines regardless of the user's ClearType Tuner
-        // settings. Natural symmetric preserves DirectWrite's vertical
-        // and horizontal antialiasing while avoiding RGB subpixel
-        // coverage in our offscreen atlas. A mild contrast bump offsets
-        // the perceived weight loss from dropping ClearType.
-        //
-        // CJK fallback glyphs need a separate, stronger grayscale
-        // contrast. The user-visible complaint in #78 was not Latin
-        // weight after the RGB-fringe fix; it was CJK strokes looking
-        // too thin. Keep Latin / PUA conservative and only switch to
-        // the heavier params for wide fallback glyph rasterization.
-        //
-        // If CreateCustomRenderingParams fails (very rare — it's a pure
-        // parameter validator) we leave the default params in place.
-        let text_rendering_params = custom_text_rendering_params(dwrite, TEXT_ENHANCED_CONTRAST);
-        let cjk_text_rendering_params = text_rendering_params
-            .is_some()
-            .then(|| custom_text_rendering_params(dwrite, CJK_TEXT_ENHANCED_CONTRAST))
-            .flatten();
+        // Store neutral grayscale coverage in the atlas. Baking gamma and
+        // contrast here would bake the white-on-black DrawText colors into
+        // every glyph, then incorrectly reuse those values for dark text on
+        // light themes. The pixel shader applies DirectWrite-compatible,
+        // foreground-aware correction when it knows the real colors.
+        let linear_text_rendering_params = linear_text_rendering_params(dwrite)
+            .context("creating linear DirectWrite rendering parameters failed")?;
         // SAFETY: grayscale AA. Setting the mode is cheap; if a driver
         // clamps it, the shader still collapses coverage to one scalar
         // so colored subpixel fringe cannot escape to the final frame.
         unsafe {
             d2d_rt.SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE_GRAYSCALE);
-            if let Some(params) = text_rendering_params.as_ref() {
-                d2d_rt.SetTextRenderingParams(params);
-            }
+            d2d_rt.SetTextRenderingParams(&linear_text_rendering_params);
         }
 
         let color = D2D1_COLOR_F {
@@ -488,8 +472,7 @@ impl GlyphCache {
             _atlas_texture: atlas_texture,
             atlas_srv,
             d2d_rt,
-            text_rendering_params,
-            cjk_text_rendering_params,
+            _linear_text_rendering_params: linear_text_rendering_params,
             white_brush,
             black_brush,
             allocator,
@@ -755,9 +738,6 @@ impl GlyphCache {
                     utf16_slice,
                     target_baseline,
                 );
-                if is_cjk_text && let Some(params) = self.cjk_text_rendering_params.as_ref() {
-                    self.d2d_rt.SetTextRenderingParams(params);
-                }
                 self.d2d_rt.DrawText(
                     utf16_slice,
                     format,
@@ -766,9 +746,6 @@ impl GlyphCache {
                     D2D1_DRAW_TEXT_OPTIONS_NONE,
                     DWRITE_MEASURING_MODE_NATURAL,
                 );
-                if is_cjk_text && let Some(params) = self.text_rendering_params.as_ref() {
-                    self.d2d_rt.SetTextRenderingParams(params);
-                }
             } else {
                 self.d2d_rt.DrawText(
                     utf16_slice,
@@ -1096,25 +1073,29 @@ fn make_text_format_with_weight(
     Ok(format)
 }
 
-fn custom_text_rendering_params(
-    dwrite: &IDWriteFactory,
-    enhanced_contrast: f32,
-) -> Option<IDWriteRenderingParams> {
-    // SAFETY: constants are valid for IDWriteFactory. ClearType level
-    // stays zero because this atlas is sampled and composited by our
-    // own shader; RGB subpixel coverage would survive screenshots and
-    // remote displays as colored fringe.
-    unsafe {
-        dwrite
-            .CreateCustomRenderingParams(
-                1.8,
-                enhanced_contrast,
-                0.0,
-                DWRITE_PIXEL_GEOMETRY_FLAT,
-                DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC,
-            )
-            .ok()
+fn linear_text_rendering_params(dwrite: &IDWriteFactory) -> Result<IDWriteRenderingParams> {
+    // Factory1 exposes a separate grayscale-enhanced-contrast argument. Set
+    // gamma and both contrast channels to their neutral values so DrawText
+    // writes reusable coverage instead of white-on-black corrected coverage.
+    // ClearType remains disabled because this offscreen texture is later
+    // sampled, scaled, and composited over transparent backgrounds.
+    let factory = dwrite
+        .cast::<IDWriteFactory1>()
+        .context("IDWriteFactory1 is unavailable")?;
+    let params = unsafe {
+        factory.CreateCustomRenderingParams(
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            DWRITE_PIXEL_GEOMETRY_FLAT,
+            DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC,
+        )
     }
+    .context("IDWriteFactory1::CreateCustomRenderingParams failed")?;
+    params
+        .cast::<IDWriteRenderingParams>()
+        .context("IDWriteRenderingParams1 -> IDWriteRenderingParams failed")
 }
 
 fn text_layout_baseline(
@@ -1428,7 +1409,7 @@ fn is_wide_codepoint(codepoint: u32) -> bool {
         .is_some_and(|width| width >= 2)
 }
 
-fn is_cjk_codepoint(codepoint: u32) -> bool {
+pub(super) fn is_cjk_codepoint(codepoint: u32) -> bool {
     matches!(
         codepoint,
         // Hangul Jamo.

--- a/crates/con-ghostty/src/windows/render/atlas.rs
+++ b/crates/con-ghostty/src/windows/render/atlas.rs
@@ -39,7 +39,7 @@ use windows::Win32::Graphics::DirectWrite::{
     DWRITE_LINE_METRICS, DWRITE_MEASURING_MODE_NATURAL, DWRITE_PIXEL_GEOMETRY_FLAT,
     DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC, IDWriteFactory, IDWriteFactory1,
     IDWriteFontCollection, IDWriteFontFace, IDWriteFontFallback, IDWriteRenderingParams,
-    IDWriteTextFormat, IDWriteTextFormat1,
+    IDWriteRenderingParams1, IDWriteTextFormat, IDWriteTextFormat1,
 };
 use windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT_B8G8R8A8_UNORM, DXGI_SAMPLE_DESC};
 use windows::Win32::Graphics::Dxgi::IDXGISurface;
@@ -48,6 +48,9 @@ use windows_numerics::Matrix3x2;
 
 const LOCALE_NAME_BUFFER_LENGTH: usize = 85;
 const FALLBACK_LOCALE_NAME: &str = "en-US";
+const DEFAULT_TEXT_GAMMA: f32 = 1.8;
+const DEFAULT_GRAYSCALE_CONTRAST: f32 = 1.0;
+const CJK_GRAYSCALE_CONTRAST_FLOOR: f32 = 1.45;
 
 static USER_LOCALE_NAME: LazyLock<Vec<u16>> = LazyLock::new(user_locale_name);
 
@@ -110,6 +113,24 @@ pub struct CellMetrics {
     pub cell_width_px: u32,
     pub cell_height_px: u32,
     pub baseline_px: u32,
+}
+
+/// DirectWrite's color-dependent grayscale correction inputs. The atlas keeps
+/// reusable coverage; the final text pass applies these values after the real
+/// foreground color is known.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct GlyphRenderingParams {
+    pub gamma_ratios: [f32; 4],
+    pub grayscale_contrast: f32,
+    pub cjk_grayscale_contrast: f32,
+}
+
+impl GlyphRenderingParams {
+    const LEGACY_ATLAS: Self = Self {
+        gamma_ratios: [0.0; 4],
+        grayscale_contrast: 0.0,
+        cjk_grayscale_contrast: 0.0,
+    };
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -176,7 +197,8 @@ pub struct GlyphCache {
     /// Linear grayscale rasterization parameters. The atlas stores neutral
     /// coverage; foreground-aware gamma and contrast correction happens in
     /// the pixel shader when the actual text color is known.
-    _linear_text_rendering_params: IDWriteRenderingParams,
+    _text_rendering_params: Option<IDWriteRenderingParams>,
+    rendering_params: GlyphRenderingParams,
     white_brush: ID2D1SolidColorBrush,
     /// Opaque-black brush. Used to clear each slot before `DrawText` so
     /// any stale pixels — from a neighbouring scaled-PUA glyph that bled
@@ -410,14 +432,15 @@ impl GlyphCache {
         // every glyph, then incorrectly reuse those values for dark text on
         // light themes. The pixel shader applies DirectWrite-compatible,
         // foreground-aware correction when it knows the real colors.
-        let linear_text_rendering_params = linear_text_rendering_params(dwrite)
-            .context("creating linear DirectWrite rendering parameters failed")?;
+        let (text_rendering_params, rendering_params) = text_rendering_params(dwrite);
         // SAFETY: grayscale AA. Setting the mode is cheap; if a driver
         // clamps it, the shader still collapses coverage to one scalar
         // so colored subpixel fringe cannot escape to the final frame.
         unsafe {
             d2d_rt.SetTextAntialiasMode(D2D1_TEXT_ANTIALIAS_MODE_GRAYSCALE);
-            d2d_rt.SetTextRenderingParams(&linear_text_rendering_params);
+            if let Some(params) = text_rendering_params.as_ref() {
+                d2d_rt.SetTextRenderingParams(params);
+            }
         }
 
         let color = D2D1_COLOR_F {
@@ -472,7 +495,8 @@ impl GlyphCache {
             _atlas_texture: atlas_texture,
             atlas_srv,
             d2d_rt,
-            _linear_text_rendering_params: linear_text_rendering_params,
+            _text_rendering_params: text_rendering_params,
+            rendering_params,
             white_brush,
             black_brush,
             allocator,
@@ -504,6 +528,10 @@ impl GlyphCache {
     #[allow(dead_code)] // used once atlas-grow lands.
     pub fn atlas_size(&self) -> u32 {
         self.atlas_size
+    }
+
+    pub fn rendering_params(&self) -> GlyphRenderingParams {
+        self.rendering_params
     }
 
     /// Return the glyph rect for a (codepoint, style) key, rasterizing
@@ -1073,29 +1101,114 @@ fn make_text_format_with_weight(
     Ok(format)
 }
 
-fn linear_text_rendering_params(dwrite: &IDWriteFactory) -> Result<IDWriteRenderingParams> {
-    // Factory1 exposes a separate grayscale-enhanced-contrast argument. Set
-    // gamma and both contrast channels to their neutral values so DrawText
-    // writes reusable coverage instead of white-on-black corrected coverage.
-    // ClearType remains disabled because this offscreen texture is later
-    // sampled, scaled, and composited over transparent backgrounds.
+fn text_rendering_params(
+    dwrite: &IDWriteFactory,
+) -> (Option<IDWriteRenderingParams>, GlyphRenderingParams) {
+    match foreground_aware_text_rendering_params(dwrite) {
+        Ok(params) => params,
+        Err(error) => {
+            // Windows 10+ exposes IDWriteFactory1, but preserve a usable
+            // terminal if a remote/compatibility environment rejects it. In
+            // that case DirectWrite bakes correction into the atlas and the
+            // shader's identity parameters avoid correcting it twice.
+            log::warn!(
+                "foreground-aware DirectWrite correction unavailable ({error:#}); using legacy atlas correction"
+            );
+            let legacy = unsafe {
+                dwrite.CreateCustomRenderingParams(
+                    DEFAULT_TEXT_GAMMA,
+                    1.15,
+                    0.0,
+                    DWRITE_PIXEL_GEOMETRY_FLAT,
+                    DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC,
+                )
+            }
+            .ok();
+            (legacy, GlyphRenderingParams::LEGACY_ATLAS)
+        }
+    }
+}
+
+fn foreground_aware_text_rendering_params(
+    dwrite: &IDWriteFactory,
+) -> Result<(Option<IDWriteRenderingParams>, GlyphRenderingParams)> {
+    // This follows Windows Terminal's AtlasEngine contract: read the user's
+    // DirectWrite parameters once, rasterize neutral grayscale coverage, and
+    // defer color-dependent gamma/contrast correction to the pixel shader.
     let factory = dwrite
         .cast::<IDWriteFactory1>()
         .context("IDWriteFactory1 is unavailable")?;
+    let defaults = unsafe { factory.CreateRenderingParams() }
+        .context("IDWriteFactory1::CreateRenderingParams failed")?;
+    let defaults_v1 = defaults
+        .cast::<IDWriteRenderingParams1>()
+        .context("IDWriteRenderingParams1 is unavailable")?;
+
+    let gamma = finite_or(unsafe { defaults.GetGamma() }, DEFAULT_TEXT_GAMMA).clamp(1.0, 2.2);
+    let grayscale_contrast = finite_or(
+        unsafe { defaults_v1.GetGrayscaleEnhancedContrast() },
+        DEFAULT_GRAYSCALE_CONTRAST,
+    )
+    .max(0.0);
     let params = unsafe {
         factory.CreateCustomRenderingParams(
             1.0,
             0.0,
             0.0,
-            0.0,
-            DWRITE_PIXEL_GEOMETRY_FLAT,
-            DWRITE_RENDERING_MODE_NATURAL_SYMMETRIC,
+            defaults.GetClearTypeLevel(),
+            defaults.GetPixelGeometry(),
+            defaults.GetRenderingMode(),
         )
     }
     .context("IDWriteFactory1::CreateCustomRenderingParams failed")?;
-    params
+    let params = params
         .cast::<IDWriteRenderingParams>()
-        .context("IDWriteRenderingParams1 -> IDWriteRenderingParams failed")
+        .context("IDWriteRenderingParams1 -> IDWriteRenderingParams failed")?;
+
+    Ok((
+        Some(params),
+        GlyphRenderingParams {
+            gamma_ratios: gamma_ratios(gamma),
+            grayscale_contrast,
+            cjk_grayscale_contrast: grayscale_contrast.max(CJK_GRAYSCALE_CONTRAST_FLOOR),
+        },
+    ))
+}
+
+fn finite_or(value: f32, fallback: f32) -> f32 {
+    if value.is_finite() { value } else { fallback }
+}
+
+/// Polynomial coefficients used by DirectWrite's grayscale alpha correction.
+/// The source table and normalization are from Windows Terminal's
+/// MIT-licensed `dwrite_helpers.cpp`.
+fn gamma_ratios(gamma: f32) -> [f32; 4] {
+    const TARGETS: [[f32; 4]; 13] = [
+        [0.0000, 0.0000, 0.0000, 0.0000],
+        [0.0166, -0.0807, 0.2227, -0.0751],
+        [0.0350, -0.1760, 0.4325, -0.1370],
+        [0.0543, -0.2821, 0.6302, -0.1876],
+        [0.0739, -0.3963, 0.8167, -0.2287],
+        [0.0933, -0.5161, 0.9926, -0.2616],
+        [0.1121, -0.6395, 1.1588, -0.2877],
+        [0.1300, -0.7649, 1.3159, -0.3080],
+        [0.1469, -0.8911, 1.4644, -0.3234],
+        [0.1627, -1.0170, 1.6051, -0.3347],
+        [0.1773, -1.1420, 1.7385, -0.3426],
+        [0.1908, -1.2652, 1.8650, -0.3476],
+        [0.2031, -1.3864, 1.9851, -0.3501],
+    ];
+    let index =
+        ((finite_or(gamma, DEFAULT_TEXT_GAMMA) * 10.0 + 0.5) as i32).clamp(10, 22) as usize - 10;
+    let target = TARGETS[index];
+    let norm_13 = 65_536.0 / (255.0 * 255.0);
+    let norm_24 = 256.0 / 255.0;
+    [
+        target[0] * norm_13,
+        target[1] * norm_24,
+        target[2] * norm_13,
+        target[3] * norm_24,
+    ]
 }
 
 fn text_layout_baseline(
@@ -1437,7 +1550,16 @@ pub(super) fn is_cjk_codepoint(codepoint: u32) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_cjk_codepoint, is_wide_codepoint};
+    use super::{gamma_ratios, is_cjk_codepoint, is_wide_codepoint};
+
+    #[test]
+    fn gamma_ratios_match_directwrite_default() {
+        let actual = gamma_ratios(1.8);
+        let expected = [0.148054421, -0.894594550, 1.47590804, -0.324668258];
+        for (actual, expected) in actual.into_iter().zip(expected) {
+            assert!((actual - expected).abs() < 0.000_001);
+        }
+    }
 
     #[test]
     fn wide_codepoint_follows_unicode_width() {

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -51,7 +51,7 @@ use windows::Win32::Graphics::Dxgi::DXGI_ERROR_WAS_STILL_DRAWING;
 
 use super::profile::{perf_trace_enabled, perf_trace_verbose};
 use super::vt::{ATTR_INVERSE, ATTR_STRIKE, ATTR_UNDERLINE, Cell, KittyPlacement, ScreenSnapshot};
-use atlas::{GlyphCache, GlyphKey};
+use atlas::{GlyphCache, GlyphKey, is_cjk_codepoint};
 use image_pipeline::{ImageLayer, ImagePipeline};
 use pipeline::{Globals, Instance, Pipeline, instance_for_cell};
 
@@ -66,6 +66,8 @@ const ALTERNATE_SCREEN_BACKGROUND_OPACITY_FLOOR: f32 = 1.0;
 const INITIAL_INSTANCE_CAPACITY: u32 = 16 * 1024;
 const RENDER_ATTR_DEFAULT_BG: u32 = 1 << 8;
 const RENDER_ATTR_CURSOR: u32 = 1 << 9;
+/// Renderer-private CJK grayscale contrast profile.
+const INTERNAL_ATTR_CJK: u32 = 1 << 10;
 
 #[derive(Debug, Clone)]
 pub struct RendererConfig {
@@ -1014,7 +1016,12 @@ impl Renderer {
                 glyph,
                 cell.fg,
                 apply_opacity(cell.bg),
-                render_attrs,
+                render_attrs
+                    | if is_cjk_codepoint(cell.codepoint) {
+                        INTERNAL_ATTR_CJK
+                    } else {
+                        0
+                    },
             );
             has_wide_glyph |= glyph.w as u32 > cell_w_px;
             instances.push(instance);
@@ -1849,6 +1856,7 @@ fn create_staging_texture(
 
 #[cfg(test)]
 mod tests {
+    use super::{Renderer, RendererConfig};
     use std::sync::Arc;
     use super::{Renderer, RendererConfig};
 
@@ -1950,5 +1958,14 @@ mod tests {
             ..RendererConfig::default()
         };
         Renderer::new(&config).expect("preferred DirectWrite fallback chain should be valid");
+    }
+
+    #[test]
+    fn renderer_initializes_with_linear_grayscale_atlas() {
+        let renderer = Renderer::new(&RendererConfig::default())
+            .expect("Windows renderer should initialize with WARP fallback");
+        let metrics = renderer.metrics();
+        assert!(metrics.cell_width_px > 0);
+        assert!(metrics.cell_height_px > 0);
     }
 }

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -1069,6 +1069,7 @@ impl Renderer {
         let background_instance_count = instances.len() as u32 - text_instance_count;
 
         let metrics = atlas.metrics();
+        let rendering_params = atlas.rendering_params();
         let atlas_size = atlas.atlas_size() as f32;
         let atlas_srv = atlas.atlas_srv().clone();
         drop(atlas);
@@ -1102,6 +1103,10 @@ impl Renderer {
             grid_cols: snapshot.cols as u32,
             grid_rows: snapshot.rows as u32,
             inv_atlas_size: [1.0 / atlas_size, 1.0 / atlas_size],
+            gamma_ratios: rendering_params.gamma_ratios,
+            grayscale_contrast: rendering_params.grayscale_contrast,
+            cjk_grayscale_contrast: rendering_params.cjk_grayscale_contrast,
+            _padding: [0.0; 2],
         };
         pipeline
             .upload_globals(&self.context, &globals)
@@ -1858,7 +1863,6 @@ fn create_staging_texture(
 mod tests {
     use super::{Renderer, RendererConfig};
     use std::sync::Arc;
-    use super::{Renderer, RendererConfig};
 
     use super::{
         KittyReadbackState, KittyVisual, KittyVisualState, ReadbackRegion, merge_readback_regions,

--- a/crates/con-ghostty/src/windows/render/pipeline.rs
+++ b/crates/con-ghostty/src/windows/render/pipeline.rs
@@ -536,3 +536,19 @@ pub fn instance_for_cell(
         attrs,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::compile_shader;
+
+    #[test]
+    fn embedded_terminal_shaders_compile() {
+        let source = include_str!("shaders.hlsl");
+        for entry in ["vs_text", "vs_cell"] {
+            compile_shader(source, entry, "vs_5_0").expect("vertex shader should compile");
+        }
+        for entry in ["ps_background", "ps_cursor", "ps_text"] {
+            compile_shader(source, entry, "ps_5_0").expect("pixel shader should compile");
+        }
+    }
+}

--- a/crates/con-ghostty/src/windows/render/pipeline.rs
+++ b/crates/con-ghostty/src/windows/render/pipeline.rs
@@ -60,6 +60,10 @@ pub struct Globals {
     /// (1/atlas_w, 1/atlas_h) — lets the VS normalize pixel-space
     /// glyph UVs into the [0,1] range the sampler expects.
     pub inv_atlas_size: [f32; 2],
+    pub gamma_ratios: [f32; 4],
+    pub grayscale_contrast: f32,
+    pub cjk_grayscale_contrast: f32,
+    pub _padding: [f32; 2],
 }
 
 pub struct Pipeline {
@@ -539,7 +543,12 @@ pub fn instance_for_cell(
 
 #[cfg(test)]
 mod tests {
-    use super::compile_shader;
+    use super::{Globals, compile_shader};
+
+    #[test]
+    fn globals_match_four_hlsl_constant_registers() {
+        assert_eq!(std::mem::size_of::<Globals>(), 64);
+    }
 
     #[test]
     fn embedded_terminal_shaders_compile() {

--- a/crates/con-ghostty/src/windows/render/shaders.hlsl
+++ b/crates/con-ghostty/src/windows/render/shaders.hlsl
@@ -28,6 +28,7 @@ struct VSInstance {
     // Low bits mirror Ghostty cell attrs. Con reserves:
     //   bit 8 = default background
     //   bit 9 = cursor cell
+    //   bit 10 = CJK contrast profile
     uint   attrs         : ATTRS;
 };
 
@@ -38,6 +39,7 @@ struct VSOut {
     nointerpolation float4 fg : FGCOLOR;
     nointerpolation float4 bg : BGCOLOR;
     nointerpolation uint   attrs : ATTRS;
+    nointerpolation uint hasGlyph : TEXCOORD2;
 };
 
 static const uint ATTR_UNDERLINE  = 4u;
@@ -53,6 +55,43 @@ float4 unpackRGBA(uint v) {
         float((v >>  8) & 0xFF),
         float( v        & 0xFF)
     ) / 255.0;
+}
+
+// DirectWrite-compatible grayscale gamma correction, adapted from Windows
+// Terminal's MIT-licensed AtlasEngine dwrite_helpers.hlsl. The atlas contains
+// neutral linear coverage; correction must happen here because only the pixel
+// shader knows whether the glyph is dark-on-light or light-on-dark.
+float enhanceContrast(float alpha, float contrast) {
+    return alpha * (contrast + 1.0) / (alpha * contrast + 1.0);
+}
+
+float applyAlphaCorrection(float alpha, float foregroundIntensity) {
+    // Polynomial ratios for DirectWrite's default gamma 1.8.
+    const float4 gammaRatios = float4(
+        0.148054421,
+       -0.894594550,
+        1.47590804,
+       -0.324668258
+    );
+    return alpha + alpha * (1.0 - alpha)
+        * ((gammaRatios.x * foregroundIntensity + gammaRatios.y) * alpha
+            + (gammaRatios.z * foregroundIntensity + gammaRatios.w));
+}
+
+float correctedGrayscaleCoverage(
+    float rawCoverage,
+    float3 foreground,
+    float grayscaleEnhancedContrast
+) {
+    // DirectWrite applies its grayscale contrast adjustment primarily to dark
+    // foreground colors. This avoids over-bold white text while keeping dark
+    // text smooth and readable on Con's default light theme.
+    float contrast = grayscaleEnhancedContrast * saturate(
+        dot(foreground, float3(0.30, 0.59, 0.11) * -4.0) + 3.0
+    );
+    float contrasted = enhanceContrast(rawCoverage, contrast);
+    float intensity = dot(foreground, float3(0.25, 0.50, 0.25));
+    return saturate(applyAlphaCorrection(contrasted, intensity));
 }
 
 uint2 quadCorner(uint vid) {
@@ -77,6 +116,7 @@ VSOut vertexOut(uint vid, VSInstance inst, float2 quadSize) {
     o.fg = unpackRGBA(inst.fg);
     o.bg = unpackRGBA(inst.bg);
     o.attrs = inst.attrs;
+    o.hasGlyph = all(inst.atlasSize > 0u) ? 1u : 0u;
     return o;
 }
 
@@ -144,7 +184,8 @@ float4 ps_cursor(VSOut i) : SV_Target {
 
 float4 ps_text(VSOut i) : SV_Target {
     float3 coverageRgb = atlas.Sample(samp, i.atlasUV).rgb;
-    float coverage = max(coverageRgb.r, max(coverageRgb.g, coverageRgb.b));
+    float rawCoverage = i.hasGlyph != 0u
+        ? max(coverageRgb.r, max(coverageRgb.g, coverageRgb.b)) : 0.0;
 
     float pxUV = 1.0 / max(cellSize.y, 1.0);
     float bandCoverage = 0.0;
@@ -163,6 +204,9 @@ float4 ps_text(VSOut i) : SV_Target {
         color.a = 1.0;
     }
 
+    float coverage = correctedGrayscaleCoverage(
+        rawCoverage, color.rgb, (i.attrs & 1024u) != 0u ? 1.45 : 1.0
+    );
     float alpha = color.a * max(coverage, bandCoverage);
     return float4(color.rgb * alpha, alpha);
 }

--- a/crates/con-ghostty/src/windows/render/shaders.hlsl
+++ b/crates/con-ghostty/src/windows/render/shaders.hlsl
@@ -17,6 +17,10 @@ cbuffer Globals : register(b0) {
     uint   gridCols;
     uint   gridRows;
     float2 invAtlasSize;
+    float4 gammaRatios;
+    float  grayscaleContrast;
+    float  cjkGrayscaleContrast;
+    float2 globalsPadding;
 };
 
 struct VSInstance {
@@ -66,13 +70,6 @@ float enhanceContrast(float alpha, float contrast) {
 }
 
 float applyAlphaCorrection(float alpha, float foregroundIntensity) {
-    // Polynomial ratios for DirectWrite's default gamma 1.8.
-    const float4 gammaRatios = float4(
-        0.148054421,
-       -0.894594550,
-        1.47590804,
-       -0.324668258
-    );
     return alpha + alpha * (1.0 - alpha)
         * ((gammaRatios.x * foregroundIntensity + gammaRatios.y) * alpha
             + (gammaRatios.z * foregroundIntensity + gammaRatios.w));
@@ -205,7 +202,9 @@ float4 ps_text(VSOut i) : SV_Target {
     }
 
     float coverage = correctedGrayscaleCoverage(
-        rawCoverage, color.rgb, (i.attrs & 1024u) != 0u ? 1.45 : 1.0
+        rawCoverage,
+        color.rgb,
+        (i.attrs & 1024u) != 0u ? cjkGrayscaleContrast : grayscaleContrast
     );
     float alpha = color.a * max(coverage, bandCoverage);
     return float4(color.rgb * alpha, alpha);

--- a/postmortem/2026-07-21-windows-font-coverage-gamma.md
+++ b/postmortem/2026-07-21-windows-font-coverage-gamma.md
@@ -1,0 +1,23 @@
+# Windows terminal glyph edges looked rough
+
+## What happened
+
+Windows terminal text could look rough, uneven, or overly thin, especially at small sizes, 125% display scaling, and with dark foreground text on the default light theme. Earlier work removed ClearType RGB fringes, but the remaining grayscale path still did not match DirectWrite's final text composition.
+
+## Root cause
+
+The glyph atlas rasterized a white brush onto black with hard-coded DirectWrite gamma and enhanced contrast. Those corrected coverage values were then reused for every foreground/background pair and composited in HLSL with a simple linear interpolation.
+
+That bakes a white-on-black assumption into the atlas. DirectWrite grayscale correction depends on the actual foreground intensity, so applying the baked coverage to dark-on-light text produces different edge weight from light-on-dark text. Background-only instances also sampled atlas texel `(0, 0)`, allowing the first cached glyph's edge to contaminate cells that had no glyph.
+
+## Fix applied
+
+- Rasterize the Direct2D atlas with neutral gamma and contrast through `IDWriteFactory1` while retaining grayscale antialiasing.
+- Apply DirectWrite-compatible, foreground-aware gamma and grayscale contrast correction in the pixel shader, based on Windows Terminal's MIT-licensed AtlasEngine formulas.
+- Preserve a separate CJK contrast profile through a renderer-private instance attribute while keeping the existing medium-weight CJK format.
+- Mark zero-sized atlas instances as glyph-free in the vertex shader so the pixel shader forces their glyph coverage to zero.
+- Add a test that compiles both embedded HLSL entry points.
+
+## What we learned
+
+A reusable glyph atlas should contain neutral coverage, not coverage corrected for the colors used while populating the atlas. Gamma/contrast correction belongs at the final composition stage where the real foreground color is available. Grayscale antialiasing remains preferable to ClearType for Con's offscreen, transparent, and rescaled composition path because it avoids device-specific RGB subpixel fringes.

--- a/postmortem/2026-07-21-windows-font-coverage-gamma.md
+++ b/postmortem/2026-07-21-windows-font-coverage-gamma.md
@@ -12,11 +12,12 @@ That bakes a white-on-black assumption into the atlas. DirectWrite grayscale cor
 
 ## Fix applied
 
-- Rasterize the Direct2D atlas with neutral gamma and contrast through `IDWriteFactory1` while retaining grayscale antialiasing.
-- Apply DirectWrite-compatible, foreground-aware gamma and grayscale contrast correction in the pixel shader, based on Windows Terminal's MIT-licensed AtlasEngine formulas.
+- Read the active DirectWrite gamma and grayscale contrast once at renderer startup, then rasterize the Direct2D atlas with neutral gamma and contrast through `IDWriteFactory1` while retaining grayscale antialiasing.
+- Apply DirectWrite-compatible, foreground-aware gamma and grayscale contrast correction in the pixel shader, based on Windows Terminal's MIT-licensed AtlasEngine formulas. The shader receives the system-derived values rather than assuming the default text tuner settings.
 - Preserve a separate CJK contrast profile through a renderer-private instance attribute while keeping the existing medium-weight CJK format.
 - Mark zero-sized atlas instances as glyph-free in the vertex shader so the pixel shader forces their glyph coverage to zero.
-- Add a test that compiles both embedded HLSL entry points.
+- Fall back to the previous atlas-corrected path if the newer DirectWrite interface is unexpectedly unavailable, so rendering quality can degrade without preventing a terminal pane from opening.
+- Add tests for the DirectWrite gamma coefficients, renderer initialization, and every embedded HLSL entry point.
 
 ## What we learned
 


### PR DESCRIPTION
Windows terminal glyphs now keep neutral grayscale coverage in the atlas and apply DirectWrite-compatible correction only in the final text pass, where the actual foreground color is known. This avoids baking a white-on-black assumption into glyphs reused by both light and dark themes.

The original implementation and Windows comparison work are by @batkiz. The maintainer pass rebases it onto the beta.97 renderer, preserves the ordered fallback/CJK work from #348, and aligns the parameter flow more closely with Windows Terminal's AtlasEngine:

- read the active DirectWrite gamma and grayscale contrast once at renderer startup;
- derive the same gamma-ratio coefficients used by Windows Terminal;
- pass system-derived Latin and tuned CJK contrast profiles through the D3D11 constant buffer;
- keep the atlas grayscale-only, avoiding ClearType RGB fringe in transparent, scaled, screenshot, and remote-display paths;
- prevent glyph-free instances from sampling atlas texel `(0, 0)`;
- fall back to the previous atlas-corrected path if the newer DirectWrite interface is unexpectedly unavailable, rather than preventing the pane from opening.

### Scope

Windows renderer only. macOS continues to use embedded libghostty/Metal; Linux continues to use its own terminal paint path.

### Validation

- `CON_ZIG_BIN=/opt/homebrew/bin/zig cargo test -p con-ghostty` (macOS): 18 passed.
- `python3 scripts/docs/validate-manifest.py`: 13 pages, 13 routes.
- `git diff --check` passed.
- Windows-native CI compiles the DirectWrite/D3D11 implementation, initializes the renderer through WARP, verifies the Rust/HLSL constant-buffer size, checks the DirectWrite 1.8 gamma coefficients, and compiles all embedded shader entry points.

### Source

The correction formulas and coefficient table are adapted from Microsoft Windows Terminal's MIT-licensed `src/renderer/atlas/dwrite_helpers.{cpp,hlsl}`.

Closes the rendering-quality portion of #273. Original contributor authorship is preserved in the commit history and changelog.
