### PR TITLE
proposal(windows): force full readback on viewport changes

### DIFF
--- a/crates/con-ghostty/src/windows/render/mod.rs
+++ b/crates/con-ghostty/src/windows/render/mod.rs
@@ -130,6 +130,8 @@ pub struct Renderer {
     /// 0` on a quiet VT — still produces a frame (the cleared background),
     /// giving the pane something to show before the shell has printed anything.
     last_generation: Mutex<u64>,
+    /// Viewport offset of the last submitted frame. Commit only after drawing succeeds.
+    last_scroll_offset: Mutex<Option<u64>>,
     /// Wall-clock time of the last `Rendered` outcome. Drives the
     /// `MIN_FALLBACK_PRESENT_INTERVAL` cap that decouples presentation
     /// rate from the VT update rate, so continuous-output TUIs (issue
@@ -258,6 +260,7 @@ impl Renderer {
             has_full_frame: Mutex::new(false),
             kitty_readback: Mutex::new(KittyReadbackState::default()),
             last_generation: Mutex::new(u64::MAX),
+            last_scroll_offset: Mutex::new(None),
             last_presented_at: Mutex::new(None),
             width_px: width,
             height_px: height,
@@ -407,15 +410,22 @@ impl Renderer {
         let prof_started = perf_trace_enabled().then(Instant::now);
         let geometry_hash =
             geometry_fingerprint(snapshot.cols, snapshot.rows, self.width_px, self.height_px);
+        let scroll_offset = snapshot.scrollbar.map_or(0, |scrollbar| scrollbar.offset);
+        let scroll_changed = *self
+            .last_scroll_offset
+            .lock()
+            .expect("last_scroll_offset mutex poisoned")
+            != Some(scroll_offset);
         let combined = snapshot
             .generation
             .wrapping_mul(0x9E37_79B9_7F4A_7C15)
             .wrapping_add(geometry_hash.rotate_left(13));
-        let needs_draw = *self
-            .last_generation
-            .lock()
-            .expect("last_generation mutex poisoned in render()")
-            != combined;
+        let needs_draw = scroll_changed
+            || *self
+                .last_generation
+                .lock()
+                .expect("last_generation mutex poisoned in render()")
+                != combined;
 
         let mut ring = self
             .staging_ring
@@ -506,7 +516,8 @@ impl Renderer {
             // Image damage is relative to the last frame handed to GPUI.
             // Partial patches are safe only when no older mailbox slot can be
             // presented first and change that baseline.
-            let can_partial_readback = in_flight_before_submit == 0
+            let can_partial_readback = !scroll_changed
+                && in_flight_before_submit == 0
                 && *self
                     .has_full_frame
                     .lock()
@@ -527,6 +538,10 @@ impl Renderer {
                 .last_generation
                 .lock()
                 .expect("last_generation mutex poisoned after submit") = combined;
+            *self
+                .last_scroll_offset
+                .lock()
+                .expect("last_scroll_offset mutex poisoned after submit") = Some(scroll_offset);
             submit_ms = submit_started
                 .map(|started| started.elapsed().as_secs_f64() * 1000.0)
                 .unwrap_or(0.0);

--- a/postmortem/2026-09-06-windows-scroll-readback-proposal.md
+++ b/postmortem/2026-09-06-windows-scroll-readback-proposal.md
@@ -1,0 +1,21 @@
+# Windows scroll readback proposal
+
+## What happened
+
+The experiments in upstream issue #273 reported blank or stale rows after scrolling. The original mixed commit `4bc1c6b` also changed session restore defaults, making the rendering change difficult to evaluate separately.
+
+## Root cause
+
+The experimental diagnosis was that a viewport transition could reuse dirty-row readback regions from the prior viewport. This has not been reproduced on beta.95: upstream now has stronger snapshot recovery and image damage tracking.
+
+## Fix proposed
+
+Force a draw and full readback when the viewport offset changes. Retain partial readback for an unchanged viewport. Record the offset only after drawing and copy submission succeed so an error cannot suppress a retry. Keep upstream's cursor viewport visibility; the old `offset == 0` cursor condition is not carried forward.
+
+## Validation still required
+
+On Windows, compare the parent and this branch with the same machine, font, DPI, window size and scrollback. Use the existing `CON_GHOSTTY_PROFILE=1` and `CON_GHOSTTY_PROFILE_VERBOSE=1` instrumentation. Exercise wheel scrolling, scrollbar dragging, resize, sustained TUI output and Kitty images. Report median/p95 frame time, readback rows/bytes, CPU/GPU usage and any stale-frame reproduction. Keep this proposal in draft until the measurements establish whether it is still necessary and acceptable.
+
+## What we learned
+
+Viewport invalidation and transcript persistence need separate review. Older experimental fixes must be reassessed against current upstream recovery guarantees.


### PR DESCRIPTION
Force a draw and full readback when the viewport offset changes, retaining partial readback for an unchanged viewport. Commit the offset only after successful drawing/copy submission so failures remain retryable.

Extracted from the rendering half of `4bc1c6b` by @batkiz and adapted to upstream's mailbox and Kitty damage tracking. The accompanying note separates the historical diagnosis from current evidence.

**Measurements required before merge:** reproduce on current upstream and compare parent/head under wheel/scrollbar scrolling, resize, sustained TUI output and Kitty images. Record median/p95 frame time, readback rows/bytes and CPU/GPU load using CON_GHOSTTY_PROFILE and CON_GHOSTTY_PROFILE_VERBOSE. No Windows performance numbers are claimed.

### Upstream review

Follow-up to #273 and merged #346, submitted upstream following [the maintainer's invitation](https://github.com/nowledge-co/con-terminal/pull/346#issuecomment-5563609274). Based directly on upstream `main` at `f4170e16` (beta.96). This PR contains only its own change; it does not accumulate other pending layers. Overlapping files may need conflict resolution as sibling PRs merge, but there is no dependency on another unmerged PR.

Supersedes the fork-only draft https://github.com/batkiz/con-terminal/pull/6. Original contributor authorship is preserved.

### Validation

- `git diff upstream/main --check` passed.
- `CON_SKIP_GHOSTTY_VT=1 cargo check -p con-ghostty --tests --target x86_64-pc-windows-gnu --offline` passed on this branch. This is type checking only, with native VT building/linking skipped.
- Fresh native Windows/Linux CI, full UI compilation and the applicable manual visual/runtime checks remain to be completed; the author currently has no Windows device available.

### Related PRs

- #346 — live terminal font settings (merged)
- #348 — feat(terminal): support ordered font fallback and Windows CJK selection
- #349 — fix(windows): apply foreground-aware grayscale glyph correction
- #350 — feat(terminal): configure the default shell command
- #351 — refactor(windows): synchronize theme palette and margin background
- #352 — proposal(windows): disable terminal text restore by default (draft)
- #353 — proposal(windows): force full readback on viewport changes (draft)
- #354 — feat(ui): scale icons with configured font sizes
