### PR TITLE
refactor(windows): synchronize theme palette and margin background

### DIFF
--- a/crates/con-ghostty/src/windows/backend.rs
+++ b/crates/con-ghostty/src/windows/backend.rs
@@ -63,13 +63,7 @@ impl WindowsGhosttyApp {
         }
         if let Some(colors) = colors {
             let theme = theme_from_colors(colors);
-            config.clear_color = [
-                colors.background[0] as f32 / 255.0,
-                colors.background[1] as f32 / 255.0,
-                colors.background[2] as f32 / 255.0,
-                1.0,
-            ];
-            config.theme = Some(theme);
+            config.apply_theme(&theme);
         }
         if let Some(op) = background_opacity {
             config.background_opacity = clamp_opacity(op);

--- a/crates/con-ghostty/src/windows/host_view.rs
+++ b/crates/con-ghostty/src/windows/host_view.rs
@@ -399,13 +399,7 @@ impl RenderSession {
             // palette would leave the border showing the previous
             // theme's background. Mirror what `WindowsGhosttyApp::
             // update_appearance` does at session construction.
-            config.clear_color = [
-                theme.bg[0] as f32 / 255.0,
-                theme.bg[1] as f32 / 255.0,
-                theme.bg[2] as f32 / 255.0,
-                1.0,
-            ];
-            config.theme = Some(theme.clone());
+            config.apply_theme(theme);
             // `set_theme` bumps the VT generation itself, so the next
             // prepaint re-runs draw_cells with the new palette + new
             // clear_color + any new opacity.

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -87,6 +87,21 @@ pub struct RendererConfig {
     pub theme: Option<ThemeColors>,
 }
 
+impl RendererConfig {
+    /// Apply a terminal color theme, keeping `clear_color`
+    /// and the VT palette in agreement. Call this whenever the user
+    /// switches themes; also call `VtScreen::set_theme` for an existing session.
+    pub fn apply_theme(&mut self, theme: &ThemeColors) {
+        self.clear_color = [
+            theme.bg[0] as f32 / 255.0,
+            theme.bg[1] as f32 / 255.0,
+            theme.bg[2] as f32 / 255.0,
+            1.0,
+        ];
+        self.theme = Some(theme.clone());
+    }
+}
+
 impl Default for RendererConfig {
     fn default() -> Self {
         Self {
@@ -94,7 +109,7 @@ impl Default for RendererConfig {
             font_size_px: 14.0,
             initial_width: 800,
             initial_height: 600,
-            clear_color: [0.06, 0.06, 0.07, 1.0],
+            clear_color: [16.0 / 255.0, 15.0 / 255.0, 15.0 / 255.0, 1.0],
             background_opacity: 1.0,
             theme: None,
         }

--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -109,7 +109,7 @@ impl Default for RendererConfig {
             font_size_px: 14.0,
             initial_width: 800,
             initial_height: 600,
-            clear_color: [16.0 / 255.0, 15.0 / 255.0, 15.0 / 255.0, 1.0],
+            clear_color: [0.06, 0.06, 0.07, 1.0],
             background_opacity: 1.0,
             theme: None,
         }


### PR DESCRIPTION
Centralize RendererConfig theme application so the VT palette configuration and clear color are updated together by both app and live-session paths; preserve the existing renderer fallback clear color.

Current upstream already synchronizes live-session margins, so this is a small consolidation rather than a claim to fix #242. The old render-state fallback and cursor-offset workaround are superseded by upstream snapshot recovery and viewport cursor handling and are not reintroduced. Extracted from `7669fdd` by @batkiz.

### Upstream review

Follow-up to #273 and merged #346, submitted upstream following [the maintainer's invitation](https://github.com/nowledge-co/con-terminal/pull/346#issuecomment-5563609274). Based directly on upstream `main` at `f4170e16` (beta.96). This PR contains only its own change; it does not accumulate other pending layers. Overlapping files may need conflict resolution as sibling PRs merge, but there is no dependency on another unmerged PR.

Supersedes the fork-only draft https://github.com/batkiz/con-terminal/pull/4. Original contributor authorship is preserved.

### Validation

- `git diff upstream/main --check` passed.
- `CON_SKIP_GHOSTTY_VT=1 cargo check -p con-ghostty --tests --target x86_64-pc-windows-gnu --offline` passed on this branch. This is type checking only, with native VT building/linking skipped.
- Fresh native Windows/Linux CI, full UI compilation and the applicable manual visual/runtime checks remain to be completed; the author currently has no Windows device available.

### Related PRs

- #346 — live terminal font settings (merged)
- #348 — feat(terminal): support ordered font fallback and Windows CJK selection
- #349 — fix(windows): apply foreground-aware grayscale glyph correction
- #350 — feat(terminal): configure the default shell command
- #351 — refactor(windows): synchronize theme palette and margin background
- #352 — proposal(windows): disable terminal text restore by default (draft)
- #353 — proposal(windows): force full readback on viewport changes (draft)
- #354 — feat(ui): scale icons with configured font sizes