### PR TITLE
docs: finalize beta.97 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to con are documented here.
 
 con is still pre-release, so entries may group related beta work while the product shape is stabilizing.
 
-## `v0.1.0-beta.97` - unreleased
+## `v0.1.0-beta.97` - 2026-09-09
 
 ### Added
 


### PR DESCRIPTION
Finalize the beta.97 changelog with the release date 2026-09-09.

The release notes cover #348, #350, and #354 with contributor credit to @batkiz. #351 is an internal behavior-preserving refactor and does not need an end-user release note.

Validation:
- `git diff --check`
- `python3 scripts/docs/validate-manifest.py`
- Final feature heads passed native Windows and Ubuntu CI plus macOS E2E before merge.